### PR TITLE
Deprecate deployVMConsoleProxy feature gate

### DIFF
--- a/tests/infrastructure/vm_console_proxy/conftest.py
+++ b/tests/infrastructure/vm_console_proxy/conftest.py
@@ -39,12 +39,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="class")
-def feature_gate_for_vm_console_proxy(hyperconverged_resource_scope_class):
+def enabled_vm_console_proxy_spec(hyperconverged_resource_scope_class):
     with ResourceEditorValidateHCOReconcile(
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {
-                    "featureGates": {"deployVmConsoleProxy": True},
+                    "deployVmConsoleProxy": True,
                 }
             }
         },

--- a/tests/infrastructure/vm_console_proxy/test_vm_console_proxy.py
+++ b/tests/infrastructure/vm_console_proxy/test_vm_console_proxy.py
@@ -9,7 +9,7 @@ from utilities.vnc_utils import VNCConnection
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures("feature_gate_for_vm_console_proxy")
+@pytest.mark.usefixtures("enabled_vm_console_proxy_spec")
 class TestVmConsoleProxyEnablement:
     @pytest.mark.dependency(name="test_vm_proxy_cluster_resources_available")
     @pytest.mark.polarion("CNV-10416")

--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -12,7 +12,6 @@ TEMPLATE_VALIDATOR = "templateValidator"
 DEVELOPER_CONFIGURATION = "developerConfiguration"
 # featuregates:
 DEPLOY_KUBE_SECONDARY_DNS = "deployKubeSecondaryDNS"
-NON_ROOT = "nonRoot"
 DISABLE_MDEV_CONFIGURATION = "disableMDevConfiguration"
 PERSISTENT_RESERVATION = "persistentReservation"
 FG_DISABLED = False
@@ -50,7 +49,6 @@ HCO_DEFAULT_FEATUREGATES = {
     DEPLOY_KUBE_SECONDARY_DNS: FG_DISABLED,
     DISABLE_MDEV_CONFIGURATION: FG_DISABLED,
     PERSISTENT_RESERVATION: FG_DISABLED,
-    "deployVmConsoleProxy": FG_DISABLED,
     "autoResourceLimits": FG_DISABLED,
     "alignCPUs": FG_DISABLED,
     "enableApplicationAwareQuota": FG_DISABLED,


### PR DESCRIPTION
##### Short description:
Replace any place that uses the spec.featureGates.DeployVMConsoleProxy field, with spec.DeployVMConsoleProxy

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Removed "nonRoot" const as well since its not being used.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-52378