### PR TITLE
[4.18] Fix ServiceMesh tests and adjust to OSSM 3.0.1

### DIFF
--- a/tests/network/utils.py
+++ b/tests/network/utils.py
@@ -7,7 +7,6 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.deployment import Deployment
 from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.service import Service
-from ocp_resources.service_mesh_member_roll import ServiceMeshMemberRoll
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -15,7 +14,6 @@ from tests.network.constants import BRCNV, SERVICE_MESH_PORT
 from utilities import console
 from utilities.constants import (
     IPV4_STR,
-    ISTIO_SYSTEM_DEFAULT_NS,
     OS_FLAVOR_FEDORA,
     SSH_PORT_22,
     TIMEOUT_1MIN,
@@ -43,7 +41,6 @@ range {DHCP_IP_RANGE_START} {DHCP_IP_RANGE_END};
 }}
 EOF
 """
-SERVICE_MESH_VM_MEMORY_REQ = "128M"
 SERVICE_MESH_INJECT_ANNOTATION = "sidecar.istio.io/inject"
 
 
@@ -69,27 +66,6 @@ class ServiceMeshDeploymentService(Service):
         ]
         if self.port_name:
             self.res["spec"]["ports"][0]["name"] = self.port_name
-
-
-class ServiceMeshMemberRollForTests(ServiceMeshMemberRoll):
-    def __init__(
-        self,
-        members,
-    ):
-        """
-        Service Mesh Member Roll creation
-        Args:
-            members (list): Namespaces to be added to Service Mesh
-        """
-        super().__init__(
-            name="default",
-            namespace=ISTIO_SYSTEM_DEFAULT_NS,
-        )
-        self.members = members
-
-    def to_dict(self):
-        super().to_dict()
-        self.res["spec"] = {"members": self.members}
 
 
 class FedoraVirtualMachineForServiceMesh(VirtualMachineForTests):


### PR DESCRIPTION
Major changes in this PR:

- Enable gateway injection
- Remove ServiceMeshMemberRoll resource which is no longer used in OSSM 3

##### jira-ticket:
https://issues.redhat.com/browse/CNV-58812

