### PR TITLE
Split pod network connectivity test per IP family

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -50,6 +50,7 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11125")
     @pytest.mark.ipv6
+    @pytest.mark.jira("CNV-58529", run=True)
     def test_ipv6_linux_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,
@@ -144,6 +145,7 @@ class TestConnectivityOVSBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11128")
     @pytest.mark.ipv6
+    @pytest.mark.jira("CNV-58529", run=True)
     def test_ipv6_ovs_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,


### PR DESCRIPTION
Towards stabilizing network tier-2 tests, and specifically the gating ones, this PR
- splits the pod network connectivity test to IPv4 and IPv6 cases
- marks the IPv6 tests with the ticket that trackes this limitation.
