### PR TITLE
 Fix ServiceMesh tests and adjust to OSSM 3

### DIFF
--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -36,7 +36,7 @@ from tests.network.utils import (
     authentication_request,
 )
 from utilities.constants import PORT_80, TIMEOUT_4MIN, TIMEOUT_10SEC
-from utilities.infra import add_scc_to_service_account, create_ns, unique_name
+from utilities.infra import add_scc_to_service_account, create_ns, label_project, unique_name
 from utilities.virt import running_vm, vm_console_run_commands, wait_for_console
 
 LOGGER = logging.getLogger(__name__)
@@ -441,3 +441,8 @@ def vmi_http_server(vm_fedora_with_service_mesh_annotation):
         vm=vm_fedora_with_service_mesh_annotation,
         commands=[f'while true ; do  echo -e "HTTP/1.1 200 OK\n\n $(date)" | nc -l -p {SERVICE_MESH_PORT}  ; done &'],
     )
+
+
+@pytest.fixture(scope="module")
+def label_istio_injection_namespace(namespace, admin_client):
+    label_project(name=namespace.name, label={"istio-injection": "enabled"}, admin_client=admin_client)

--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -32,7 +32,6 @@ from tests.network.utils import (
     FedoraVirtualMachineForServiceMesh,
     ServiceMeshDeployments,
     ServiceMeshDeploymentService,
-    ServiceMeshMemberRollForTests,
     authentication_request,
 )
 from utilities.constants import PORT_80, TIMEOUT_4MIN, TIMEOUT_10SEC
