### PR TITLE
[IUO] Skip non-served api versions

### DIFF
--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -373,6 +373,9 @@ class TestMustGatherCluster:
     def test_crd_resources(self, admin_client, must_gather_for_test, kubevirt_crd_by_type):
         crd_name = kubevirt_crd_by_type.name
         for version in kubevirt_crd_by_type.instance.spec.versions:
+            if not version.served:
+                LOGGER.warning(f"Skipping {version.name} for {crd_name} because it is not served")
+                continue
             resource_objs = admin_client.resources.get(
                 api_version=version.name,
                 kind=kubevirt_crd_by_type.instance.spec.names.kind,


### PR DESCRIPTION
##### Short description:
At test_crd_resources test, if we will try to get non-served api version, The test will fail.
We need to test only the served ones.

##### Which issue(s) this PR fixes:
Failures in 4.17 + 4.18 branches.

##### Special notes for reviewer:
Starting from main because we need to apply it going forward as well

##### jira-ticket:

