### PR TITLE
Support the addition of kubevirtIpamController to ClusterNetworkAddonsOperator

### DIFF
--- a/tests/network/cluster_addons_operator/test_network_addons_operator.py
+++ b/tests/network/cluster_addons_operator/test_network_addons_operator.py
@@ -51,6 +51,7 @@ EXPECTED_CNAO_COMP = [
     "linuxBridge",
     "ovs",
     "tlsSecurityProfile",
+    "kubevirtIpamController",
 ]
 MANAGED_BY = "managed-by"
 COMP_LABELS = ["component", "version", "part-of", MANAGED_BY]


### PR DESCRIPTION
Starting 4.18, kubevirtIpamController is defaultly added to ClusterNetworkAddonsOperator (as part of the UserDefinedNetwork effort).
This fix also resolves a tier2 test that currently fails on 4.18.