### PR TITLE
[4.19][Upgrade] Adjust automation to support gating upgrade test

### DIFF
--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade.py
@@ -42,6 +42,7 @@ class TestUpgrade:
             nodes=nodes,
         )
 
+    @pytest.mark.gating
     @pytest.mark.cnv_upgrade
     @pytest.mark.polarion("CNV-2991")
     @pytest.mark.dependency(name=IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID)
@@ -82,6 +83,7 @@ class TestUpgrade:
             expected_images=related_images_from_target_csv.values(),
         )
 
+    @pytest.mark.gating
     @pytest.mark.cnv_upgrade
     @pytest.mark.polarion("CNV-9933")
     @pytest.mark.dependency(name=IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID)

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -56,6 +56,7 @@ pytestmark = [
 class TestUpgradeVirt:
     """Pre-upgrade tests"""
 
+    @pytest.mark.gating
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2974")
@@ -65,6 +66,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             assert vm.vmi.status == VirtualMachineInstance.Status.RUNNING
 
+    @pytest.mark.gating
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2987")
@@ -78,6 +80,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             vm_console_run_commands(vm=vm, commands=["ls"])
 
+    @pytest.mark.gating
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4208")
@@ -132,6 +135,7 @@ class TestUpgradeVirt:
 
     """ Post-upgrade tests """
 
+    @pytest.mark.gating
     @pytest.mark.polarion("CNV-5932")
     @pytest.mark.order(after=IUO_CNV_ALERT_ORDERING_NODE_ID, before=AFTER_UPGRADE_STORAGE_ORDERING)
     @pytest.mark.dependency(
@@ -150,6 +154,7 @@ class TestUpgradeVirt:
         """
         assert not unupdated_vmi_pods_names, f"The following VMI Pods were not updated: {unupdated_vmi_pods_names}"
 
+    @pytest.mark.gating
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2978")
@@ -167,6 +172,7 @@ class TestUpgradeVirt:
             vm.vmi.wait_until_running()
         verify_linux_boot_time(vm_list=vms_for_upgrade, initial_boot_time=linux_boot_time_before_upgrade)
 
+    @pytest.mark.gating
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-2980")
@@ -183,6 +189,7 @@ class TestUpgradeVirt:
         for vm in vms_for_upgrade:
             vm_console_run_commands(vm=vm, commands=["ls"])
 
+    @pytest.mark.gating
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4209")


### PR DESCRIPTION
##### Short description:
Add gating marker to some upgrade tests, to support candidate(prod) -> candidate(stage) upgrade test.
The test should create a VM with instancetype(OCS-virt), upgrade, and check that the VM is healthy.

##### More details:
Should be run with `-m gating --upgrade=cnv --cnv-image=<img> --cnv-version=<version> --cnv-channel=candidate`

The selected tests:

```
<Package cnv-tests>
  <Package tests>
    <Package virt>
      <Package upgrade>
        <Module test_upgrade_virt.py>
          <Class TestUpgradeVirt>
            <Function test_is_vm_running_before_upgrade>
            <Function test_vm_ssh_before_upgrade>
            <Function test_vm_console_before_upgrade>
    <Package install_upgrade_operators>
      <Package product_upgrade>
        <Module test_upgrade.py>
          <Class TestUpgrade>
            <Function test_cnv_upgrade_process>
    <Package virt>
      <Package upgrade>
        <Module test_upgrade_virt.py>
          <Class TestUpgradeVirt>
            <Function test_vmi_pod_image_updates_after_upgrade_optin>
            <Function test_is_vm_running_after_upgrade>
            <Function test_vm_console_after_upgrade>
            <Function test_vm_ssh_after_upgrade>
```


##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: