### PR TITLE
[virt] add arm64 support for common template tests

### DIFF
--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -21,18 +21,25 @@ from utilities.constants import (
     CNV_PODS_NO_HPP_CSI_HPP_POOL,
     CNV_PROMETHEUS_RULES,
     DATA_SOURCE_NAME,
+    DV_SIZE_STR,
     FLAVOR_STR,
     HCO_CATALOG_SOURCE,
     HPP_CAPABILITIES,
+    IMAGE_NAME_STR,
+    IMAGE_PATH_STR,
     INSTANCE_TYPE_STR,
     IPV4_STR,
     IPV6_STR,
+    LATEST_RELEASE_STR,
     LINUX_BRIDGE,
+    OS_STR,
+    OS_VERSION_STR,
     OVS_BRIDGE,
     PREFERENCE_STR,
     PRODUCTION_CATALOG_SOURCE,
     TEKTON_AVAILABLE_PIPELINEREF,
     TEKTON_AVAILABLE_TASKS,
+    TEMPLATE_LABELS_STR,
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TLS_CUSTOM_POLICY,
@@ -43,6 +50,7 @@ from utilities.constants import (
     WIN_2K25,
     WIN_10,
     WIN_11,
+    WORKLOAD_STR,
     Images,
     NamespacesNames,
     StorageClassNames,
@@ -186,15 +194,6 @@ data_import_cron_matrix = [
     {"rhel9": {"instance_type": "u1.medium", "preference": "rhel.9"}},
     {"rhel10-beta": {"instance_type": "u1.medium", "preference": "rhel.10"}},
 ]
-
-IMAGE_NAME_STR = "image_name"
-IMAGE_PATH_STR = "image_path"
-DV_SIZE_STR = "dv_size"
-TEMPLATE_LABELS_STR = "template_labels"
-OS_STR = "os"
-WORKLOAD_STR = "workload"
-LATEST_RELEASE_STR = "latest_released"
-OS_VERSION_STR = "os_version"
 
 rhel_os_matrix = [
     {

--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -1,19 +1,51 @@
+import os
 from typing import Any
 
 import pytest_testconfig
+from ocp_resources.template import Template
 
 from utilities.constants import (
     ARM_64,
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
+    FLAVOR_STR,
     PREFERENCE_STR,
     Images,
 )
+from utilities.infra import get_latest_os_dict_list
 
 global config
 global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")
 
 Images.Cirros.RAW_IMG_XZ = "cirros-0.4.0-aarch64-disk.raw.xz"
 EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR] = f"rhel.9.{ARM_64}"
+
+IMAGE_NAME_STR = "image_name"
+IMAGE_PATH_STR = "image_path"
+DV_SIZE_STR = "dv_size"
+TEMPLATE_LABELS_STR = "template_labels"
+OS_STR = "os"
+WORKLOAD_STR = "workload"
+LATEST_RELEASE_STR = "latest_released"
+OS_VERSION_STR = "os_version"
+
+rhel_os_matrix = [
+    {
+        "rhel-9-5": {
+            OS_VERSION_STR: "9.5",
+            IMAGE_NAME_STR: Images.Rhel.RHEL9_5_ARM64_IMG,
+            IMAGE_PATH_STR: os.path.join(Images.Rhel.DIR, Images.Rhel.RHEL9_5_ARM64_IMG),
+            DV_SIZE_STR: Images.Rhel.DEFAULT_DV_SIZE,
+            LATEST_RELEASE_STR: True,
+            TEMPLATE_LABELS_STR: {
+                OS_STR: "rhel9.5",
+                WORKLOAD_STR: Template.Workload.SERVER,
+                FLAVOR_STR: Template.Flavor.TINY,
+            },
+        }
+    },
+]
+
+latest_rhel_os_dict = get_latest_os_dict_list(os_list=[rhel_os_matrix])[0]
 
 
 for _dir in dir():

--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -6,9 +6,17 @@ from ocp_resources.template import Template
 
 from utilities.constants import (
     ARM_64,
+    DV_SIZE_STR,
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
     FLAVOR_STR,
+    IMAGE_NAME_STR,
+    IMAGE_PATH_STR,
+    LATEST_RELEASE_STR,
+    OS_STR,
+    OS_VERSION_STR,
     PREFERENCE_STR,
+    TEMPLATE_LABELS_STR,
+    WORKLOAD_STR,
     Images,
 )
 from utilities.infra import get_latest_os_dict_list
@@ -18,15 +26,6 @@ global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", 
 
 Images.Cirros.RAW_IMG_XZ = "cirros-0.4.0-aarch64-disk.raw.xz"
 EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR] = f"rhel.9.{ARM_64}"
-
-IMAGE_NAME_STR = "image_name"
-IMAGE_PATH_STR = "image_path"
-DV_SIZE_STR = "dv_size"
-TEMPLATE_LABELS_STR = "template_labels"
-OS_STR = "os"
-WORKLOAD_STR = "workload"
-LATEST_RELEASE_STR = "latest_released"
-OS_VERSION_STR = "os_version"
 
 rhel_os_matrix = [
     {

--- a/tests/os_params.py
+++ b/tests/os_params.py
@@ -1,16 +1,12 @@
 from pytest_testconfig import config as py_config
 
-from utilities.virt import get_rhel_os_dict, get_windows_os_dict
+from utilities.virt import get_windows_os_dict
 
 # Common templates
 
 RHEL_LATEST = py_config["latest_rhel_os_dict"]
 RHEL_LATEST_LABELS = RHEL_LATEST["template_labels"]
 RHEL_LATEST_OS = RHEL_LATEST_LABELS["os"]
-RHEL_7_8 = get_rhel_os_dict(rhel_version="rhel-7-8")
-RHEL_7_8_TEMPLATE_LABELS = RHEL_7_8["template_labels"]
-RHEL_8_10 = get_rhel_os_dict(rhel_version="rhel-8-10")
-RHEL_8_10_TEMPLATE_LABELS = RHEL_8_10["template_labels"]
 
 WINDOWS_10 = get_windows_os_dict(windows_version="win-10")
 WINDOWS_10_TEMPLATE_LABELS = WINDOWS_10["template_labels"]

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -5,12 +5,12 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.kubevirt import KubeVirt
 from pytest_testconfig import config as py_config
 
-from tests.os_params import RHEL_8_10, RHEL_8_10_TEMPLATE_LABELS
 from tests.virt.node.general.constants import MachineTypesNames
 from utilities.hco import is_hco_tainted, update_hco_annotations
 from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
+    get_rhel_os_dict,
     migrate_vm_and_verify,
     restart_vm_wait_for_running_vm,
     running_vm,
@@ -19,6 +19,9 @@ from utilities.virt import (
 
 pytestmark = pytest.mark.post_upgrade
 LOGGER = logging.getLogger(__name__)
+
+RHEL_8_10 = get_rhel_os_dict(rhel_version="rhel-8-10")
+RHEL_8_10_TEMPLATE_LABELS = RHEL_8_10["template_labels"]
 
 
 def validate_machine_type(expected_machine_type, vm):

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -804,3 +804,13 @@ HPP_CAPABILITIES = {
     "online_resize": False,
     "wffc": True,
 }
+
+# Common templates matrix constants
+IMAGE_NAME_STR = "image_name"
+IMAGE_PATH_STR = "image_path"
+DV_SIZE_STR = "dv_size"
+TEMPLATE_LABELS_STR = "template_labels"
+OS_STR = "os"
+WORKLOAD_STR = "workload"
+LATEST_RELEASE_STR = "latest_released"
+OS_VERSION_STR = "os_version"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -53,6 +53,7 @@ class Images:
         RHEL9_3_IMG = "rhel-93.qcow2"
         RHEL9_4_IMG = "rhel-94.qcow2"
         RHEL9_5_IMG = "rhel-95.qcow2"
+        RHEL9_5_ARM64_IMG = "rhel-95-aarch64.qcow2"
         RHEL9_6_IMG = "rhel-96.qcow2"
         RHEL8_REGISTRY_GUEST_IMG = "registry.redhat.io/rhel8/rhel-guest-image"
         RHEL9_REGISTRY_GUEST_IMG = "registry.redhat.io/rhel9/rhel-guest-image"


### PR DESCRIPTION
##### Short description:
add arm64 support for common template tests

##### More details:
only rhel9 templates supported now

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-59229
