### PR TITLE
Mark network tests that don't require node's additional interfaces

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -36,6 +36,7 @@ markers =
     hugepages: tests that require nodes with hugepages
     service_mesh: tests that require the service mesh operator to be installed
     jumbo_frame: tests that require network configurations supporting jumbo frames
+    single_nic: tests that dont require mutli-nic nodes, required for conformance tests for new archs, platforms etc.
     # CI
     smoke: Mark tests as smoke tests
     ci: Mark tests as CI tests

--- a/tests/network/cluster_addons_operator/test_network_addons_operator.py
+++ b/tests/network/cluster_addons_operator/test_network_addons_operator.py
@@ -215,6 +215,7 @@ def net_add_op_bridge_attached_vm(namespace, net_add_op_br1test_nad):
 
 @pytest.mark.gating
 @pytest.mark.post_upgrade
+@pytest.mark.single_nic
 @pytest.mark.polarion("CNV-2520")
 def test_component_installed_by_operator(network_addons_config_scope_session):
     """
@@ -246,6 +247,7 @@ def test_linux_bridge_functionality(net_add_op_bridge_attached_vm):
 
 
 @pytest.mark.polarion("CNV-6754")
+@pytest.mark.single_nic
 def test_cnao_labels(
     admin_client,
     network_addons_config_scope_session,

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -218,7 +218,11 @@ def network_sanity(
     failure_msgs = []
     collected_tests = request.session.items
 
-    def _verify_multi_nic():
+    def _verify_multi_nic(request=request):
+        marker_args = request.config.getoption("-m")
+        if marker_args and "single_nic" in marker_args and "not single_nic" not in marker_args:
+            LOGGER.info("Running only single-NIC network cases, no need to verify multi NIC support")
+            return
         LOGGER.info("Verifying if the cluster has multiple NICs for network tests")
         if len(hosts_common_available_ports) <= 1:
             failure_msgs.append(
@@ -290,7 +294,7 @@ def network_sanity(
             else:
                 LOGGER.info("Validated network lane is running against an IPV4 supported cluster")
 
-    _verify_multi_nic()
+    _verify_multi_nic(request=request)
     _verify_dpdk()
     _verify_service_mesh()
     _verify_jumbo_frame()

--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -50,6 +50,7 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11125")
     @pytest.mark.ipv6
+    @pytest.mark.single_nic
     @pytest.mark.jira("CNV-58529", run=True)
     def test_ipv6_linux_bridge(
         self,

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -102,6 +102,7 @@ def cloud_init_ipv6_network_data(dual_stack_network_data):
     indirect=False,
 )
 @pytest.mark.gating
+@pytest.mark.single_nic
 def test_connectivity_over_pod_network(
     ip_family,
     pod_net_vma,

--- a/tests/network/general/test_dhcp6_configurations_on_ipv4_single_stack_cluster.py
+++ b/tests/network/general/test_dhcp6_configurations_on_ipv4_single_stack_cluster.py
@@ -73,6 +73,7 @@ def listening_dhcpv6_pid_in_virt_launcher_pod(worker_node1_pod_executor, virt_la
 
 @pytest.mark.polarion("CNV-7407")
 @pytest.mark.ipv4
+@pytest.mark.single_nic
 def test_dhcp6_disabled_on_ipv4_single_stack_cluster(
     fail_if_not_ipv4_single_stack_cluster,
     vm_cirros,

--- a/tests/network/general/test_ip_family_services.py
+++ b/tests/network/general/test_ip_family_services.py
@@ -105,6 +105,7 @@ def expected_num_families_in_service(request, dual_stack_cluster):
 
 class TestServiceConfigurationViaManifest:
     @pytest.mark.polarion("CNV-5789")
+    @pytest.mark.single_nic
     def test_service_with_configured_ip_families(
         self,
         running_vm_for_exposure,
@@ -116,6 +117,7 @@ class TestServiceConfigurationViaManifest:
         ), "Wrong ipFamilies set in service"
 
     @pytest.mark.polarion("CNV-5831")
+    @pytest.mark.single_nic
     def test_service_with_default_ip_family_policy(
         self,
         running_vm_for_exposure,
@@ -151,6 +153,7 @@ class TestServiceConfigurationViaVirtctl:
         ],
         indirect=["virtctl_expose_service", "expected_num_families_in_service"],
     )
+    @pytest.mark.single_nic
     def test_vitrctl_expose_services(
         self,
         expected_num_families_in_service,

--- a/tests/network/general/test_network_naming.py
+++ b/tests/network/general/test_network_naming.py
@@ -12,6 +12,7 @@ def invalid_network_names():
 
 
 @pytest.mark.polarion("CNV-8304")
+@pytest.mark.single_nic
 def test_vm_with_illegal_network_name(namespace, unprivileged_client, invalid_network_names):
     vm_name = "unsupported-network-name-vm"
 

--- a/tests/network/general/test_vm_ips_report.py
+++ b/tests/network/general/test_vm_ips_report.py
@@ -38,12 +38,14 @@ def report_masquerade_ip_vmi(unprivileged_client, namespace):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4455")
+@pytest.mark.single_nic
 def test_report_masquerade_ip(report_masquerade_ip_vmi):
     assert_ip_mismatch(vm=report_masquerade_ip_vmi)
 
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-4153")
+@pytest.mark.single_nic
 def test_report_masquerade_ip_after_migration(report_masquerade_ip_vmi):
     src_node = report_masquerade_ip_vmi.instance.status.nodeName
     with VirtualMachineInstanceMigration(

--- a/tests/network/jumbo_frame/test_pod_network_ovn.py
+++ b/tests/network/jumbo_frame/test_pod_network_ovn.py
@@ -17,6 +17,7 @@ pytestmark = [
 class TestJumboPodNetworkOnly:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-9660")
+    @pytest.mark.single_nic
     def test_jumbo_traffic_over_pod_network_separate_nodes(
         self,
         running_vma_jumbo_primary_interface_worker_1,
@@ -31,6 +32,7 @@ class TestJumboPodNetworkOnly:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-9671")
+    @pytest.mark.single_nic
     def test_jumbo_traffic_over_pod_network_same_node(
         self,
         running_vma_jumbo_primary_interface_worker_1,
@@ -45,6 +47,7 @@ class TestJumboPodNetworkOnly:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-9672")
+    @pytest.mark.single_nic
     def test_jumbo_negative_traffic_over_pod_network_with_oversized_traffic(
         self,
         running_vma_jumbo_primary_interface_worker_1,

--- a/tests/network/kubemacpool/test_kubemacpool.py
+++ b/tests/network/kubemacpool/test_kubemacpool.py
@@ -120,6 +120,7 @@ class TestNegatives:
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4405")
+@pytest.mark.single_nic
 def test_kmp_down(namespace, kmp_down):
     with pytest.raises(ApiException):
         with VirtualMachineForTests(name="kmp-down-vm", namespace=namespace.name):

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -83,6 +83,7 @@ def vm_console_connection_ready(running_vm_for_migration):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-6733")
+@pytest.mark.single_nic
 def test_connectivity_after_migration(
     namespace,
     running_vm_static,

--- a/tests/network/network_policy/test_network_policy.py
+++ b/tests/network/network_policy/test_network_policy.py
@@ -114,6 +114,7 @@ def running_network_policy_vmb(network_policy_vmb):
 
 @pytest.mark.order(before="test_network_policy_allow_http80")
 @pytest.mark.polarion("CNV-369")
+@pytest.mark.single_nic
 def test_network_policy_deny_all_http(
     deny_all_http_ports,
     network_policy_vma,
@@ -134,6 +135,7 @@ def test_network_policy_deny_all_http(
 
 @pytest.mark.order(before="test_network_policy_allow_all_http")
 @pytest.mark.polarion("CNV-2775")
+@pytest.mark.single_nic
 def test_network_policy_allow_http80(
     allow_http80_port,
     network_policy_vma,
@@ -155,6 +157,7 @@ def test_network_policy_allow_http80(
 
 
 @pytest.mark.polarion("CNV-2774")
+@pytest.mark.single_nic
 def test_network_policy_allow_all_http(
     allow_all_http_ports,
     network_policy_vma,

--- a/tests/network/ovs_optin/test_ovs_optin.py
+++ b/tests/network/ovs_optin/test_ovs_optin.py
@@ -51,6 +51,7 @@ def hyperconverged_ovs_annotations_removed(
 @pytest.mark.sno
 class TestOVSOptIn:
     @pytest.mark.polarion("CNV-5520")
+    @pytest.mark.single_nic
     def test_ovs_installed(
         self,
         admin_client,
@@ -66,6 +67,7 @@ class TestOVSOptIn:
         )
 
     @pytest.mark.polarion("CNV-5533")
+    @pytest.mark.single_nic
     def test_ovs_not_installed_annotations_removed(
         self,
         admin_client,
@@ -80,6 +82,7 @@ class TestOVSOptIn:
         )
 
     @pytest.mark.polarion("CNV-5531")
+    @pytest.mark.single_nic
     def test_ovs_not_installed_annotations_disabled(
         self,
         admin_client,

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -11,6 +11,7 @@ pytestmark = pytest.mark.service_mesh
 
 class TestSMTrafficManagement:
     @pytest.mark.polarion("CNV-5782")
+    @pytest.mark.single_nic
     def test_service_mesh_traffic_management(
         self,
         traffic_management_service_mesh_convergence,
@@ -25,6 +26,7 @@ class TestSMTrafficManagement:
         )
 
     @pytest.mark.polarion("CNV-7304")
+    @pytest.mark.single_nic
     def test_service_mesh_traffic_management_manipulated_rule(
         self,
         traffic_management_service_mesh_convergence,
@@ -43,6 +45,7 @@ class TestSMTrafficManagement:
 class TestSMPeerAuthentication:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-5784")
+    @pytest.mark.single_nic
     def test_authentication_policy_from_mesh(
         self,
         peer_authentication_service_mesh_deployment,
@@ -56,6 +59,7 @@ class TestSMPeerAuthentication:
 
     @pytest.mark.polarion("CNV-7305")
     @pytest.mark.ipv4
+    @pytest.mark.single_nic
     def test_authentication_policy_outside_mesh(
         self,
         outside_mesh_vm_fedora_with_service_mesh_annotation,
@@ -70,6 +74,7 @@ class TestSMPeerAuthentication:
             )
 
     @pytest.mark.polarion("CNV-7128")
+    @pytest.mark.single_nic
     def test_service_mesh_inbound_traffic_blocked(
         self,
         outside_mesh_vm_fedora_with_service_mesh_annotation,

--- a/tests/network/single_node_tests/test_network_sno_deployment.py
+++ b/tests/network/single_node_tests/test_network_sno_deployment.py
@@ -20,6 +20,7 @@ def network_daemonset_deployment_resources(admin_client, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-8255")
+@pytest.mark.single_nic
 def test_desired_number_of_cnao_pods_on_sno_cluster(
     network_daemonset_deployment_resources,
 ):

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -102,6 +102,7 @@ def client(vma_udn, vmb_udn_non_migratable):
 @pytest.mark.ipv4
 class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11624")
+    @pytest.mark.single_nic
     def test_ip_address_in_running_vm_matches_udn_subnet(self, namespaced_layer2_user_defined_network, vma_udn):
         ip = lookup_iface_status(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name)[IP_ADDRESS]
         (subnet,) = namespaced_layer2_user_defined_network.subnets
@@ -110,6 +111,7 @@ class TestPrimaryUdn:
         )
 
     @pytest.mark.polarion("CNV-11674")
+    @pytest.mark.single_nic
     def test_ip_address_is_preserved_after_live_migration(self, vma_udn):
         ip_before_migration = lookup_iface_status(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name)[
             IP_ADDRESS
@@ -125,6 +127,7 @@ class TestPrimaryUdn:
         )
 
     @pytest.mark.polarion("CNV-11434")
+    @pytest.mark.single_nic
     def test_vm_egress_connectivity(self, vmb_udn_non_migratable):
         assert lookup_iface_status(
             vm=vmb_udn_non_migratable, iface_name=lookup_primary_network(vm=vmb_udn_non_migratable).name
@@ -132,6 +135,7 @@ class TestPrimaryUdn:
         vmb_udn_non_migratable.console(commands=[f"ping -c 3 {PUBLIC_DNS_SERVER_IP}"], timeout=TIMEOUT_1MINUTE)
 
     @pytest.mark.polarion("CNV-11418")
+    @pytest.mark.single_nic
     def test_basic_connectivity_between_udn_vms(self, vma_udn, vmb_udn_non_migratable):
         target_vm_ip = lookup_iface_status(
             vm=vmb_udn_non_migratable, iface_name=lookup_primary_network(vm=vmb_udn_non_migratable).name
@@ -139,6 +143,7 @@ class TestPrimaryUdn:
         vma_udn.console(commands=[f"ping -c 3 {target_vm_ip}"], timeout=TIMEOUT_1MIN)
 
     @pytest.mark.polarion("CNV-11427")
+    @pytest.mark.single_nic
     def test_connectivity_is_preserved_after_live_migration(self, vma_udn, server, client):
         migrate_vm_and_verify(vm=vma_udn)
         assert is_tcp_connection(server=server, client=client)


### PR DESCRIPTION
Acceptance tests for new architectures, platforms etc. shouldn't depend on having extra NICs on the cluster nodes, except for the primary interface. In order to have satisfactory coveage in these tests, we mark all the these tests with the a new marker, which can and should be used for these types of tests.
