### PR TITLE
 Add storage capabilities to the storage class matrix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -635,7 +635,6 @@ def pytest_sessionstart(session):
         log_level=session.config.getoption("log_cli_level") or logging.INFO,
     )
 
-    ######### py_config_scs = py_config.get("storage_class_matrix", [])
     # Save the default storage_class_matrix before it is updated
     # with runtime storage_class_matrix value(s)
     py_config["system_storage_class_matrix"] = py_config.get("storage_class_matrix", [])

--- a/conftest.py
+++ b/conftest.py
@@ -51,7 +51,6 @@ from utilities.pytest_utils import (
     separator,
     skip_if_pytest_flags_exists,
     stop_if_run_in_progress,
-    update_storage_class_matrix_config,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -635,15 +634,15 @@ def pytest_sessionstart(session):
         log_file=tests_log_file,
         log_level=session.config.getoption("log_cli_level") or logging.INFO,
     )
-    # Add HPP-CSI-BASIC/HPP-CSI-PVC-BLOCK to global config's storage_class_matrix, only
-    # if command line option --storage-class-matrix includes them:
-    py_config_scs = update_storage_class_matrix_config(
-        session=session, pytest_config_matrix=py_config.get("storage_class_matrix", [])
-    )
-
-    # Save the default storage_class_matrix before it is updated
-    # with runtime storage_class_matrix value(s)
-    py_config["system_storage_class_matrix"] = py_config_scs
+    # # Add HPP-CSI-BASIC/HPP-CSI-PVC-BLOCK to global config's storage_class_matrix, only
+    # # if command line option --storage-class-matrix includes them:
+    # py_config_scs = update_storage_class_matrix_config(
+    #     session=session, pytest_config_matrix=py_config.get("storage_class_matrix", [])
+    # )
+    #
+    # # Save the default storage_class_matrix before it is updated
+    # # with runtime storage_class_matrix value(s)
+    # py_config["system_storage_class_matrix"] = py_config_scs
 
     _update_os_related_config()
 

--- a/conftest.py
+++ b/conftest.py
@@ -635,6 +635,11 @@ def pytest_sessionstart(session):
         log_level=session.config.getoption("log_cli_level") or logging.INFO,
     )
 
+    ######### py_config_scs = py_config.get("storage_class_matrix", [])
+    # Save the default storage_class_matrix before it is updated
+    # with runtime storage_class_matrix value(s)
+    py_config["system_storage_class_matrix"] = py_config.get("storage_class_matrix", [])
+
     _update_os_related_config()
 
     matrix_addoptions = [matrix for matrix in session.config.invocation_params.args if "-matrix=" in matrix]

--- a/conftest.py
+++ b/conftest.py
@@ -634,15 +634,6 @@ def pytest_sessionstart(session):
         log_file=tests_log_file,
         log_level=session.config.getoption("log_cli_level") or logging.INFO,
     )
