### PR TITLE
Update default storage class setup for upgrade

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,10 +187,10 @@ from utilities.storage import (
     get_storage_class_with_specified_volume_mode,
     get_test_artifact_server_url,
     is_snapshot_supported_by_sc,
-    re_import_boot_sources,
     remove_default_storage_classes,
     sc_is_hpp_with_immediate_volume_binding,
     update_default_sc,
+    verify_boot_sources_reimported,
 )
 from utilities.virt import (
     VirtualMachineForCloning,
@@ -2665,22 +2665,22 @@ def updated_default_storage_class_ocs_virt(
         )
         == "false"
     ):
-        failed_update_boot_sources = False
+        boot_source_imported_successfully = False
         with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
             with update_default_sc(default=True, storage_class=ocs_storage_class):
-                failed_update_boot_sources = re_import_boot_sources(
+                boot_source_imported_successfully = verify_boot_sources_reimported(
                     admin_client=admin_client,
                     namespace=golden_images_namespace.name,
                 )
-                if not failed_update_boot_sources:
+                if boot_source_imported_successfully:
                     yield
 
-        # on teardown, delete the boot sources and wait for the original sources to re-create
-        re_import_boot_sources(
+        # on teardown, wait for the original sources to re-create
+        verify_boot_sources_reimported(
             admin_client=admin_client,
             namespace=golden_images_namespace.name,
         )
-        if failed_update_boot_sources:
+        if not boot_source_imported_successfully:
             exit_pytest_execution(message=f"Failed to set {ocs_storage_class.name} as default storage class")
     else:
         yield


### PR DESCRIPTION
##### Short description:
Currently, when we are switching to ocs-virt sc before an upgrade, we are deleting the bootsources as well.
For 4.18+, switching the sc should be enough.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-56878