### PR TITLE
must-gather collection can hang on a cluster , so add timeout for run_command() call

### DIFF
--- a/utilities/must_gather.py
+++ b/utilities/must_gather.py
@@ -3,12 +3,18 @@ import shlex
 
 from pyhelper_utils.shell import run_command
 
-from utilities.constants import TIMEOUT_15MIN
+from utilities.constants import TIMEOUT_15MIN, TIMEOUT_20MIN
 
 
 def run_must_gather(
-    image_url="", target_base_dir="", script_name="", flag_names="", timeout=f"{TIMEOUT_15MIN}s", since=None
-):
+    image_url: str = "",
+    target_base_dir: str = "",
+    script_name: str = "",
+    flag_names: str = "",
+    timeout: str = f"{TIMEOUT_15MIN}s",
+    since: str | None = None,
+    run_command_timeout: int = TIMEOUT_20MIN,
+) -> str:
     """
     Run must gather command with an option to create target directory.
 
@@ -24,6 +30,8 @@ def run_must_gather(
             must-gather. However, flag_names can not be passed without script_name
         since (str, optional): since when the data should be collected. format is: '(+|-)[0-9]+(s|m|h|d)'
         timeout (str, optional): runs the debug pods for specified duration
+        run_command_timeout(str, optional): timeout value for run_command call
+
     Returns:
         str: command output
     """
@@ -42,7 +50,7 @@ def run_must_gather(
     if flag_names:
         flag_string = "".join([f" --{flag_name}" for flag_name in flag_names.split(",")])
         base_command += f" {flag_string}"
-    return run_command(command=shlex.split(base_command), check=False)[1]
+    return run_command(command=shlex.split(base_command), check=False, timeout=run_command_timeout)[1]
 
 
 def get_must_gather_output_file(path):

--- a/utilities/must_gather.py
+++ b/utilities/must_gather.py
@@ -13,7 +13,6 @@ def run_must_gather(
     flag_names: str = "",
     timeout: str = f"{TIMEOUT_15MIN}s",
     since: str | None = None,
-    run_command_timeout: int = TIMEOUT_20MIN,
 ) -> str:
     """
     Run must gather command with an option to create target directory.
@@ -30,7 +29,6 @@ def run_must_gather(
             must-gather. However, flag_names can not be passed without script_name
         since (str, optional): since when the data should be collected. format is: '(+|-)[0-9]+(s|m|h|d)'
         timeout (str, optional): runs the debug pods for specified duration
-        run_command_timeout(str, optional): timeout value for run_command call
 
     Returns:
         str: command output
@@ -50,7 +48,7 @@ def run_must_gather(
     if flag_names:
         flag_string = "".join([f" --{flag_name}" for flag_name in flag_names.split(",")])
         base_command += f" {flag_string}"
-    return run_command(command=shlex.split(base_command), check=False, timeout=run_command_timeout)[1]
+    return run_command(command=shlex.split(base_command), check=False, timeout=TIMEOUT_20MIN)[1]
 
 
 def get_must_gather_output_file(path):


### PR DESCRIPTION
##### Short description:
subprocess.run would wait indefinitely when timeout=None. We should explicitly set timeout for must-gather calls.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
