### PR TITLE
Add update method to handle consecutive updates safely

### DIFF
--- a/utilities/network.py
+++ b/utilities/network.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 import shlex
+from typing import Any
 
 import netaddr
 from ocp_resources.network_addons_config import NetworkAddonsConfig
@@ -172,6 +173,12 @@ class BridgeNodeNetworkConfigurationPolicy(NodeNetworkConfigurationPolicy):
                 self.set_interface(interface=_port)
 
         super().to_dict()
+
+    def update(self, resource_dict: dict[str, Any]) -> None:
+        initial_success_status_time = self._get_last_successful_transition_time()
+        super().update(resource_dict=resource_dict)
+        if resource_dict.get("spec") and initial_success_status_time:
+            self._wait_for_nncp_status_update(initial_transition_time=initial_success_status_time)
 
 
 class LinuxBridgeNodeNetworkConfigurationPolicy(BridgeNodeNetworkConfigurationPolicy):


### PR DESCRIPTION
##### Short description:
Add update method to handle consecutive updates safely
##### More details:
Add update method to handle consecutive updates safely
    
    Added an update method in NodeNetworkConfigurationPolicy to wait for
    NNCP status updates before applying changes. This prevents API failures
    caused by the admission webhook rejecting updates while NNCP is still
    in progress.
##### What this PR does / why we need it:
Example of failure:
```
failed on teardown with "kubernetes.dynamic.exceptions.ForbiddenError: 403
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': 'f10ebbbc-01e8-456d-a1c5-e55298504ece', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': '559d612b-12c3-4f4d-9114-023ee53b8190', 'X-Kubernetes-Pf-Prioritylevel-Uid': '205f5378-334e-481f-94f3-6ad523816633', 'Date': 'Mon, 24 Mar 2025 09:41:26 GMT', 'Content-Length': '475'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \\"nodenetworkconfigurationpolicies-update-validate.nmstate.io\\" denied the request: failed to admit NodeNetworkConfigurationPolicy dhcp-vlan-client-2-nncp: message: policy dhcp-vlan-client-2-nncp is still in progress. ","reason":"failed to admit NodeNetworkConfigurationPolicy dhcp-vlan-client-2-nncp: message: policy dhcp-vlan-client-2-nncp is still in progress. ","code":403}\n'
```
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-58740
