### PR TITLE
[CherryPicked]: [cnv-4.18] Triaging kubevirt cnao kubemacpool manager up

### DIFF
--- a/tests/observability/network/conftest.py
+++ b/tests/observability/network/conftest.py
@@ -6,7 +6,6 @@ from ocp_resources.daemonset import DaemonSet
 from ocp_resources.network_addons_config import NetworkAddonsConfig
 from pytest_testconfig import config as py_config
 
-from tests.observability.utils import wait_for_kubemacpool_pods_error_state
 from utilities.constants import (
     CLUSTER_NETWORK_ADDONS_OPERATOR,
     KMP_VM_ASSIGNMENT_LABEL,
@@ -39,7 +38,6 @@ def updated_cnao_kubemacpool_with_bad_image_csv(
     updated_csv_dict_bad_kubemacpool_image,
 ):
     with ResourceEditorValidateHCOReconcile(patches={csv_scope_class: updated_csv_dict_bad_kubemacpool_image}):
-        wait_for_kubemacpool_pods_error_state(dyn_client=admin_client, hco_namespace=hco_namespace)
         yield
     wait_for_pods_running(admin_client=admin_client, namespace=hco_namespace)
 


### PR DESCRIPTION
##### Short description:
Triaging kubevirt_cnao_kubemacpool_manager_up
removed the util that waits for kubemacpool
for being in pending state because it makes the test flaky,
sometime these pods deleted because the image switching and
it fails the test on the setup because it doesn't find them.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-57412
