### PR TITLE
Fix MemoryDeltaFromRequestedBytes tests flakiness

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -33,6 +33,7 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_VNC_ACTIVE_CONNECTIONS_BY_VMI,
 )
 from tests.observability.metrics.utils import (
+    RSS_MEMORY_COMMAND,
     SINGLE_VM,
     ZERO_CPU_CORES,
     binding_name_and_type_from_vm_or_vmi,
@@ -106,7 +107,6 @@ UPLOAD_STR = "upload"
 CDI_UPLOAD_PRIME = "cdi-upload-prime"
 IP_RE_PATTERN_FROM_INTERFACE = r"eth0.*?inet (\d+\.\d+\.\d+\.\d+)/\d+"
 IP_ADDR_SHOW_COMMAND = shlex.split("ip addr show")
-RSS_MEMORY_COMMAND = shlex.split("bash -c \"cat /sys/fs/cgroup/memory.stat | grep '^anon ' | awk '{print $2}'\"")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -823,53 +823,6 @@ def vm_for_test_with_resource_limits(namespace):
     ) as vm:
         running_vm(vm=vm)
         yield vm
-
-
-@pytest.fixture(scope="class")
-def highest_memory_usage_virt_api_pod(hco_namespace, admin_client):
-    oc_adm_top_pod_output = (
-        run_command(command=shlex.split(f"oc adm top pod -n {hco_namespace.name} -l kubevirt.io=virt-api"))[1]
-        .strip()
-        .split("\n")[1:]
-    )
-    virt_api_with_highest_memory_usage = max(
-        {pod.split()[0]: int(bitmath.parse_string_unsafe(pod.split()[2])) for pod in oc_adm_top_pod_output}.items(),
-        key=lambda pod: pod[1],
-    )
-    return {
-        "virt_api_pod": virt_api_with_highest_memory_usage[0],
-        "memory_usage": virt_api_with_highest_memory_usage[1],
-    }
-
-
-@pytest.fixture(scope="class")
-def virt_api_requested_memory(hco_namespace, admin_client, highest_memory_usage_virt_api_pod):
-    return float(
-        bitmath.parse_string_unsafe(
-            get_pod_by_name_prefix(
-                dyn_client=admin_client,
-                pod_prefix=highest_memory_usage_virt_api_pod["virt_api_pod"],
-                namespace=hco_namespace.name,
-            )
-            .instance.spec.containers[0]
-            .resources.requests.memory
-        )
-    )
-
-
-@pytest.fixture()
-def virt_api_rss_memory(admin_client, hco_namespace, highest_memory_usage_virt_api_pod):
-    return int(
-        bitmath.Byte(
-            int(
-                get_pod_by_name_prefix(
-                    dyn_client=admin_client,
-                    pod_prefix=highest_memory_usage_virt_api_pod["virt_api_pod"],
-                    namespace=hco_namespace.name,
-                ).execute(command=RSS_MEMORY_COMMAND)
-            )
-        ).MiB
-    )
 
 
 @pytest.fixture()

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -1,4 +1,3 @@
-import bitmath
 import pytest
 
 from tests.observability.metrics.constants import (
@@ -14,7 +13,7 @@ from tests.observability.metrics.utils import (
     assert_vmi_dommemstat_with_metric_value,
     compare_kubevirt_vmi_info_metric_with_vm_info,
     get_vm_metrics,
-    validate_metric_value_within_range,
+    validate_memory_delta_metrics_value_within_range,
 )
 from tests.observability.utils import validate_metrics_value
 from utilities.constants import KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS, VIRT_API, VIRT_HANDLER
@@ -179,46 +178,56 @@ class TestVMIMetrics:
 class TestMemoryDeltaFromRequestedBytes:
     @pytest.mark.polarion("CNV-11632")
     def test_metric_kubevirt_memory_delta_from_requested_bytes_working_set(
-        self, prometheus, highest_memory_usage_virt_api_pod, virt_api_requested_memory
+        self, prometheus, admin_client, hco_namespace
     ):
-        validate_metric_value_within_range(
+        validate_memory_delta_metrics_value_within_range(
             prometheus=prometheus,
             metric_name=f"kubevirt_memory_delta_from_requested_bytes{{container='{VIRT_API}', "
             f"reason='memory_working_set_delta_from_request'}}",
-            expected_value=float(
-                bitmath.MiB(highest_memory_usage_virt_api_pod["memory_usage"] - virt_api_requested_memory).Byte
-            ),
+            rss=False,
+            admin_client=admin_client,
+            hco_namespace=hco_namespace.name,
         )
 
     @pytest.mark.polarion("CNV-11633")
     def test_metric_kubevirt_memory_delta_from_requested_bytes_rss(
-        self, prometheus, virt_api_rss_memory, virt_api_requested_memory
+        self,
+        prometheus,
+        admin_client,
+        hco_namespace,
     ):
-        validate_metric_value_within_range(
+        validate_memory_delta_metrics_value_within_range(
             prometheus=prometheus,
             metric_name=f"kubevirt_memory_delta_from_requested_bytes{{container='{VIRT_API}', "
             f"reason='memory_rss_delta_from_request'}}",
-            expected_value=float(bitmath.MiB(virt_api_rss_memory - virt_api_requested_memory).Byte),
+            rss=True,
+            admin_client=admin_client,
+            hco_namespace=hco_namespace.name,
         )
 
     @pytest.mark.polarion("CNV-11690")
     def test_metric_cnv_abnormal_working_set(
-        self, prometheus, highest_memory_usage_virt_api_pod, virt_api_requested_memory
+        self,
+        prometheus,
+        admin_client,
+        hco_namespace,
     ):
-        validate_metric_value_within_range(
+        validate_memory_delta_metrics_value_within_range(
             prometheus=prometheus,
             metric_name=f"cnv_abnormal{{container='{VIRT_API}', reason='memory_working_set_delta_from_request'}}",
-            expected_value=float(
-                bitmath.MiB(highest_memory_usage_virt_api_pod["memory_usage"] - virt_api_requested_memory).Byte
-            ),
+            rss=False,
+            admin_client=admin_client,
+            hco_namespace=hco_namespace.name,
         )
 
     @pytest.mark.polarion("CNV-11691")
-    def test_metric_cnv_abnormal_rss(self, prometheus, virt_api_rss_memory, virt_api_requested_memory):
-        validate_metric_value_within_range(
+    def test_metric_cnv_abnormal_rss(self, prometheus, admin_client, hco_namespace):
+        validate_memory_delta_metrics_value_within_range(
             prometheus=prometheus,
             metric_name=f"cnv_abnormal{{container='{VIRT_API}', reason='memory_rss_delta_from_request'}}",
-            expected_value=float(bitmath.MiB(virt_api_rss_memory - virt_api_requested_memory).Byte),
+            rss=True,
+            admin_client=admin_client,
+            hco_namespace=hco_namespace.name,
         )
 
 


### PR DESCRIPTION
##### Short description:
Fixed MemoryDeltaFromRequestedBytes tests by coverting the fixtures used into utils that used in sampler so the expected value will be updated, before the expected value pulled one time and sometime it is higher than the metric value and it needs to be updated.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-60162