### PR TITLE
Update auto_update_boot_source_vm to use instance types

### DIFF
--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -187,10 +187,12 @@ sysprep_source_matrix = ["ConfigMap", "Secret"]
 # If the DataImportCron uses a different prefix than the DataSource name
 # use data_import_cron_prefix in matrix dict to specify new prefix.
 auto_update_data_source_matrix = [
-    {"centos-stream9": {"template_os": "centos-stream9"}},
-    {"fedora": {"template_os": "fedora"}},
-    {"rhel8": {"template_os": "rhel8.4"}},
-    {"rhel9": {"template_os": "rhel9.0"}},
+    {"centos-stream9"},
+    {"centos-stream10"},
+    {"fedora"},
+    {"rhel8"},
+    {"rhel9"},
+    {"rhel10-beta"},
 ]
 
 IMAGE_NAME_STR = "image_name"

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
@@ -30,11 +30,13 @@ RHEL9_NAME = "rhel9"
 
 def assert_os_version_mismatch_in_vm(vm, latest_fedora_release_version):
     vm_os = vm.ssh_exec.os.release_str.lower()
-    expected_os_params = re.match(r"(?P<os_name>[a-z]+)(?:\.stream|\.|$)(?P<os_ver>[0-9]*)", vm.instance.spec.preference.name).groupdict()
+    expected_os_params = re.match(
+        r"(?P<os_name>[a-z]+)(?:\.stream|\.|$)(?P<os_ver>[0-9]*)", vm.instance.spec.preference.name
+    ).groupdict()
     expected_name_in_vm_os = (
         "red hat" if expected_os_params["os_name"] == OS_FLAVOR_RHEL else expected_os_params["os_name"]
     )
-    expected_os_params['os_ver'] = expected_os_params['os_ver'] or latest_fedora_release_version
+    expected_os_params["os_ver"] = expected_os_params["os_ver"] or latest_fedora_release_version
     assert re.match(rf"{expected_name_in_vm_os}.*{expected_os_params['os_ver']}.*", vm_os), (
         f"Wrong VM OS, expected: {expected_name_in_vm_os}, actual: {vm_os}"
     )

--- a/utilities/ssp.py
+++ b/utilities/ssp.py
@@ -78,14 +78,7 @@ def wait_for_at_least_one_auto_update_data_import_cron(admin_client, namespace):
 
 
 def matrix_auto_boot_data_import_cron_prefixes():
-    data_import_cron_prefixes = []
-    for data_source_matrix_entry in py_config["auto_update_data_source_matrix"]:
-        data_source_name = [*data_source_matrix_entry][0]
-        data_import_cron_prefixes.append(
-            data_source_matrix_entry[data_source_name].get("data_import_cron_prefix", data_source_name)
-        )
-
-    return data_import_cron_prefixes
+    return [list(data_source_name)[0] for data_source_name in py_config["auto_update_data_source_matrix"]]
 
 
 def get_data_import_crons(admin_client, namespace):


### PR DESCRIPTION
##### Short description:
Use instance types instead of templates to create VM from provided data sources

##### More details:
Since centos-10/rhel-10 don't have templates we can't add them to the testing matrix, as such we should update VM creation method in Data Source tests

 - Add centos-stream10, rhel-10 the testing matrix `auto_update_data_source_matrix`
 - Remove `template_os` from `auto_update_data_source_matrix`
 - Change  creation method in `auto_update_boot_source_vm` to use instance types
 - Change assertion method in `assert_os_version_mismatch_in_vm` to assert: `vm guest OS == preference name given by the data source label`
 - Change `matrix_auto_boot_data_import_cron_prefixes` since the matrix no longer has `auto_update_data_source_matrix`

##### What this PR does / why we need it:
Add coverage for centos10/rhel10-beta

##### Special notes for reviewer:
Next release rhel10-beta naming will be needed to change to rhel-10

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-41859
