### PR TITLE
Automate Fedora VM build for the tests

### DIFF
--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -1,0 +1,51 @@
+name: "Component Builder"
+on:
+  pull_request_target:
+    paths:
+      - 'containers/fedora/**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  guest-fedora-amd64:
+    runs-on: ubuntu-latest
+    env:
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+      FEDORA_VERSION: 41
+      CPU_ARCH: amd64
+      FULL_EMULATION: "true"
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install dependencies for VM build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            qemu-system-x86 \
+            libvirt-daemon-system \
+            virtinst cloud-image-utils \
+            libguestfs-tools
+      - name: Tweak hosted runner to enable 'virt-sysprep'
+        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
+        run: sudo chmod 0644 /boot/vmlinuz*
+      - name: Fetch base Fedora image
+        working-directory: ./containers/fedora
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.11"
+      - name: Create VM
+        working-directory: ./containers/fedora
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
+          ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+        run: ./build.sh
+      - name: Report artifacts
+        working-directory: ./containers/fedora
+        run: |
+          ls -la
+          podman images

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -44,8 +44,16 @@ jobs:
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
         run: ./build.sh
-      - name: Report artifacts
-        working-directory: ./containers/fedora
+      - name: Logging to quay.io
+        run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Tag & Push image to staging
+        env:
+          local_repository: "localhost/fedora"
+          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          remote_tag: "${{ env.FEDORA_VERSION }}-dev"
         run: |
-          ls -la
-          podman images
+          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
+          podman push "${remote_repository}":"${arch_tag}"
+          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag}"
+          podman manifest push "${remote_repository}":"${remote_tag}" --all --format=v2s2

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -45,7 +45,7 @@ case "$CPU_ARCH" in
 	;;
 esac
 
-if [ $FULL_EMULATION = "true" ]; then
+if [ "$FULL_EMULATION" = "true" ]; then
     VIRT_TYPE="qemu"
 fi
 
@@ -59,7 +59,7 @@ echo "Create cloud-init user data ISO"
 cloud-localds $CLOUD_INIT_ISO user-data
 
 # When running on CI, the latest Fedora may not be yet supported by virt-install
-# therefor use a lower one. It should have no influence on the result.
+# therefore use a lower one. It should have no influence on the result.
 OS_VARIANT=$NAME
 if [ $FEDORA_VERSION -gt 40 ]; then
    OS_VARIANT="fedora40"

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -3,9 +3,11 @@ set -xe
 
 # Function to restore the password placeholder
 cleanup() {
+    set +x
     if [ -f user-data ] && [ -n "$FEDORA_PASSWORD" ]; then
         sed -i "s/password: $FEDORA_PASSWORD/password: $PASSWORD_PLACEHOLDER/" user-data
     fi
+    set -x
 }
 trap cleanup EXIT
 
@@ -43,12 +45,25 @@ case "$CPU_ARCH" in
 	;;
 esac
 
+if [ $FULL_EMULATION = "true" ]; then
+    VIRT_TYPE="qemu"
+fi
+
+set +x
 FEDORA_PASSWORD=$(uv run get_fedora_password.py)
 PASSWORD_PLACEHOLDER="CHANGE_ME"
 sed -i "s/password: $PASSWORD_PLACEHOLDER/password: $FEDORA_PASSWORD/" user-data
+set -x
 
 echo "Create cloud-init user data ISO"
 cloud-localds $CLOUD_INIT_ISO user-data
+
+# When running on CI, the latest Fedora may not be yet supported by virt-install
+# therefor use a lower one. It should have no influence on the result.
+OS_VARIANT=$NAME
+if [ $FEDORA_VERSION -gt 40 ]; then
+   OS_VARIANT="fedora40"
+fi
 
 echo "Run the VM (ctrl+] to exit)"
 virt-install \
@@ -58,14 +73,13 @@ virt-install \
   --name $NAME \
   --disk $FEDORA_IMAGE,device=disk \
   --disk $CLOUD_INIT_ISO,device=cdrom \
-  --os-variant $NAME \
+  --os-variant $OS_VARIANT \
   --virt-type $VIRT_TYPE \
   --graphics none \
   --network default \
+  --noautoconsole \
+  --wait 30 \
   --import
-
-echo "Stop Fedora VM"
-virsh destroy "${NAME}" || true
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr

--- a/containers/fedora/user-data
+++ b/containers/fedora/user-data
@@ -21,15 +21,15 @@ write_files:
         [Install]
         WantedBy=cloud-init.service
 runcmd:
-  - sudo systemctl daemon-reload
+  - systemctl daemon-reload
   - dnf install -y tcpdump qemu-guest-agent iperf3 dmidecode nginx lldpad kernel-modules nmap dhcp-server dhcp-relay sshpass podman ethtool libibverbs dpdk stress-ng iotop fio
-  - sudo dnf autoremove
-  - sudo dnf clean all
-  - rpm -q kernel-core | sort | head -1 | xargs sudo rpm -e
-  - sudo systemctl enable wait-for-cloud-init
-  - sudo systemctl enable qemu-guest-agent
-  - sudo sed -i 's/listen       80;/listen       80;\n\tlisten       81;/g' /etc/nginx/nginx.conf
-  - sudo systemctl enable nginx
-  - sudo systemctl enable sshd
+  - dnf autoremove
+  - dnf clean all
+  - rpm -q kernel-core | sort | head -1 | xargs rpm -e
+  - systemctl enable wait-for-cloud-init
+  - systemctl enable qemu-guest-agent
+  - sed -i 's/listen       80;/listen       80;\n\tlisten       81;/g' /etc/nginx/nginx.conf
+  - systemctl enable nginx
+  - systemctl enable sshd
   - grubby --args="net.ifnames=0" --update-kernel=ALL
-  - sudo shutdown
+  - shutdown


### PR DESCRIPTION
##### Short description:
Automate Fedora VM build for the tests

##### What this PR does / why we need it:
Preparing the Fedora VM image for the tests is currently carried out manually.
This is problematic as the human factor here presents a high risk (for mistakes.

This change aims to automate the process.

As a follow up, consider:
- Prepare arm64.
- Push the container image artifact to production quay registry on merge.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced an automated workflow to build and push Fedora-based container images, supporting manual and pull request triggers.
  - Improved container build script to handle virtualization type selection and Fedora version compatibility more robustly.
  - Enhanced security in build logs by limiting sensitive output exposure during password handling.
  - Updated cloud-init configuration to simplify command execution by removing unnecessary privilege escalation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->