### PR TITLE
whitelist alert SSPCommonTemplatesModificationReverted on healthy clu…

### DIFF
--- a/tests/observability/alerts/utils.py
+++ b/tests/observability/alerts/utils.py
@@ -3,8 +3,10 @@ import logging
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.namespace import Namespace
 
-KUBEVIRT_HYPERCONVERGED_OPERATOR_HEALTH_STATUS = "kubevirt_hyperconverged_operator_health_status"
+from tests.observability.alerts.constants import SSP_COMMON_TEMPLATES_MODIFICATION_REVERTED
 
+KUBEVIRT_HYPERCONVERGED_OPERATOR_HEALTH_STATUS = "kubevirt_hyperconverged_operator_health_status"
+ALLOW_ALERTS_ON_HEALTHY_CLUSTER_LIST = [SSP_COMMON_TEMPLATES_MODIFICATION_REVERTED]
 CONTAINERIZED_DATA_IMPORTER = "containerized-data-importer"
 LOGGER = logging.getLogger(__name__)
 
@@ -17,8 +19,9 @@ def verify_no_listed_alerts_on_cluster(prometheus, alerts_list):
     for alert in alerts_list:
         alerts_by_name = prometheus.get_all_alerts_by_alert_name(alert_name=alert)
         if alerts_by_name and alerts_by_name[0]["state"] == "firing":
+            if alert in ALLOW_ALERTS_ON_HEALTHY_CLUSTER_LIST:
+                continue
             fired_alerts[alert] = alerts_by_name
-
     assert not fired_alerts, f"Alerts should not be fired on healthy cluster.\n {fired_alerts}"
 
 


### PR DESCRIPTION
##### Short description:
whitelisting alert SSPCommonTemplatesModificationReverted in healthy cluster

##### More details:

the alert is firing due to previous test **test_alert_template_modification_reverted** (CNV-7616)
when the test is trying to update one of the common template and get reverted, it takes 1 hour for the alert to turn-off 
where the alert get catched in **::test_no_ssp_alerts_on_healthy_cluster**  as fired alert 

##### What this PR does / why we need it:
this pr will cause the test test_no_ssp_alerts_on_healthy_cluster to dismiss this alert becaue it fails on tier2 tests

##### Which issue(s) this PR fixes:
the test test_no_ssp_alerts_on_healthy_cluster is failing in tier 2 observability 
##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
