### PR TITLE
[4.18] Resolve IPv6 gating tests in non-supporting clusters

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -50,6 +50,7 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11125")
     @pytest.mark.ipv6
+    @pytest.mark.jira("CNV-58530", run=True)
     def test_ipv6_linux_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,
@@ -144,6 +145,7 @@ class TestConnectivityOVSBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11128")
     @pytest.mark.ipv6
+    @pytest.mark.jira("CNV-58530", run=True)
     def test_ipv6_ovs_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -4,6 +4,7 @@ VM to VM connectivity
 
 import pytest
 
+from utilities.constants import IPV4_STR, IPV6_STR
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
     compose_cloud_init_data_dict,
@@ -73,12 +74,30 @@ def cloud_init_ipv6_network_data(dual_stack_network_data):
     return compose_cloud_init_data_dict(ipv6_network_data=dual_stack_network_data)
 
 
+@pytest.mark.parametrize(
+    "ip_family",
+    [
+        pytest.param(
+            IPV4_STR,
+            marks=[
+                pytest.mark.polarion("CNV-2332"),
+                pytest.mark.ipv4,
+            ],
+        ),
+        pytest.param(
+            IPV6_STR,
+            marks=[
+                pytest.mark.polarion("CNV-11845"),
+                pytest.mark.ipv6,
+                pytest.mark.jira("CNV-58530 ", run=True),
+            ],
+        ),
+    ],
+    indirect=False,
+)
 @pytest.mark.gating
-@pytest.mark.polarion("CNV-2332")
 def test_connectivity_over_pod_network(
-    fail_if_not_ipv4_supported_cluster_from_mtx,
-    fail_if_not_ipv6_supported_cluster_from_mtx,
-    ip_stack_version_matrix__module__,
+    ip_family,
     pod_net_vma,
     pod_net_vmb,
     pod_net_running_vma,
@@ -88,7 +107,7 @@ def test_connectivity_over_pod_network(
     """
     Check connectivity
     """
-    dst_ip = get_ip_from_vm_or_virt_handler_pod(family=ip_stack_version_matrix__module__, vm=pod_net_running_vmb)
+    dst_ip = get_ip_from_vm_or_virt_handler_pod(family=ip_family, vm=pod_net_running_vmb)
     assert dst_ip, f"Cannot get valid IP address from {pod_net_running_vmb.vmi.name}."
 
     ping_cmd = f"ping -c 3 {dst_ip}"


### PR DESCRIPTION
Towards stabilizing network tier-2 tests, and specifically the gating ones, this PR
- splits the pod network connectivity test to IPv4 and IPv6 cases
- marks the IPv6 tests with the ticket that tracks this limitation.
