### PR TITLE
Remove migration_policy_with_bandwidth

### DIFF
--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -283,7 +283,6 @@ class TestKubevirtVmiMigrationStartAndEnd:
     def test_metric_kubevirt_vmi_migration_start_time_seconds(
         self,
         prometheus,
-        migration_policy_with_bandwidth_scope_class,
         vm_for_migration_metrics_test,
         vm_migration_metrics_vmim_scope_class,
     ):
@@ -301,7 +300,6 @@ class TestKubevirtVmiMigrationStartAndEnd:
     def test_metric_kubevirt_vmi_migration_end_time_seconds(
         self,
         prometheus,
-        migration_policy_with_bandwidth_scope_class,
         vm_for_migration_metrics_test,
         vm_migration_metrics_vmim_scope_class,
         migration_succeeded_scope_class,


### PR DESCRIPTION


##### Short description:
Remove migration_policy_with_bandwidth_scope_class fixture from TestKubevirtVmiMigrationMetrics test class.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-58124