-    # # Add HPP-CSI-BASIC/HPP-CSI-PVC-BLOCK to global config's storage_class_matrix, only
-    # # if command line option --storage-class-matrix includes them:
-    # py_config_scs = update_storage_class_matrix_config(
-    #     session=session, pytest_config_matrix=py_config.get("storage_class_matrix", [])
-    # )
-    #
-    # # Save the default storage_class_matrix before it is updated
-    # # with runtime storage_class_matrix value(s)
-    # py_config["system_storage_class_matrix"] = py_config_scs
 
     _update_os_related_config()
 

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -128,8 +128,6 @@ cnv_vm_resource_requests_units_matrix = [
 
 bridge_device_matrix = [LINUX_BRIDGE, OVS_BRIDGE]
 
-# storage_class_matrix can be overwritten to include hostpath-csi-pvc-block and hostpath-csi-basic along with ocs,
-# via command line argument. Example usage can be found in README.md.
 storage_class_matrix = [
     {
         StorageClassNames.CEPH_RBD_VIRTUALIZATION: {

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -23,6 +23,7 @@ from utilities.constants import (
     DATA_SOURCE_NAME,
     FLAVOR_STR,
     HCO_CATALOG_SOURCE,
+    HPP_CAPABILITIES,
     INSTANCE_TYPE_STR,
     IPV4_STR,
     IPV6_STR,
@@ -47,6 +48,7 @@ from utilities.constants import (
     StorageClassNames,
 )
 from utilities.infra import get_latest_os_dict_list
+from utilities.storage import HppCsiStorageClass
 
 global config
 
@@ -133,9 +135,14 @@ storage_class_matrix = [
         StorageClassNames.CEPH_RBD_VIRTUALIZATION: {
             "volume_mode": DataVolume.VolumeMode.BLOCK,
             "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
             "default": True,
         }
     },
+    {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES},
+    {HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_CAPABILITIES},
 ]
 
 default_storage_class, default_storage_class_configuration = _get_default_storage_class(sc_list=storage_class_matrix)

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -145,16 +145,6 @@ storage_class_matrix = [
     {HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_CAPABILITIES},
 ]
 
-storage_class_matrix_snapshot_matrix = []
-for storage_class in storage_class_matrix:
-    storage_class_name = [*storage_class][0]
-    # import ipdb
-    # ipdb.set_trace()
-    if storage_class[storage_class_name]["snapshot"] is True:
-        storage_class_matrix_snapshot_matrix.append(storage_class)
-# import ipdb
-# ipdb.set_trace()
-
 default_storage_class, default_storage_class_configuration = _get_default_storage_class(sc_list=storage_class_matrix)
 default_volume_mode = default_storage_class_configuration["volume_mode"]
 default_access_mode = default_storage_class_configuration["access_mode"]

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -145,6 +145,16 @@ storage_class_matrix = [
     {HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_CAPABILITIES},
 ]
 
+storage_class_matrix_snapshot_matrix = []
+for storage_class in storage_class_matrix:
+    storage_class_name = [*storage_class][0]
+    # import ipdb
+    # ipdb.set_trace()
+    if storage_class[storage_class_name]["snapshot"] is True:
+        storage_class_matrix_snapshot_matrix.append(storage_class)
+# import ipdb
+# ipdb.set_trace()
+
 default_storage_class, default_storage_class_configuration = _get_default_storage_class(sc_list=storage_class_matrix)
 default_volume_mode = default_storage_class_configuration["volume_mode"]
 default_access_mode = default_storage_class_configuration["access_mode"]

--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -15,12 +15,18 @@ storage_class_matrix = [
         StorageClassNames.PORTWORX_CSI_DB_SHARED: {
             "volume_mode": DataVolume.VolumeMode.FILE,
             "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
         }
     },
     {
         StorageClassNames.TRIDENT_CSI_FSX: {
             "volume_mode": DataVolume.VolumeMode.FILE,
             "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
             "default": True,
         }
     },
@@ -28,6 +34,9 @@ storage_class_matrix = [
         StorageClassNames.IO2_CSI: {
             "volume_mode": DataVolume.VolumeMode.BLOCK,
             "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
         }
     },
 ]

--- a/tests/global_config_ibm_spectrum_sc.py
+++ b/tests/global_config_ibm_spectrum_sc.py
@@ -12,6 +12,9 @@ storage_class_matrix = [
         StorageClassNames.IBM_SPECTRUM_SCALE: {
             "volume_mode": DataVolume.VolumeMode.FILE,
             "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
             "default": True,
         }
     },

--- a/tests/global_config_interop_sno.py
+++ b/tests/global_config_interop_sno.py
@@ -11,6 +11,9 @@ storage_class_matrix = [
         "sno-storage": {
             "volume_mode": DataVolume.VolumeMode.FILE,
             "access_mode": DataVolume.AccessMode.RWO,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": True,
         }
     },
 ]

--- a/tests/global_config_lvms.py
+++ b/tests/global_config_lvms.py
@@ -28,6 +28,9 @@ storage_class_matrix = [
         StorageClassNames.TOPOLVM: {
             VOLUME_MODE: DataVolume.VolumeMode.BLOCK,
             ACCESS_MODE: RWO,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": True,
             "default": True,
         }
     },

--- a/tests/global_config_nfs.py
+++ b/tests/global_config_nfs.py
@@ -13,6 +13,9 @@ storage_class_matrix = [
         StorageClassNames.NFS: {
             "volume_mode": DataVolume.VolumeMode.FILE,
             "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": False,
+            "online_resize": False,
+            "wffc": False,
             "default": True,
         }
     },

--- a/tests/global_config_rh_it.py
+++ b/tests/global_config_rh_it.py
@@ -15,6 +15,9 @@ storage_class_matrix = [
         StorageClassNames.RH_INTERNAL_NFS: {
             "volume_mode": DataVolume.VolumeMode.FILE,
             "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
             "default": True,
         }
     },

--- a/tests/global_config_sno.py
+++ b/tests/global_config_sno.py
@@ -28,6 +28,9 @@ storage_class_matrix = [
         StorageClassNames.TOPOLVM: {
             VOLUME_MODE: DataVolume.VolumeMode.BLOCK,
             ACCESS_MODE: RWO,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": True,
             "default": True,
         }
     },

--- a/tests/global_config_sno_hpp.py
+++ b/tests/global_config_sno_hpp.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest_testconfig
 
-from utilities.constants import ALL_CNV_DAEMONSETS, ALL_CNV_DEPLOYMENTS, ALL_CNV_PODS, HPP_VOLUME_MODE_ACCESS_MODE
+from utilities.constants import ALL_CNV_DAEMONSETS, ALL_CNV_DEPLOYMENTS, ALL_CNV_PODS, HPP_CAPABILITIES
 from utilities.storage import HppCsiStorageClass
 
 global config
@@ -15,8 +15,8 @@ cnv_daemonset_matrix = ALL_CNV_DAEMONSETS
 
 
 storage_class_matrix = [
-    {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_VOLUME_MODE_ACCESS_MODE},
-    {HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_VOLUME_MODE_ACCESS_MODE},
+    {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES},
+    {HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_CAPABILITIES},
 ]
 
 

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -242,14 +242,14 @@ def test_disk_image_after_clone(
             },
             marks=(pytest.mark.polarion("CNV-3545"), pytest.mark.gating()),
         ),
-        # pytest.param(
-        #     {
-        #         "dv_name": "dv-source-win",
-        #         "image": f"{Images.Windows.DIR}/{Images.Windows.WIN11_IMG}",
-        #         "dv_size": Images.Windows.DEFAULT_DV_SIZE,
-        #     },
-        #     marks=(pytest.mark.polarion("CNV-3552"), pytest.mark.tier3()),
-        # ),
+        pytest.param(
+            {
+                "dv_name": "dv-source-win",
+                "image": f"{Images.Windows.DIR}/{Images.Windows.WIN11_IMG}",
+                "dv_size": Images.Windows.DEFAULT_DV_SIZE,
+            },
+            marks=(pytest.mark.polarion("CNV-3552"), pytest.mark.tier3()),
+        ),
     ],
     indirect=True,
 )
@@ -268,9 +268,9 @@ def test_successful_snapshot_clone(
         storage_class=storage_class,
     ) as cdv:
         cdv.wait_for_dv_success()
-        # if OS_FLAVOR_WINDOWS not in data_volume_snapshot_capable_storage_scope_function.url.split("/")[-1]:
-        #     with create_vm_from_dv(dv=cdv) as vm_dv:
-        #         check_disk_count_in_vm(vm=vm_dv)
+        if OS_FLAVOR_WINDOWS not in data_volume_snapshot_capable_storage_scope_function.url.split("/")[-1]:
+            with create_vm_from_dv(dv=cdv) as vm_dv:
+                check_disk_count_in_vm(vm=vm_dv)
         pvc = cdv.pvc
         assert_use_populator(
             pvc=pvc,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -242,14 +242,14 @@ def test_disk_image_after_clone(
             },
             marks=(pytest.mark.polarion("CNV-3545"), pytest.mark.gating()),
         ),
-        pytest.param(
-            {
-                "dv_name": "dv-source-win",
-                "image": f"{Images.Windows.DIR}/{Images.Windows.WIN11_IMG}",
-                "dv_size": Images.Windows.DEFAULT_DV_SIZE,
-            },
-            marks=(pytest.mark.polarion("CNV-3552"), pytest.mark.tier3()),
-        ),
+        # pytest.param(
+        #     {
+        #         "dv_name": "dv-source-win",
+        #         "image": f"{Images.Windows.DIR}/{Images.Windows.WIN11_IMG}",
+        #         "dv_size": Images.Windows.DEFAULT_DV_SIZE,
+        #     },
+        #     marks=(pytest.mark.polarion("CNV-3552"), pytest.mark.tier3()),
+        # ),
     ],
     indirect=True,
 )
@@ -268,9 +268,9 @@ def test_successful_snapshot_clone(
         storage_class=storage_class,
     ) as cdv:
         cdv.wait_for_dv_success()
