### PR TITLE
[virt] fix get_oc_image_info sampler

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -62,6 +62,7 @@ from utilities.constants import (
     SSH_PORT_22,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
+    TIMEOUT_1SEC,
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
@@ -2214,28 +2215,29 @@ def wait_for_kv_stabilize(admin_client, hco_namespace):
     wait_for_hco_conditions(admin_client=admin_client, hco_namespace=hco_namespace)
 
 
-def get_oc_image_info(
+def get_oc_image_info(  # type: ignore[return]
     image: str, pull_secret: str | None = None, architecture: str = LINUX_AMD_64
 ) -> dict[str, Any] | Any:
+    def _get_image_json(cmd: str) -> dict[str, Any]:
+        return json.loads(run_command(command=shlex.split(cmd), check=False)[1])
+
     base_command = f"oc image -o json info {image} --filter-by-os {architecture}"
     if pull_secret:
         base_command = f"{base_command} --registry-config={pull_secret}"
     sample = None
     try:
         for sample in TimeoutSampler(
-            wait_timeout=10,
-            sleep=1,
+            wait_timeout=TIMEOUT_10SEC,
+            sleep=TIMEOUT_1SEC,
             exceptions_dict={JSONDecodeError: [], TypeError: []},
-            func=run_command,
-            command=shlex.split(base_command),
-            check=False,
+            func=_get_image_json,
+            cmd=base_command,
         ):
-            command_out = sample[1]
-            return json.loads(command_out)
+            if sample:
+                return sample
     except TimeoutExpiredError:
-        LOGGER.error(f"Failed to parse {base_command} output: {sample}")
+        LOGGER.error(f"Failed to parse {base_command}\noutput: {sample}")
         raise
-    return None
 
 
 def taint_node_no_schedule(node):

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2217,7 +2217,7 @@ def wait_for_kv_stabilize(admin_client, hco_namespace):
 
 def get_oc_image_info(  # type: ignore[return]
     image: str, pull_secret: str | None = None, architecture: str = LINUX_AMD_64
-) -> dict[str, Any] | Any:
+) -> dict[str, Any]:
     def _get_image_json(cmd: str) -> dict[str, Any]:
         return json.loads(run_command(command=shlex.split(cmd), check=False)[1])
 
@@ -2236,7 +2236,7 @@ def get_oc_image_info(  # type: ignore[return]
             if sample:
                 return sample
     except TimeoutExpiredError:
-        LOGGER.error(f"Failed to parse {base_command}\noutput: {sample}")
+        LOGGER.error(f"Failed to parse {base_command}")
         raise
 
 


### PR DESCRIPTION
##### Short description:
fix `TimeoutSampler` usage in `get_oc_image_info` (fails on first exception catched)
`failed on setup with "json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)"`
now should correctly re-try for 10 sec getting image

##### More details:
Possibly should fix flake when first attempt fails due to connectivity issue

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

