### PR TITLE
SSH: use .namespace - compatible with 4.19 and 4.20/4.99

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1020,7 +1020,7 @@ class VirtualMachineForTests(VirtualMachine):
 
     @property
     def virtctl_port_forward_cmd(self):
-        return f"{VIRTCTL} port-forward --stdio=true vm/{self.name}/{self.namespace} {SSH_PORT_22}"
+        return f"{VIRTCTL} port-forward --stdio=true vm/{self.name}.{self.namespace} {SSH_PORT_22}"
 
     @property
     def login_params(self):


### PR DESCRIPTION
##### Short description:

Supported options from @0xFelix:
4.18: [type/]name[.namespace] starting point
4.19: type/name[.namespace] preferred, name[.namespace] still working with a warning
4.20: type/name[/namespace], backward compatibility for type/name.namespace
4.21: type/name[/namespace] only

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
