### PR TITLE
Test for kube_daemonset_status_number_ready

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -4,6 +4,7 @@ import shlex
 
 import bitmath
 import pytest
+from ocp_resources.daemonset import DaemonSet
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
@@ -65,6 +66,7 @@ from utilities.constants import (
     TWO_CPU_SOCKETS,
     TWO_CPU_THREADS,
     VERSION_LABEL_KEY,
+    VIRT_HANDLER,
     WARNING_STR,
     Images,
 )
@@ -886,4 +888,14 @@ def vm_virt_launcher_pod_requested_memory(vm_for_test):
         bitmath.parse_string_unsafe(
             vm_for_test.vmi.virt_launcher_pod.instance.spec.containers[0].resources.requests.memory
         ).bytes
+    )
+
+
+@pytest.fixture()
+def virt_handler_pods_count(hco_namespace):
+    return str(
+        DaemonSet(
+            name=VIRT_HANDLER,
+            namespace=hco_namespace.name,
+        ).instance.status.numberReady
     )

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -15,7 +15,8 @@ from tests.observability.metrics.utils import (
     get_vm_metrics,
     validate_metric_value_within_range,
 )
-from utilities.constants import KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS, VIRT_API
+from tests.observability.utils import validate_metrics_value
+from utilities.constants import KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS, VIRT_API, VIRT_HANDLER
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
@@ -217,4 +218,14 @@ class TestMemoryDeltaFromRequestedBytes:
             prometheus=prometheus,
             metric_name=f"cnv_abnormal{{container='{VIRT_API}', reason='memory_rss_delta_from_request'}}",
             expected_value=float(bitmath.MiB(virt_api_rss_memory - virt_api_requested_memory).Byte),
+        )
+
+
+class TestKubeDaemonsetStatusNumberReady:
+    @pytest.mark.polarion("CNV-11727")
+    def test_kube_daemonset_status_number_ready(self, prometheus, virt_handler_pods_count):
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=f"kube_daemonset_status_number_ready{{daemonset='{VIRT_HANDLER}'}}",
+            expected_value=virt_handler_pods_count,
         )


### PR DESCRIPTION
##### Short description:
Test for the metric kube_daemonset_status_number_ready
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
