### PR TITLE
WIP: [4.18] allow pending alert Networkaddonesconfignotready in upgrade

### DIFF
--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -25,7 +25,7 @@ from utilities.constants import (
     ICSP_FILE,
     IDMS_FILE,
     INFO_STR,
-    PENDING_STR,
+    PENDING_STATE,
     PRODUCTION_CATALOG_SOURCE,
     TIMEOUT_5MIN,
     TIMEOUT_10MIN,
@@ -246,7 +246,7 @@ def alert_dictionary_hco_not_installed():
             "severity": INFO_STR,
             "operator_health_impact": CRITICAL_STR,
         },
-        "state": PENDING_STR,
+        "state": PENDING_STATE,
     }
 
 

--- a/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
+++ b/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
@@ -15,7 +15,7 @@ from tests.install_upgrade_operators.product_install.utils import (
 )
 from utilities.constants import (
     KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS,
-    PENDING_STR,
+    PENDING_STATE,
     TIMEOUT_10MIN,
 )
 from utilities.exceptions import ResourceMismatch
@@ -47,7 +47,7 @@ def test_cnv_installation_without_hco_cr_alert(
     validate_alerts(
         prometheus=prometheus,
         alert_dict=alert_dictionary_hco_not_installed,
-        state=PENDING_STR,
+        state=PENDING_STATE,
         timeout=TIMEOUT_10MIN,
     )
 

--- a/tests/observability/virt/test_virt_metrics_alerts.py
+++ b/tests/observability/virt/test_virt_metrics_alerts.py
@@ -3,7 +3,7 @@ import pytest
 from tests.observability.constants import KUBEVIRT_STR_LOWER, KUBEVIRT_VIRT_OPERATOR_READY
 from tests.observability.utils import validate_metrics_value
 from utilities.constants import (
-    PENDING_STR,
+    PENDING_STATE,
     TIMEOUT_5MIN,
     TIMEOUT_10MIN,
     VIRT_API,
@@ -45,7 +45,7 @@ class TestLowReadyVirtOperatorCount:
                         "operator_health_impact": WARNING_STR,
                         "kubernetes_operator_component": KUBEVIRT_STR_LOWER,
                     },
-                    "state": PENDING_STR,
+                    "state": PENDING_STATE,
                     "check_alert_cleaned": True,
                 },
                 marks=(pytest.mark.polarion("CNV-11380")),
@@ -108,7 +108,7 @@ class TestVirtHandlerDaemonSet:
                         "operator_health_impact": WARNING_STR,
                         "kubernetes_operator_component": KUBEVIRT_STR_LOWER,
                     },
-                    "state": PENDING_STR,
+                    "state": PENDING_STATE,
                     "check_alert_cleaned": True,
                 },
                 marks=pytest.mark.polarion("CNV-3814"),

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -654,7 +654,7 @@ OPERATOR_HEALTH_IMPACT_VALUES = {
     NONE_STRING: "0",
 }
 FIRING_STATE = "firing"
-PENDING_STR = "pending"
+PENDING_STATE = "pending"
 KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS = "kubevirt_hco_hyperconverged_cr_exists"
 ES_LIVE_MIGRATE_IF_POSSIBLE = "LiveMigrateIfPossible"
 ES_NONE = "None"


### PR DESCRIPTION
##### Short description:
(Cherry pick)
We need to set up the upgrade automation, such as if this alert is in pending state and not firing, the alert test won't fail.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

