### PR TITLE
Add service_mesh marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -34,6 +34,7 @@ markers =
     numa: tests that require numa configured on nodes
     sriov: tests that require sriov net-cards on nodes
     hugepages: tests that require nodes with hugepages
+    service_mesh: tests that require the service mesh operator to be installed
     # CI
     smoke: Mark tests as smoke tests
     ci: Mark tests as CI tests

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -6,7 +6,7 @@ from tests.network.service_mesh.utils import (
 )
 from tests.network.utils import assert_authentication_request
 
-pytestmark = pytest.mark.special_infra
+pytestmark = pytest.mark.service_mesh
 
 
 class TestSMTrafficManagement:


### PR DESCRIPTION
##### Short description:
Add service_mesh marker
##### More details:
Add service_mesh marker
    
    Added the `service_mesh` marker to the `pytest.ini` file for tests
    requiring the service mesh operator.
    Replaced the incorrect `special_infra` marker with
    `service_mesh` in the relevant test file. The `special_infra` marker
    was replaced because the service mesh operator does not require any
    special infrastructure or node-level configurations, making it
    inaccurate for tests related to the service mesh.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
