### PR TITLE
Add jumbo_frame marker and mark related tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -35,6 +35,7 @@ markers =
     sriov: tests that require sriov net-cards on nodes
     hugepages: tests that require nodes with hugepages
     service_mesh: tests that require the service mesh operator to be installed
+    jumbo_frame: tests that require network configurations supporting jumbo frames
     # CI
     smoke: Mark tests as smoke tests
     ci: Mark tests as CI tests

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -27,6 +27,8 @@ pytestmark = [
         "hyperconverged_ovs_annotations_enabled_scope_session",
         "workers_type",
     ),
+    pytest.mark.special_infra,
+    pytest.mark.jumbo_frame,
 ]
 
 

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -21,6 +21,8 @@ pytestmark = [
     pytest.mark.usefixtures(
         "hyperconverged_ovs_annotations_enabled_scope_session",
     ),
+    pytest.mark.special_infra,
+    pytest.mark.jumbo_frame,
 ]
 
 

--- a/tests/network/jumbo_frame/test_pod_network_ovn.py
+++ b/tests/network/jumbo_frame/test_pod_network_ovn.py
@@ -8,6 +8,11 @@ import pytest
 from tests.network.utils import assert_no_ping, get_destination_ip_address
 from utilities.network import assert_ping_successful
 
+pytestmark = [
+    pytest.mark.special_infra,
+    pytest.mark.jumbo_frame,
+]
+
 
 class TestJumboPodNetworkOnly:
     @pytest.mark.ipv4


### PR DESCRIPTION
##### Short description:
Add jumbo_frame marker and mark related tests
##### More details:
Add jumbo_frame marker and mark related tests
    
    Added a new jumbo_frame pytest marker to categorize tests
    requiring network configurations that support jumbo frames.
    
    Marked existing jumbo frame related tests with the jumbo_frame
    marker for better classification. Also, marked the jumbo frame
    tests with the special_infra marker as they require infrastructure
    network NICs to support jumbo frames.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
