### PR TITLE
[4.18] Use upgrade markers expliciity for test collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Command to run entire upgrade test suite for ocp upgrade, including pre and post
 Command to run only ocp upgrade test, without any pre/post validation:
 
 ```bash
--m ocp_upgrade --upgrade ocp --ocp-image <ocp_image_to_upgrade_to>
+-m product_upgrade_test --upgrade ocp --ocp-image <ocp_image_to_upgrade_to>
 ```
 
 To upgrade to ocp version: 4.10.16, using <https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.10.16>, following command can be used:
@@ -250,7 +250,7 @@ Command to run entire upgrade test suite for cnv upgrade, including pre and post
 Command to run only cnv upgrade test, without any pre/post validation:
 
 ```bash
--m cnv_upgrade --upgrade cnv --cnv-version <target_version> --cnv-image <cnv_image_to_upgrade_to>
+-m product_upgrade_test --upgrade cnv --cnv-version <target_version> --cnv-image <cnv_image_to_upgrade_to>
 ```
 
 To upgrade to cnv 4.Y.z, using the cnv image that has been shipped, following command could be used:

--- a/conftest.py
+++ b/conftest.py
@@ -342,28 +342,27 @@ def mark_tests_by_team(item: Item) -> None:
 def filter_upgrade_tests(
     items: list[Item],
     config: Config,
-    upgrade_markers: list[str],
 ) -> tuple[list[Item], list[Item]]:
     upgrade_tests, non_upgrade_tests = [], []
+    upgrade_markers = {"upgrade", "upgrade_custom"}
+    chosen_upgrade_markers = {marker for marker in upgrade_markers if config.getoption(f"--{marker}")}
+    upgrade_markers_to_collect = chosen_upgrade_markers or upgrade_markers
 
     for item in items:
-        if set(upgrade_markers).intersection(set(item.keywords)):
+        if upgrade_markers_to_collect.intersection(set(item.keywords)):
             upgrade_tests.append(item)
         else:
             non_upgrade_tests.append(item)
 
-    if any(config.getoption(f"--{marker}") for marker in upgrade_markers):
-        # If performing OCP upgrade, remove tests marked with pytest.mark.cnv_upgrade.
-        # If performing CNV upgrade, remove test marked with pytest.mark.ocp_upgrade,
-        # and determine if we are running the cnv upgrade test for production source or for stage/osbs.
-        cnv_source = config.getoption("--cnv-source")
-
+    # If upgrade marker configured, select specific upgrade tests by marker, and discard the others.
+    if chosen_upgrade_markers:
         upgrade_tests, discard = remove_upgrade_tests_based_on_config(
-            cnv_source=cnv_source,
+            cnv_source=config.getoption("--cnv-source"),
             upgrade_tests=upgrade_tests,
         )
         return upgrade_tests, [*non_upgrade_tests, *discard]
 
+    # If no upgrade marker in config, discard all upgrade tests.
     return non_upgrade_tests, upgrade_tests
 
 
@@ -373,41 +372,28 @@ def remove_upgrade_tests_based_on_config(
 ) -> tuple[list[Item], list[Item]]:
     """
     Filter the correct upgrade tests to execute based on config, since only one lane can be chosen.
+    If performing OCP upgrade, keep only the tests with pytest.mark.ocp_upgrade.
+    If performing EUS upgrade, keep only the tests with pytest.mark.eus_upgrade.
+    If performing CNV upgrade, keep only the tests with pytest.mark.cnv_upgrade.
+    In addition, determine if we are running the cnv upgrade test for production source or for stage/osbs.
 
     Args:
         cnv_source(str): cnv source option.
         upgrade_tests(list): list of upgrade tests.
     """
-    ocp_upgrade_test: Item
-    cnv_upgrade_test_with_prod_src: Item
-    cnv_upgrade_test_no_prod_src: Item
-    eus_upgrade_test: Item
-    cnv_upgrade_tests: list[Item] = []
+    keep: list[Item] = []
+    marker_str = f"{py_config['upgraded_product']}_upgrade"
 
     for test in upgrade_tests:
-        if "ocp_upgrade" in test.keywords:
-            ocp_upgrade_test = test
-        elif "eus_upgrade" in test.keywords:
-            eus_upgrade_test = test
-        elif "cnv_upgrade" in test.keywords:
-            cnv_upgrade_tests.append(test)
-            if "production_source" in test.name:
-                cnv_upgrade_test_with_prod_src = test
-            else:
-                cnv_upgrade_test_no_prod_src = test
+        if marker_str == "cnv_upgrade" and "cnv_upgrade_process" in test.name:
+            # choose the right cnv_upgrade test according to cnv_source.
+            # production cnv_upgrade_test if prod source, otherwise the stage/osbs one
+            if (cnv_source == "production") == ("production_source" in test.name):
+                keep.append(test)
+        elif marker_str in test.keywords:
+            keep.append(test)
 
