### PR TITLE
[Minor change]:Use KUBECONFIG constant

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -66,6 +66,7 @@ from utilities.constants import (
     EXCLUDED_OLD_CPU_MODELS,
     HCO_CATALOG_SOURCE,
     IMAGE_CRON_STR,
+    KUBECONFIG,
     KUBELET_READY_CONDITION,
     NET_UTIL_CONTAINER_IMAGE,
     OC_ADM_LOGS_COMMAND,
@@ -818,7 +819,7 @@ def run_virtctl_command(command, virtctl_binary=VIRTCTL, namespace=None, check=F
         tuple: True, out if command succeeded, False, err otherwise.
     """
     virtctl_cmd = [virtctl_binary]
-    kubeconfig = os.getenv("KUBECONFIG")
+    kubeconfig = os.getenv(KUBECONFIG)
     if namespace:
         virtctl_cmd.extend(["-n", namespace])
 


### PR DESCRIPTION
##### Short description:
This is just some minor improvement to use KUBECONFIG constant in infra.py instead of a string value.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

