### PR TITLE
 Align Layer2UserDefinedNetwork with UDN API changes

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -49,7 +49,7 @@ def namespaced_layer2_user_defined_network(udn_namespace):
         namespace=udn_namespace.name,
         role="Primary",
         subnets=["10.10.0.0/24"],
-        ipam_lifecycle="Persistent",
+        ipam={"lifecycle": "Persistent"},
     ) as udn:
         udn.wait_for_condition(
             condition="NetworkAllocationSucceeded",


### PR DESCRIPTION
##### Short description:
Align Layer2UserDefinedNetwork with UDN API changes
##### More details:
Replace ipam_lifecycle with ipam dict for flexible IPAM
configuration and improved compatibility with UDN API changes.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
This PR depends on:
https://github.com/RedHatQE/openshift-python-wrapper/pull/2329
##### jira-ticket:

