### PR TITLE
[Upgrade] Allow user to choose subscription channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,22 +232,30 @@ Note: OCP images information can be found at: <https://openshift-release.apps.ci
 Currently, automation supports ocp upgrades using stable, ci, nightly and rc images for ocp
 
 #### CNV upgrade
+Parameters:
+
+| Parameter Name  |      Requirement      |  Default Value  |    Possible Value     |
+|:----------------|:---------------------:|:---------------:|:---------------------:|
+| `--cnv-version` |     **Required**      |        -        |         4.Y.z         |
+| `--cnv-image`   |     **Required**      |        -        |     -image path-      |
+| `--cnv-source`  |     **Optional**      |      osbs       | osbs, fbc, production |
+| `--cnv-channel` |     **Optional**      |     stable      |   stable, candidate   |
 
 Command to run entire upgrade test suite for cnv upgrade, including pre and post upgrade validation:
 
 ```bash
---upgrade cnv --cnv-version <target_version> --cnv-source <osbs|production|staging> --cnv-image <cnv_image_to_upgrade_to>
+--upgrade cnv --cnv-version <target_version> --cnv-image <cnv_image_to_upgrade_to>
 ```
 
 Command to run only cnv upgrade test, without any pre/post validation:
 
 ```bash
--m product_upgrade_test --upgrade cnv --cnv-version <target_version> --cnv source <osbs|production|staging> --cnv-image <cnv_image_to_upgrade_to>
+-m cnv_upgrade --upgrade cnv --cnv-version <target_version> --cnv-image <cnv_image_to_upgrade_to>
 ```
 
 To upgrade to cnv 4.Y.z, using the cnv image that has been shipped, following command could be used:
 ```bash
---upgrade cnv --cnv-version 4.Y.z --cnv-source osbs --cnv-image <cnv_image_to_upgrade_to>
+--upgrade cnv --cnv-version 4.Y.z --cnv-image <cnv_image_to_upgrade_to>
 ```
 
 #### EUS upgrade

--- a/conftest.py
+++ b/conftest.py
@@ -122,6 +122,12 @@ def pytest_addoption(parser):
         default="osbs",
         choices=["production", "fbc", "osbs"],
     )
+    install_upgrade_group.addoption(
+        "--cnv-channel",
+        help="Subscription channel for CNV index image",
+        default="stable",
+        choices=["stable", "candidate"],
+    )
 
     # OCP upgrade options
     install_upgrade_group.addoption(
@@ -287,6 +293,7 @@ def pytest_cmdline_main(config):
     # tests.upgrade_params.UPGRADE_TEST_DEPENDENCY_NODE_ID which is needed for pytest dependency marker
     py_config["upgraded_product"] = upgrade_option or config.getoption("--upgrade_custom") or "cnv"
     py_config["cnv_source"] = config.getoption("--cnv-source")
+    py_config["cnv_subscription_channel"] = config.getoption("--cnv-channel")
 
     # [rhel|fedora|windows|centos]-os-matrix and latest-[rhel|fedora|windows|centos] are mutually exclusive
     rhel_os_violation = config.getoption("rhel_os_matrix") and config.getoption("latest_rhel")

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -153,6 +153,7 @@ def updated_cnv_subscription_source(cnv_subscription_scope_session, cnv_registry
     update_subscription_source(
         subscription=cnv_subscription_scope_session,
         subscription_source=cnv_registry_source["cnv_subscription_source"],
+        subscription_channel=py_config["cnv_subscription_channel"],
     )
 
 

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -624,13 +624,20 @@ def update_image_in_catalog_source(dyn_client, image, catalog_source_name, cr_na
         wait_for_package_manifest_to_exist(dyn_client=dyn_client, catalog_name=catalog_source_name, cr_name=cr_name)
 
 
-def update_subscription_source(subscription, subscription_source):
-    LOGGER.info(f"Update subscription {subscription.name} source to {subscription_source}")
+def update_subscription_source(
+    subscription: Subscription,
+    subscription_source: str,
+    subscription_channel: str,
+) -> None:
+    LOGGER.info(
+        f"Update subscription {subscription.name} source to {subscription_source} on {subscription_channel} channel"
+    )
     ResourceEditor({
         subscription: {
             "spec": {
-                "source": subscription_source,
+                "channel": subscription_channel,
                 "installPlanApproval": "Manual",
+                "source": subscription_source,
             }
         }
     }).update()


### PR DESCRIPTION
##### Short description:
Cherry pick from 4.17.

With candidate/nightly channel being added, upon CNV upgrade we should be able too choose A channel to pull the target image from.

##### More details:
Relevant for CNV upgrade only.
EUS should always use stable.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
