### PR TITLE
Add IPv4 support check to network sanity validation

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -208,6 +208,7 @@ def network_sanity(
     cluster_network_mtu,
     network_overhead,
     sriov_workers,
+    ipv4_supported_cluster,
 ):
     """
     Ensures the test cluster meets network requirements before executing tests.
@@ -281,11 +282,20 @@ def network_sanity(
                     f"has {len(sriov_workers)} SRIOV-capable worker nodes"
                 )
 
+    def _verify_ipv4():
+        if any(test.get_closest_marker("ipv4") for test in collected_tests):
+            LOGGER.info("Verifying if the cluster supports running IPV4 tests...")
+            if not ipv4_supported_cluster:
+                failure_msgs.append("IPv4 is not supported in this cluster")
+            else:
+                LOGGER.info("Validated network lane is running against an IPV4 supported cluster")
+
     _verify_multi_nic()
     _verify_dpdk()
     _verify_service_mesh()
     _verify_jumbo_frame()
     _verify_sriov()
+    _verify_ipv4()
 
     if failure_msgs:
         err_msg = "\n".join(failure_msgs)


### PR DESCRIPTION
##### Short description:
Add IPv4 support check to network sanity validation
##### More details:
Add IPv4 support check to network sanity validation
    
    Introduced a check to ensure the cluster supports
    IPv4 before running relevant tests.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