-    if py_config["upgraded_product"] == "cnv":
-        discard = [
-            cnv_upgrade_test_no_prod_src if cnv_source == "production" else cnv_upgrade_test_with_prod_src,
-            ocp_upgrade_test,
-            eus_upgrade_test,
-        ]
-    elif py_config["upgraded_product"] == "ocp":
-        discard = [*cnv_upgrade_tests, eus_upgrade_test]
-    else:
-        discard = [*cnv_upgrade_tests, ocp_upgrade_test]
-
-    keep = [test for test in upgrade_tests if test not in discard]
+    discard = [test for test in upgrade_tests if test not in keep]
     return keep, discard
 
 
@@ -492,15 +478,7 @@ def pytest_collection_modifyitems(session, config, items):
 
         mark_tests_by_team(item=item)
     #  Collect only 'upgrade_custom' tests when running pytest with --upgrade_custom
-    if config.getoption("--upgrade_custom"):
-        keep, discard = filter_upgrade_tests(items=items, config=config, upgrade_markers=["upgrade_custom"])
-    #  Collect only 'upgrade' tests when running pytest with --upgrade
-    elif config.getoption("--upgrade"):
-        keep, discard = filter_upgrade_tests(items=items, config=config, upgrade_markers=["upgrade"])
-    #  For non-upgrade tests we should exclude both markers: 'upgrade' and 'upgrade_custom'
-    else:
-        keep, discard = filter_upgrade_tests(items=items, config=config, upgrade_markers=["upgrade", "upgrade_custom"])
-
+    keep, discard = filter_upgrade_tests(items=items, config=config)
     items[:] = keep
     if discard:
         config.hook.pytest_deselected(items=discard)

--- a/pytest.ini
+++ b/pytest.ini
@@ -44,6 +44,7 @@ markers =
     install: Tests that self-manage HCO/CNV installation
     upgrade: Run regular upgrade lanes with default configuration
     upgrade_custom: Run custom upgrade lanes with non-default configuration (e.g. with hco featuregates customized)
+    product_upgrade_test: Marks product upgrade tests
     post_upgrade: Marks tests which should be executed after upgrade
     cnv_upgrade: Mark cnv upgrade test
     ocp_upgrade: Mark ocp upgrade test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2125,12 +2125,6 @@ def generated_ssh_key_for_vm_access(ssh_key_tmpdir_scope_session):
 
 
 @pytest.fixture(scope="session")
-def skip_on_ocp_upgrade(pytestconfig):
-    if pytestconfig.option.upgrade == "ocp":
-        pytest.skip("This test is not supported for OCP upgrade")
-
-
-@pytest.fixture(scope="session")
 def rhel9_http_image_url():
     return get_http_image_url(image_directory=Images.Rhel.DIR, image_name=Images.Rhel.RHEL9_4_IMG)
 

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -317,17 +317,6 @@ def fired_alerts_during_upgrade(fired_alerts_before_upgrade, alert_dir, promethe
 
 
 @pytest.fixture(scope="session")
-def is_eus_upgrade(pytestconfig):
-    return pytestconfig.option.upgrade == EUS
-
-
-@pytest.fixture(scope="session")
-def skip_on_eus_upgrade(is_eus_upgrade):
-    if is_eus_upgrade:
-        pytest.skip("This test is not supported for EUS upgrade")
-
-
-@pytest.fixture(scope="session")
 def eus_cnv_upgrade_path(eus_target_cnv_version):
     # Get the shortest path to the target (EUS) version
     upgrade_path_to_target_version = get_shortest_upgrade_path(target_version=eus_target_cnv_version)

--- a/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
@@ -9,7 +9,9 @@ from utilities.infra import get_related_images_name_and_version
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.product_upgrade_test
 @pytest.mark.upgrade
+@pytest.mark.upgrade_custom
 @pytest.mark.eus_upgrade
 class TestEUSToEUSUpgrade:
     @pytest.mark.polarion("CNV-9509")

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.usefixtures(
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.product_upgrade_test
 @pytest.mark.sno
 @pytest.mark.upgrade
 @pytest.mark.upgrade_custom

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
@@ -17,10 +17,15 @@ from utilities.data_collector import collect_alerts_data
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.upgrade_custom,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.sno,
+]
 
-@pytest.mark.upgrade_custom
-@pytest.mark.sno
-@pytest.mark.upgrade
+
 class TestUpgradeIUO:
     """Post-upgrade tests"""
 
@@ -32,7 +37,6 @@ class TestUpgradeIUO:
     )
     def test_alerts_fired_during_upgrade(
         self,
-        skip_on_eus_upgrade,
         prometheus_scope_function,
         fired_alerts_during_upgrade,
     ):
