### PR TITLE
CherryPicked: [cnv-4.18] Triage kubevirt_vmi_migration_metrics (#316)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2418,6 +2418,16 @@ def migration_policy_with_bandwidth():
         yield mp
 
 
+@pytest.fixture(scope="class")
+def migration_policy_with_bandwidth_scope_class():
+    with MigrationPolicy(
+        name="migration-policy",
+        bandwidth_per_migration="128Ki",
+        vmi_selector=MIGRATION_POLICY_VM_LABEL,
+    ) as mp:
+        yield mp
+
+
 @pytest.fixture(scope="session")
 def gpu_nodes(nodes):
     return get_nodes_with_label(nodes=nodes, label="nvidia.com/gpu.present")

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -102,20 +102,32 @@ def initial_migration_metrics_values(prometheus, migration_metrics_dict):
 
 
 @pytest.fixture(scope="class")
-def vm_for_migration_metrics_test(namespace):
+def vm_for_migration_metrics_test(namespace, cpu_for_migration):
     name = "vm-for-migration-metrics-test"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
+        cpu_model=cpu_for_migration,
         additional_labels=MIGRATION_POLICY_VM_LABEL,
     ) as vm:
-        running_vm(vm=vm)
+        running_vm(vm=vm, check_ssh_connectivity=False)
         yield vm
 
 
 @pytest.fixture()
 def vm_migration_metrics_vmim(vm_for_migration_metrics_test):
+    with VirtualMachineInstanceMigration(
+        name="vm-migration-metrics-vmim",
+        namespace=vm_for_migration_metrics_test.namespace,
+        vmi_name=vm_for_migration_metrics_test.vmi.name,
+    ) as vmim:
+        vmim.wait_for_status(status=vmim.Status.RUNNING, timeout=TIMEOUT_3MIN)
+        yield vmim
+
+
+@pytest.fixture(scope="class")
+def vm_migration_metrics_vmim_scope_class(vm_for_migration_metrics_test):
     with VirtualMachineInstanceMigration(
         name="vm-migration-metrics-vmim",
         namespace=vm_for_migration_metrics_test.namespace,
@@ -218,13 +230,12 @@ class TestMigrationMetrics:
             metric_to_check=migration_metrics_dict[Resource.Status.RUNNING],
         )
 
+
+class TestKubevirtVmiMigrationMetrics:
     @pytest.mark.parametrize(
         "query",
         [
-            pytest.param(
-                KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES,
-                marks=(pytest.mark.polarion("CNV-11417")),
-            ),
+            pytest.param(KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES, marks=(pytest.mark.polarion("CNV-11417"))),
             pytest.param(
                 KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES,
                 marks=(pytest.mark.polarion("CNV-11600")),
@@ -239,16 +250,17 @@ class TestMigrationMetrics:
             ),
         ],
     )
-    def test_kubevirt_vmi_migration_data_processed_bytes(
+    def test_kubevirt_vmi_migration_metrics(
         self,
         prometheus,
         namespace,
         admin_client,
-        migration_policy_with_bandwidth,
+        migration_policy_with_bandwidth_scope_class,
         vm_for_migration_metrics_test,
-        vm_migration_metrics_vmim,
+        vm_migration_metrics_vmim_scope_class,
         query,
     ):
         wait_for_non_empty_metrics_value(
-            prometheus=prometheus, metric_name=query.format(vm_name=vm_for_migration_metrics_test.name)
+            prometheus=prometheus,
+            metric_name=f"last_over_time({query.format(vm_name=vm_for_migration_metrics_test.name)}[8m])",
         )


### PR DESCRIPTION

##### Short description:
* Triage kubevirt_vmi_migration_metrics

Triaging kubevirt_vmi_migration_metrics failures
by changing the query to check for the last_over_time by 5 mins, also changed the scope of fixtures in order to reduce the test execution tim.

* Added test for kubevirt_vmi_migration_dirty_memory_rate_bytes

Added test to TestKubevirtVmiMigrationMetrics test class because it has the same setup.

* Added cpu_for_migration to vm fixutre

Added cpu_for_migration to vm for migration

* Added cpu_for_migration to vm fixutre

Added cpu_for_migration to vm for migration
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-57551
