### PR TITLE
 Instance type and preference runtime data is now stored under status and is no longer in VM Spec

### DIFF
--- a/tests/infrastructure/instance_types/utils.py
+++ b/tests/infrastructure/instance_types/utils.py
@@ -1,4 +1,8 @@
+from typing import Literal
+
+from ocp_resources.controller_revision import ControllerRevision
 from ocp_resources.resource import Resource
+from ocp_resources.virtual_machine import VirtualMachine
 
 
 def get_mismatch_vendor_label(resources_list):
@@ -13,3 +17,29 @@ def get_mismatch_vendor_label(resources_list):
 def assert_mismatch_vendor_label(resources_list):
     failed_labels = get_mismatch_vendor_label(resources_list=resources_list)
     assert not failed_labels, f"The following resources have miss match vendor label: {failed_labels}"
+
+
+def get_controller_revision(
+    vm_instance: VirtualMachine, ref_type: Literal["instancetype", "preference"]
+) -> ControllerRevision:
+    ref_mapping = {
+        "instancetype": vm_instance.instance.status.instancetypeRef.controllerRevisionRef.name,
+        "preference": vm_instance.instance.status.preferenceRef.controllerRevisionRef.name,
+    }
+
+    return ControllerRevision(
+        name=ref_mapping[ref_type],
+        namespace=vm_instance.namespace,
+    )
+
+
+def assert_instance_revision_and_memory_update(
+    vm_for_test: VirtualMachine, old_revision_name: str, updated_memory: str
+) -> None:
+    guest_memory = vm_for_test.vmi.instance.spec.domain.memory.guest
+    assert vm_for_test.instance.status.instancetypeRef.controllerRevisionRef.name != old_revision_name, (
+        "The revisionName is still {old_revision_name}, not updated after editing"
+    )
+    assert guest_memory == updated_memory, (
+        "The Guest Memory in VMI is {guest_memory}, not updated to {updated_memory} after editing"
+    )


### PR DESCRIPTION
Instance type and preference runtime data is now stored under status and is no longer mutated into the VM Spec

- Move functions to utils and add hints
- Remove tests where we update RevisionName

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-46345
