### PR TITLE
Locate the exact nc process

### DIFF
--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -110,7 +110,7 @@ def start_nc_response_on_vm(flat_l2_port, vm, num_connections):
         ],
         verify_commands_output=False,
     )
-    fetch_pid_from_linux_vm(vm=vm, process_name="nc", exact_match=True)
+    fetch_pid_from_linux_vm(vm=vm, process_name="nc")
 
 
 def is_port_number_available(

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -110,7 +110,7 @@ def start_nc_response_on_vm(flat_l2_port, vm, num_connections):
         ],
         verify_commands_output=False,
     )
-    fetch_pid_from_linux_vm(vm=vm, process_name="nc")
+    fetch_pid_from_linux_vm(vm=vm, process_name="nc", exact_match=True)
 
 
 def is_port_number_available(

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2258,11 +2258,10 @@ def start_and_fetch_processid_on_linux_vm(vm, process_name, args="", use_nohup=F
     return fetch_pid_from_linux_vm(vm=vm, process_name=process_name)
 
 
-def fetch_pid_from_linux_vm(vm, process_name, exact_match=False):
-    match_arg = "-x " if exact_match else ""
+def fetch_pid_from_linux_vm(vm, process_name):
     cmd_res = run_ssh_commands(
         host=vm.ssh_exec,
-        commands=shlex.split(f"pgrep {process_name} {match_arg}|| true"),
+        commands=shlex.split(f"pgrep {process_name} -x || true"),
     )[0].strip()
     assert cmd_res, f"VM {vm.name}, '{process_name}' process not found"
     return int(cmd_res)

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2258,10 +2258,11 @@ def start_and_fetch_processid_on_linux_vm(vm, process_name, args="", use_nohup=F
     return fetch_pid_from_linux_vm(vm=vm, process_name=process_name)
 
 
-def fetch_pid_from_linux_vm(vm, process_name):
+def fetch_pid_from_linux_vm(vm, process_name, exact_match=False):
+    match_arg = "-x " if exact_match else ""
     cmd_res = run_ssh_commands(
         host=vm.ssh_exec,
-        commands=shlex.split(f"pgrep {process_name} || true"),
+        commands=shlex.split(f"pgrep {process_name} {match_arg}|| true"),
     )[0].strip()
     assert cmd_res, f"VM {vm.name}, '{process_name}' process not found"
     return int(cmd_res)


### PR DESCRIPTION
Fix failures of localnet tests, by searching for the exact relevant nc process.

The need for this fix came up after `test_multi_network_policy_is_effective_post_migration` failed with
```
18:20:52  2025-01-13T16:20:41.275569 pyhelper_utils.shell INFO [SSH][vmc-flat-l2-1736785156-5188904] Executed: pgrep nc || true, rc:0, out: 5
...
...
18:20:52    File "/cnv-tests/tests/network/flat_overlay/conftest.py", line 373, in vmc_nc_connection_initialization
18:20:52      start_nc_response_on_vm(vm=vmc_flat_overlay, num_connections=CONNECTION_REQUESTS, flat_l2_port=flat_l2_port)
18:20:52    File "/cnv-tests/tests/network/flat_overlay/utils.py", line 113, in start_nc_response_on_vm
18:20:52      fetch_pid_from_linux_vm(vm=vm, process_name="nc")
18:20:52    File "/cnv-tests/utilities/virt.py", line 2267, in fetch_pid_from_linux_vm
18:20:52      return int(cmd_res)
18:20:52             ^^^^^^^^^^^^
18:20:52  ValueError: invalid literal for int() with base 10: '5\n11\n1246'
```
Instead of `pgrep` returning one PID of the requested `nc` process, it returns 3 PIDs (5, 11, 1246) of processes that have "nc" in their name or command-line attributes.
