### PR TITLE
[virt] fix aaq gating flake

### DIFF
--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -23,7 +23,7 @@ from tests.virt.cluster.aaq.utils import (
     wait_for_aacrq_object_created,
 )
 from tests.virt.constants import AAQ_NAMESPACE_LABEL, ACRQ_NAMESPACE_LABEL, ACRQ_TEST
-from tests.virt.utils import enable_aaq_feature_gate, wait_when_pod_in_gated_state
+from tests.virt.utils import enable_aaq_feature_gate, wait_for_virt_launcher_pod, wait_when_pod_in_gated_state
 from utilities.constants import (
     POD_CONTAINER_SPEC,
     POD_SECURITY_CONTEXT_SPEC,
@@ -146,6 +146,7 @@ def vm_for_aaq_test_in_gated_state(namespace, unprivileged_client):
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:
         vm.wait_for_specific_status(status=VirtualMachine.Status.STARTING)
+        wait_for_virt_launcher_pod(vmi=vm.vmi)
         wait_when_pod_in_gated_state(pod=vm.vmi.virt_launcher_pod)
         yield vm
 

--- a/tests/virt/cluster/aaq/utils.py
+++ b/tests/virt/cluster/aaq/utils.py
@@ -6,7 +6,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.virt.constants import PODS_STR
-from tests.virt.utils import check_arq_status_values, wait_when_pod_in_gated_state
+from tests.virt.utils import check_arq_status_values, wait_for_virt_launcher_pod, wait_when_pod_in_gated_state
 from utilities.constants import (
     AAQ_VIRTUAL_RESOURCES,
     AAQ_VMI_POD_USAGE,
@@ -22,6 +22,7 @@ def restart_vm_wait_for_gated_state(vm):
     vm.restart()
     vmi_old_pod.wait_deleted()
     vm.wait_for_specific_status(status=VirtualMachine.Status.STARTING)
+    wait_for_virt_launcher_pod(vmi=vm.vmi)
     wait_when_pod_in_gated_state(pod=vm.vmi.virt_launcher_pod)
 
 

--- a/tests/virt/node/owner_references/test_vm_owner_references.py
+++ b/tests/virt/node/owner_references/test_vm_owner_references.py
@@ -3,18 +3,11 @@ Check VM, VMI, POD owner references
 """
 
 import pytest
-from timeout_sampler import TimeoutSampler
 
+from tests.virt.utils import wait_for_virt_launcher_pod
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 pytestmark = pytest.mark.post_upgrade
-
-
-def _wait_for_virt_launcher_pod(vmi):
-    samples = TimeoutSampler(wait_timeout=30, sleep=1, func=lambda: vmi.virt_launcher_pod)
-    for sample in samples:
-        if sample:
-            return
 
 
 @pytest.fixture()
@@ -24,10 +17,11 @@ def fedora_vm(unprivileged_client, namespace):
         name=name,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
+        client=unprivileged_client,
     ) as vm:
         vm.start(wait=True)
         vm.vmi.wait_until_running()
-        _wait_for_virt_launcher_pod(vmi=vm.vmi)
+        wait_for_virt_launcher_pod(vmi=vm.vmi)
         yield vm
 
 

--- a/tests/virt/upgrade_custom/aaq/conftest.py
+++ b/tests/virt/upgrade_custom/aaq/conftest.py
@@ -5,7 +5,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 
 from tests.virt.constants import AAQ_NAMESPACE_LABEL, ACRQ_NAMESPACE_LABEL
 from tests.virt.upgrade_custom.aaq.constants import UPGRADE_QUOTA_FOR_ONE_VMI
-from tests.virt.utils import enable_aaq_feature_gate, wait_when_pod_in_gated_state
+from tests.virt.utils import enable_aaq_feature_gate, wait_for_virt_launcher_pod, wait_when_pod_in_gated_state
 from utilities.infra import (
     create_ns,
 )
@@ -70,6 +70,7 @@ def vm_for_arq_upgrade_test_in_gated_state(namespace_for_arq_upgrade_test):
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:
         vm.wait_for_specific_status(status=VirtualMachine.Status.STARTING)
+        wait_for_virt_launcher_pod(vmi=vm.vmi)
         wait_when_pod_in_gated_state(pod=vm.vmi.virt_launcher_pod)
         yield vm
 

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -334,3 +334,14 @@ def get_match_expressions_dict(nodes_list):
             }
         ]
     }
+
+
+def wait_for_virt_launcher_pod(vmi):
+    samples = TimeoutSampler(wait_timeout=30, sleep=1, func=lambda: vmi.virt_launcher_pod)
+    try:
+        for sample in samples:
+            if sample:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"Virt-laucher pod for VMI {vmi.name} was not found!")
+        raise

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -17,11 +17,13 @@ from utilities.constants import (
     OS_PROC_NAME,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
+    TIMEOUT_1SEC,
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_15SEC,
+    TIMEOUT_30SEC,
 )
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
@@ -337,7 +339,7 @@ def get_match_expressions_dict(nodes_list):
 
 
 def wait_for_virt_launcher_pod(vmi):
-    samples = TimeoutSampler(wait_timeout=30, sleep=1, func=lambda: vmi.virt_launcher_pod)
+    samples = TimeoutSampler(wait_timeout=TIMEOUT_30SEC, sleep=TIMEOUT_1SEC, func=lambda: vmi.virt_launcher_pod)
     try:
         for sample in samples:
             if sample:


### PR DESCRIPTION
##### Short description:
added step to wait for virt-launcher pod to appear before calling vm.vmi.virt_launcher_pod

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

