### PR TITLE
tests, net, libs: Introduce network cloud-init data structure

### DIFF
--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import pytest
 
 import utilities.network
+from tests.network.libs import cloudinit as netcloud
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
     BondNodeNetworkConfigurationPolicy,
@@ -126,8 +127,7 @@ def ovs_linux_bond_bridge_attached_vma(
     name = "bond-vma"
     networks = OrderedDict()
     networks[ovs_linux_br1bond_nad.name] = ovs_linux_br1bond_nad.name
-    network_data_data = {"ethernets": {"eth1": {"addresses": ["10.200.3.1/24"]}}}
-    cloud_init_data = cloud_init_network_data(data=network_data_data)
+    netdata = netcloud.NetworkData(ethernets={"eth1": netcloud.EthernetDevice(addresses=["10.200.3.1/24"])})
 
     with VirtualMachineForTests(
         namespace=namespace.name,
@@ -136,7 +136,7 @@ def ovs_linux_bond_bridge_attached_vma(
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        cloud_init_data=cloud_init_data,
+        cloud_init_data=netcloud.cloudinit(netdata=netdata),
         client=unprivileged_client,
     ) as vm:
         vm.start(wait=True)

--- a/tests/network/libs/apimachinery.py
+++ b/tests/network/libs/apimachinery.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+
+def dict_normalization_for_dataclass(data: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Filter out none values and converts key characters containing underscores into dashes."""
+    return {key.replace("_", "-"): val for (key, val) in data if val is not None}

--- a/tests/network/libs/cloudinit.py
+++ b/tests/network/libs/cloudinit.py
@@ -1,0 +1,62 @@
+from dataclasses import asdict, dataclass, field
+from typing import Any, Final
+
+NETWORK_DATA: Final[str] = "networkData"
+
+
+@dataclass
+class MatchSelector:
+    macaddress: str
+
+
+@dataclass
+class EthernetDevice:
+    """
+    Ethernet Device
+
+    Example:
+        addresses:
+        - 1.1.1.1/24
+        - d10:0:2::2
+        gateway6: d10:0:2::1
+    """
+
+    dhcp4: bool | None = None
+    addresses: list[str] | None = None
+    gateway6: str | None = None
+
+    match: MatchSelector | None = None
+    set_name: str | None = None
+
+
+@dataclass
+class NetworkData:
+    """
+    Cloud init network data.
+    https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html
+
+    Example:
+        version: 2
+        ethernets:
+          eth0:
+            addresses:
+            - 1.1.1.1/24
+            - d10:0:2::2
+            gateway6: d10:0:2::1
+    """
+
+    version: int = field(default=2, init=False)
+    ethernets: dict[str, EthernetDevice]
+
+
+def cloudinit(netdata: NetworkData) -> dict[str, Any]:
+    return {NETWORK_DATA: todict(netdata)}
+
+
+def todict(netdata: NetworkData) -> dict[str, Any]:
+    return asdict(obj=netdata, dict_factory=_dict_normalization)
+
+
+def _dict_normalization(data: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Filter out none values and converts key characters containing underscores into dashes."""
+    return {key.replace("_", "-"): val for (key, val) in data if val is not None}

--- a/tests/network/libs/cloudinit.py
+++ b/tests/network/libs/cloudinit.py
@@ -1,6 +1,8 @@
 from dataclasses import asdict, dataclass, field
 from typing import Any, Final
 
+from tests.network.libs.apimachinery import dict_normalization_for_dataclass
+
 NETWORK_DATA: Final[str] = "networkData"
 
 
@@ -54,9 +56,4 @@ def cloudinit(netdata: NetworkData) -> dict[str, Any]:
 
 
 def todict(netdata: NetworkData) -> dict[str, Any]:
-    return asdict(obj=netdata, dict_factory=_dict_normalization)
-
-
-def _dict_normalization(data: list[tuple[str, Any]]) -> dict[str, Any]:
-    """Filter out none values and converts key characters containing underscores into dashes."""
-    return {key.replace("_", "-"): val for (key, val) in data if val is not None}
+    return asdict(obj=netdata, dict_factory=dict_normalization_for_dataclass)

--- a/tests/network/libs/nodenetworkconfigurationpolicy.py
+++ b/tests/network/libs/nodenetworkconfigurationpolicy.py
@@ -7,6 +7,8 @@ from ocp_resources.node_network_configuration_policy_latest import NodeNetworkCo
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import retry
 
+from tests.network.libs.apimachinery import dict_normalization_for_dataclass
+
 WAIT_FOR_STATUS_TIMEOUT_SEC = 90
 WAIT_FOR_STATUS_INTERVAL_SEC = 5
 
@@ -94,14 +96,9 @@ class NodeNetworkConfigurationPolicy(Nncp):
         self._desired_state = desired_state
         super().__init__(
             name=name,
-            desired_state=asdict(desired_state, dict_factory=self._dict_normalization),
+            desired_state=asdict(desired_state, dict_factory=dict_normalization_for_dataclass),
             node_selector=node_selector,
         )
-
-    @staticmethod
-    def _dict_normalization(data: list[tuple[str, Any]]) -> dict[str, Any]:
-        """Filter out none values and converts key characters containing underscores into dashes."""
-        return {key.replace("_", "-"): val for (key, val) in data if val is not None}
 
     @property
     def desired_state_spec(self) -> DesiredState:


### PR DESCRIPTION
##### Short description:
Introduce network cloud-init data structure and use it 

##### What this PR does / why we need it:

Introduce a new data structure for network cloud-init.
It is aimed to replace the existing dict-based configuration.

Usage example:
```python
from tests.network.libs import cloudinit

nd = cloudinit.NetworkData(ethernets={
    "eth0": EthernetDevice(
        dhcp4=False,
        addresses=["1.1.1.1/24", "d10:0:2::2"],
        gateway6="d10:0:2::1",
    )
})

nd_yaml = yaml.safe_dump(cloudinit.todict(netdata=nd), sort_keys=False)
cloudinit_dict = cloudinit.cloudinit(netdata=nd)
```


##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
