### PR TITLE
[4.19][Upgrade] Modify cnv upgrade MCP check for osbs source

### DIFF
--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -88,7 +88,7 @@ def updated_image_content_source_policy(
     admin_client,
     nodes,
     tmpdir_factory,
-    machine_config_pools,
+    active_machine_config_pools,
     machine_config_pools_conditions,
     cnv_image_url,
     cnv_image_name,
@@ -119,7 +119,7 @@ def updated_image_content_source_policy(
     )
     apply_icsp_idms(
         file_paths=[file_path],
-        machine_config_pools=machine_config_pools,
+        machine_config_pools=active_machine_config_pools,
         mcp_conditions=machine_config_pools_conditions,
         nodes=nodes,
         is_idms_file=is_idms_cluster,
@@ -431,9 +431,18 @@ def eus_applied_all_icsp(
     )
 
 
+@pytest.fixture(scope="session")
+def active_machine_config_pools(machine_config_pools):
+    return [
+        machine_config_pool
+        for machine_config_pool in machine_config_pools
+        if machine_config_pool.instance.status.machineCount > 0
+    ]
+
+
 @pytest.fixture()
-def machine_config_pools_conditions(machine_config_pools):
-    return get_machine_config_pools_conditions(machine_config_pools=machine_config_pools)
+def machine_config_pools_conditions(active_machine_config_pools):
+    return get_machine_config_pools_conditions(machine_config_pools=active_machine_config_pools)
 
 
 @pytest.fixture(scope="session")

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
@@ -27,7 +27,7 @@ class TestUpgrade:
         self,
         admin_client,
         nodes,
-        machine_config_pools,
+        active_machine_config_pools,
         machine_config_pools_conditions,
         extracted_ocp_version_from_image_url,
         updated_ocp_upgrade_channel,
@@ -37,7 +37,7 @@ class TestUpgrade:
         verify_upgrade_ocp(
             admin_client=admin_client,
             target_ocp_version=extracted_ocp_version_from_image_url,
-            machine_config_pools_list=machine_config_pools,
+            machine_config_pools_list=active_machine_config_pools,
             initial_mcp_conditions=machine_config_pools_conditions,
             nodes=nodes,
         )


### PR DESCRIPTION
##### Short description:
Cherry pick from https://github.com/RedHatQE/openshift-virtualization-tests/pull/737

##### More details:
KubeVirtDeprecatedAPIRequested alert - fired because worker's MCP fails to update and we collect must gather - which in turn collecting VirtualMachineInstancePresets which is deprecated API.

So on compact clusters - we should wait only for "master" MCP upgrade.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: