### PR TITLE
tests, net, flat_overlay: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -17,7 +17,6 @@ from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
     fetch_pid_from_linux_vm,
-    running_vm,
     vm_console_run_commands,
 )
 
@@ -49,7 +48,8 @@ def create_flat_overlay_vm(
         cloud_init_data=cloud_init_data,
         node_selector=get_node_selector_dict(node_selector=worker_node_hostname),
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the virtual machine startup process in test utilities for improved clarity and control. No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->