### PR TITLE
Use upgrade markers explicitly for test collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Command to run entire upgrade test suite for ocp upgrade, including pre and post
 Command to run only ocp upgrade test, without any pre/post validation:
 
 ```bash
--m ocp_upgrade --upgrade ocp --ocp-image <ocp_image_to_upgrade_to>
+-m iuo --upgrade ocp --ocp-image <ocp_image_to_upgrade_to>
 ```
 
 To upgrade to ocp version: 4.10.16, using <https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.10.16>, following command can be used:
@@ -242,7 +242,7 @@ Command to run entire upgrade test suite for cnv upgrade, including pre and post
 Command to run only cnv upgrade test, without any pre/post validation:
 
 ```bash
--m cnv_upgrade --upgrade cnv --cnv-version <target_version> --cnv source <osbs|production|staging> --cnv-image <cnv_image_to_upgrade_to>
+-m iuo --upgrade cnv --cnv-version <target_version> --cnv source <osbs|production|staging> --cnv-image <cnv_image_to_upgrade_to>
 ```
 
 To upgrade to cnv 4.Y.z, using the cnv image that has been shipped, following command could be used:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Command to run entire upgrade test suite for ocp upgrade, including pre and post
 Command to run only ocp upgrade test, without any pre/post validation:
 
 ```bash
--m iuo --upgrade ocp --ocp-image <ocp_image_to_upgrade_to>
+-m product_upgrade_test --upgrade ocp --ocp-image <ocp_image_to_upgrade_to>
 ```
 
 To upgrade to ocp version: 4.10.16, using <https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.10.16>, following command can be used:
@@ -242,7 +242,7 @@ Command to run entire upgrade test suite for cnv upgrade, including pre and post
 Command to run only cnv upgrade test, without any pre/post validation:
 
 ```bash
--m iuo --upgrade cnv --cnv-version <target_version> --cnv source <osbs|production|staging> --cnv-image <cnv_image_to_upgrade_to>
+-m product_upgrade_test --upgrade cnv --cnv-version <target_version> --cnv source <osbs|production|staging> --cnv-image <cnv_image_to_upgrade_to>
 ```
 
 To upgrade to cnv 4.Y.z, using the cnv image that has been shipped, following command could be used:

--- a/conftest.py
+++ b/conftest.py
@@ -339,25 +339,23 @@ def filter_upgrade_tests(
     upgrade_markers: list[str],
 ) -> tuple[list[Item], list[Item]]:
     upgrade_tests, non_upgrade_tests = [], []
+    upgrade_markers_set = set(upgrade_markers)
 
     for item in items:
-        if set(upgrade_markers).intersection(set(item.keywords)):
+        if upgrade_markers_set.intersection(set(item.keywords)):
             upgrade_tests.append(item)
         else:
             non_upgrade_tests.append(item)
 
+    # If upgrade marker configured, select specific upgrade tests by marker, and discard the others.
     if any(config.getoption(f"--{marker}") for marker in upgrade_markers):
-        # If performing OCP upgrade, remove tests marked with pytest.mark.cnv_upgrade.
-        # If performing CNV upgrade, remove test marked with pytest.mark.ocp_upgrade,
-        # and determine if we are running the cnv upgrade test for production source or for stage/osbs.
-        cnv_source = config.getoption("--cnv-source")
-
         upgrade_tests, discard = remove_upgrade_tests_based_on_config(
-            cnv_source=cnv_source,
+            cnv_source=config.getoption("--cnv-source"),
             upgrade_tests=upgrade_tests,
         )
         return upgrade_tests, [*non_upgrade_tests, *discard]
 
+    # If no upgrade marker in config, discard all upgrade tests.
     return non_upgrade_tests, upgrade_tests
 
 
@@ -367,42 +365,28 @@ def remove_upgrade_tests_based_on_config(
 ) -> tuple[list[Item], list[Item]]:
     """
     Filter the correct upgrade tests to execute based on config, since only one lane can be chosen.
+    If performing OCP upgrade, keep only the tests with pytest.mark.ocp_upgrade.
+    If performing EUS upgrade, keep only the tests with pytest.mark.eus_upgrade.
+    If performing CNV upgrade, keep only the tests with pytest.mark.cnv_upgrade.
+    In addition, determine if we are running the cnv upgrade test for production source or for stage/osbs.
 
     Args:
         cnv_source(str): cnv source option.
         upgrade_tests(list): list of upgrade tests.
     """
