### PR TITLE
net: Refactor the UDN tests and move generic helpers to libs.net

### DIFF
--- a/libs/net/udn.py
+++ b/libs/net/udn.py
@@ -1,0 +1,9 @@
+from typing import Final
+
+from libs.vm.spec import Interface, NetBinding, Network
+
+UDN_BINDING_PLUGIN_NAME: Final[str] = "l2bridge"
+
+
+def udn_primary_network(name: str) -> tuple[Interface, Network]:
+    return Interface(name=name, binding=NetBinding(name=UDN_BINDING_PLUGIN_NAME)), Network(name=name, pod={})

--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -1,57 +1,68 @@
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+from collections.abc import Callable
+from typing import Any, Final
+
+from kubernetes.dynamic.client import ResourceField
+from timeout_sampler import TimeoutExpiredError, retry
+
+from libs.vm.vm import BaseVirtualMachine
+
+LOOKUP_IFACE_STATUS_TIMEOUT_SEC: Final[int] = 30
+RETRY_INTERVAL_SEC: Final[int] = 5
 
 
-class VMInterfaceNotFoundError(Exception):
+class VMInterfaceStatusNotFoundError(Exception):
     pass
 
 
-def get_iface(vm, iface_name):
-    try:
-        return wait_for_vm_iface(
-            vm=vm,
-            iface_name=iface_name,
-            timeout=30,
-            sleep=5,
-            predicate=lambda interface: "guest-agent" in interface["infoSource"] and interface["ipAddress"],
-        )
-    except TimeoutExpiredError:
-        raise VMInterfaceNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
-
-
-def wait_for_vm_iface(vm, iface_name, timeout, sleep, predicate=lambda iface: True):
-    samples = TimeoutSampler(
-        wait_timeout=timeout,
-        sleep=sleep,
-        func=iface_lookup,
-        vm=vm,
-        iface_name=iface_name,
-        predicate=predicate,
-        exceptions_dict={VMInterfaceNotFoundError: []},
-    )
-    for sample in samples:
-        if sample:
-            return sample
-
-
-def iface_lookup(vm, iface_name, predicate):
+def lookup_iface_status(vm: BaseVirtualMachine, iface_name: str) -> ResourceField:
     """
-    Returns the interface requested if found and the predicate function (to which the interface is
-    sent) returns True. Else, raise VMInterfaceNotFound.
+    Returns the network interface status requested if found, otherwise raises VMInterfaceStatusNotFoundError.
+    The interface status information is expected to be sourced from the guest-agent with an IP address.
 
     Args:
         vm (BaseVirtualMachine): VM in which to search for the network interface.
         iface_name (str): The name of the requested interface.
-        predicate (function): A function that takes a network interface as an argument
-            and returns a boolean value. This function should define the condition that
+
+    Returns:
+        iface (ResourceField): The requested interface.
+
+    Raises:
+        VMInterfaceStatusNotFoundError: If the requested interface was not found in the vmi status.
+    """
+    try:
+        return _lookup_iface_status(
+            vm=vm,
+            iface_name=iface_name,
+            predicate=lambda interface: "guest-agent" in interface["infoSource"] and interface["ipAddress"],
+        )
+    except TimeoutExpiredError:
+        raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
+
+
+@retry(
+    wait_timeout=LOOKUP_IFACE_STATUS_TIMEOUT_SEC,
+    sleep=RETRY_INTERVAL_SEC,
+    exceptions_dict={VMInterfaceStatusNotFoundError: []},
+)
+def _lookup_iface_status(vm: BaseVirtualMachine, iface_name: str, predicate: Callable[[Any], bool]) -> ResourceField:
+    """
+    Returns the interface requested if found and the predicate function (to which the interface is
+    sent) returns True. Else, raise VMInterfaceStatusNotFoundError.
+
+    Args:
+        vm (BaseVirtualMachine): VM in which to search for the network interface.
+        iface_name (str): The name of the requested interface.
+        predicate (Callable[[dict[str, Any]], bool]): A function that takes a network interface as an argument
+            and returns a boolean value. this function should define the condition that
             the interface needs to meet.
 
     Returns:
-        iface (dict): The requested interface.
+        iface (ResourceField): The requested interface.
 
     Raises:
-        VMInterfaceNotFound: If the requested interface was not found in the VM.
+        VMInterfaceStatusNotFoundError: If the requested interface was not found in the VM.
     """
     for iface in vm.vmi.interfaces:
         if iface.name == iface_name and predicate(iface):
             return iface
