### PR TITLE
Introduce `wait_for_agent_connected` method

### DIFF
--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.node import Node
-from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine import VirtualMachine, VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
 from libs.vm.spec import (
@@ -71,6 +71,12 @@ class BaseVirtualMachine(VirtualMachine):
             timeout=timeout,
             verify_commands_output=True,
             command_output=True,
+        )
+
+    def wait_for_agent_connected(self) -> None:
+        self.vmi.wait_for_condition(
+            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+            status=VirtualMachineInstance.Condition.Status.TRUE,
         )
 
 

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -5,7 +5,6 @@ Connectivity over bond bridge on secondary interface
 from collections import OrderedDict
 
 import pytest
-from ocp_resources.resource import Resource
 
 import utilities.network
 from tests.network.libs import cloudinit as netcloud
@@ -177,9 +176,7 @@ def ovs_linux_bond_bridge_attached_vms(ovs_linux_bond_bridge_attached_vma, ovs_l
     vms = (ovs_linux_bond_bridge_attached_vma, ovs_linux_bond_bridge_attached_vmb)
     for vm in vms:
         vm.wait_for_ready_status(status=True)
-        vm.vmi.wait_for_condition(
-            condition=Resource.Condition.Type.AGENT_CONNECTED, status=Resource.Condition.Status.TRUE
-        )
+        vm.wait_for_agent_connected()
     yield vms
 
 

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -61,17 +61,13 @@ def pod_net_vmb(
 
 @pytest.fixture()
 def pod_net_running_vma(pod_net_vma):
-    pod_net_vma.vmi.wait_for_condition(
-        condition=pod_net_vma.Condition.Type.AGENT_CONNECTED, status=pod_net_vma.Condition.Status.TRUE
-    )
+    pod_net_vma.wait_for_agent_connected()
     return pod_net_vma
 
 
 @pytest.fixture()
 def pod_net_running_vmb(pod_net_vmb):
-    pod_net_vmb.vmi.wait_for_condition(
-        condition=pod_net_vmb.Condition.Type.AGENT_CONNECTED, status=pod_net_vmb.Condition.Status.TRUE
-    )
+    pod_net_vmb.wait_for_agent_connected()
     return pod_net_vmb
 
 

--- a/tests/network/connectivity/utils.py
+++ b/tests/network/connectivity/utils.py
@@ -1,7 +1,5 @@
 from collections import OrderedDict
 
-from ocp_resources.resource import Resource
-
 from utilities.constants import IPV6_STR
 from utilities.network import (
     compose_cloud_init_data_dict,
@@ -40,9 +38,7 @@ def create_running_vm(
         client=client,
     ) as vm:
         vm.start(wait=True)
-        vm.vmi.wait_for_condition(
-            condition=Resource.Condition.Type.AGENT_CONNECTED, status=Resource.Condition.Status.TRUE
-        )
+        vm.wait_for_agent_connected()
         yield vm
 
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -1,7 +1,6 @@
 import ipaddress
 
 import pytest
-from ocp_resources.resource import Resource
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
@@ -67,7 +66,7 @@ def udn_affinity_label():
 def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
     with udn_vm(namespace_name=udn_namespace.name, name="vma-udn", template_labels=dict((udn_affinity_label,))) as vm:
         vm.start(wait=True)
-        vm.vmi.wait_for_condition(condition="AgentConnected", status=Resource.Condition.Status.TRUE)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -75,7 +74,7 @@ def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_
 def vmb_udn_non_migratable(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
     with udn_vm(namespace_name=udn_namespace.name, name="vmb-udn", template_labels=dict((udn_affinity_label,))) as vm:
         vm.start(wait=True)
-        vm.vmi.wait_for_condition(condition="AgentConnected", status=Resource.Condition.Status.TRUE)
+        vm.wait_for_agent_connected()
         yield vm
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

Replace the `wait_for_guest_agent` function in `utilities/virt` module
with a direct call to the wrapper implementation and a method in the
`VirtualMachineForTests` class.

Add the same method to the newer `VirtualMachineBase` under `libs/vm`.

Switch all usages of the underlying general `wait_for_condition` with
the `AGENT_CONNECTED` type, to the new method.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
