### PR TITLE
tests, net, kmp: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -6,7 +6,7 @@ from utilities.constants import KMP_VM_ASSIGNMENT_LABEL, LINUX_BRIDGE
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import create_ns, get_node_selector_dict, name_prefix
 from utilities.network import network_device, network_nad
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 from . import utils as kmp_utils
 
@@ -221,24 +221,32 @@ def vm_b(
 
 @pytest.fixture(scope="class")
 def running_vm_a(vm_a):
-    return running_vm(vm=vm_a, wait_for_cloud_init=True)
+    vm_a.start(wait=True)
+    vm_a.wait_for_agent_connected()
+    return vm_a
 
 
 @pytest.fixture(scope="class")
 def running_vm_b(vm_b):
-    return running_vm(vm=vm_b, wait_for_cloud_init=True)
+    vm_b.start(wait=True)
+    vm_b.wait_for_agent_connected()
+    return vm_b
 
 
 @pytest.fixture(scope="function")
 def restarted_vmi_a(vm_a):
     vm_a.stop(wait=True)
-    return running_vm(vm=vm_a, wait_for_cloud_init=True)
+    vm_a.start(wait=True)
+    vm_a.wait_for_agent_connected()
+    return vm_a
 
 
 @pytest.fixture(scope="function")
 def restarted_vmi_b(vm_b):
     vm_b.stop(wait=True)
-    return running_vm(vm=vm_b, wait_for_cloud_init=True)
+    vm_b.start(wait=True)
+    vm_b.wait_for_agent_connected()
+    return vm_b
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of virtual machine test fixtures by directly managing VM startup and readiness steps within the test setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->