### PR TITLE
Remove references to closed issue CNV-19348

### DIFF
--- a/utilities/network.py
+++ b/utilities/network.py
@@ -47,7 +47,6 @@ from utilities.constants import (
     WORKERS_TYPE,
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.infra import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 IFACE_UP_STATE = NodeNetworkConfigurationPolicy.Interface.State.UP
@@ -502,18 +501,7 @@ def get_vmi_ip_v4_by_name(vm, name):
         utilities.virt.wait_for_vm_interfaces(vmi=vmi)
         return _extract_interface_ips()
 
-    # TODO: Investigate why on BMs (bm02+03-cnvqe2-rdu2) it takes so long for the IP to be seen in the VMI.
-    # When Jira ticket CNV-19348 is closed: 1. Revert the wait_timout back to 2 minutes; 2. the check of the
-    # workers_type is redundant.
-    wait_timeout = (
-        TIMEOUT_8MIN
-        if (
-            (os.environ[WORKERS_TYPE] == utilities.infra.ClusterHosts.Type.PHYSICAL)
-            and is_jira_open(jira_id="CNV-19348")
-        )
-        else TIMEOUT_2MIN
-    )
-    sampler = TimeoutSampler(wait_timeout=wait_timeout, sleep=1, func=_get_interface_ips)
+    sampler = TimeoutSampler(wait_timeout=TIMEOUT_2MIN, sleep=1, func=_get_interface_ips)
     try:
         for ip_addresses in sampler:
             for ip_address in ip_addresses:


### PR DESCRIPTION
CNV-19348 seems like it no longer appears, and it's not required to wait that long for the interfaces to be visible - including on bare-metal.
