### PR TITLE
Update instance type hotplug test data name moved to status

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -169,14 +169,18 @@ def get_image_name_from_csv(image_string, csv_related_images):
     raise ResourceNotFoundError(f"no image with the string {image_string} was found in the csv_dict")
 
 
-def hotplug_resource_and_verify_hotplug(vm, client, sockets=None, memory_guest=None):
+def hotplug_spec_vm_and_verify_hotplug(vm, client, sockets=None, memory_guest=None):
     assert sockets or memory_guest, "No resource for update provided!!!"
-
-    if vm.instance.spec.get("instancetype"):
-        hotplug_instance_type_vm(vm=vm, sockets=sockets, memory_guest=memory_guest)
-    else:
-        hotplug_spec_vm(vm=vm, sockets=sockets, memory_guest=memory_guest)
+    hotplug_spec_vm(vm=vm, sockets=sockets, memory_guest=memory_guest)
     verify_hotplug(vm=vm, client=client, sockets=sockets, memory_guest=memory_guest)
+
+
+def hotplug_instance_type_vm_and_verify(vm, client, instance_type):
+    instance_type_spec = instance_type.instance.spec
+    update_vm_instancetype_name(vm=vm, instance_type_name=instance_type.name)
+    verify_hotplug(
+        vm=vm, client=client, sockets=instance_type_spec.cpu.guest, memory_guest=instance_type_spec.memory.guest
+    )
 
 
 def verify_hotplug(vm, client, sockets=None, memory_guest=None):
@@ -209,12 +213,9 @@ def hotplug_spec_vm(vm, sockets=None, memory_guest=None):
     ResourceEditor(patches=patch).update()
 
 
-def hotplug_instance_type_vm(vm, sockets=None, memory_guest=None):
-    patch = {
-        vm.vm_instance_type: {"spec": {"cpu": {"guest": sockets} if sockets else {"memory": {"guest": memory_guest}}}}
-    }
+def update_vm_instancetype_name(vm, instance_type_name):
+    patch = {vm: {"spec": {"instancetype": {"name": instance_type_name}}}}
     ResourceEditor(patches=patch).update()
