### PR TITLE
Add fixture to check if Service Mesh is installed

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -100,6 +100,12 @@ def istio_system_namespace(admin_client):
     return Namespace(name=ISTIO_SYSTEM_DEFAULT_NS, client=admin_client).exists
 
 
+@pytest.fixture(scope="session")
+def service_mesh_installed_validation(istio_system_namespace):
+    if not istio_system_namespace:
+        pytest.fail(reason="Service Mesh is not installed.")
+
+
 @pytest.fixture(scope="module")
 def sriov_workers_node1(sriov_workers):
     """

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -6,7 +6,7 @@ from tests.network.service_mesh.utils import (
 )
 from tests.network.utils import assert_authentication_request
 
-pytestmark = pytest.mark.special_infra
+pytestmark = [pytest.mark.usefixtures("service_mesh_installed_validation"), pytest.mark.special_infra]
 
 
 class TestSMTrafficManagement:


### PR DESCRIPTION
##### Short description:
Add fixture to check if Service Mesh is installed
##### More details:
Introduced a new pytest fixture to verify that the Service Mesh is installed before running tests.
The fixture is used in service_mesh_member_roll to ensure that the tests will not run if the Service Mesh is not present.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
This is a follow up PR after: https://github.com/RedHatQE/openshift-virtualization-tests/pull/287 , which I used the same logic as it was for skipping, but now for assertion.
##### jira-ticket:
