### PR TITLE
remove create_folder_and_mirror_file

### DIFF
--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -26,7 +26,7 @@ from tests.virt.node.descheduler.utils import (
     wait_vmi_failover,
 )
 from tests.virt.utils import get_match_expressions_dict
-from utilities.constants import BREW_REGISTERY_SOURCE, FILTER_BY_OS_OPTION, TIMEOUT_5SEC, TIMEOUT_30MIN, TIMEOUT_30SEC
+from utilities.constants import FILTER_BY_OS_OPTION, TIMEOUT_5SEC, TIMEOUT_30MIN, TIMEOUT_30SEC
 from utilities.infra import (
     check_pod_disruption_budget_for_completed_migrations,
     create_ns,

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -26,7 +26,7 @@ from tests.virt.node.descheduler.utils import (
     wait_vmi_failover,
 )
 from tests.virt.utils import get_match_expressions_dict
-from utilities.constants import TIMEOUT_5SEC, TIMEOUT_30MIN, TIMEOUT_30SEC
+from utilities.constants import BREW_REGISTERY_SOURCE, FILTER_BY_OS_OPTION, TIMEOUT_5SEC, TIMEOUT_30MIN, TIMEOUT_30SEC
 from utilities.infra import (
     check_pod_disruption_budget_for_completed_migrations,
     create_ns,
@@ -34,11 +34,11 @@ from utilities.infra import (
 )
 from utilities.operator import (
     create_catalog_source,
-    create_folder_and_mirror_file,
     create_icsp_idms_from_file,
     create_operator_group,
     create_subscription,
     delete_existing_icsp_idms,
+    get_generated_icsp_idms,
     get_install_plan_from_subscription,
     wait_for_catalogsource_ready,
     wait_for_mcp_updated_condition_true,
@@ -106,15 +106,15 @@ def created_descheduler_subscription(
 
 @pytest.fixture(scope="module")
 def generated_descheduler_icsp_idms(
-    tmp_path_factory, generated_pulled_secret, openshift_current_version, ocp_qe_art_image_url, is_idms_cluster
+    pull_secret_directory, generated_pulled_secret, openshift_current_version, ocp_qe_art_image_url, is_idms_cluster
 ):
-    return create_folder_and_mirror_file(
-        path_factory=tmp_path_factory,
-        operator_name=DESCHEDULER_OPERATOR_DEPLOYMENT_NAME,
-        image=ocp_qe_art_image_url,
-        pull_secret=generated_pulled_secret,
-        is_idms_file=is_idms_cluster,
-        cnv_version=openshift_current_version,
+    return get_generated_icsp_idms(
+        image_url=ocp_qe_art_image_url,
+        registry_source="manifest",
+        generated_pulled_secret=generated_pulled_secret,
+        pull_secret_directory=pull_secret_directory,
+        is_idms_cluster=is_idms_cluster,
+        filter_options=f"--index-{FILTER_BY_OS_OPTION}",
     )
 
 

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -32,7 +32,6 @@ from utilities.constants import (
     BASE_EXCEPTIONS_DICT,
     BREW_REGISTERY_SOURCE,
     DEFAULT_RESOURCE_CONDITIONS,
-    FILTER_BY_OS_OPTION,
     ICSP_FILE,
     IDMS_FILE,
     TIMEOUT_5MIN,
@@ -46,22 +45,6 @@ from utilities.constants import (
 from utilities.data_collector import collect_ocp_must_gather
 
 LOGGER = logging.getLogger(__name__)
-
-
-def create_folder_and_mirror_file(path_factory, operator_name, image, pull_secret, is_idms_file, cnv_version=None):
-    temp_folder_path = path_factory.mktemp(f"{operator_name}-folder")
-    folder_name = f"{temp_folder_path}/{operator_name}-manifest"
-    mirror_cmd = create_icsp_idms_command(
-        image=image,
-        source_url=BREW_REGISTERY_SOURCE,
-        folder_name=folder_name,
-        pull_secret=pull_secret,
-        filter_options=f"--index-{FILTER_BY_OS_OPTION}",
-    )
-
-    return generate_icsp_idms_file(
-        folder_name=folder_name, command=mirror_cmd, is_idms_file=is_idms_file, cnv_version=cnv_version
-    )
 
 
 def create_icsp_idms_command(image, source_url, folder_name, pull_secret=None, filter_options=""):
@@ -730,9 +713,10 @@ def get_generated_icsp_idms(
     pull_secret_directory: str,
     is_idms_cluster: bool,
     cnv_version: str | None = None,
+    filter_options: str = "",
 ) -> str:
     pull_secret = None
-    if BREW_REGISTERY_SOURCE in image_url:
+    if image_url.startswith(tuple([BREW_REGISTERY_SOURCE, "quay.io"])):
         registry_source = BREW_REGISTERY_SOURCE
         pull_secret = generated_pulled_secret
     cnv_mirror_cmd = create_icsp_idms_command(
@@ -740,6 +724,7 @@ def get_generated_icsp_idms(
         source_url=registry_source,
         folder_name=pull_secret_directory,
         pull_secret=pull_secret,
+        filter_options=filter_options,
     )
     icsp_file_path = generate_icsp_idms_file(
         folder_name=pull_secret_directory,


### PR DESCRIPTION
##### Short description:
remove create_folder_and_mirror_file

##### More details:
create_folder_and_mirror_file is only used in descheduler `generated_descheduler_icsp_idms`, it can be removed to reduce code complexity

##### What this PR does / why we need it:
Make the code more readable

##### Special notes for reviewer:
An alternate to use `get_generated_icsp_idms` was considered, this require more complex changes and testing since it defines `pull_secret` in a condition, as such I decided to focus this PR only on the removal of the function.
