### PR TITLE
[virt] remove nodes_intel_cpu_model fixture

### DIFF
--- a/tests/virt/cluster/longevity_tests/conftest.py
+++ b/tests/virt/cluster/longevity_tests/conftest.py
@@ -45,9 +45,8 @@ def multi_vms(
     unprivileged_client,
     multi_datasources,
     rhsm_created_secret,
-    nodes_intel_cpu_model,
+    modern_cpu_for_migration,
     vm_cpu_flags,
-    fips_enabled_cluster,
 ):
     yield from create_dv_vms(
         vm_deploys=vm_deploys,
@@ -55,7 +54,7 @@ def multi_vms(
         namespace=namespace,
         datasources=multi_datasources,
         vm_params=request.param["vm_params"],
-        nodes_common_cpu_model=nodes_intel_cpu_model,
+        nodes_common_cpu_model=modern_cpu_for_migration,
         cpu_flags=vm_cpu_flags,
     )
 
@@ -76,7 +75,7 @@ def wsl2_vms_with_pids(multi_vms):
 
 
 @pytest.fixture()
-def multi_dv(request, admin_client, golden_images_namespace, fips_enabled_cluster):
+def multi_dv(request, admin_client, golden_images_namespace):
     yield from create_multi_dvs(
         namespace=golden_images_namespace,
         client=admin_client,

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -4,11 +4,6 @@ from utilities.constants import AMD, INTEL
 
 
 @pytest.fixture(scope="session")
-def nodes_intel_cpu_model(cluster_common_modern_node_cpu, nodes_cpu_vendor):
-    return cluster_common_modern_node_cpu if nodes_cpu_vendor == INTEL else None
-
-
-@pytest.fixture(scope="session")
 def nodes_cpu_virt_extension(nodes_cpu_vendor):
     if nodes_cpu_vendor == INTEL:
         return "vmx"

--- a/tests/virt/node/conftest.py
+++ b/tests/virt/node/conftest.py
@@ -34,7 +34,7 @@ def vm_with_memory_load(
     unprivileged_client,
     namespace,
     golden_image_data_source_scope_function,
-    nodes_intel_cpu_model,
+    modern_cpu_for_migration,
     vm_cpu_flags,
 ):
     with vm_instance_from_template(
@@ -42,7 +42,7 @@ def vm_with_memory_load(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_scope_function,
-        vm_cpu_model=nodes_intel_cpu_model,
+        vm_cpu_model=modern_cpu_for_migration,
         vm_cpu_flags=vm_cpu_flags,
     ) as vm:
         yield vm

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -69,7 +69,7 @@ def windows_wsl2_vm(
     namespace,
     unprivileged_client,
     golden_image_data_source_scope_class,
-    nodes_intel_cpu_model,
+    modern_cpu_for_migration,
     vm_cpu_flags,
 ):
     """Create Windows 10/11 VM, Run VM and wait for WSL2 guest to start"""
@@ -80,7 +80,7 @@ def windows_wsl2_vm(
         namespace=namespace.name,
         client=unprivileged_client,
         data_source=golden_image_data_source_scope_class,
-        cpu_model=nodes_intel_cpu_model,
+        cpu_model=modern_cpu_for_migration,
         cpu_flags=vm_cpu_flags,
         memory_guest=Images.Windows.DEFAULT_MEMORY_SIZE_WSL,
         cpu_cores=16,


### PR DESCRIPTION
##### Short description:
`nodes_intel_cpu_model` fixture is not needed anymore after introduction of `modern_cpu_for_migration fixture`

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-48680
