### PR TITLE
Refactor network_sanity fixture comment for generalization

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -202,7 +202,9 @@ def ovn_kubernetes_cluster(admin_client):
 @pytest.fixture(scope="session", autouse=True)
 def network_sanity(hosts_common_available_ports, junitxml_plugin, request):
     """
-    Perform verification that the cluster is a multi-nic one otherwise exit run
+    Ensures the test cluster meets network requirements before executing tests.
+    A failure in these checks results in pytest exiting with a predefined
+    return code and a message recorded in JUnit XML.
     """
     failure_msgs = []
 


### PR DESCRIPTION
##### Short description:
Refactor network_sanity fixture comment for generalization
##### More details:
Updated the network_sanity fixture docstring to be more generic. Removed specific details about multi-NIC verification to prepare for future expansions where additional network checks will be added.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
This PR is a follow up for:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/408#pullrequestreview-2669521318
##### jira-ticket:

