### PR TITLE
Add tier3 marker to checkup framework tests

### DIFF
--- a/tests/network/checkup_framework/test_checkup_framework.py
+++ b/tests/network/checkup_framework/test_checkup_framework.py
@@ -10,7 +10,10 @@ from tests.network.checkup_framework.utils import (
     wait_for_job_finish,
 )
 
-pytestmark = pytest.mark.usefixtures("framework_resources")
+pytestmark = [
+    pytest.mark.usefixtures("framework_resources"),
+    pytest.mark.tier3,
+]
 
 CNCF_IO_RESOURCE = Resource.ApiGroup.K8S_CNI_CNCF_IO
 CONNECTIVITY_ISSUE_ERROR_REGEX_MESSAGE = "run: ping parser: no connectivity - 100% packet loss"


### PR DESCRIPTION
##### Short description:
Add tier3 marker to checkup framework tests
##### More details:
Add tier3 marker to checkup framework tests
    
    Added the tier3 marker to checkup framework tests in
    test_checkup_framework.py. This ensures proper test categorization
    and filtering when running test suites.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