-    raise VMInterfaceNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
+    raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")

--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -1,0 +1,57 @@
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+
+class VMInterfaceNotFoundError(Exception):
+    pass
+
+
+def get_iface(vm, iface_name):
+    try:
+        return wait_for_vm_iface(
+            vm=vm,
+            iface_name=iface_name,
+            timeout=30,
+            sleep=5,
+            predicate=lambda interface: "guest-agent" in interface["infoSource"] and interface["ipAddress"],
+        )
+    except TimeoutExpiredError:
+        raise VMInterfaceNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
+
+
+def wait_for_vm_iface(vm, iface_name, timeout, sleep, predicate=lambda iface: True):
+    samples = TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=sleep,
+        func=iface_lookup,
+        vm=vm,
+        iface_name=iface_name,
+        predicate=predicate,
+        exceptions_dict={VMInterfaceNotFoundError: []},
+    )
+    for sample in samples:
+        if sample:
+            return sample
+
+
+def iface_lookup(vm, iface_name, predicate):
+    """
+    Returns the interface requested if found and the predicate function (to which the interface is
+    sent) returns True. Else, raise VMInterfaceNotFound.
+
+    Args:
+        vm (BaseVirtualMachine): VM in which to search for the network interface.
+        iface_name (str): The name of the requested interface.
+        predicate (function): A function that takes a network interface as an argument
+            and returns a boolean value. This function should define the condition that
+            the interface needs to meet.
+
+    Returns:
+        iface (dict): The requested interface.
+
+    Raises:
+        VMInterfaceNotFound: If the requested interface was not found in the VM.
+    """
+    for iface in vm.vmi.interfaces:
+        if iface.name == iface_name and predicate(iface):
+            return iface
+    raise VMInterfaceNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")

--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -4,6 +4,7 @@ from typing import Any, Final
 from kubernetes.dynamic.client import ResourceField
 from timeout_sampler import TimeoutExpiredError, retry
 
+from libs.vm.spec import Network
 from libs.vm.vm import BaseVirtualMachine
 
 LOOKUP_IFACE_STATUS_TIMEOUT_SEC: Final[int] = 30
@@ -70,3 +71,10 @@ def _lookup_iface_status(vm: BaseVirtualMachine, iface_name: str, predicate: Cal
         if iface.name == iface_name and predicate(iface):
             return iface
     raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
+
+
+def lookup_primary_network(vm: BaseVirtualMachine) -> Network:
+    for network in vm.instance.spec.template.spec.networks:
+        if network.pod is not None:
+            return Network(**network)
+    raise VMInterfaceSpecNotFoundError(f"No interface connected to the primary network was found in VM {vm.name}.")

--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -10,6 +10,10 @@ LOOKUP_IFACE_STATUS_TIMEOUT_SEC: Final[int] = 30
 RETRY_INTERVAL_SEC: Final[int] = 5
 
 
+class VMInterfaceSpecNotFoundError(Exception):
+    pass
+
+
 class VMInterfaceStatusNotFoundError(Exception):
     pass
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -3,7 +3,7 @@ import ipaddress
 import pytest
 from ocp_resources.resource import Resource
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
-from ocp_resources.utils.constants import TIMEOUT_1MINUTE, TIMEOUT_30SEC
+from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from libs.vm import affinity
@@ -112,11 +112,7 @@ def namespaced_layer2_user_defined_network(namespace):
         subnets=["10.10.0.0/24"],
         ipam_lifecycle="Persistent",
     ) as udn:
-        udn.wait_for_condition(
-            condition="NetworkReady",
-            status=Resource.Condition.Status.TRUE,
-            timeout=TIMEOUT_30SEC,
-        )
+        udn.wait_for_network_ready()
         yield udn
 
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -4,8 +4,8 @@ import pytest
 from ocp_resources.resource import Resource
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from libs.net.vmspec import VMInterfaceNotFoundError, get_iface
 from libs.vm import affinity
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
@@ -39,68 +39,12 @@ def udn_primary_network(name):
     return Interface(name=name, binding=NetBinding(name="l2bridge")), Network(name=name, pod={})
 
 