@@ -215,16 +214,9 @@ def httpbin_service_service_mesh(httpbin_deployment_service_mesh, httpbin_servic
 
 
 @pytest.fixture(scope="module")
-def service_mesh_member_roll(service_mesh_tests_namespace):
-    with ServiceMeshMemberRollForTests(members=[service_mesh_tests_namespace.name]) as smmr:
-        yield smmr
-
-
-@pytest.fixture(scope="module")
 def vm_fedora_with_service_mesh_annotation(
     unprivileged_client,
     service_mesh_tests_namespace,
-    service_mesh_member_roll,
 ):
     vm_name = "service-mesh-vm"
     with FedoraVirtualMachineForServiceMesh(
@@ -412,9 +404,9 @@ def change_routing_to_v2(
 
 
 @pytest.fixture(scope="class")
-def peer_authentication_strict_service_mesh(service_mesh_member_roll, service_mesh_tests_namespace):
+def peer_authentication_strict_service_mesh(service_mesh_tests_namespace):
     with PeerAuthenticationForTests(
-        name=service_mesh_member_roll.name,
+        name="default",
         namespace=service_mesh_tests_namespace.name,
     ) as pa:
         yield pa
@@ -424,7 +416,6 @@ def peer_authentication_strict_service_mesh(service_mesh_member_roll, service_me
 def peer_authentication_service_mesh_deployment(
     istio_system_namespace,
     service_mesh_tests_namespace,
-    service_mesh_member_roll,
     vm_fedora_with_service_mesh_annotation,
     ns_outside_of_service_mesh,
     httpbin_service_service_mesh,

--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -437,7 +437,7 @@ def vmi_http_server(vm_fedora_with_service_mesh_annotation):
     )
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def service_mesh_tests_namespace(namespace, admin_client):
     # The namespace used for the ServiceMesh tests must be added the `istio-injection` label.
     label_project(name=namespace.name, label={"istio-injection": "enabled"}, admin_client=admin_client)

--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -176,10 +176,10 @@ def ns_outside_of_service_mesh(admin_client):
 
 
 @pytest.fixture(scope="class")
-def httpbin_deployment_service_mesh(namespace):
+def httpbin_deployment_service_mesh(service_mesh_tests_namespace):
     with ServiceMeshDeployments(
         name="httpbin",
-        namespace=namespace.name,
+        namespace=service_mesh_tests_namespace.name,
         version=ServiceMeshDeployments.ApiVersion.V1,
         image=HTTPBIN_IMAGE,
         command=shlex.split(HTTPBIN_COMMAND),
@@ -215,22 +215,22 @@ def httpbin_service_service_mesh(httpbin_deployment_service_mesh, httpbin_servic
 
 
 @pytest.fixture(scope="module")
-def service_mesh_member_roll(namespace):
-    with ServiceMeshMemberRollForTests(members=[namespace.name]) as smmr:
+def service_mesh_member_roll(service_mesh_tests_namespace):
+    with ServiceMeshMemberRollForTests(members=[service_mesh_tests_namespace.name]) as smmr:
         yield smmr
 
 
 @pytest.fixture(scope="module")
 def vm_fedora_with_service_mesh_annotation(
     unprivileged_client,
-    namespace,
+    service_mesh_tests_namespace,
     service_mesh_member_roll,
 ):
     vm_name = "service-mesh-vm"
     with FedoraVirtualMachineForServiceMesh(
         client=unprivileged_client,
         name=vm_name,
-        namespace=namespace.name,
+        namespace=service_mesh_tests_namespace.name,
     ) as vm:
         vm.custom_service_enable(
             service_name=vm_name,
@@ -276,10 +276,10 @@ def outside_mesh_console_ready_vm(
 
 
 @pytest.fixture(scope="class")
-def server_deployment_v1(namespace):
+def server_deployment_v1(service_mesh_tests_namespace):
     with ServiceMeshDeployments(
         name=SERVER_DEMO_NAME,
-        namespace=namespace.name,
+        namespace=service_mesh_tests_namespace.name,
         version=ServiceMeshDeployments.ApiVersion.V1,
         image=SERVER_V1_IMAGE,
         strategy=SERVER_DEPLOYMENT_STRATEGY,
@@ -412,15 +412,18 @@ def change_routing_to_v2(
 
 
 @pytest.fixture(scope="class")
-def peer_authentication_strict_service_mesh(service_mesh_member_roll, namespace):
-    with PeerAuthenticationForTests(name=service_mesh_member_roll.name, namespace=namespace.name) as pa:
+def peer_authentication_strict_service_mesh(service_mesh_member_roll, service_mesh_tests_namespace):
+    with PeerAuthenticationForTests(
+        name=service_mesh_member_roll.name,
+        namespace=service_mesh_tests_namespace.name,
+    ) as pa:
         yield pa
 
 
 @pytest.fixture(scope="class")
 def peer_authentication_service_mesh_deployment(
     istio_system_namespace,
-    namespace,
+    service_mesh_tests_namespace,
     service_mesh_member_roll,
     vm_fedora_with_service_mesh_annotation,
     ns_outside_of_service_mesh,
@@ -443,6 +446,8 @@ def vmi_http_server(vm_fedora_with_service_mesh_annotation):
     )
 
 
-@pytest.fixture(scope="module")
-def label_istio_injection_namespace(namespace, admin_client):
+@pytest.fixture(scope="module", autouse=True)
+def service_mesh_tests_namespace(namespace, admin_client):
+    # The namespace used for the ServiceMesh tests must be added the `istio-injection` label.
     label_project(name=namespace.name, label={"istio-injection": "enabled"}, admin_client=admin_client)
+    return namespace

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -6,10 +6,7 @@ from tests.network.service_mesh.utils import (
 )
 from tests.network.utils import assert_authentication_request
 
-pytestmark = [
-    pytest.mark.service_mesh,
-    pytest.mark.usefixtures("label_istio_injection_namespace"),
-]
+pytestmark = pytest.mark.service_mesh
 
 
 class TestSMTrafficManagement:

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -6,7 +6,10 @@ from tests.network.service_mesh.utils import (
 )
 from tests.network.utils import assert_authentication_request
 
-pytestmark = pytest.mark.service_mesh
+pytestmark = [
+    pytest.mark.service_mesh,
+    pytest.mark.usefixtures("label_istio_injection_namespace"),
+]
 
 
 class TestSMTrafficManagement:

--- a/tests/network/utils.py
+++ b/tests/network/utils.py
@@ -7,7 +7,6 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.deployment import Deployment
 from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.service import Service
-from ocp_resources.service_mesh_member_roll import ServiceMeshMemberRoll
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -15,7 +14,6 @@ from tests.network.constants import BRCNV, SERVICE_MESH_PORT
 from utilities import console
 from utilities.constants import (
     IPV4_STR,
-    ISTIO_SYSTEM_DEFAULT_NS,
     OS_FLAVOR_FEDORA,
     SSH_PORT_22,
     TIMEOUT_1MIN,
@@ -43,7 +41,6 @@ range {DHCP_IP_RANGE_START} {DHCP_IP_RANGE_END};
 }}
 EOF
 """
-SERVICE_MESH_VM_MEMORY_REQ = "128M"
 SERVICE_MESH_INJECT_ANNOTATION = "sidecar.istio.io/inject"
 
 
@@ -69,27 +66,6 @@ class ServiceMeshDeploymentService(Service):
         ]
         if self.port_name:
             self.res["spec"]["ports"][0]["name"] = self.port_name
-
-
-class ServiceMeshMemberRollForTests(ServiceMeshMemberRoll):
-    def __init__(
-        self,
-        members,
-    ):
-        """
-        Service Mesh Member Roll creation
-        Args:
-            members (list): Namespaces to be added to Service Mesh
-        """
-        super().__init__(
-            name="default",
-            namespace=ISTIO_SYSTEM_DEFAULT_NS,
-        )
-        self.members = members
-
-    def to_dict(self):
-        super().to_dict()
-        self.res["spec"] = {"members": self.members}
 
 
 class FedoraVirtualMachineForServiceMesh(VirtualMachineForTests):


### PR DESCRIPTION
OSSM moved from ver. 2 to 3. This fix adjusts to ver. 3 by enabling gateway injection, which is performed by labeling the work namespace with the matching label {istio-injection: enabled}.
