### PR TITLE
 Virt: Add several seconds timeout for checking values after ARQ memory hotplug

### DIFF
--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -228,6 +228,7 @@ class TestARQSupportMemoryHotplug:
                 REQUESTS_CPU_VMI_STR: vmi_spec_domain.cpu.sockets,
                 REQUESTS_MEMORY_VMI_STR: vmi_spec_domain.memory.guest,
             },
+            application_aware_resource_quota=application_aware_resource_quota,
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION

##### Short description:
Keeping gating test stable, improve the ARQ memory hotplug logic. Add timeout sampler which will wait for 5 seconds for new values after the hotplug

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-56865