@@ -45,6 +49,7 @@ class TestUpgradeIUO:
             collect_alerts_data()
             raise AssertionError(f"Following alerts were fired during upgrade: {fired_alerts_during_upgrade}")
 
+    @pytest.mark.eus_upgrade
     @pytest.mark.polarion("CNV-6866")
     @pytest.mark.order(before=IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID, after=IUO_CNV_ALERT_ORDERING_NODE_ID)
     @pytest.mark.dependency(
@@ -55,6 +60,7 @@ class TestUpgradeIUO:
         LOGGER.info("Verify nodes taints after upgrade.")
         verify_nodes_taints_after_upgrade(nodes=nodes, nodes_taints_before_upgrade=nodes_taints_before_upgrade)
 
+    @pytest.mark.eus_upgrade
     @pytest.mark.polarion("CNV-6924")
     @pytest.mark.order(before=IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID, after=IUO_CNV_ALERT_ORDERING_NODE_ID)
     @pytest.mark.dependency(

--- a/tests/network/upgrade/test_upgrade_network.py
+++ b/tests/network/upgrade/test_upgrade_network.py
@@ -29,8 +29,14 @@ from utilities.network import (
 LOGGER = logging.getLogger(__name__)
 DEPENDENCIES_NODE_ID_PREFIX = f"{os.path.abspath(__file__)}::TestUpgradeNetwork"
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+]
 
-@pytest.mark.upgrade
+
 @pytest.mark.usefixtures("running_vm_with_bridge")
 class TestUpgradeNetwork:
     """Pre-upgrade tests"""

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -23,9 +23,15 @@ from utilities.virt import migrate_vm_and_verify
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+]
+
 
 @pytest.mark.usefixtures("updated_default_storage_class_ocs_virt")
-@pytest.mark.upgrade
 class TestUpgradeStorage:
     """Pre-upgrade tests"""
 

--- a/tests/upgrade_params.py
+++ b/tests/upgrade_params.py
@@ -10,7 +10,7 @@ if py_config["upgraded_product"] == EUS:
 else:
     upgrade_class = "TestUpgrade"
     upgrade_source_suffix = "_production_source" if py_config["cnv_source"] == "production" else ""
-    test_name = f"test_{py_config['upgraded_product']}{upgrade_source_suffix}_upgrade_process"
+    test_name = f"test{upgrade_source_suffix}_{py_config['upgraded_product']}_upgrade_process"
     file_name = f"{UPGRADE_PACKAGE_NAME}/test_upgrade.py"
 
 IUO_UPGRADE_TEST_ORDERING_NODE_ID = IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID = f"{file_name}::{upgrade_class}::{test_name}"

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -45,12 +45,18 @@ AFTER_UPGRADE_STORAGE_ORDERING = [
     SNAPSHOT_RESTORE_CHECK_AFTER_UPGRADE_ID,
 ]
 
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+]
 
-@pytest.mark.upgrade
+
 @pytest.mark.usefixtures("base_templates")
 class TestUpgradeVirt:
     """Pre-upgrade tests"""
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2974")
     @pytest.mark.order("first")
@@ -59,6 +65,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             assert vm.vmi.status == VirtualMachineInstance.Status.RUNNING
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2987")
     @pytest.mark.order(before=MIGRATION_BEFORE_UPGRADE_TEST_ORDERING)
@@ -71,6 +78,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             vm_console_run_commands(vm=vm, commands=["ls"])
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4208")
     @pytest.mark.order(before=MIGRATION_BEFORE_UPGRADE_TEST_ORDERING)
@@ -82,6 +90,7 @@ class TestUpgradeVirt:
     def test_vm_ssh_before_upgrade(self, vms_for_upgrade):
         verify_vms_ssh_connectivity(vms_list=vms_for_upgrade)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.polarion("CNV-2975")
     @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
     @pytest.mark.dependency(
@@ -94,6 +103,7 @@ class TestUpgradeVirt:
             if vm_is_migrateable(vm=vm):
                 migrate_vm_and_verify(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6999")
     @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID, after=MIGRATION_BEFORE_UPGRADE_TEST_NODE_ID)
@@ -107,6 +117,7 @@ class TestUpgradeVirt:
     ):
         verify_vms_ssh_connectivity(vms_list=[manual_run_strategy_vm, always_run_strategy_vm])
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.high_resource_vm
     @pytest.mark.polarion("CNV-7243")
