### PR TITLE
Remove ErrorUnschedulable from VM_ERROR_STATUSES

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -88,7 +88,6 @@ CIRROS_IMAGE = "kubevirt/cirros-container-disk-demo:latest"
 FLAVORS_EXCLUDED_FROM_CLOUD_INIT = (OS_FLAVOR_WINDOWS, OS_FLAVOR_CIRROS)
 VM_ERROR_STATUSES = [
     VirtualMachine.Status.CRASH_LOOPBACK_OFF,
-    VirtualMachine.Status.ERROR_UNSCHEDULABLE,
     VirtualMachine.Status.ERROR_PVC_NOT_FOUND,
     VirtualMachine.Status.IMAGE_PULL_BACK_OFF,
     VirtualMachine.Status.ERR_IMAGE_PULL,
@@ -1575,11 +1574,7 @@ def get_rhel_os_dict(rhel_version):
 
 def assert_vm_not_error_status(vm):
     vm_status = vm.printable_status
-    error_list = VM_ERROR_STATUSES.copy()
-    vm_devices = vm.instance.spec.template.spec.domain.devices
-    if vm_devices.gpus:
-        error_list.remove(VirtualMachine.Status.ERROR_UNSCHEDULABLE)
-    assert vm_status not in error_list, f"VM {vm.name} error status: {vm_status}"
+    assert vm_status not in VM_ERROR_STATUSES, f"VM {vm.name} error status: {vm_status}"
 
 
 def wait_for_running_vm(


### PR DESCRIPTION
##### Short description:
Currenly, VMS that reaches this status - fails the test immidietly.
But this is a recoverable one for a VM.
So we should give a chance for those VM's to recover.

##### More details:
for example, the printable status in this case is `ErrorUnschedulable.` at first, but after less that one min its recovering:

```
{'lastProbeTime': None, 'lastTransitionTime': '2025-01-09T05:00:18Z', 'message': '0/3 nodes are available: 3 Insufficient bridge.network.kubevirt.io/mg-br1. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.', 'reason': 'Unschedulable', 'status': 'False', 'type': 'PodScheduled 
```


##### What this PR does / why we need it:
Some scheduled t2 + upgrade + post uprade jobs are unstable because of it.


##### Special notes for reviewer:
Maybe its a specific issue with compact cluster.
But anyway, since this error is recoverable it shouldn't fail tests right away in general.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-54781
