### PR TITLE
Pull method created data import cron

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import re
 
@@ -20,7 +19,6 @@ from tests.infrastructure.golden_images.constants import (
 from tests.infrastructure.golden_images.update_boot_source.utils import (
     template_labels,
 )
-
 from utilities.constants import TIMEOUT_1MIN, TIMEOUT_2MIN, TIMEOUT_5MIN, TIMEOUT_10MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import create_ns


### PR DESCRIPTION
##### Short description:
Change the method we used to create a new data import cron

##### More details:
Changed the way the data import cron is created to deploy the resource from a complete new object

##### What this PR does / why we need it:
Latest DataImportCron object added required resource on pull_method, which is blocking the creation of the current resource.

In addition since it is not a required resource, created a PR for the wrapper we use - https://github.com/RedHatQE/openshift-python-wrapper/pull/2280

##### Which issue(s) this PR fixes:
Failing test class `TestDataImportCronDefaultStorageClass` 