@@ -132,7 +143,6 @@ class TestUpgradeVirt:
     )
     def test_vmi_pod_image_updates_after_upgrade_optin(
         self,
-        skip_on_ocp_upgrade,
         unupdated_vmi_pods_names,
     ):
         """
@@ -140,6 +150,7 @@ class TestUpgradeVirt:
         """
         assert not unupdated_vmi_pods_names, f"The following VMI Pods were not updated: {unupdated_vmi_pods_names}"
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2978")
     @pytest.mark.order(after=[IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID], before=AFTER_UPGRADE_STORAGE_ORDERING)
@@ -156,6 +167,7 @@ class TestUpgradeVirt:
             vm.vmi.wait_until_running()
         verify_linux_boot_time(vm_list=vms_for_upgrade, initial_boot_time=linux_boot_time_before_upgrade)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2980")
     @pytest.mark.order(after=[IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID], before=AFTER_UPGRADE_STORAGE_ORDERING)
@@ -171,6 +183,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             vm_console_run_commands(vm=vm, commands=["ls"])
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4209")
     @pytest.mark.order(after=[IMAGE_UPDATE_AFTER_UPGRADE_NODE_ID], before=AFTER_UPGRADE_STORAGE_ORDERING)
@@ -185,6 +198,7 @@ class TestUpgradeVirt:
     def test_vm_ssh_after_upgrade(self, vms_for_upgrade):
         verify_vms_ssh_connectivity(vms_list=vms_for_upgrade)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-7000")
     @pytest.mark.order(
@@ -204,6 +218,7 @@ class TestUpgradeVirt:
         )
         verify_vms_ssh_connectivity(vms_list=run_strategy_vmi_list)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-7244")
     @pytest.mark.order(
@@ -228,6 +243,7 @@ class TestUpgradeVirt:
         verify_vms_ssh_connectivity(vms_list=[windows_vm])
         verify_windows_boot_time(windows_vm=windows_vm, initial_boot_time=windows_boot_time_before_upgrade)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.polarion("CNV-2979")
     @pytest.mark.order(
         after=[
@@ -250,6 +266,7 @@ class TestUpgradeVirt:
                 migrate_vm_and_verify(vm=vm)
                 vm_console_run_commands(vm=vm, commands=["ls"], timeout=1100)
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-3682")
     @pytest.mark.order(
@@ -271,6 +288,7 @@ class TestUpgradeVirt:
                 == vms_for_upgrade_dict_before[vm.name]["spec"]["template"]["spec"]["domain"]["machine"]["type"]
             )
 
+    @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5749")
     @pytest.mark.order(

--- a/tests/virt/upgrade_custom/aaq/test_upgrade_virt_aaq.py
+++ b/tests/virt/upgrade_custom/aaq/test_upgrade_virt_aaq.py
@@ -14,13 +14,17 @@ from utilities.constants import DEPENDENCY_SCOPE_SESSION
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.usefixtures(
-    "enabled_aaq_feature_gate_scope_session",
-)
+pytestmark = [
+    pytest.mark.upgrade_custom,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.sno,
+    pytest.mark.usefixtures(
+        "enabled_aaq_feature_gate_scope_session",
+    ),
+]
 
 
-@pytest.mark.sno
-@pytest.mark.upgrade_custom
 class TestUpgradeVirtAAQ:
     """Pre-upgrade tests"""
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ commands =
     uv run pytest --upgrade=cnv --cnv-image=NA --cnv-version=NA --collect-only
     uv run pytest --upgrade=ocp --ocp-image=NA --collect-only
     uv run pytest --upgrade=eus --eus-ocp-images=NA,NA --collect-only
+    uv run pytest --upgrade_custom=cnv --cnv-image=NA --cnv-version=NA --collect-only
+    uv run pytest --upgrade_custom=ocp --ocp-image=NA --collect-only
     uv run pytest --tc-file=tests/global_config_aws.py --collect-only
     uv run pytest --tc-file=tests/global_config_rh_it.py --collect-only
     uv run pytest --tc-file=tests/global_config.py -m smoke --collect-only


### PR DESCRIPTION
##### Short description:
Cherry pick from [main](https://github.com/RedHatQE/openshift-virtualization-tests/pull/448)

##### More details:
Use explicit upgrade marker to detect test related to an upgrade lane(ocp/cnv/eus).
  If performing OCP upgrade, keep only the tests with pytest.mark.ocp_upgrade.
  If performing EUS upgrade, keep only the tests with pytest.mark.eus_upgrade.
  If performing CNV upgrade, keep only the tests with pytest.mark.cnv_upgrade.
  In addition,for cnv upgrade, determine if we are running the cnv upgrade test for production source or for stage/osbs.

##### What this PR does / why we need it:
It will allow to choose specific tests per upgrade type, which is more flexible when adding/removing upgrade tests,
and know excatly which should be running.
In addition, we can get rid of the programmatic skips. 

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-57035