### PR TITLE
[IUO] Ignore hco-bearer-token resource if jira open

### DIFF
--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -29,6 +29,7 @@ class TestRelatedObjects:
         self,
         admin_client,
         hco_namespace,
+        skip_if_hco_bearer_token_bug_open,
         ocp_resource_by_name,
         pre_update_resource_version,
         updated_resource_labels,


### PR DESCRIPTION
##### Short description:
Currently hco-bearer-auth resource have reconciling bug.
Until its fixed, the automation should skip it.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
