### PR TITLE
Fix checkup failures and remove bug markers

### DIFF
--- a/tests/network/checkup_framework/test_checkup_framework.py
+++ b/tests/network/checkup_framework/test_checkup_framework.py
@@ -10,14 +10,11 @@ from tests.network.checkup_framework.utils import (
     wait_for_job_finish,
 )
 
-pytestmark = [
-    pytest.mark.jira("CNV-55124", run=False),
-    pytest.mark.usefixtures("framework_resources"),
-]
+pytestmark = pytest.mark.usefixtures("framework_resources")
 
 CNCF_IO_RESOURCE = Resource.ApiGroup.K8S_CNI_CNCF_IO
 CONNECTIVITY_ISSUE_ERROR_REGEX_MESSAGE = (
-    "run: failed to run check: failed due to connectivity issue: \\d+ packets transmitted, 0 packets received"
+    "run: ping parser: no connectivity - 100% packet loss"
 )
 CONDITION_TIMEOUT_REGEX_MESSAGE = (
     r"setup: failed to wait for VMI 'test-checkup-framework/latency-check-target-.*' IP address to "
@@ -39,7 +36,6 @@ LATENCY_NONEXISTENT_CONFIGMAP_ENV_JOB_ERROR_REGEX_MESSAGE = f'configmaps "{NONEX
 LATENCY_NO_ENV_VARIABLES_JOB_ERROR_REGEX_MESSAGE = 'missing required environment variable: "CONFIGMAP_NAMESPACE"'
 
 
-@pytest.mark.jira("CNV-48962", run=False)
 @pytest.mark.polarion("CNV-8578")
 def test_disconnected_network_job_failure(
     latency_disconnected_configmap, latency_disconnected_network_job, latency_disconnected_network_job_failure
@@ -50,7 +46,6 @@ def test_disconnected_network_job_failure(
     )
 
 
-@pytest.mark.jira("CNV-48962", run=False)
 @pytest.mark.polarion("CNV-9535")
 def test_disconnected_network_sriov_job_failure(
     latency_disconnected_configmap_sriov,

--- a/tests/network/checkup_framework/test_checkup_framework.py
+++ b/tests/network/checkup_framework/test_checkup_framework.py
@@ -13,9 +13,7 @@ from tests.network.checkup_framework.utils import (
 pytestmark = pytest.mark.usefixtures("framework_resources")
 
 CNCF_IO_RESOURCE = Resource.ApiGroup.K8S_CNI_CNCF_IO
-CONNECTIVITY_ISSUE_ERROR_REGEX_MESSAGE = (
-    "run: ping parser: no connectivity - 100% packet loss"
-)
+CONNECTIVITY_ISSUE_ERROR_REGEX_MESSAGE = "run: ping parser: no connectivity - 100% packet loss"
 CONDITION_TIMEOUT_REGEX_MESSAGE = (
     r"setup: failed to wait for VMI 'test-checkup-framework/latency-check-target-.*' IP address to "
     "appear on status: timed out waiting for the condition"

--- a/tests/network/checkup_framework/utils.py
+++ b/tests/network/checkup_framework/utils.py
@@ -256,13 +256,15 @@ def wait_for_job_failure(job):
         job_status = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            func=lambda: job.instance.status.conditions[0],
+            func=lambda: job.instance.status.conditions,
         )
         for sample in job_status:
-            if sample["type"] == job.Status.FAILED and sample["status"] == job.Condition.Status.TRUE:
-                return
-            if sample["type"] == job.Status.SUCCEEDED and sample["status"] == job.Condition.Status.TRUE:
-                raise ResourceValueError(f"Job {job.name} has succeeded and should have failed.")
+            if sample:
+                for condition in sample:
+                    if condition["type"] == job.Status.FAILED and condition["status"] == job.Condition.Status.TRUE:
+                        return
+                    if condition["type"] == job.Status.SUCCEEDED and condition["status"] == job.Condition.Status.TRUE:
+                        raise ResourceValueError(f"Job {job.name} has succeeded and should have failed.")
     except TimeoutExpiredError:
         for status in job_status:
             LOGGER.error(f"Job {job.name} current status is {status} and not {job.Status.FAILED} as expected.")

--- a/tests/network/checkup_framework/utils.py
+++ b/tests/network/checkup_framework/utils.py
@@ -262,9 +262,9 @@ def wait_for_job_failure(job):
         )
         for sample in job_status:
             for condition in sample:
-                if condition["type"] == job.Status.FAILED and condition["status"] == job.Condition.Status.TRUE:
+                if condition["type"] == job.Status.FAILED:
                     return
-                if condition["type"] == job.Status.SUCCEEDED and condition["status"] == job.Condition.Status.TRUE:
+                if condition["type"] == job.Status.SUCCEEDED:
                     raise ResourceValueError(f"Job {job.name} has succeeded and should have failed.")
     except TimeoutExpiredError:
         for status in job_status:


### PR DESCRIPTION
1. Revert "Skip checkup framework tests due to CNV-55124".
2. Iterate over all job's status conditions to find the relevant one.
3. Remove ping-parser bug marker after verifying its fix.
This fix is based on the change in checkup presented in https://github.com/kiagnose/kiagnose/pull/264