-    ResourceEditor(patches={vm: {"spec": {"instancetype": {"revisionName": ""}}}}).update()
 
 
 def clean_up_migration_jobs(client, vm):

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -9,7 +9,7 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.utils import clean_up_migration_jobs, hotplug_resource_and_verify_hotplug, hotplug_spec_vm
+from tests.utils import clean_up_migration_jobs, hotplug_spec_vm, hotplug_spec_vm_and_verify_hotplug
 from tests.virt.cluster.aaq.constants import (
     ACRQ_QUOTA_HARD_SPEC,
     ARQ_QUOTA_HARD_SPEC,
@@ -258,7 +258,7 @@ def hotplug_vm_for_aaq_test(namespace, unprivileged_client, cpu_for_migration):
 
 @pytest.fixture()
 def hotplugged_resource(request, unprivileged_client, hotplug_vm_for_aaq_test, admin_client):
-    hotplug_resource_and_verify_hotplug(
+    hotplug_spec_vm_and_verify_hotplug(
         vm=hotplug_vm_for_aaq_test,
         client=unprivileged_client,
         sockets=request.param.get("sockets"),

--- a/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
+++ b/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
@@ -2,7 +2,7 @@ import bitmath
 import pytest
 from ocp_resources.resource_quota import ResourceQuota
 
-from tests.utils import hotplug_resource_and_verify_hotplug
+from tests.utils import hotplug_spec_vm_and_verify_hotplug
 from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
@@ -45,7 +45,7 @@ def vm_auto_resource_limits(request, namespace, unprivileged_client, cpu_for_mig
 
 @pytest.fixture()
 def hotplugged_vm_with_cpu_auto_limits(vm_auto_resource_limits, unprivileged_client):
-    hotplug_resource_and_verify_hotplug(
+    hotplug_spec_vm_and_verify_hotplug(
         vm=vm_auto_resource_limits, client=unprivileged_client, sockets=CPU_SOCKET_HOTPLUG
     )
 

--- a/tests/virt/node/conftest.py
+++ b/tests/virt/node/conftest.py
@@ -7,8 +7,8 @@ from ocp_resources.template import Template
 
 from tests.utils import (
     clean_up_migration_jobs,
-    hotplug_resource_and_verify_hotplug,
     hotplug_spec_vm,
+    hotplug_spec_vm_and_verify_hotplug,
 )
 from tests.virt.utils import append_feature_gate_to_hco
 from utilities.constants import (
@@ -81,7 +81,7 @@ def hotplugged_sockets_memory_guest(request, admin_client, hotplugged_vm, unpriv
     if param.get("skip_migration"):
         hotplug_spec_vm(vm=hotplugged_vm, sockets=param.get("sockets"), memory_guest=param.get("memory_guest"))
     else:
-        hotplug_resource_and_verify_hotplug(
+        hotplug_spec_vm_and_verify_hotplug(
             vm=hotplugged_vm,
             client=unprivileged_client,
             sockets=param.get("sockets"),

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -190,7 +190,7 @@ class TestMemoryHotPlug:
     def test_hotplug_memory_above_max_value(self, hotplugged_vm):
         with pytest.raises(UnprocessibleEntityError):
             hotplug_spec_vm(vm=hotplugged_vm, memory_guest=TWELVE_GI_MEMORY)
-            pytest.fail("Memory value set higher then max value!")
+            pytest.fail("Memory value set higher than max value!")
 
     @pytest.mark.parametrize(
         "hotplugged_sockets_memory_guest",

--- a/utilities/ssp.py
+++ b/utilities/ssp.py
@@ -12,6 +12,7 @@ from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.namespace import Namespace
 from ocp_resources.ssp import SSP
 from ocp_resources.template import Template
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -21,6 +22,8 @@ import utilities.storage
 import utilities.virt
 from utilities.constants import (
     DEFAULT_RESOURCE_CONDITIONS,
+    EIGHT_CPU_SOCKETS,
+    FOUR_GI_MEMORY,
     SSP_KUBEVIRT_HYPERCONVERGED,
     SSP_OPERATOR,
     TCP_TIMEOUT_30SEC,
@@ -299,3 +302,15 @@ def verify_ssp_pod_is_running(
         else:
             LOGGER.error(f"SSP pod was not running for last {TIMEOUT_6MIN} seconds")
             raise
+
+
+def cluster_instance_type_for_hot_plug(guest_sockets: int, cpu_model: str | None) -> VirtualMachineClusterInstancetype:
+    return VirtualMachineClusterInstancetype(
+        name=f"hot-plug-{guest_sockets}-cpu-instance-type",
+        memory={"guest": FOUR_GI_MEMORY},
+        cpu={
+            "guest": guest_sockets,
+            "model": cpu_model,
+            "maxSockets": EIGHT_CPU_SOCKETS,
+        },
+    )


### PR DESCRIPTION
##### Short description:
Fix hot plug tests since the VM instance type data is now moved to status

##### More details:
 - We now only hot-plug a VM with instance type by changing the instance type name, and we no longer use versioning.
 - Moved test_restart_hotplugged_vm after we test the CPU decrease warning, this way we can also verify restarting the VM gives the correct CPU value 
 - I have verified can live update a VM memory and CPU in the same time, so I removed the assertion
 - Added skip to `test_hotplug_cpu_above_max_value` with reference to [bug](https://issues.redhat.com/browse/CNV-60474)

##### What this PR does / why we need it:
Fix failing tests on instance type hot plug

##### Special notes for reviewer:
`test_hotplug_cpu_above_max_value` failure might also be related to - https://issues.redhat.com/browse/CNV-60547
for now we tag it with 60474



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved clarity and maintainability of hotplug-related test utilities by splitting and renaming functions for different VM types.
  - Updated test fixtures and dependencies to use explicit instance type configurations for different CPU socket counts.
  - Adjusted test logic to verify CPU counts after restart and handle error cases with new instance type fixtures.
  - Corrected typos in assertion messages and updated test method dependencies.
  - Added a helper function to create cluster instance types configured for hot-plug CPU scenarios.
  - Unified hotplug verification calls to a single method for consistency across tests.

- **Tests**
  - Enhanced test coverage for CPU and memory hotplug scenarios with new and updated fixtures.
  - Reorganized and updated test dependencies for more accurate validation of hotplug behavior.
  - Added a new test for VM restart verification after CPU decrease.
  - Marked a test for CPU hotplug above max value as not currently running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->