### PR TITLE
Virt:Skip guest agent info tests on win2025 until get latest build

### DIFF
--- a/tests/virt/cluster/common_templates/conftest.py
+++ b/tests/virt/cluster/common_templates/conftest.py
@@ -6,6 +6,7 @@ from packaging import version
 from tests.utils import vm_object_from_template
 from tests.virt.cluster.common_templates.utils import skip_on_guest_agent_version
 from utilities.constants import REGEDIT_PROC_NAME
+from utilities.infra import is_jira_open
 from utilities.storage import create_or_update_data_source, data_volume
 from utilities.virt import (
     start_and_fetch_processid_on_linux_vm,
@@ -192,6 +193,13 @@ def golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_cl
         os_matrix=windows_os_matrix__class__,
         data_source_object=golden_image_data_source_multi_windows_os_multi_storage_scope_class,
     )
+
+
+@pytest.fixture()
+def xfail_guest_agent_info_on_win2025(windows_os_matrix__class__):
+    # Bug fixed on qemu-ga but not get the latest build, skip win-2025 until get the latest build
+    if "win-2025" in [*windows_os_matrix__class__][0] and is_jira_open(jira_id="CNV-52655"):
+        pytest.xfail(reason="Expected failure on Windows 2025 until the latest Guest Agent build is available")
 
 
 # Tablet

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -66,7 +66,9 @@ class TestCommonTemplatesWindows:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-3512")
     def test_vmi_guest_agent_info(
-        self, golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class
+        self,
+        xfail_guest_agent_info_on_win2025,
+        golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class,
     ):
         """Test Guest OS agent info."""
         validate_os_info_vmi_vs_windows_os(
@@ -77,7 +79,9 @@ class TestCommonTemplatesWindows:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-4196")
     def test_virtctl_guest_agent_os_info(
-        self, golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class
+        self,
+        xfail_guest_agent_info_on_win2025,
+        golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class,
     ):
         validate_os_info_virtctl_vs_windows_os(
             vm=golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class,


### PR DESCRIPTION
##### Short description:
win2025 guest agent case failed continuously, bug fixed on qemu-ga but not get the latest build, skip it until there's the latest build
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
CNV-Tracker: https://issues.redhat.com/browse/CNV-52655
