### PR TITLE
Update test name to reflect accurate behavior after live migration

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -152,7 +152,7 @@ class TestPrimaryUdn:
         )
 
     @pytest.mark.polarion("CNV-11674")
-    def test_ip_address_is_preserved_during_live_migration(self, namespaced_layer2_user_defined_network, vma_udn):
+    def test_ip_address_is_preserved_after_live_migration(self, namespaced_layer2_user_defined_network, vma_udn):
         ip_before_migration = get_iface(vm=vma_udn, iface_name=vm_primary_network_name(vm=vma_udn))[IP_ADDRESS]
         assert ip_before_migration
         migrate_vm_and_verify(vm=vma_udn)


### PR DESCRIPTION
##### Short description:
Update test name to reflect accurate behavior after live migration
##### More details:
Renamed the test `test_ip_address_is_preserved_during_live_migration` to `test_ip_address_is_preserved_after_live_migration` to improve clarity.

This ensures the test name accurately reflects its purpose: verifying that the IP address is preserved after live migration. The update enhances readability and aligns the test name with its intended behavior.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: