### PR TITLE
Remove tests covering gn1

### DIFF
--- a/tests/infrastructure/instance_types/test_common_vm_instancetype.py
+++ b/tests/infrastructure/instance_types/test_common_vm_instancetype.py
@@ -35,19 +35,6 @@ def test_cx1_instancetype_profile(skip_if_no_huge_pages, unprivileged_client, na
         running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 
 
-@pytest.mark.tier3
-@pytest.mark.polarion("CNV-10400")
-def test_gn1_instancetype_profile(skip_if_no_gpu_node, unprivileged_client, namespace):
-    with VirtualMachineForTests(
-        client=unprivileged_client,
-        name="rhel-vm-with-gn1",
-        namespace=namespace.name,
-        image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
-        vm_instance_type=VirtualMachineClusterInstancetype(name="gn1.xlarge"),
-    ) as vm:
-        running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
-
-
 @pytest.mark.post_upgrade
 @pytest.mark.polarion("CNV-11288")
 def test_common_instancetype_owner(base_vm_cluster_instancetypes):


### PR DESCRIPTION
##### Short description:
GN instance type  is not available
##### More details:
https://github.com/kubevirt/common-instancetypes/commit/e92465229845769950efd0edee4d1e3ac4f44f0b
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

