### PR TITLE
[Chaos] Fix test_pod_delete_migration with virt_launcher failure

### DIFF
--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -188,7 +188,7 @@ def rebooting_control_plane_node(
 def pod_deleting_process(request, admin_client):
     pod_prefix = request.param["pod_prefix"]
     namespace_name = request.param["namespace_name"]
-    pod_deleting_process = create_pod_deleting_process(
+    process = create_pod_deleting_process(
         dyn_client=admin_client,
         pod_prefix=pod_prefix,
         namespace_name=namespace_name,
@@ -196,15 +196,12 @@ def pod_deleting_process(request, admin_client):
         interval=request.param["interval"],
         max_duration=request.param["max_duration"],
     )
-    pod_deleting_process.start()
-    yield pod_deleting_process
-    terminate_process(process=pod_deleting_process)
-
-    pod_deleting_process_recover(
-        resource=request.param["resource"],
-        namespace=namespace_name,
-        pod_prefix=pod_prefix,
-    )
+    process.start()
+    yield {
+        "namespace_name": namespace_name,
+        "pod_prefix": pod_prefix,
+    }
+    terminate_process(process=process)
 
 
 @pytest.fixture()

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -2,6 +2,7 @@ import random
 
 import pytest
 from ocp_resources.deployment import Deployment
+from ocp_resources.namespace import Namespace
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from tests.chaos.constants import STRESS_NG
@@ -20,6 +21,7 @@ from utilities.constants import (
     NamespacesNames,
     StorageClassNames,
 )
+from utilities.infra import wait_for_pods_running
 from utilities.virt import wait_for_vmi_relocation_and_running
 
 pytestmark = [
@@ -62,6 +64,7 @@ def test_pod_delete_migration(
     chaos_vm_rhel9,
     pod_deleting_process,
     tainted_node_for_vm_chaos_rhel9_migration,
+    admin_client,
 ):
     """
     This experiment tests the robustness of the cluster
@@ -71,6 +74,12 @@ def test_pod_delete_migration(
     """
 
     wait_for_vmi_relocation_and_running(vm=chaos_vm_rhel9, initial_node=tainted_node_for_vm_chaos_rhel9_migration)
+    wait_for_pods_running(
+        admin_client=admin_client,
+        namespace=Namespace(name=pod_deleting_process["namespace_name"]),
+        number_of_consecutive_checks=10,
+        filter_pods_by_name=pod_deleting_process["pod_prefix"],
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/chaos/utils.py
+++ b/tests/chaos/utils.py
@@ -404,6 +404,8 @@ def pod_deleting_process_recover(resource, namespace, pod_prefix):
         if resource_obj.kind == Deployment.kind:
             resource_obj.wait_for_replicas()
 
+    LOGGER.info("Pod recovery process completed successfully.")
+
 
 def get_instance_type(name):
     """


### PR DESCRIPTION
##### Short description:
During the teardown phase, the virt-launcher Pod is deleted along with the VM and will not be recreated.
However, pod_deleting_process_recover still attempts to locate the virt-launcher Pod, and raising a ResourceNotFoundError

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
