### PR TITLE
Update infra test for data sources pointing to a volumesnapshot

### DIFF
--- a/tests/infrastructure/instance_types/test_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_vm_preference.py
@@ -68,9 +68,7 @@ def fedora_data_volume_template(dv_template_api, golden_images_fedora_data_sourc
     fedora_dv_template = data_volume_template_with_source_ref_dict(data_source=golden_images_fedora_data_source)
     if dv_template_api == "pvc":
         return pvc_api_adjustments(dv_template=fedora_dv_template)
-    else:
-        del fedora_dv_template["spec"]["storage"]["storageClassName"]
-        return fedora_dv_template
+    return fedora_dv_template
 
 
 @pytest.fixture()

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -582,12 +582,12 @@ def data_volume_dict_modify_to_source_ref(dv, data_source):
 
 
 def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
-    data_source_pvc_dict_spec = data_source.source.instance.to_dict()["spec"]
+    data_source_source_dict_spec = data_source.source.instance.to_dict()["spec"]
     dv = DataVolume(
         name=data_source.name,
         namespace=data_source.namespace,
-        size=data_source_pvc_dict_spec.get("resources", {}).get("requests", {}).get("storage"),
-        storage_class=storage_class or data_source_pvc_dict_spec.get("storageClassName"),
+        size=data_source_source_dict_spec.get("resources", {}).get("requests", {}).get("storage"),
+        storage_class=storage_class or data_source_source_dict_spec.get("storageClassName"),
         api_name="storage",
     )
     return data_volume_dict_modify_to_source_ref(dv=dv, data_source=data_source)


### PR DESCRIPTION
##### Short description:
Fix tests that fail due to data sources pointing to volumesnapshot instead of PVC

##### More details:
 - remove deletion of storageClassName section when using auto import data sources (the storage class returned is empty)
 - in `data_volume_template_with_source_ref_dict` changed "pvc" to "source" to be more accurate

##### What this PR does / why we need it:
Fix failing test `test_vm_pref_storage_class`

