### PR TITLE
Test for kubevirt_vm_create_date_timestamp_seconds

### DIFF
--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -259,7 +259,7 @@ class TestVMStatusLastTransitionMetrics:
     indirect=True,
 )
 @pytest.mark.usefixtures("vm_for_test")
-class TestVmConsolesMetrics:
+class TestVmConsolesAndVmCreateDateTimestampMetrics:
     @pytest.mark.polarion("CNV-11024")
     def test_kubevirt_console_active_connections(self, prometheus, vm_for_test, connected_vm_console_successfully):
         validate_metrics_value(
@@ -274,6 +274,14 @@ class TestVmConsolesMetrics:
             prometheus=prometheus,
             metric_name=KUBEVIRT_VNC_ACTIVE_CONNECTIONS_BY_VMI.format(vm_name=vm_for_test.name),
             expected_value="1",
+        )
+
+    @pytest.mark.polarion("CNV-11805")
+    def test_metric_kubevirt_vm_create_date_timestamp_seconds(self, prometheus, vm_for_test):
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=f"kubevirt_vm_create_date_timestamp_seconds{{name='{vm_for_test.name}'}}",
+            expected_value=str(timestamp_to_seconds(timestamp=vm_for_test.instance.metadata.creationTimestamp)),
         )
 
 


### PR DESCRIPTION
##### Short description:
Test for kubevirt_vm_create_date_timestamp_seconds metric.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
