### PR TITLE
[4.18] Wait for node update when creating linux bridge 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,7 @@ from utilities.network import (
     get_cluster_cni_type,
     network_device,
     network_nad,
+    wait_for_node_marked_by_bridge,
     wait_for_ovs_daemonset_resource,
     wait_for_ovs_status,
 )
@@ -1773,13 +1774,14 @@ def bridge_on_one_node(worker_node1):
 
 
 @pytest.fixture(scope="session")
-def upgrade_bridge_marker_nad(bridge_on_one_node, kmp_enabled_namespace):
+def upgrade_bridge_marker_nad(bridge_on_one_node, kmp_enabled_namespace, worker_node1):
     with network_nad(
         nad_type=LINUX_BRIDGE,
         nad_name=bridge_on_one_node.bridge_name,
         interface_name=bridge_on_one_node.bridge_name,
         namespace=kmp_enabled_namespace,
     ) as nad:
+        wait_for_node_marked_by_bridge(bridge_nad=nad, node=worker_node1)
         yield nad
 
 


### PR DESCRIPTION
##### Short description:
Cherry pick from [4.19 ](https://github.com/RedHatQE/openshift-virtualization-tests/pull/418)

Tests that are using VM with bridge interface is flaky,
because on slow clusters the node might not update yet with allocatable/capacity status.
It affect IUO must gather tests, and network upgrade tests.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
