### PR TITLE
[virt] fix aaq enabling in hco

### DIFF
--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -23,7 +23,7 @@ from tests.virt.cluster.aaq.utils import (
     wait_for_aacrq_object_created,
 )
 from tests.virt.constants import AAQ_NAMESPACE_LABEL, ACRQ_NAMESPACE_LABEL, ACRQ_TEST
-from tests.virt.utils import enable_aaq_feature_gate, wait_for_virt_launcher_pod, wait_when_pod_in_gated_state
+from tests.virt.utils import enable_aaq_hco, wait_for_virt_launcher_pod, wait_when_pod_in_gated_state
 from utilities.constants import (
     POD_CONTAINER_SPEC,
     POD_SECURITY_CONTEXT_SPEC,
@@ -47,8 +47,8 @@ LOGGER = logging.getLogger(__name__)
 
 # AAQ - ApplicationAwareQuota, operator for managing resource quotas per component
 @pytest.fixture(scope="package")
-def enabled_aaq_feature_gate_scope_package(admin_client, hco_namespace, hyperconverged_resource_scope_package):
-    with enable_aaq_feature_gate(
+def enabled_aaq_hco_scope_package(admin_client, hco_namespace, hyperconverged_resource_scope_package):
+    with enable_aaq_hco(
         client=admin_client,
         hco_namespace=hco_namespace,
         hyperconverged_resource=hyperconverged_resource_scope_package,

--- a/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
+++ b/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
@@ -9,7 +9,7 @@ LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestAAQDifferentAllocationMethods"
 
 pytestmark = pytest.mark.usefixtures(
-    "enabled_aaq_feature_gate_scope_package",
+    "enabled_aaq_hco_scope_package",
     "updated_namespace_with_aaq_label",
 )
 

--- a/tests/virt/cluster/aaq/test_acrq.py
+++ b/tests/virt/cluster/aaq/test_acrq.py
@@ -12,7 +12,7 @@ TESTS_ACRQ_CLASS_NAME = "TestApplicationAwareClusterResourceQuota"
 
 
 @pytest.mark.usefixtures(
-    "enabled_aaq_feature_gate_scope_package",
+    "enabled_aaq_hco_scope_package",
     "enabled_acrq_support",
     "updated_namespace_with_aaq_label",
     "application_aware_cluster_resource_quota",

--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -35,7 +35,7 @@ TESTS_VM_CLASS_NAME = "TestARQCanManageVMs"
 
 pytestmark = [
     pytest.mark.usefixtures(
-        "enabled_aaq_feature_gate_scope_package",
+        "enabled_aaq_hco_scope_package",
         "updated_namespace_with_aaq_label",
     ),
     pytest.mark.gating,

--- a/tests/virt/upgrade_custom/aaq/conftest.py
+++ b/tests/virt/upgrade_custom/aaq/conftest.py
@@ -5,7 +5,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 
 from tests.virt.constants import AAQ_NAMESPACE_LABEL, ACRQ_NAMESPACE_LABEL
 from tests.virt.upgrade_custom.aaq.constants import UPGRADE_QUOTA_FOR_ONE_VMI
-from tests.virt.utils import enable_aaq_feature_gate, wait_for_virt_launcher_pod, wait_when_pod_in_gated_state
+from tests.virt.utils import enable_aaq_hco, wait_for_virt_launcher_pod, wait_when_pod_in_gated_state
 from utilities.infra import (
     create_ns,
 )
@@ -18,8 +18,8 @@ from utilities.virt import (
 
 # AAQ Upgrade
 @pytest.fixture(scope="session")
-def enabled_aaq_feature_gate_scope_session(admin_client, hco_namespace, hyperconverged_resource_scope_session):
-    with enable_aaq_feature_gate(
+def enabled_aaq_hco_scope_session(admin_client, hco_namespace, hyperconverged_resource_scope_session):
+    with enable_aaq_hco(
         client=admin_client,
         hco_namespace=hco_namespace,
         hyperconverged_resource=hyperconverged_resource_scope_session,

--- a/tests/virt/upgrade_custom/aaq/test_upgrade_virt_aaq.py
+++ b/tests/virt/upgrade_custom/aaq/test_upgrade_virt_aaq.py
@@ -19,7 +19,7 @@ pytestmark = [
     pytest.mark.cnv_upgrade,
     pytest.mark.ocp_upgrade,
     pytest.mark.usefixtures(
-        "enabled_aaq_feature_gate_scope_session",
+        "enabled_aaq_hco_scope_session",
     ),
 ]
 

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -268,14 +268,8 @@ def flatten_dict(dictionary, parent_key=""):
 
 
 @contextmanager
-def enable_aaq_feature_gate(client, hco_namespace, hyperconverged_resource, enable_acrq_support=False):
-    patches = {
-        hyperconverged_resource: {
-            "spec": {
-                "featureGates": {"enableApplicationAwareQuota": True},
-            }
-        }
-    }
+def enable_aaq_hco(client, hco_namespace, hyperconverged_resource, enable_acrq_support=False):
+    patches = {hyperconverged_resource: {"spec": {"enableApplicationAwareQuota": True}}}
     if enable_acrq_support:
         patches[hyperconverged_resource]["spec"]["applicationAwareConfig"] = {
             "allowApplicationAwareClusterResourceQuota": True


### PR DESCRIPTION
##### Short description:
enableApplicationAwareQuota was moved from featuregate to hco spec (https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3391)
updated feature enable accordingly

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: