### PR TITLE
Add vmi_pod check for kubevirt_vmi_info

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -672,6 +672,7 @@ def single_metric_vmi_guest_os_kernel_release_info(single_metric_vm):
         ].strip(),
         "namespace": single_metric_vm.namespace,
         NODE_STR: single_metric_vm.vmi.virt_launcher_pod.node.name,
+        "vmi_pod": single_metric_vm.vmi.virt_launcher_pod.name,
     }
 
 


### PR DESCRIPTION
##### Short description:
Adding new vmi_pod label to check to the
test for kubevirt_vmi_info metric.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