-    ocp_upgrade_test = None
-    cnv_upgrade_test_with_prod_src = None
-    cnv_upgrade_test_no_prod_src = None
-    eus_upgrade_test = None
-    cnv_upgrade_tests: list[Item] = []
+    keep: list[Item] = []
+    marker_str = f"{py_config['upgraded_product']}_upgrade"
 
     for test in upgrade_tests:
-        if "ocp_upgrade" in test.keywords:
-            ocp_upgrade_test = test
-        elif "eus_upgrade" in test.keywords:
-            eus_upgrade_test = test
-        elif "cnv_upgrade" in test.keywords:
-            cnv_upgrade_tests.append(test)
-            if "production_source" in test.name:
-                cnv_upgrade_test_with_prod_src = test
-            else:
-                cnv_upgrade_test_no_prod_src = test
+        if marker_str == "cnv_upgrade" and "cnv_upgrade_process" in test.name:
+            # choose the right cnv_upgrade test according to cnv_source.
+            # production cnv_upgrade_test if prod source, otherwise the stage/osbs one
+            if (cnv_source == "production") == ("production_source" in test.name):
+                keep.append(test)
+        elif marker_str in test.keywords:
+            keep.append(test)
 
-    if py_config["upgraded_product"] == "cnv":
-        tests_to_remove = [
-            cnv_upgrade_test_no_prod_src if cnv_source == "production" else cnv_upgrade_test_with_prod_src,
-            ocp_upgrade_test,
-            eus_upgrade_test,
-        ]
-    elif py_config["upgraded_product"] == "ocp":
-        tests_to_remove = [*cnv_upgrade_tests, eus_upgrade_test]
-    else:
-        tests_to_remove = [*cnv_upgrade_tests, ocp_upgrade_test]
-
-    discard = [test for test in tests_to_remove if test is not None]
-    keep = [test for test in upgrade_tests if test not in discard]
+    discard = [test for test in upgrade_tests if test not in keep]
     return keep, discard
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -48,6 +48,7 @@ markers =
     install: Tests that self-manage HCO/CNV installation
     upgrade: Run regular upgrade lanes with default configuration
     upgrade_custom: Run custom upgrade lanes with non-default configuration (e.g. with hco featuregates customized)
+    product_upgrade_test: Marks product upgrade tests
     post_upgrade: Marks tests which should be executed after upgrade
     cnv_upgrade: Mark cnv upgrade test
     ocp_upgrade: Mark ocp upgrade test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2082,12 +2082,6 @@ def generated_ssh_key_for_vm_access(ssh_key_tmpdir_scope_session):
 
 
 @pytest.fixture(scope="session")
-def skip_on_ocp_upgrade(pytestconfig):
-    if pytestconfig.option.upgrade == "ocp":
-        pytest.skip("This test is not supported for OCP upgrade")
-
-
-@pytest.fixture(scope="session")
 def rhel9_http_image_url():
     return get_http_image_url(image_directory=Images.Rhel.DIR, image_name=Images.Rhel.RHEL9_4_IMG)
 

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -316,17 +316,6 @@ def fired_alerts_during_upgrade(fired_alerts_before_upgrade, alert_dir, promethe
 
 
 @pytest.fixture(scope="session")
-def is_eus_upgrade(pytestconfig):
-    return pytestconfig.option.upgrade == EUS
-
-
-@pytest.fixture(scope="session")
-def skip_on_eus_upgrade(is_eus_upgrade):
-    if is_eus_upgrade:
-        pytest.skip("This test is not supported for EUS upgrade")
-
-
-@pytest.fixture(scope="session")
 def eus_cnv_upgrade_path(eus_target_cnv_version):
     # Get the shortest path to the target (EUS) version
     upgrade_path_to_target_version = get_shortest_upgrade_path(target_version=eus_target_cnv_version)

--- a/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
@@ -9,7 +9,9 @@ from utilities.infra import get_related_images_name_and_version
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.product_upgrade_test
 @pytest.mark.upgrade
+@pytest.mark.upgrade_custom
 @pytest.mark.eus_upgrade
 class TestEUSToEUSUpgrade:
     @pytest.mark.polarion("CNV-9509")

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.usefixtures(
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.product_upgrade_test
 @pytest.mark.sno
 @pytest.mark.upgrade
 @pytest.mark.upgrade_custom

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
@@ -17,10 +17,15 @@ from utilities.data_collector import collect_alerts_data
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.upgrade_custom,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.sno,
+]
 
-@pytest.mark.upgrade_custom
-@pytest.mark.sno
-@pytest.mark.upgrade
+
 class TestUpgradeIUO:
     """Post-upgrade tests"""
 
@@ -32,7 +37,6 @@ class TestUpgradeIUO:
     )
     def test_alerts_fired_during_upgrade(
         self,
-        skip_on_eus_upgrade,
         prometheus_scope_function,
         fired_alerts_during_upgrade,
     ):
@@ -45,6 +49,7 @@ class TestUpgradeIUO:
             collect_alerts_data()
             raise AssertionError(f"Following alerts were fired during upgrade: {fired_alerts_during_upgrade}")
 
+    @pytest.mark.eus_upgrade
     @pytest.mark.polarion("CNV-6866")
     @pytest.mark.order(before=IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID, after=IUO_CNV_ALERT_ORDERING_NODE_ID)
     @pytest.mark.dependency(
@@ -55,6 +60,7 @@ class TestUpgradeIUO:
         LOGGER.info("Verify nodes taints after upgrade.")
         verify_nodes_taints_after_upgrade(nodes=nodes, nodes_taints_before_upgrade=nodes_taints_before_upgrade)
 
+    @pytest.mark.eus_upgrade
     @pytest.mark.polarion("CNV-6924")
     @pytest.mark.order(before=IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID, after=IUO_CNV_ALERT_ORDERING_NODE_ID)
     @pytest.mark.dependency(

--- a/tests/network/upgrade/test_upgrade_network.py
+++ b/tests/network/upgrade/test_upgrade_network.py
@@ -29,8 +29,14 @@ from utilities.network import (
 LOGGER = logging.getLogger(__name__)
 DEPENDENCIES_NODE_ID_PREFIX = f"{os.path.abspath(__file__)}::TestUpgradeNetwork"
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+]
 
-@pytest.mark.upgrade
+
 @pytest.mark.usefixtures("running_vm_with_bridge")
 class TestUpgradeNetwork:
     """Pre-upgrade tests"""

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -23,9 +23,15 @@ from utilities.virt import migrate_vm_and_verify
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+]
+
 
 @pytest.mark.usefixtures("updated_default_storage_class_ocs_virt")
-@pytest.mark.upgrade
 class TestUpgradeStorage:
     """Pre-upgrade tests"""
 

--- a/tests/upgrade_params.py
+++ b/tests/upgrade_params.py
@@ -10,7 +10,7 @@ if py_config["upgraded_product"] == EUS:
 else:
     upgrade_class = "TestUpgrade"
     upgrade_source_suffix = "_production_source" if py_config["cnv_source"] == "production" else ""
-    test_name = f"test_{py_config['upgraded_product']}{upgrade_source_suffix}_upgrade_process"
+    test_name = f"test{upgrade_source_suffix}_{py_config['upgraded_product']}_upgrade_process"
     file_name = f"{UPGRADE_PACKAGE_NAME}/test_upgrade.py"
 
 IUO_UPGRADE_TEST_ORDERING_NODE_ID = IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID = f"{file_name}::{upgrade_class}::{test_name}"

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -43,12 +43,18 @@ AFTER_UPGRADE_STORAGE_ORDERING = [
     SNAPSHOT_RESTORE_CHECK_AFTER_UPGRADE_ID,
 ]
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+]
 
-@pytest.mark.upgrade
+
 @pytest.mark.usefixtures("base_templates")
 class TestUpgradeVirt:
     """Pre-upgrade tests"""
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2974")
     @pytest.mark.order("first")
@@ -57,6 +63,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             assert vm.vmi.status == VirtualMachineInstance.Status.RUNNING
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2987")
     @pytest.mark.order(before=MIGRATION_BEFORE_UPGRADE_TEST_ORDERING)
@@ -69,6 +76,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             vm_console_run_commands(vm=vm, commands=["ls"])
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4208")
     @pytest.mark.order(before=MIGRATION_BEFORE_UPGRADE_TEST_ORDERING)
@@ -80,6 +88,7 @@ class TestUpgradeVirt:
     def test_vm_ssh_before_upgrade(self, vms_for_upgrade):
         verify_vms_ssh_connectivity(vms_list=vms_for_upgrade)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.polarion("CNV-2975")
     @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
     @pytest.mark.dependency(
@@ -93,6 +102,7 @@ class TestUpgradeVirt:
                 continue
             migrate_vm_and_verify(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6999")
     @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID, after=MIGRATION_BEFORE_UPGRADE_TEST_NODE_ID)
@@ -106,6 +116,7 @@ class TestUpgradeVirt:
     ):
         verify_vms_ssh_connectivity(vms_list=[manual_run_strategy_vm, always_run_strategy_vm])
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.high_resource_vm
     @pytest.mark.polarion("CNV-7243")
@@ -130,7 +141,6 @@ class TestUpgradeVirt:
     )
     def test_vmi_pod_image_updates_after_upgrade_optin(
         self,
-        skip_on_ocp_upgrade,
         unupdated_vmi_pods_names,
     ):
         """
@@ -138,6 +148,7 @@ class TestUpgradeVirt:
         """
         assert not unupdated_vmi_pods_names, f"The following VMI Pods were not updated: {unupdated_vmi_pods_names}"
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2978")
     @pytest.mark.order(after=[IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID], before=AFTER_UPGRADE_STORAGE_ORDERING)
@@ -153,6 +164,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             vm.vmi.wait_until_running()
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2980")
     @pytest.mark.order(after=[IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID], before=AFTER_UPGRADE_STORAGE_ORDERING)
@@ -168,6 +180,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             vm_console_run_commands(vm=vm, commands=["ls"])
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4209")
     @pytest.mark.order(after=[IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID], before=AFTER_UPGRADE_STORAGE_ORDERING)
@@ -182,6 +195,7 @@ class TestUpgradeVirt:
     def test_vm_ssh_after_upgrade(self, vms_for_upgrade):
         verify_vms_ssh_connectivity(vms_list=vms_for_upgrade)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-7000")
     @pytest.mark.order(
@@ -201,6 +215,7 @@ class TestUpgradeVirt:
         )
         verify_vms_ssh_connectivity(vms_list=run_strategy_vmi_list)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-7244")
     @pytest.mark.order(
@@ -223,6 +238,7 @@ class TestUpgradeVirt:
     ):
         verify_vms_ssh_connectivity(vms_list=[windows_vm])
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.polarion("CNV-2979")
     @pytest.mark.order(
         after=[
@@ -246,6 +262,7 @@ class TestUpgradeVirt:
             migrate_vm_and_verify(vm=vm)
             vm_console_run_commands(vm=vm, commands=["ls"], timeout=1100)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-3682")
     @pytest.mark.order(
@@ -267,6 +284,7 @@ class TestUpgradeVirt:
                 == vms_for_upgrade_dict_before[vm.name]["spec"]["template"]["spec"]["domain"]["machine"]["type"]
             )
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5749")
     @pytest.mark.order(

--- a/tests/virt/upgrade_custom/aaq/test_upgrade_virt_aaq.py
+++ b/tests/virt/upgrade_custom/aaq/test_upgrade_virt_aaq.py
@@ -14,13 +14,17 @@ from utilities.constants import DEPENDENCY_SCOPE_SESSION
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.usefixtures(
-    "enabled_aaq_feature_gate_scope_session",
-)
+pytestmark = [
+    pytest.mark.upgrade_custom,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.usefixtures(
+        "enabled_aaq_feature_gate_scope_session",
+    ),
+]
 
 
 @pytest.mark.sno
-@pytest.mark.upgrade_custom
 class TestUpgradeVirtAAQ:
     """Pre-upgrade tests"""
 


### PR DESCRIPTION
##### Short description:
Use explicit upgrade marker to detect test related to an upgrade lane(ocp/cnv/eus).

##### More details:
  If performing OCP upgrade, keep only the tests with pytest.mark.ocp_upgrade.
  If performing EUS upgrade, keep only the tests with pytest.mark.eus_upgrade.
  If performing CNV upgrade, keep only the tests with pytest.mark.cnv_upgrade.
  In addition,for cnv upgrade, determine if we are running the cnv upgrade test for production source or for stage/osbs.

##### What this PR does / why we need it:
It will allow to choose specific tests per upgrade type, which is more flexible when adding/removing upgrade tests,
and know excatly which should be running.
In addition, we can get rid of the programmatic skips. 

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-57035