### PR TITLE
Set the cluster default cpu by using defaultCPUModel param in HCO

### DIFF
--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -2,10 +2,10 @@ import pytest
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.virtual_machine import VirtualMachine
 
+from utilities.constants import HCO_DEFAULT_CPU_MODEL_KEY
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
-HCO_CPU_MODEL_KEY = "defaultCPUModel"
 KUBEVIRT_CPU_MODEL_KEY = "cpuModel"
 VMI_CPU_MODEL_KEY = "host-model"
 
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
 
 def assert_updated_hco_default_cpu_model(hco_resource, expected_cpu_model):
-    hco_cpu_model = hco_resource.instance.spec.get(HCO_CPU_MODEL_KEY)
+    hco_cpu_model = hco_resource.instance.spec.get(HCO_DEFAULT_CPU_MODEL_KEY)
     assert hco_cpu_model == expected_cpu_model, (
         f"HCO CPU model: '{hco_cpu_model}' doesn't match with expected CPU model: '{expected_cpu_model}"
     )
@@ -27,7 +27,7 @@ def assert_vmi_cpu_model(vmi_resource, expected_cpu_model):
 
 
 def assert_kubevirt_cpu_model(kubevirt_resource, hco_resource):
-    hco_cpu_model = hco_resource.instance.spec.get(HCO_CPU_MODEL_KEY)
+    hco_cpu_model = hco_resource.instance.spec.get(HCO_DEFAULT_CPU_MODEL_KEY)
     kubevirt_cpu_model = kubevirt_resource.instance.spec.configuration.get(KUBEVIRT_CPU_MODEL_KEY)
     assert kubevirt_cpu_model == hco_cpu_model, (
         f"Kubevirt CPU model '{kubevirt_cpu_model}' doesn't match with the expected CPU model '{hco_cpu_model}'"
@@ -70,7 +70,7 @@ def hco_with_default_cpu_model_set(
         patches={
             hyperconverged_resource_scope_function: {
                 "spec": {
-                    HCO_CPU_MODEL_KEY: cluster_common_node_cpu,
+                    HCO_DEFAULT_CPU_MODEL_KEY: cluster_common_node_cpu,
                 },
             }
         },
@@ -91,8 +91,8 @@ def test_default_value_for_cpu_model(
     Default value for CPU model in kubevirt should be 'None'
     and for VMI should be 'host-model'
     """
-    assert HCO_CPU_MODEL_KEY not in hco_spec_scope_module, (
-        f"HCO is not expected to contain default value for '{HCO_CPU_MODEL_KEY}', "
+    assert HCO_DEFAULT_CPU_MODEL_KEY not in hco_spec_scope_module, (
+        f"HCO is not expected to contain default value for '{HCO_DEFAULT_CPU_MODEL_KEY}', "
         f"HCO spec values are: {hco_spec_scope_module}"
     )
     assert KUBEVIRT_CPU_MODEL_KEY not in kubevirt_hyperconverged_spec_scope_module["configuration"], (

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,6 +21,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from utilities.constants import (
     DISK_SERIAL,
+    HCO_DEFAULT_CPU_MODEL_KEY,
     RHSM_SECRET_NAME,
     TIMEOUT_1SEC,
     TIMEOUT_5SEC,
@@ -28,7 +29,7 @@ from utilities.constants import (
     TIMEOUT_10SEC,
     TIMEOUT_30MIN,
 )
-from utilities.hco import ResourceEditorValidateHCOReconcile, update_hco_annotations
+from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import ExecCommandOnPod, get_artifactory_header
 from utilities.virt import (
     VirtualMachineForTests,
@@ -261,10 +262,10 @@ def assert_restart_required_codition(vm, expected_message):
 
 @contextmanager
 def update_cluster_cpu_model(admin_client, hco_namespace, hco_resource, cpu_model):
-    with update_hco_annotations(
-        resource=hco_resource,
-        path="cpuModel",
-        value=cpu_model,
+    with ResourceEditorValidateHCOReconcile(
+        patches={hco_resource: {"spec": {HCO_DEFAULT_CPU_MODEL_KEY: cpu_model}}},
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
     ):
         wait_for_updated_kv_value(
             admin_client=admin_client,

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -783,3 +783,5 @@ WIN_2K22 = "win2k22"
 PUBLIC_DNS_SERVER_IP = "8.8.8.8"
 
 BIND_IMMEDIATE_ANNOTATION = {f"{Resource.ApiGroup.CDI_KUBEVIRT_IO}/storage.bind.immediate.requested": "true"}
+
+HCO_DEFAULT_CPU_MODEL_KEY = "defaultCPUModel"


### PR DESCRIPTION
Use defaultCPUModel parameter instead of json patch annotations

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
