### PR TITLE
Fix eus_hco_target_version

### DIFF
--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -48,7 +48,7 @@ from utilities.operator import (
     create_operator_group,
     create_subscription,
     generate_icsp_idms_file,
-    get_hco_version_name,
+    get_hco_csv_name_by_version,
     get_install_plan_from_subscription,
     get_mcp_updating_transition_times,
     wait_for_catalogsource_ready,
@@ -207,7 +207,7 @@ def cnv_install_plan_installed(
     )
     install_plan.wait_for_status(status=install_plan.Status.COMPLETE, timeout=TIMEOUT_5MIN)
     csv = get_csv_by_name(
-        csv_name=get_hco_version_name(cnv_target_version=cnv_version_to_install),
+        csv_name=get_hco_csv_name_by_version(cnv_target_version=cnv_version_to_install),
         admin_client=admin_client,
         namespace=created_cnv_namespace.name,
     )

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -58,7 +58,7 @@ def wait_for_operator_condition(dyn_client, hco_namespace, name, upgradable):
 def wait_for_install_plan(
     dyn_client: DynamicClient,
     hco_namespace: str,
-    hco_target_version: str,
+    hco_target_csv_name: str,
     is_production_source: bool,
 ) -> InstallPlan:
     install_plan_sampler = TimeoutSampler(
@@ -71,7 +71,7 @@ def wait_for_install_plan(
         },  # Ignore ConflictError during install plan reconciliation
         dyn_client=dyn_client,
         hco_namespace=hco_namespace,
-        hco_target_version=hco_target_version,
+        hco_target_version=hco_target_csv_name,
     )
     subscription = get_subscription(
         admin_client=dyn_client,
@@ -102,7 +102,7 @@ def wait_for_install_plan(
                             ip.clean_up()
                             continue
                     if (
-                        hco_target_version == ip_instance.spec.clusterServiceVersionNames[0]
+                        hco_target_csv_name == ip_instance.spec.clusterServiceVersionNames[0]
                         and ip.name == install_plan_name_in_subscription
                     ):
                         return ip
@@ -113,7 +113,7 @@ def wait_for_install_plan(
 
     except TimeoutExpiredError:
         LOGGER.error(
-            f"timeout waiting for target install plan: version={hco_target_version}, "
+            f"timeout waiting for target install plan: version={hco_target_csv_name}, "
             f"subscription install plan: {install_plan_name_in_subscription}"
         )
         raise

--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -158,7 +158,7 @@ def migratable_vms(admin_client, hco_namespace, upgrade_namespaces):
 
 @pytest.fixture()
 def unupdated_vmi_pods_names(
-    admin_client, hco_namespace, hco_target_version, upgrade_namespaces, migratable_vms, eus_hco_target_version
+    admin_client, hco_namespace, hco_target_csv_name, eus_hco_target_csv_name, upgrade_namespaces, migratable_vms
 ):
     wait_for_automatic_vm_migrations(vm_list=migratable_vms)
 
@@ -171,7 +171,7 @@ def unupdated_vmi_pods_names(
     return validate_vms_pod_updated(
         admin_client=admin_client,
         hco_namespace=hco_namespace,
-        hco_target_version=hco_target_version or eus_hco_target_version,
+        hco_target_csv_name=hco_target_csv_name or eus_hco_target_csv_name,
         vm_list=migratable_vms,
     )
 

--- a/tests/virt/upgrade/utils.py
+++ b/tests/virt/upgrade/utils.py
@@ -152,11 +152,11 @@ def wait_for_automatic_vm_migrations(vm_list):
         raise
 
 
-def validate_vms_pod_updated(admin_client, hco_namespace, hco_target_version, vm_list):
+def validate_vms_pod_updated(admin_client, hco_namespace, hco_target_csv_name, vm_list):
     csv = get_csv_by_name(
         admin_client=admin_client,
         namespace=hco_namespace.name,
-        csv_name=hco_target_version,
+        csv_name=hco_target_csv_name,
     )
     target_related_images = get_related_images_name_and_version(csv=csv)
     return [

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -719,7 +719,7 @@ def wait_for_cluster_operator_stabilize(admin_client, wait_timeout=TIMEOUT_20MIN
             raise
 
 
-def get_hco_version_name(cnv_target_version: str) -> str:
+def get_hco_csv_name_by_version(cnv_target_version: str) -> str:
     return f"kubevirt-hyperconverged-operator.v{cnv_target_version}"
 
 


### PR DESCRIPTION
##### Short description:
_**"Cherry pick" from 4.16 branch.**_

 1. eus_hco_target_version should use fixtures from the same scope(might fail optin test)
2. cnv_version fixture is redudant - can be removed.
3. change the names of fixtures and util function to match their purpose:
   getting the cnv name of the target version

##### More details:
the name changes:

```
      hco_target_version -> hco_target_version_csv_name
      eus_hco_target_version -> eus_hco_target_version_csv_name
      get_hco_version -> get_hco_csv_name_by_version
```

##### What this PR does / why we need it:
post upgrade test using this fixture may fail.
In addition the fixture/naming test is misleading.

##### Special notes for reviewer:

##### jira-ticket:

