### PR TITLE
Utilities - Add NodeNetworkConfigurationPolicy resource to libs/net

### DIFF
--- a/tests/network/cluster_addons_operator/test_network_addons_operator.py
+++ b/tests/network/cluster_addons_operator/test_network_addons_operator.py
@@ -17,6 +17,16 @@ from ocp_resources.validating_webhook_config import ValidatingWebhookConfigurati
 
 import utilities.network
 from tests.network.constants import EXPECTED_CNAO_COMP_NAMES
+from tests.network.libs.nodenetworkconfigurationpolicy import (
+    STP,
+    Bridge,
+    BridgeOptions,
+    DesiredState,
+    Interface,
+    IPv4,
+    IPv6,
+    NodeNetworkConfigurationPolicy,
+)
 from utilities.constants import CLUSTER_NETWORK_ADDONS_OPERATOR, LINUX_BRIDGE
 from utilities.infra import get_node_selector_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
@@ -149,21 +159,41 @@ def check_components(network_addons_config_scope_session):
 
 @pytest.fixture(scope="module")
 def net_add_op_bridge_device(worker_node1):
-    with utilities.network.network_device(
-        interface_type=LINUX_BRIDGE,
-        nncp_name="test-network-operator",
-        interface_name="net-add-br",
+    desired_state = DesiredState(
+        interfaces=[
+            Interface(
+                name="net-add-br",
+                state=NodeNetworkConfigurationPolicy.Interface.State.UP,
+                type=LINUX_BRIDGE,
+                ipv4=IPv4(enabled=False),
+                ipv6=IPv6(enabled=False),
+                bridge=Bridge(BridgeOptions(STP(enabled=False))),
+            )
+        ]
+    )
+    with NodeNetworkConfigurationPolicy(
+        name="test-network-operator",
+        desired_state=desired_state,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-    ) as br_dev:
-        yield br_dev
+    ) as nncp:
+        nncp.wait_for_status_success()
+        yield nncp
 
 
 @pytest.fixture(scope="module")
 def net_add_op_br1test_nad(namespace, net_add_op_bridge_device):
+    bridge_name = next(
+        (
+            interface.name
+            for interface in net_add_op_bridge_device.desired_state_spec.interfaces
+            if interface.type == LINUX_BRIDGE
+        ),
+    )
+
     with utilities.network.network_nad(
         nad_type=LINUX_BRIDGE,
-        nad_name=net_add_op_bridge_device.bridge_name,
-        interface_name=net_add_op_bridge_device.bridge_name,
+        nad_name=bridge_name,
+        interface_name=bridge_name,
         namespace=namespace,
     ) as nad:
         yield nad

--- a/tests/network/libs/nodenetworkconfigurationpolicy.py
+++ b/tests/network/libs/nodenetworkconfigurationpolicy.py
@@ -1,0 +1,140 @@
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from ocp_resources.exceptions import NNCPConfigurationFailed
+from ocp_resources.node_network_configuration_policy_latest import NodeNetworkConfigurationPolicy as Nncp
+from ocp_resources.resource import ResourceEditor
+from timeout_sampler import retry
+
+WAIT_FOR_STATUS_TIMEOUT_SEC = 90
+WAIT_FOR_STATUS_INTERVAL_SEC = 5
+
+
+@dataclass
+class IP:
+    enabled: bool
+    dhcp: bool | None = None
+    auto_dns: bool | None = None
+
+
+@dataclass
+class IPv4(IP):
+    pass
+
+
+@dataclass
+class IPv6(IP):
+    autoconf: bool | None = None
+
+
+@dataclass
+class STP:
+    enabled: bool
+
+
+@dataclass
+class BridgeOptions:
+    stp: STP
+
+
+@dataclass
+class Port:
+    name: str
+
+
+@dataclass
+class Bridge:
+    options: BridgeOptions | None = None
+    port: list[Port] | None = None
+    allow_extra_patch_ports: bool | None = None
+
+
+@dataclass
+class Interface:
+    name: str
+    type: str
+    state: str
+    ipv4: IPv4 | None = None
+    ipv6: IPv6 | None = None
+    bridge: Bridge | None = None
+
+
+@dataclass
+class DesiredState:
+    """
+    Represents the desired network configuration for NMstate.
+    Following the NMstate YAML-based API specification:
+    https://nmstate.io/devel/yaml_api.html
+    """
+
+    interfaces: list[Interface]
+
+
+class NodeNetworkConfigurationPolicy(Nncp):
+    """
+    NodeNetworkConfigurationPolicy object.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        desired_state: DesiredState,
+        node_selector: dict[str, str] | None = None,
+    ):
+        """
+        Create and manage NodeNetworkConfigurationPolicy
+
+        Args:
+            name (str): Name of the NodeNetworkConfigurationPolicy object.
+            desired_state (DesiredState): Desired policy configuration - interface creation, modification or removal.
+            node_selector (dict, optional): A node selector that specifies the nodes to apply the node network
+                configuration policy to.
+        """
+        self._desired_state = desired_state
+        super().__init__(
+            name=name,
+            desired_state=asdict(desired_state, dict_factory=self._dict_normalization),
+            node_selector=node_selector,
+        )
+
+    @staticmethod
+    def _dict_normalization(data: list[tuple[str, Any]]) -> dict[str, Any]:
+        """Filter out none values and converts key characters containing underscores into dashes."""
+        return {key.replace("_", "-"): val for (key, val) in data if val is not None}
+
+    @property
+    def desired_state_spec(self) -> DesiredState:
+        return self._desired_state
+
+    def clean_up(self) -> bool:
+        self._delete_interfaces()
+        self.wait_for_status_success()
+        return super().clean_up()
+
+    @retry(
+        wait_timeout=WAIT_FOR_STATUS_TIMEOUT_SEC,
+        sleep=WAIT_FOR_STATUS_INTERVAL_SEC,
+        exceptions_dict={AssertionError: []},  # Using a no-op exception so any other error will be raised
+    )
+    def wait_for_status_success(self) -> dict[str, Any]:
+        conditions = (
+            condition
+            for condition in self.instance.status.conditions
+            if condition["status"] == Nncp.Condition.Status.TRUE
+        )
+
+        for condition in conditions:
+            if condition["type"] == Nncp.Condition.AVAILABLE:
+                self.logger.info(f"{self.kind}/{self.name} configured successfully")
+                return condition
+            if condition["type"] == Nncp.Condition.DEGRADED:
+                raise NNCPConfigurationFailed(f"{self.name} failed on condition:\n{condition}")
+        return {}
+
+    def _delete_interfaces(self) -> None:
+        desired_state = deepcopy(self.desired_state)
+        for iface in desired_state["interfaces"]:
+            iface["state"] = Nncp.Interface.State.ABSENT
+        if desired_state["interfaces"]:
+            ResourceEditor(patches={self: {"spec": {"desiredState": desired_state}}}).update()


### PR DESCRIPTION
##### Short description:
Introducing a new NodeNetworkConfigurationPolicy (NNCP) resource to the libs/net library. This resource is meant to replace usage oc NNCP in the wrapper, which has large amount of functions added to it, which makes it difficult to add new helpers and functionalities.

##### More details:
The new NNCP is used in an existing test - test_linux_bridge_functionality.

##### What this PR does / why we need it:
As part of the initiative to create simpler resources and reduce dependency, this PR introduces a new NNCP resource in the lib directory.

