### PR TITLE
Remove IP stack related skips

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -69,24 +69,6 @@ def dual_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
 
 
 @pytest.fixture()
-def skip_if_not_ipv4_supported_cluster_from_mtx(
-    request,
-    ipv4_supported_cluster,
-):
-    if ip_version_data_from_matrix(request=request) == IPV4_STR and not ipv4_supported_cluster:
-        pytest.skip("IPv4 is not supported in this cluster")
-
-
-@pytest.fixture()
-def skip_if_not_ipv6_supported_cluster_from_mtx(
-    request,
-    ipv6_supported_cluster,
-):
-    if ip_version_data_from_matrix(request=request) == IPV6_STR and not ipv6_supported_cluster:
-        pytest.skip("IPv6 is not supported in this cluster")
-
-
-@pytest.fixture()
 def worker_node1_pod_executor(workers_utility_pods, worker_node1):
     return ExecCommandOnPod(utility_pods=workers_utility_pods, node=worker_node1)
 

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -16,14 +16,12 @@ from tests.network.utils import get_vlan_index_number, vm_for_brcnv_tests
 from utilities.constants import (
     CLUSTER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
-    IPV4_STR,
-    IPV6_STR,
     ISTIO_SYSTEM_DEFAULT_NS,
     OVS_BRIDGE,
     VIRT_HANDLER,
 )
 from utilities.infra import ExecCommandOnPod, get_deployment_by_name, get_node_selector_dict
-from utilities.network import get_cluster_cni_type, ip_version_data_from_matrix, network_nad
+from utilities.network import get_cluster_cni_type, network_nad
 
 
 @pytest.fixture(scope="session")

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -76,8 +76,6 @@ def cloud_init_ipv6_network_data(dual_stack_network_data):
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-2332")
 def test_connectivity_over_pod_network(
-    skip_if_not_ipv4_supported_cluster_from_mtx,
-    skip_if_not_ipv6_supported_cluster_from_mtx,
     ip_stack_version_matrix__module__,
     pod_net_vma,
     pod_net_vmb,

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -390,8 +390,6 @@ def test_connectivity_after_migration_and_restart(
 def test_migration_with_masquerade(
     ip_stack_version_matrix__module__,
     admin_client,
-    skip_if_not_ipv4_supported_cluster_from_mtx,
-    skip_if_not_ipv6_supported_cluster_from_mtx,
     vma,
     vmb,
     running_vma,


### PR DESCRIPTION
Remove skip_if_not_ipv4_supported_cluster_from_mtx and skip_if_not_ipv6_supported_cluster_from_mtx. The aim is running network tests on dual-stack clusters only.
##### jira-ticket:
https://issues.redhat.com/browse/CNV-56583