### PR TITLE
tests, net, jumbo frame: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/jumbo_frame/conftest.py
+++ b/tests/network/jumbo_frame/conftest.py
@@ -10,7 +10,6 @@ from tests.network.jumbo_frame.utils import (
 from utilities.constants import LINUX_BRIDGE, WORKER_NODE_LABEL_KEY
 from utilities.infra import get_node_selector_dict
 from utilities.network import get_vmi_ip_v4_by_name, network_device, network_nad
-from utilities.virt import running_vm
 
 
 @pytest.fixture(scope="class")
@@ -26,7 +25,8 @@ def running_vma_jumbo_primary_interface_worker_1(
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         client=unprivileged_client,
     ) as vm:
-        running_vm(vm=vm)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -43,7 +43,8 @@ def running_vmb_jumbo_primary_interface_worker_2(
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         client=unprivileged_client,
     ) as vm:
-        running_vm(vm=vm)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -60,7 +61,8 @@ def running_vmc_jumbo_primary_interface_worker_1(
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         client=unprivileged_client,
     ) as vm:
-        running_vm(vm=vm)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -80,7 +82,8 @@ def running_vmd_jumbo_primary_interface_and_secondary_interface(
         cloud_init_data=cloud_init_data,
         networks={secondary_linux_bridge_nad.name: secondary_linux_bridge_nad.name},
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -100,7 +103,8 @@ def running_vme_jumbo_primary_interface_and_secondary_interface(
         cloud_init_data=cloud_init_data,
         networks={secondary_linux_bridge_nad.name: secondary_linux_bridge_nad.name},
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -16,7 +16,7 @@ from utilities.network import (
     network_device,
     network_nad,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 BOND_NAME = "jfbond1"
 BRIDGE_NAME = "brbond1"
@@ -188,12 +188,14 @@ def bond_bridge_attached_vmb(
 
 @pytest.fixture(scope="class")
 def running_bond_bridge_attached_vma(bond_bridge_attached_vma):
-    return running_vm(vm=bond_bridge_attached_vma, wait_for_cloud_init=True)
+    bond_bridge_attached_vma.wait_for_agent_connected()
+    return bond_bridge_attached_vma
 
 
 @pytest.fixture(scope="class")
 def running_bond_bridge_attached_vmb(bond_bridge_attached_vmb):
-    return running_vm(vm=bond_bridge_attached_vmb, wait_for_cloud_init=True)
+    bond_bridge_attached_vmb.wait_for_agent_connected()
+    return bond_bridge_attached_vmb
 
 
 class TestBondJumboFrame:

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -15,7 +15,7 @@ from utilities.network import (
     network_device,
     network_nad,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 pytestmark = [
     pytest.mark.usefixtures(
@@ -106,7 +106,8 @@ def bridge_attached_vma(worker_node1, namespace, unprivileged_client, br1test_br
         cloud_init_data=cloud_init_data,
         client=unprivileged_client,
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -128,7 +129,8 @@ def bridge_attached_vmb(worker_node2, namespace, unprivileged_client, br1test_br
         cloud_init_data=cloud_init_data,
         client=unprivileged_client,
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated test fixtures for network jumbo frame scenarios to explicitly start virtual machines and wait for agent connectivity, replacing previous helper function usage.
  - Improved clarity and control in test setup for VM readiness in bond and bridge network tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->