### PR TITLE
Fixing kubevirt_api_request_deprecated_total

### DIFF
--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -23,8 +23,9 @@ KUBEVIRT_CNAO_CR_READY = "kubevirt_cnao_cr_ready"
 KUBEVIRT_CNAO_KUBEMACPOOL_DUPLICATE_MACS = "kubevirt_cnao_kubemacpool_duplicate_macs"
 KUBEVIRT_CNAO_CR_KUBEMACPOOL_DEPLOYED = "kubevirt_cnao_cr_kubemacpool_deployed"
 KUBEVIRT_CNAO_KUBEMACPOOL_MANAGER_UP = "kubevirt_cnao_kubemacpool_manager_up"
-KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_AND_RESOURCE = (
-    f"kubevirt_api_request_deprecated_total{{version='{Resource.ApiVersion.V1ALPHA3}',resource='virtualmachines'}}"
+KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_VERB_AND_RESOURCE = (
+    f"kubevirt_api_request_deprecated_total{{version='{Resource.ApiVersion.V1ALPHA3}',"
+    f"resource='virtualmachines', verb='{'POST'}'}}"
 )
 CPU_USER = "cpu.user"
 CPU_SYSTEM = "cpu.system"

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -2,7 +2,7 @@ import bitmath
 import pytest
 
 from tests.observability.metrics.constants import (
-    KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_AND_RESOURCE,
+    KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_VERB_AND_RESOURCE,
     KUBEVIRT_VMI_INFO,
     KUBEVIRT_VMI_MEMORY_DOMAIN_BYTE,
     KUBEVIRT_VMI_MEMORY_SWAP_IN_TRAFFIC_BYTES,
@@ -237,6 +237,6 @@ class TestKubevirtApiRequestDeprecatedTotal:
     def test_metric_kubevirt_api_request_deprecated_total(self, prometheus, generated_api_deprecated_requests):
         validate_metrics_value(
             prometheus=prometheus,
-            metric_name=KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_AND_RESOURCE,
+            metric_name=KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_VERB_AND_RESOURCE,
             expected_value=str(generated_api_deprecated_requests),
         )


### PR DESCRIPTION
##### Short description:
Fixing test for kubevirt_api_request_deprecated_total. The test changed the VirtualMachine import which led to failures to all other tests that came after it.
In order to avoid changing the import I created an instance of VirtualMachine with deprecated api version and did calls that raised the metric value.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
