### PR TITLE
Include disk-uploader pipeline in tekton tests

### DIFF
--- a/tests/infrastructure/tekton/test_tekton_custom_ns.py
+++ b/tests/infrastructure/tekton/test_tekton_custom_ns.py
@@ -7,7 +7,9 @@ from ocp_resources.pipeline import Pipeline
 from ocp_resources.resource import Resource
 from ocp_resources.task import Task
 
-from tests.infrastructure.tekton.utils import wait_for_tekton_resource_availability
+from tests.infrastructure.tekton.utils import (
+    wait_for_tekton_resource_availability,
+)
 from utilities.constants import WIN_2K22, WIN_2K25, WIN_10, WIN_11
 
 pytestmark = pytest.mark.tier3
@@ -74,8 +76,4 @@ class TestTektonEfiPipelineExecution:
         assert (
             final_status_pipelinerun.status == Resource.Condition.Status.TRUE
             and final_status_pipelinerun.type == Resource.Condition.Phase.SUCCEEDED
-        ), (
-            "Pipelines failed to succeed. Reason: "
-            f"{pipelinerun_from_pipeline_template.instance.status.conditions[0]['message']}."
-            f"Skipped Tasks: {pipelinerun_from_pipeline_template.instance.status.skippedTasks}"
-        )
+        ), f"Pipelines failed to succeed. Pipeline status: {final_status_pipelinerun.instance.status}"

--- a/tests/infrastructure/tekton/test_tekton_pipeline_disk_uploader.py
+++ b/tests/infrastructure/tekton/test_tekton_pipeline_disk_uploader.py
@@ -1,0 +1,17 @@
+import pytest
+from ocp_resources.resource import Resource
+
+pytestmark = pytest.mark.tier3
+
+
+@pytest.mark.usefixtures("extracted_kubevirt_tekton_resources", "processed_yaml_files")
+@pytest.mark.polarion("CNV-11721")
+def test_disk_uploader_pipelinerun(
+    vm_for_disk_uploader,
+    pipelinerun_for_disk_uploader,
+    final_status_pipelinerun_for_disk_uploader,
+):
+    assert (
+        final_status_pipelinerun_for_disk_uploader.status == Resource.Condition.Status.TRUE
+        and final_status_pipelinerun_for_disk_uploader.type == Resource.Condition.Phase.SUCCEEDED
+    ), f"Pipelines failed to succeed. Pipeline status: {final_status_pipelinerun_for_disk_uploader.instance.status}"


### PR DESCRIPTION
##### Short description:
Tekton task disk-uploader is introduced. This patch creates a basic pipeline with disk-uploader task and run the pipeline with defined parameters.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

