### PR TITLE
Storage: cleanup DataSource in checkup tests

### DIFF
--- a/tests/storage/checkups/conftest.py
+++ b/tests/storage/checkups/conftest.py
@@ -196,13 +196,7 @@ def ocs_rbd_non_virt_vm_for_checkups_test(admin_client, checkups_namespace):
 
 
 @pytest.fixture()
-def cleaned_up_broken_data_source(golden_images_namespace):
-    yield
-    DataSource(name=BROKEN_DATA_SOURCE_NAME, namespace=golden_images_namespace.name).clean_up(wait=True)
-
-
-@pytest.fixture()
-def broken_data_import_cron(golden_images_namespace, cleaned_up_broken_data_source):
+def broken_data_import_cron(golden_images_namespace):
     with DataImportCron(
         name="broken-data-import-cron",
         namespace=golden_images_namespace.name,
@@ -229,6 +223,8 @@ def broken_data_import_cron(golden_images_namespace, cleaned_up_broken_data_sour
         },
     ) as data_import_cron:
         yield data_import_cron
+    # DataImportCron created a DataSource, but it is not supposed to clean it up
+    DataSource(name=BROKEN_DATA_SOURCE_NAME, namespace=golden_images_namespace.name).clean_up(wait=True)
 
 
 @pytest.fixture()

--- a/tests/storage/checkups/conftest.py
+++ b/tests/storage/checkups/conftest.py
@@ -34,7 +34,6 @@ from utilities.infra import create_ns
 from utilities.storage import update_default_sc
 
 KUBEVIRT_STORAGE_CHECKUP = "kubevirt-storage-checkup"
-BROKEN_DATA_SOURCE_NAME = "broken-data-source"
 
 
 @pytest.fixture(scope="package")
@@ -197,12 +196,13 @@ def ocs_rbd_non_virt_vm_for_checkups_test(admin_client, checkups_namespace):
 
 @pytest.fixture()
 def broken_data_import_cron(golden_images_namespace):
+    data_source = DataSource(name="broken-data-source", namespace=golden_images_namespace.name)
     with DataImportCron(
         name="broken-data-import-cron",
         namespace=golden_images_namespace.name,
         schedule=WILDCARD_CRON_EXPRESSION,
         garbage_collect=OUTDATED,
-        managed_data_source=BROKEN_DATA_SOURCE_NAME,
+        managed_data_source=data_source.name,
         annotations=BIND_IMMEDIATE_ANNOTATION,
         template={
             "spec": {
@@ -224,7 +224,7 @@ def broken_data_import_cron(golden_images_namespace):
     ) as data_import_cron:
         yield data_import_cron
     # DataImportCron created a DataSource, but it is not supposed to clean it up
-    DataSource(name=BROKEN_DATA_SOURCE_NAME, namespace=golden_images_namespace.name).clean_up(wait=True)
+    data_source.clean_up(wait=True)
 
 
 @pytest.fixture()


### PR DESCRIPTION
##### Short description:
`DataImportCron` creates a `DataSource`, but it is not supposed to clean it up, so we must clean it up on teardown. 

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
