### PR TITLE
[4.19][Upgrade] Fix network and virt pre-upgrade tests

### DIFF
--- a/tests/network/upgrade/utils.py
+++ b/tests/network/upgrade/utils.py
@@ -16,8 +16,8 @@ def assert_bridge_and_vms_on_same_node(vm_a, vm_b, bridge):
 
 def assert_node_is_marked_by_bridge(bridge_nad, vm):
     for bridge_annotation in bridge_nad.instance.metadata.annotations.values():
-        assert bridge_annotation in vm.vmi.node.instance.status.capacity.keys()
-        assert bridge_annotation in vm.vmi.node.instance.status.allocatable.keys()
+        assert bridge_annotation in vm.privileged_vmi.node.instance.status.capacity.keys()
+        assert bridge_annotation in vm.privileged_vmi.node.instance.status.allocatable.keys()
 
 
 def assert_nmstate_bridge_creation(bridge):

--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -192,7 +192,7 @@ def vm_from_template(
     cpu_model,
     template_labels,
     networks=None,
-    run_strategy=None,
+    run_strategy=VirtualMachine.RunStrategy.HALTED,
     eviction_strategy=None,
 ):
     with VirtualMachineForTestsFromTemplate(


### PR DESCRIPTION
##### Short description:
Cherry pick from https://github.com/RedHatQE/openshift-virtualization-tests/pull/621
Before upgrade, two tests fails consistently due to 4.18+ product changes.

##### More details:
**test_bridge_marker_before_upgrade**

The test trying to access the node with vm.vmi.node.instance....
Should use privleged_vmi.

**test_windows_vm_before_upgrade**

The test doesn't set RunStrategy, as required from 4.18+.
Run strategy has to be set.
