### PR TITLE
Allocate VM memory from memory_guest 

### DIFF
--- a/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
+++ b/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
@@ -64,7 +64,6 @@ def simple_rhel_vm(admin_client, namespace):
         name="rhel-vm-with-instance-type",
         namespace=namespace.name,
         image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
-        memory_requests=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
         yield vm
 

--- a/tests/infrastructure/instance_types/test_vm_override_pref.py
+++ b/tests/infrastructure/instance_types/test_vm_override_pref.py
@@ -12,7 +12,7 @@ def rhel_vm_with_preference(namespace, admin_client, vm_preference_for_test):
             name="rhel-vm-with-preference",
             namespace=namespace.name,
             image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
-            memory_requests=Images.Rhel.DEFAULT_MEMORY_SIZE,
+            memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
             vm_preference=vm_preference,
             disk_type="scsi",
         ) as vm:

--- a/tests/infrastructure/instance_types/test_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_vm_preference.py
@@ -55,7 +55,7 @@ def rhel_vm_with_storage_preference(
         client=unprivileged_client,
         name="rhel-vm-with-storage-pref",
         namespace=namespace.name,
-        memory_requests=Images.Rhel.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
         vm_preference=vm_storage_class_preference,
         data_volume_template=fedora_data_volume_template,
     ) as vm:


### PR DESCRIPTION
##### Short description:
Code Improvement:
- VM to automatically use memory_guest from the instance type.Setting memory_guest manually will cause a conflict with the instance type.(VM field(s) spec.template.spec.domain.memory conflicts with selected instance type.)
- For preference only tests, replaced memory_requests with memory_guest.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

