### PR TITLE
[4.18][IUO] Ignore hco-bearer-token resource if jira open

### DIFF
--- a/tests/install_upgrade_operators/strict_reconciliation/conftest.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/conftest.py
@@ -16,8 +16,9 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
     wait_for_resource_version_update,
 )
 from tests.utils import wait_for_cr_labels_change
-from utilities.constants import TIMEOUT_1MIN, VERSION_LABEL_KEY
+from utilities.constants import HCO_BEARER_AUTH, TIMEOUT_1MIN, VERSION_LABEL_KEY
 from utilities.hco import ResourceEditorValidateHCOReconcile
+from utilities.infra import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 DISABLED_KUBEVIRT_FEATUREGATES_IN_SNO = ["LiveMigration", "SRIOVLiveMigration"]
@@ -205,3 +206,14 @@ def updated_resource_labels(ocp_resource_by_name):
     ):
         wait_for_cr_labels_change(expected_value=expected_labels, component=ocp_resource_by_name, timeout=TIMEOUT_1MIN)
         yield expected_labels
+
+
+@pytest.fixture(scope="package")
+def is_jira_59519_open():
+    return is_jira_open(jira_id="CNV-59519")
+
+
+@pytest.fixture()
+def skip_if_hco_bearer_token_bug_open(is_jira_59519_open, ocp_resource_by_name):
+    if is_jira_59519_open and ocp_resource_by_name.name == HCO_BEARER_AUTH:
+        pytest.skip(f"{HCO_BEARER_AUTH} resource labels doesn't reconcile due to 59519 bug")

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -29,6 +29,7 @@ class TestRelatedObjects:
         self,
         admin_client,
         hco_namespace,
+        skip_if_hco_bearer_token_bug_open,
         ocp_resource_by_name,
         pre_update_resource_version,
         updated_resource_labels,


### PR DESCRIPTION
##### Short description:
Cherry-pick from [main](https://github.com/RedHatQE/openshift-virtualization-tests/pull/768)

Currently hco-bearer-auth resource have reconciling bug.
Until its fixed, the automation should skip it.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
