### PR TITLE
add storage_class_matrix to arm64 global config

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -2,6 +2,7 @@ import os
 from typing import Any
 
 import pytest_testconfig
+from ocp_resources.datavolume import DataVolume
 from ocp_resources.template import Template
 
 from utilities.constants import (
@@ -9,6 +10,7 @@ from utilities.constants import (
     DV_SIZE_STR,
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
     FLAVOR_STR,
+    HPP_CAPABILITIES,
     IMAGE_NAME_STR,
     IMAGE_PATH_STR,
     LATEST_RELEASE_STR,
@@ -18,14 +20,31 @@ from utilities.constants import (
     TEMPLATE_LABELS_STR,
     WORKLOAD_STR,
     Images,
+    StorageClassNames,
 )
 from utilities.infra import get_latest_os_dict_list
+from utilities.storage import HppCsiStorageClass
 
 global config
 global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")
 
 Images.Cirros.RAW_IMG_XZ = "cirros-0.4.0-aarch64-disk.raw.xz"
 EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR] = f"rhel.9.{ARM_64}"
+
+
+storage_class_matrix = [
+    {
+        StorageClassNames.TRIDENT_CSI_NFS: {
+            "volume_mode": DataVolume.VolumeMode.FILE,
+            "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
+            "default": True,
+        }
+    },
+    {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES},
+]
 
 rhel_os_matrix = [
     {

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -619,6 +619,7 @@ class StorageClassNames:
     PORTWORX_CSI_DB_SHARED = "px-csi-db-shared"
     RH_INTERNAL_NFS = "rh-internal-nfs"
     TRIDENT_CSI_FSX = "trident-csi-fsx"
+    TRIDENT_CSI_NFS = "trident-csi-nfs"
     IO2_CSI = "io2-csi"
     GPFS = "ibm-spectrum-scale-sample"
     OCI = "oci-bv"


### PR DESCRIPTION
##### Short description:
add storage_class_matrix to arm64 global config

##### More details:
arm clusters can now be deployed with hpp and trident storage classes
```
hostpath-csi-basic             kubevirt.io.hostpath-provisioner   Delete          WaitForFirstConsumer   false                  10h
hostpath-csi-pvc-block         kubevirt.io.hostpath-provisioner   Delete          WaitForFirstConsumer   false                  10h
trident-csi-nfs (default)      csi.trident.netapp.io              Delete          Immediate              true                   30m
```

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
