### PR TITLE
[IUO] add hco-bearer-auth secret to HCO resources

### DIFF
--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -1,4 +1,5 @@
 import pytest
+from deepdiff import DeepDiff
 
 from tests.install_upgrade_operators.strict_reconciliation.utils import (
     validate_related_objects,
@@ -11,9 +12,17 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
     def test_no_new_hco_related_objects(self, hco_status_related_objects):
-        assert len(hco_status_related_objects) == len(ALL_HCO_RELATED_OBJECTS), (
-            f"Expected related objects: {ALL_HCO_RELATED_OBJECTS}, actual: {hco_status_related_objects}"
-        )
+        actual_related_objects = {
+            related_object["name"]: related_object["kind"] for related_object in hco_status_related_objects
+        }
+        expected_related_objects = {
+            object_name: object_kind
+            for related_object in ALL_HCO_RELATED_OBJECTS
+            for object_name, object_kind in related_object.items()
+        }
+
+        new_related_objects = DeepDiff(t1=expected_related_objects, t2=actual_related_objects, verbose_level=2)
+        assert not new_related_objects, f"There are new HCO related objects:\n {new_related_objects.to_json(indent=2)}"
 
     @pytest.mark.polarion("CNV-7267")
     def test_hco_related_objects(

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -351,6 +351,7 @@ KUBEVIRT_USER_SETTINGS = "kubevirt-user-settings"
 KUBEVIRT_UI_FEATURES = "kubevirt-ui-features"
 KUBEVIRT_UI_CONFIG_READER = "kubevirt-ui-config-reader"
 KUBEVIRT_UI_CONFIG_READER_ROLE_BINDING = "kubevirt-ui-config-reader-rolebinding"
+HCO_BEARER_AUTH = "hco-bearer-auth"
 # components kind
 ROLEBINDING_STR = "RoleBinding"
 POD_STR = "Pod"
@@ -372,6 +373,7 @@ CONSOLE_PLUGIN_STR = "ConsolePlugin"
 KUBEVIRT_PLUGIN = "kubevirt-plugin"
 CDI_STR = "CDI"
 SSP_STR = "SSP"
+SECRET_STR = "Secret"
 KUBEVIRT_APISERVER_PROXY = "kubevirt-apiserver-proxy"
 AAQ_OPERATOR = "aaq-operator"
 WINDOWS_BOOTSOURCE_PIPELINE = "windows-bootsource-pipeline"
@@ -411,6 +413,7 @@ ALL_HCO_RELATED_OBJECTS = [
     {KUBEVIRT_UI_FEATURES: CONFIGMAP_STR},
     {KUBEVIRT_UI_CONFIG_READER: ROLE_STR},
     {KUBEVIRT_UI_CONFIG_READER_ROLE_BINDING: ROLEBINDING_STR},
+    {HCO_BEARER_AUTH: SECRET_STR},
 ]
 CNV_PODS_NO_HPP_CSI_HPP_POOL = [
     AAQ_OPERATOR,


### PR DESCRIPTION
##### Short description:
In 4.18+ versions, this hco-bearer-token secret is added to hco relatedobjects.
We need to add it to ALL_HCO_RELATED_OBJECTS list so our matrix test won't fail.

##### More details:
In addition, its really hard to understand from the log which related objects are added.
Changed the test to log only the new related objects.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

