### PR TITLE
WIP: Virt: Skip arq memory hotpulg

### DIFF
--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -210,8 +210,8 @@ class TestARQSupportMemoryHotplug:
     @pytest.mark.xfail(
         condition=is_jira_open(jira_id="CNV-56865"),
         reason=(
-                "arq memory hotplug might failed from time to time."
-                "Due to that, skip it to keep the t2 gating test always be green until fix the issue."
+            "arq memory hotplug might failed from time to time."
+            "Due to that, skip it to keep the t2 gating test always be green until fix the issue."
         ),
     )
     @pytest.mark.parametrize(

--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -25,6 +25,7 @@ from tests.virt.constants import (
     REQUESTS_MEMORY_VMI_STR,
 )
 from tests.virt.utils import check_arq_status_values, wait_when_pod_in_gated_state
+from utilities.infra import is_jira_open
 from utilities.virt import migrate_vm_and_verify, wait_for_running_vm
 
 LOGGER = logging.getLogger(__name__)
@@ -206,6 +207,13 @@ class TestARQSupportCPUHotplug:
 
 
 class TestARQSupportMemoryHotplug:
+    @pytest.mark.xfail(
+        condition=is_jira_open(jira_id="CNV-56865"),
+        reason=(
+                "arq memory hotplug might failed from time to time."
+                "Due to that, skip it to keep the t2 gating test always be green until fix the issue."
+        ),
+    )
     @pytest.mark.parametrize(
         "hotplugged_resource",
         [


### PR DESCRIPTION

##### Short description:
ARQ memory hotplug might failed from time to time. 
Due to that, skip it to  keep the t2 gating test always be green until fix the issue.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-56865