-        if OS_FLAVOR_WINDOWS not in data_volume_snapshot_capable_storage_scope_function.url.split("/")[-1]:
-            with create_vm_from_dv(dv=cdv) as vm_dv:
-                check_disk_count_in_vm(vm=vm_dv)
+        # if OS_FLAVOR_WINDOWS not in data_volume_snapshot_capable_storage_scope_function.url.split("/")[-1]:
+        #     with create_vm_from_dv(dv=cdv) as vm_dv:
+        #         check_disk_count_in_vm(vm=vm_dv)
         pvc = cdv.pvc
         assert_use_populator(
             pvc=pvc,

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -791,9 +791,11 @@ PUBLIC_DNS_SERVER_IP = "8.8.8.8"
 BIND_IMMEDIATE_ANNOTATION = {f"{Resource.ApiGroup.CDI_KUBEVIRT_IO}/storage.bind.immediate.requested": "true"}
 
 HCO_DEFAULT_CPU_MODEL_KEY = "defaultCPUModel"
-FILESYSTEM = DataVolume.VolumeMode.FILE
-RWO = DataVolume.AccessMode.RWO
-HPP_VOLUME_MODE_ACCESS_MODE = {
-    VOLUME_MODE: FILESYSTEM,
-    ACCESS_MODE: RWO,
+
+HPP_CAPABILITIES = {
+    VOLUME_MODE: DataVolume.VolumeMode.FILE,
+    ACCESS_MODE: DataVolume.AccessMode.RWO,
+    "snapshot": False,
+    "online_resize": False,
+    "wffc": True,
 }

--- a/utilities/pytest_matrix_utils.py
+++ b/utilities/pytest_matrix_utils.py
@@ -5,19 +5,14 @@ def foo_matrix(matrix):
     return matrix
 """
 
-from ocp_resources.resource import get_client
 from ocp_resources.storage_class import StorageClass
-
-from utilities.storage import is_snapshot_supported_by_sc, sc_volume_binding_mode_is_wffc
 
 
 def snapshot_matrix(matrix):
     matrix_to_return = []
     for storage_class in matrix:
-        if is_snapshot_supported_by_sc(
-            sc_name=[*storage_class][0],
-            client=get_client(),
-        ):
+        storage_class_name = [*storage_class][0]
+        if storage_class[storage_class_name]["snapshot"] is True:
             matrix_to_return.append(storage_class)
     return matrix_to_return
 
@@ -25,10 +20,8 @@ def snapshot_matrix(matrix):
 def without_snapshot_capability_matrix(matrix):
     matrix_to_return = []
     for storage_class in matrix:
-        if not is_snapshot_supported_by_sc(
-            sc_name=[*storage_class][0],
-            client=get_client(),
-        ):
+        storage_class_name = [*storage_class][0]
+        if storage_class[storage_class_name]["snapshot"] is False:
             matrix_to_return.append(storage_class)
     return matrix_to_return
 
@@ -36,8 +29,9 @@ def without_snapshot_capability_matrix(matrix):
 def online_resize_matrix(matrix):
     matrix_to_return = []
     for storage_class in matrix:
-        storage_class_object = StorageClass(name=[*storage_class][0])
-        if storage_class_object.instance.get("allowVolumeExpansion"):
+        # storage_class object must have allowVolumeExpansion: true
+        storage_class_name = [*storage_class][0]
+        if storage_class[storage_class_name]["online_resize"] is True:
             matrix_to_return.append(storage_class)
     return matrix_to_return
 
@@ -58,6 +52,7 @@ def hpp_matrix(matrix):
 def wffc_matrix(matrix):
     matrix_to_return = []
     for storage_class in matrix:
-        if sc_volume_binding_mode_is_wffc(sc=[*storage_class][0]):
+        storage_class_name = [*storage_class][0]
+        if storage_class[storage_class_name]["wffc"] is True:
             matrix_to_return.append(storage_class)
     return matrix_to_return

--- a/utilities/pytest_matrix_utils.py
+++ b/utilities/pytest_matrix_utils.py
@@ -8,13 +8,13 @@ def foo_matrix(matrix):
 from ocp_resources.storage_class import StorageClass
 
 
-# def snapshot_matrix(matrix):
-#     matrix_to_return = []
-#     for storage_class in matrix:
-#         storage_class_name = [*storage_class][0]
-#         if storage_class[storage_class_name]["snapshot"] is True:
-#             matrix_to_return.append(storage_class)
-#     return matrix_to_return
+def snapshot_matrix(matrix):
+    matrix_to_return = []
+    for storage_class in matrix:
+        storage_class_name = [*storage_class][0]
+        if storage_class[storage_class_name]["snapshot"] is True:
+            matrix_to_return.append(storage_class)
+    return matrix_to_return
 
 
 def without_snapshot_capability_matrix(matrix):

--- a/utilities/pytest_matrix_utils.py
+++ b/utilities/pytest_matrix_utils.py
@@ -8,13 +8,13 @@ def foo_matrix(matrix):
 from ocp_resources.storage_class import StorageClass
 
 
-def snapshot_matrix(matrix):
-    matrix_to_return = []
-    for storage_class in matrix:
-        storage_class_name = [*storage_class][0]
-        if storage_class[storage_class_name]["snapshot"] is True:
-            matrix_to_return.append(storage_class)
-    return matrix_to_return
+# def snapshot_matrix(matrix):
+#     matrix_to_return = []
+#     for storage_class in matrix:
+#         storage_class_name = [*storage_class][0]
+#         if storage_class[storage_class_name]["snapshot"] is True:
+#             matrix_to_return.append(storage_class)
+#     return matrix_to_return
 
 
 def without_snapshot_capability_matrix(matrix):

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -17,19 +17,11 @@ from utilities.constants import (
     CNV_TEST_RUN_IN_PROGRESS,
     CNV_TEST_RUN_IN_PROGRESS_NS,
     CNV_TESTS_CONTAINER,
-    HPP_CAPABILITIES,
     POD_SECURITY_NAMESPACE_LABELS,
     TIMEOUT_2MIN,
-    StorageClassNames,
 )
 from utilities.exceptions import MissingEnvironmentVariableError
 from utilities.infra import exit_pytest_execution
-from utilities.storage import HOSTPATH_CSI, HppCsiStorageClass
-
-HPP_STORAGE_CLASSES = {
-    HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES,
-    HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_CAPABILITIES,
-}
 
 LOGGER = logging.getLogger(__name__)
 
@@ -238,28 +230,3 @@ def get_cnv_version_explorer_url(pytest_config):
         if not version_explorer_url:
             raise MissingEnvironmentVariableError("Please set CNV_VERSION_EXPLORER_URL environment variable")
         return version_explorer_url
-
-
-def update_storage_class_matrix_config(session, pytest_config_matrix):
-    cmdline_storage_class = session.config.getoption(name="storage_class_matrix")
-    matrix_list = pytest_config_matrix
-    matrix_names = [[*sc][0] for sc in pytest_config_matrix]
-    invald_sc = []
-    if cmdline_storage_class:
-        cmdline_storage_class_matrix = cmdline_storage_class.split(",")
-        if HOSTPATH_CSI in cmdline_storage_class and StorageClassNames.TOPOLVM in cmdline_storage_class:
-            raise ValueError(
-                f"{HOSTPATH_CSI} storage classes can't be used with {StorageClassNames.TOPOLVM} "
-                f": {cmdline_storage_class}"
-            )
-        for sc in cmdline_storage_class_matrix:
-            if sc not in matrix_names:
-                if sc in HPP_STORAGE_CLASSES.keys():
-                    matrix_list.append({sc: HPP_STORAGE_CLASSES[sc]})
-                else:
-                    invald_sc.append(sc)
-    assert not invald_sc, (
-        f"Invalid sc requested via --storage-class-matix: {invald_sc}. Valid options: "
-        f"{matrix_names} and {[*HPP_STORAGE_CLASSES]}"
-    )
-    return matrix_list

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -17,7 +17,7 @@ from utilities.constants import (
     CNV_TEST_RUN_IN_PROGRESS,
     CNV_TEST_RUN_IN_PROGRESS_NS,
     CNV_TESTS_CONTAINER,
-    HPP_VOLUME_MODE_ACCESS_MODE,
+    HPP_CAPABILITIES,
     POD_SECURITY_NAMESPACE_LABELS,
     TIMEOUT_2MIN,
     StorageClassNames,
@@ -27,8 +27,8 @@ from utilities.infra import exit_pytest_execution
 from utilities.storage import HOSTPATH_CSI, HppCsiStorageClass
 
 HPP_STORAGE_CLASSES = {
-    HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_VOLUME_MODE_ACCESS_MODE,
-    HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_VOLUME_MODE_ACCESS_MODE,
+    HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES,
+    HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK: HPP_CAPABILITIES,
 }
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
##### Short description:
**Before this PR:** 
- Storage capability matix was built according to what is present in the cluster (i.e. VolumeSnapshotClass, or StorageClass's allowVolumeExpansion parameter)

**After this PR:**
- We explicitly list the storage capabilities and build the capability matrices according to the expected capability
- Making the `storage_class_matrix` values more explicit


##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
