### PR TITLE
labeler: Introduce the "labeler" github-action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+# Add 'sig-network' label to any changes within 'tests/network' folder
+# or any subfolders
+sig-network:
+- changed-files:
+  - any-glob-to-any-file:
+    - tests/network/**
+    - libs/net/**
+    - utilities/network.py

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
##### Short description:
Introduce the "labeler" github-action

##### What this PR does / why we need it:

Start using the labeler action in order to mark PRs with labels based on the location of the changed files.

This is intended to assist identify codebase areas that changed so the relevant contributors/reviewers can filter them out and attend them.

As the first example, add the `sig-network` label to changes related to the network tests & libraries.

Ref: https://github.com/actions/labeler

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Per https://github.com/actions/labeler?tab=readme-ov-file#initial-set-up-of-the-labeler-action , we will need to merge it as is and examine it on follow up PRs.

##### jira-ticket:
NONE
