### PR TITLE
 Improve VM error assertion with detailed status output

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1579,12 +1579,15 @@ def get_rhel_os_dict(rhel_version):
 
 
 def assert_vm_not_error_status(vm: VirtualMachineForTests) -> None:
-    vm_status = vm.printable_status
+    status = vm.instance.get("status")
+    printable_status = status.get("printableStatus")
     error_list = VM_ERROR_STATUSES.copy()
     vm_devices = vm.instance.spec.template.spec.domain.devices
     if vm_devices.gpus:
         error_list.remove(VirtualMachine.Status.ERROR_UNSCHEDULABLE)
-    assert vm_status not in error_list, f"VM {vm.name} error status: {vm_status}"
+    assert printable_status not in error_list, (
+        f"VM {vm.name} error printable status: {printable_status}\nVM status:\n{status}"
+    )
 
 
 def wait_for_running_vm(


### PR DESCRIPTION
##### Short description:
Improve VM error assertion with detailed status output
##### More details:
Improve VM error assertion with detailed status output
    
    Enhanced assert_vm_not_error_status to include full VM status details
    in assertion errors. This provides better debugging information when a
    VM enters an unexpected error state.
##### What this PR does / why we need it:
We have flakiness in our tests which fail on this assertion, logging the full VM status will give us the actual reason why the VM failed.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

