### PR TITLE
tests, net, checkup: Separate the DPDK checkup config helper

### DIFF
--- a/tests/network/checkup_framework/conftest.py
+++ b/tests/network/checkup_framework/conftest.py
@@ -5,6 +5,7 @@ import re
 
 import pytest
 import requests
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.resource import Resource
 from ocp_resources.role_binding import RoleBinding
 from packaging.version import Version
@@ -27,6 +28,7 @@ from tests.network.checkup_framework.utils import (
     checkup_role_binding,
     create_checkup_job,
     create_latency_configmap,
+    dpdk_checkup_config,
     generate_checkup_resources_role,
     generate_checkup_service_account,
     get_job,
@@ -827,16 +829,18 @@ def sriov_network_for_dpdk(sriov_node_policy, sriov_namespace, dpdk_checkup_name
 
 @pytest.fixture()
 def dpdk_configmap_same_node(dpdk_checkup_namespace, sriov_network_for_dpdk, worker_node1, traffic_gen_image):
-    with create_latency_configmap(
-        namespace_name=dpdk_checkup_namespace.name,
-        network_attachment_definition_name=sriov_network_for_dpdk.name,
-        configmap_name=DEFAULT_DPDK_CONFIGMAP_NAME,
-        traffic_pps=DPDK_NORMAL_TRAFFIC,
-        dpdk_gen_target_node=worker_node1.name,
-        dpdk_test_target_node=worker_node1.name,
-        dpdk_vmgen_container_diskimage=traffic_gen_image,
-        dpdk_vmtest_container_diskimage=VM_UNDER_TEST,
-        timeout=f"{DPDK_15_TIMEOUT}m",
+    with ConfigMap(
+        namespace=dpdk_checkup_namespace.name,
+        name=DEFAULT_DPDK_CONFIGMAP_NAME,
+        data=dpdk_checkup_config(
+            network_attachment_definition_name=sriov_network_for_dpdk.name,
+            traffic_pps=DPDK_NORMAL_TRAFFIC,
+            traffic_gen_target_node=worker_node1.name,
+            vm_under_test_target_node=worker_node1.name,
+            traffic_gen_container_diskimage=traffic_gen_image,
+            vm_under_test_container_diskimage=VM_UNDER_TEST,
+            timeout=f"{DPDK_15_TIMEOUT}m",
+        ),
     ) as configmap:
         yield configmap
 
@@ -845,16 +849,18 @@ def dpdk_configmap_same_node(dpdk_checkup_namespace, sriov_network_for_dpdk, wor
 def dpdk_high_traffic_configmap_same_node(
     dpdk_checkup_namespace, sriov_network_for_dpdk, worker_node1, traffic_gen_image
 ):
-    with create_latency_configmap(
-        namespace_name=dpdk_checkup_namespace.name,
-        network_attachment_definition_name=sriov_network_for_dpdk.name,
-        configmap_name=DEFAULT_DPDK_CONFIGMAP_NAME,
-        traffic_pps=DPDK_HIGH_TRAFFIC,
-        dpdk_gen_target_node=worker_node1.name,
-        dpdk_test_target_node=worker_node1.name,
-        dpdk_vmgen_container_diskimage=traffic_gen_image,
-        dpdk_vmtest_container_diskimage=VM_UNDER_TEST,
-        timeout=f"{DPDK_15_TIMEOUT}m",
+    with ConfigMap(
+        namespace=dpdk_checkup_namespace.name,
+        name=DEFAULT_DPDK_CONFIGMAP_NAME,
+        data=dpdk_checkup_config(
+            network_attachment_definition_name=sriov_network_for_dpdk.name,
+            traffic_pps=DPDK_HIGH_TRAFFIC,
+            traffic_gen_target_node=worker_node1.name,
+            vm_under_test_target_node=worker_node1.name,
+            traffic_gen_container_diskimage=traffic_gen_image,
+            vm_under_test_container_diskimage=VM_UNDER_TEST,
+            timeout=f"{DPDK_15_TIMEOUT}m",
+        ),
     ) as configmap:
         yield configmap
 
@@ -863,16 +869,18 @@ def dpdk_high_traffic_configmap_same_node(
 def dpdk_high_traffic_configmap_different_node(
     dpdk_checkup_namespace, sriov_network_for_dpdk, worker_node1, worker_node2, traffic_gen_image
 ):
-    with create_latency_configmap(
-        namespace_name=dpdk_checkup_namespace.name,
-        network_attachment_definition_name=sriov_network_for_dpdk.name,
-        configmap_name=DEFAULT_DPDK_CONFIGMAP_NAME,
-        traffic_pps=DPDK_HIGH_TRAFFIC,
-        dpdk_gen_target_node=worker_node1.name,
-        dpdk_test_target_node=worker_node2.name,
-        dpdk_vmgen_container_diskimage=traffic_gen_image,
-        dpdk_vmtest_container_diskimage=VM_UNDER_TEST,
-        timeout=f"{DPDK_15_TIMEOUT}m",
+    with ConfigMap(
+        namespace=dpdk_checkup_namespace.name,
+        name=DEFAULT_DPDK_CONFIGMAP_NAME,
+        data=dpdk_checkup_config(
+            network_attachment_definition_name=sriov_network_for_dpdk.name,
+            traffic_pps=DPDK_HIGH_TRAFFIC,
+            traffic_gen_target_node=worker_node1.name,
+            vm_under_test_target_node=worker_node2.name,
+            traffic_gen_container_diskimage=traffic_gen_image,
+            vm_under_test_container_diskimage=VM_UNDER_TEST,
+            timeout=f"{DPDK_15_TIMEOUT}m",
+        ),
     ) as configmap:
         yield configmap
 

--- a/tests/network/checkup_framework/utils.py
+++ b/tests/network/checkup_framework/utils.py
@@ -112,11 +112,6 @@ def create_latency_configmap(
     network_attachment_definition_namespace=None,
     source_node=None,
     target_node=None,
-    traffic_pps=None,
-    dpdk_gen_target_node=None,
-    dpdk_test_target_node=None,
-    dpdk_vmgen_container_diskimage=None,
-    dpdk_vmtest_container_diskimage=None,
 ):
     data = compose_configmap_data(
         timeout=timeout,
@@ -126,11 +121,6 @@ def create_latency_configmap(
         sample_duration_seconds=f"{TIMEOUT_5SEC}",
         source_node=source_node,
         target_node=target_node,
-        traffic_pps=traffic_pps,
-        dpdk_gen_target_node=dpdk_gen_target_node,
-        dpdk_test_target_node=dpdk_test_target_node,
-        dpdk_vmgen_container_diskimage=dpdk_vmgen_container_diskimage,
-        dpdk_vmtest_container_diskimage=dpdk_vmtest_container_diskimage,
     )
     with ConfigMap(namespace=namespace_name, name=configmap_name, data=data) as configmap:
         yield configmap
@@ -144,11 +134,6 @@ def compose_configmap_data(
     network_attachment_definition_namespace=None,
     source_node=None,
     target_node=None,
-    traffic_pps=None,
-    dpdk_gen_target_node=None,
-    dpdk_test_target_node=None,
-    dpdk_vmgen_container_diskimage=None,
-    dpdk_vmtest_container_diskimage=None,
 ):
     """
     Compose a dictionary with the ConfigMap data.
@@ -162,11 +147,6 @@ def compose_configmap_data(
         network_attachment_definition_namespace (str): Namespace name where the NAD was created.
         source_node (str, default=None): Node hostname. Check latency from this node to the target_node.
         target_node (str, default=None): Node hostname. Check latency from source_node to this node.
-        traffic_pps (str, default=None): [DPDK] Traffic Packets per second
-        dpdk_gen_target_node (str, default=None): [DPDK] Node name on which generator vmi will be run.
-        dpdk_test_target_node (str, default=None): [DPDK] Node name on which test vmi will be run.
-        dpdk_vmgen_container_diskimage (str, default=None): [DPDK] Source of trafficGen container image.
-        dpdk_vmtest_container_diskimage (str, default=None): [DPDK] Source of vm under test container image.
 
     Returns:
         dict: Data section of the ConfigMap.
@@ -185,16 +165,49 @@ def compose_configmap_data(
         data_dict["spec.param.sourceNode"] = source_node
     if target_node:
         data_dict["spec.param.targetNode"] = target_node
+
+    return data_dict
+
+
+def dpdk_checkup_config(
+    timeout: str,
+    network_attachment_definition_name: str,
+    traffic_gen_container_diskimage: str,
+    vm_under_test_container_diskimage: str,
+    traffic_gen_target_node: str | None = None,
+    vm_under_test_target_node: str | None = None,
+    traffic_pps: str | None = None,
+) -> dict[str, str]:
+    """
+    Compose a dictionary with the ConfigMap data for the DPDK checkup.
+
+    Args:
+        timeout (str): Timeout to wait for the checkup to finish, in duration format.
+            Valid format: Decimal number with optional fraction and a unit suffix.
+            Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+        network_attachment_definition_name (str): NAD name.
+        traffic_gen_container_diskimage (str): Source of trafficGen container image.
+        vm_under_test_container_diskimage (str, default=None): Source of vm under test container image.
+        traffic_gen_target_node (str, default=None): Node name on which generator vmi will be run.
+        vm_under_test_target_node (str, default=None): Node name on which test vmi will be run.
+        traffic_pps (str, default=None): Traffic Packets per second
+
+    Returns:
+        dict: Data section of the DPDK checkup ConfigMap.
+    """
+    data_dict = {
+        "spec.timeout": timeout,
+        "spec.param.networkAttachmentDefinitionName": network_attachment_definition_name,
+        "spec.param.trafficGenContainerDiskImage": traffic_gen_container_diskimage,
+        "spec.param.vmUnderTestContainerDiskImage": vm_under_test_container_diskimage,
+    }
+
+    if traffic_gen_target_node:
+        data_dict["spec.param.trafficGenTargetNodeName"] = traffic_gen_target_node
+    if vm_under_test_target_node:
+        data_dict["spec.param.vmUnderTestTargetNodeName"] = vm_under_test_target_node
     if traffic_pps:
         data_dict["spec.param.trafficGenPacketsPerSecond"] = traffic_pps
-    if dpdk_gen_target_node:
-        data_dict["spec.param.trafficGenTargetNodeName"] = dpdk_gen_target_node
-    if dpdk_test_target_node:
-        data_dict["spec.param.vmUnderTestTargetNodeName"] = dpdk_test_target_node
-    if dpdk_vmgen_container_diskimage:
-        data_dict["spec.param.trafficGenContainerDiskImage"] = dpdk_vmgen_container_diskimage
-    if dpdk_vmtest_container_diskimage:
-        data_dict["spec.param.vmUnderTestContainerDiskImage"] = dpdk_vmtest_container_diskimage
 
     return data_dict
 


### PR DESCRIPTION
##### Short description:
Separate the DPDK checkup config helper

##### What this PR does / why we need it:
The checkups configurations are unique per individual checkup. The DPDK one has its own unique fields, some mandatory and some optional.

This change separates the configuration creation for DPDK from the others.
It provides clarity about which arguments are relevant to the DPDK checkup, expressing also which ones are mandatory and which ones are optional.

In addition, typing has been added and a small simplification introduced to shorten the call-stack.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE
