### PR TITLE
Test kubevirt_vmi_migration_data_total_bytes

### DIFF
--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -80,3 +80,4 @@ KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES = "kubevirt_vmi_migration_dirty_m
 KUBEVIRT_VMSNAPSHOT_PERSISTENTVOLUMECLAIM_LABELS = (
     "kubevirt_vmsnapshot_persistentvolumeclaim_labels{{vm_name='{vm_name}'}}"
 )
+KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES = "kubevirt_vmi_migration_data_total_bytes{{name='{vm_name}'}}"

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -10,7 +10,7 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES,
     KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES,
     KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
-    KUBEVIRT_VMI_MIGRATION_DISK_TRANSFER_RATE_BYTES,
+    KUBEVIRT_VMI_MIGRATION_DISK_TRANSFER_RATE_BYTES, KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES,
 )
 from tests.observability.metrics.utils import get_metric_sum_value, wait_for_non_empty_metrics_value
 from utilities.constants import MIGRATION_POLICY_VM_LABEL, TIMEOUT_2MIN, TIMEOUT_3MIN
@@ -247,6 +247,10 @@ class TestKubevirtVmiMigrationMetrics:
             pytest.param(
                 KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
                 marks=(pytest.mark.polarion("CNV-11599")),
+            ),
+            pytest.param(
+                KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES,
+                marks=(pytest.mark.polarion("CNV-11802")),
             ),
         ],
     )


### PR DESCRIPTION
##### Short description:
Test for kubevirt_vmi_migration_data_total_bytes metric.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
