### PR TITLE
Replace deprecated netstat with ss

### DIFF
--- a/tests/network/utils.py
+++ b/tests/network/utils.py
@@ -249,13 +249,13 @@ def assert_ssh_alive(ssh_vm, src_ip):
         sleep=1,
         func=run_ssh_commands,
         host=ssh_vm.ssh_exec,
-        commands=[shlex.split("sudo netstat -tulpan | grep ssh")],
+        commands=[shlex.split("sudo ss -tupan | grep ssh")],
     )
     try:
         for sample in sampler:
             if sample:
                 for line in sample:
-                    if src_ip in line and "ESTABLISHED" in line:
+                    if src_ip in line and "ESTAB" in line:
                         LOGGER.info(f"SSH connection from {src_ip} to {ssh_vm.name} is alive")
                         return
     except TimeoutExpiredError:


### PR DESCRIPTION
##### Short description:
Replace deprecated netstat with ss
##### More details:
Replace deprecated netstat with ss
    
    netstat is deprecated, so this updates assert_ssh_alive
    to use ss instead. Functionality remains unchanged.
##### What this PR does / why we need it:
Currently 2 network tests are failing because of this issue:
test_ssh_vm_migration and test_ssh_alive_after_restart_nmstate_handler.
```
failed on setup with "timeout_sampler.TimeoutExpiredError: Timed Out: 30
Function: pyhelper_utils.shell.run_ssh_commands  Kwargs: {'host': <rrmngmnt.host.Host object at 0x7f92acfd11f0>, 'commands': [['sudo', 'netstat', '-tulpan', '|', 'grep', 'ssh']]}
Last exception: CommandExecFailed: Command: sudo netstat -tulpan | grep ssh - exec failed. Error: sudo: netstat: command not found
```
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Quote from netstat manual page:
```
This program is mostly obsolete.  Replacement for netstat is ss.
Replacement for netstat -r is ip route.  Replacement for netstat
-i is ip -s link.  Replacement for netstat -g is ip maddr.
```
Ref:
https://man7.org/linux/man-pages/man8/netstat.8.html?utm_source=chatgpt.com
##### jira-ticket:

