### PR TITLE
Add OCI storage class

### DIFF
--- a/tests/global_config_oci.py
+++ b/tests/global_config_oci.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+import pytest_testconfig
+from ocp_resources.datavolume import DataVolume
+
+from utilities.constants import (
+    ACCESS_MODE,
+    ALL_CNV_DAEMONSETS_NO_HPP_CSI,
+    ALL_CNV_DEPLOYMENTS_NO_HPP_POOL,
+    CNV_PODS_NO_HPP_CSI_HPP_POOL,
+    VOLUME_MODE,
+    StorageClassNames,
+)
+
+global config
+global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")
+
+
+cnv_deployment_matrix = ALL_CNV_DEPLOYMENTS_NO_HPP_POOL
+cnv_pod_matrix = CNV_PODS_NO_HPP_CSI_HPP_POOL
+cnv_daemonset_matrix = ALL_CNV_DAEMONSETS_NO_HPP_CSI
+
+
+storage_class_matrix = [
+    {
+        StorageClassNames.OCI: {
+            VOLUME_MODE: DataVolume.VolumeMode.BLOCK,
+            ACCESS_MODE: DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": True,
+            "default": True,
+        }
+    },
+]
+
+
+for _dir in dir():
+    if not config:  # noqa: F821
+        config: dict[str, Any] = {}
+    val = locals()[_dir]
+    if type(val) not in [bool, list, dict, str, int]:
+        continue
+
+    if _dir in ["encoding", "py_file"]:
+        continue
+
+    config[_dir] = locals()[_dir]  # noqa: F821

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -617,6 +617,7 @@ class StorageClassNames:
     TRIDENT_CSI_FSX = "trident-csi-fsx"
     IO2_CSI = "io2-csi"
     IBM_SPECTRUM_SCALE = "ibm-spectrum-scale-sample-uid-gid-107"
+    OCI = "oci-bv"
 
 
 # Namespace constants


### PR DESCRIPTION
##### Short description:
To run the tests with OCI storage:
`uv run pytest --storage-class-matrix=oci-bv --tc-file=tests/global_config_oci.py ...`

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