-class VMInterfaceNotFoundError(Exception):
-    pass
-
-
 def vm_primary_network_name(vm):
     vm_primary_network_type = "pod"
     for network in vm.instance.spec.template.spec.networks:
         if vm_primary_network_type in network.keys():
             return network.name
     raise VMInterfaceNotFoundError(f"No interface connected to the primary network was found in VM {vm.name}.")
-
-
-def iface_lookup(vm, iface_name, predicate):
-    """
-    Returns the interface requested if found and the predicate function (to which the interface is
-    sent) returns True. Else, raise VMInterfaceNotFound.
-
-    Args:
-        vm (BaseVirtualMachine): VM in which to search for the network interface.
-        iface_name (str): The name of the requested interface.
-        predicate (function): A function that takes a network interface as an argument
-            and returns a boolean value. This function should define the condition that
-            the interface needs to meet.
-
-    Returns:
-        iface (dict): The requested interface.
-
-    Raises:
-        VMInterfaceNotFound: If the requested interface was not found in the VM.
-    """
-    for iface in vm.vmi.interfaces:
-        if iface.name == iface_name and predicate(iface):
-            return iface
-    raise VMInterfaceNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
-
-
-def wait_for_vm_iface(vm, iface_name, timeout, sleep, predicate=lambda iface: True):
-    samples = TimeoutSampler(
-        wait_timeout=timeout,
-        sleep=sleep,
-        func=iface_lookup,
-        vm=vm,
-        iface_name=iface_name,
-        predicate=predicate,
-        exceptions_dict={VMInterfaceNotFoundError: []},
-    )
-    for sample in samples:
-        if sample:
-            return sample
-
-
-def get_iface(vm, iface_name):
-    try:
-        return wait_for_vm_iface(
-            vm=vm,
-            iface_name=iface_name,
-            timeout=30,
-            sleep=5,
-            predicate=lambda interface: "guest-agent" in interface["infoSource"] and interface[IP_ADDRESS],
-        )
-    except TimeoutExpiredError:
-        raise VMInterfaceNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
 
 
 @pytest.fixture(scope="module")

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -5,11 +5,11 @@ from ocp_resources.resource import Resource
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
+from libs.net.udn import udn_primary_network
 from libs.net.vmspec import VMInterfaceStatusNotFoundError, lookup_iface_status
 from libs.vm import affinity
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
-from libs.vm.spec import Interface, NetBinding, Network
 from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
 from utilities.virt import migrate_vm_and_verify
 
@@ -33,10 +33,6 @@ def udn_vm(namespace_name, name, template_labels=None):
         spec.template.spec.affinity = new_pod_anti_affinity(label=label)
 
     return fedora_vm(namespace=namespace_name, name=name, spec=spec)
-
-
-def udn_primary_network(name):
-    return Interface(name=name, binding=NetBinding(name="l2bridge")), Network(name=name, pod={})
 
 
 def vm_primary_network_name(vm):

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -6,7 +6,7 @@ from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
 from libs.net.udn import udn_primary_network
-from libs.net.vmspec import VMInterfaceStatusNotFoundError, lookup_iface_status
+from libs.net.vmspec import VMInterfaceSpecNotFoundError, lookup_iface_status
 from libs.vm import affinity
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
@@ -40,7 +40,7 @@ def vm_primary_network_name(vm):
     for network in vm.instance.spec.template.spec.networks:
         if vm_primary_network_type in network.keys():
             return network.name
-    raise VMInterfaceStatusNotFoundError(f"No interface connected to the primary network was found in VM {vm.name}.")
+    raise VMInterfaceSpecNotFoundError(f"No interface connected to the primary network was found in VM {vm.name}.")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### Short description:
net: Refactor the UDN tests and move generic helpers to libs.net

##### What this PR does / why we need it:

Cover several topics to cleanup the udn test module, including typing coverage:
- Introduce vmspec module and move helpers from tests to it
- Introduce an UDN module with a recommended timeout const
- Refactor lookup-iface helpers
- Move the UDN primary net creation helper to libs.net
- Diff between failing to find iface in spec and status
- Generalize the lookup for the primary network

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
It is recommended to review the changes one commit at a time.

##### jira-ticket:
NONE
