### PR TITLE
Enable UDN tests by removing "udn" marker, add ns label and update condition

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -63,7 +63,6 @@ EXCLUDE_MARKER_FROM_TIER2_MARKER = [
     "longevity",
     "ovs_brcnv",
     "node_remediation",
-    "udn",
 ]
 
 TEAM_MARKERS = {

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,6 @@ markers =
     ipv4: IPV4 based test
     ipv6: IPV6 based test
     node_remediation: Node Remediation using NodeHalthCheck with SNR & FAR
-    udn: user defined network tests
     special_infra: tests that requires special infrastructure. e.g. sriov, gpu etc.
     # CI
     smoke: Mark tests as smoke tests

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -14,10 +14,6 @@ from libs.vm.factory import base_vmspec, fedora_vm
 from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
 from utilities.virt import migrate_vm_and_verify
 
-# For version 4.18, this module can only run on clusters where FeatureGate is configured with
-# featureSet TechPreviewNoUpgrade.
-pytestmark = pytest.mark.udn
-
 IP_ADDRESS = "ipAddress"
 SERVER_PORT = 5201
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -51,7 +51,10 @@ def namespaced_layer2_user_defined_network(udn_namespace):
         subnets=["10.10.0.0/24"],
         ipam_lifecycle="Persistent",
     ) as udn:
-        udn.wait_for_network_ready()
+        udn.wait_for_condition(
+            condition="NetworkAllocationSucceeded",
+            status=udn.Condition.Status.TRUE,
+        )
         yield udn
 
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -12,6 +12,7 @@ from libs.vm import affinity
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
 from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
+from utilities.infra import create_ns
 from utilities.virt import migrate_vm_and_verify
 
 IP_ADDRESS = "ipAddress"
@@ -34,10 +35,18 @@ def udn_vm(namespace_name, name, template_labels=None):
 
 
 @pytest.fixture(scope="module")
-def namespaced_layer2_user_defined_network(namespace):
+def udn_namespace():
+    yield from create_ns(
+        name="test-user-defined-network-ns",
+        labels={"k8s.ovn.org/primary-user-defined-network": ""},
+    )
+
+
+@pytest.fixture(scope="module")
+def namespaced_layer2_user_defined_network(udn_namespace):
     with Layer2UserDefinedNetwork(
         name="layer2-udn",
-        namespace=namespace.name,
+        namespace=udn_namespace.name,
         role="Primary",
         subnets=["10.10.0.0/24"],
         ipam_lifecycle="Persistent",
@@ -52,16 +61,16 @@ def udn_affinity_label():
 
 
 @pytest.fixture(scope="class")
-def vma_udn(namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
-    with udn_vm(namespace_name=namespace.name, name="vma-udn", template_labels=dict((udn_affinity_label,))) as vm:
+def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
+    with udn_vm(namespace_name=udn_namespace.name, name="vma-udn", template_labels=dict((udn_affinity_label,))) as vm:
         vm.start(wait=True)
         vm.vmi.wait_for_condition(condition="AgentConnected", status=Resource.Condition.Status.TRUE)
         yield vm
 
 
 @pytest.fixture(scope="class")
-def vmb_udn_non_migratable(namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
-    with udn_vm(namespace_name=namespace.name, name="vmb-udn", template_labels=dict((udn_affinity_label,))) as vm:
+def vmb_udn_non_migratable(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
+    with udn_vm(namespace_name=udn_namespace.name, name="vmb-udn", template_labels=dict((udn_affinity_label,))) as vm:
         vm.start(wait=True)
         vm.vmi.wait_for_condition(condition="AgentConnected", status=Resource.Condition.Status.TRUE)
         yield vm


### PR DESCRIPTION
##### Short description:
Enable UDN tests by removing "udn" marker
##### More details:
Enable UDN tests by removing "udn" marker
    
    Removed the "udn" marker from the EXCLUDE_MARKER_FROM_TIER2_MARKER
    list in conftest.py to enable UDN tests as part of Tier 2.
    
    Removed the "udn" marker definition from pytest.ini
    and the usage of "udn" marker in test_user_defined_network.py.
    
    UDN tests are now enabled by default and will run as
    part of the Tier 2 tests without needing explicit inclusion.

Add fixture for UDN namespace with required label
    
    Added udn_namespace fixture to create a namespace
    with the required label at namespace creation.

Refactor readiness check for UDN status
    
    Replaced wait_for_network_ready() with wait_for_condition()
    to support the new NetworkAllocationSucceeded status.
    
    The old method uses NETWORK_READY, which is outdated.
    It will need to be updated or removed in the future.

##### What this PR does / why we need it:
We need this PR since, in the latest OCP 4.18++ versions, UDN is enabled by default and no longer requires the featureSet TechPreviewNoUpgrade configuration to be explicitly set.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-56407
