### PR TITLE
 Fix persistent network interface naming issue in Fedora 41

### DIFF
--- a/containers/fedora/user-data
+++ b/containers/fedora/user-data
@@ -31,4 +31,5 @@ runcmd:
   - sudo sed -i 's/listen       80;/listen       80;\n\tlisten       81;/g' /etc/nginx/nginx.conf
   - sudo systemctl enable nginx
   - sudo systemctl enable sshd
+  - grubby --args="net.ifnames=0" --update-kernel=ALL
   - sudo shutdown


### PR DESCRIPTION
##### Short description:
Fix persistent network interface naming issue in Fedora 41
##### More details:
Fix persistent network interface naming issue in Fedora 41
    
    Added virt-customize to apply net.ifnames=0 kernel argument
    to Fedora 41 image to resolve network interface persistent naming
    issues.

##### What this PR does / why we need it:
Ref for the change introduced in Fedora41 that caused the issue this PR aim to solve:
https://docs.fedoraproject.org/en-US/fedora/latest/release-notes/sysadmin/?utm_source=chatgpt.com#consistent-device-naming-in-fedora-cloud

Some tests use cloud-init with networkData defining interfaces as eth0, eth1, etc. (ethX syntax). However, Fedora 41 enforces consistent network device naming (e.g., enp1s0), causing a mismatch with our current cloud-init implementation.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Currently more than 50% ot network tests failing because of this issue.
##### jira-ticket:

