### PR TITLE
Triaging kubevirt_hco_single_stack_ipv6 failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2987,3 +2987,8 @@ def nmstate_namespace(admin_client):
     nmstate_ns = Namespace(name="openshift-nmstate")
     assert nmstate_ns.exists, "Namespace openshift-nmstate doesn't exist"
     return nmstate_ns
+
+
+@pytest.fixture()
+def ipv6_single_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
+    return ipv6_supported_cluster and not ipv4_supported_cluster

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -93,10 +93,11 @@ class TestVmNameInLabel:
 
 
 class TestVirtHCOSingleStackIpv6:
+    @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11740")
-    def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus, ipv6_supported_cluster):
+    def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus, ipv6_single_stack_cluster):
         validate_metrics_value(
             prometheus=prometheus,
             metric_name="kubevirt_hco_single_stack_ipv6",
-            expected_value="1" if ipv6_supported_cluster else "0",
+            expected_value="1" if ipv6_single_stack_cluster else "0",
         )


### PR DESCRIPTION
##### Short description:
kubevirt_hco_single_stack_ipv6 test failed duo
to wrong logic, fixed in this PR.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-56293
