### PR TITLE
tests, net, l2_bridge: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -4,6 +4,7 @@ import shlex
 from ipaddress import ip_interface
 
 import pytest
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pyhelper_utils.shell import run_ssh_commands
 
 from tests.network.constants import DHCP_IP_RANGE_END, DHCP_IP_RANGE_START
@@ -23,7 +24,6 @@ from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
     prepare_cloud_init_user_data,
-    running_vm,
 )
 
 #: Test setup
@@ -322,7 +322,11 @@ def l2_bridge_running_vm_a(namespace, worker_node1, l2_bridge_all_nads, unprivil
         client=unprivileged_client,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.vmi.wait_for_condition(
+            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+            status=VirtualMachineInstance.Condition.Status.TRUE,
+        )
         yield vm
 
 
@@ -347,7 +351,11 @@ def l2_bridge_running_vm_b(namespace, worker_node2, l2_bridge_all_nads, unprivil
         client=unprivileged_client,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.vmi.wait_for_condition(
+            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+            status=VirtualMachineInstance.Condition.Status.TRUE,
+        )
         yield vm
 
 

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from libs.net import netattachdef
 from tests.network.constants import IPV4_ADDRESS_SUBNET_PREFIX
@@ -26,7 +27,7 @@ from utilities.network import (
     get_vmi_ip_v4_by_name,
     network_nad,
 )
-from utilities.virt import migrate_vm_and_verify, running_vm
+from utilities.virt import migrate_vm_and_verify
 
 pytestmark = [
     pytest.mark.special_infra,
@@ -403,7 +404,10 @@ def mac_addresses_before_restart(running_vm_for_nic_hot_plug, hot_plugged_interf
 @pytest.fixture()
 def mac_addresses_after_restart(running_vm_for_nic_hot_plug, hot_plugged_interface_name):
     running_vm_for_nic_hot_plug.restart(wait=True)
-    running_vm(vm=running_vm_for_nic_hot_plug)
+    running_vm_for_nic_hot_plug.vmi.wait_for_condition(
+        condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+        status=VirtualMachineInstance.Condition.Status.TRUE,
+    )
 
     return get_primary_and_hot_plugged_mac_addresses(
         vm=running_vm_for_nic_hot_plug,

--- a/tests/network/l2_bridge/test_ovs_bridge.py
+++ b/tests/network/l2_bridge/test_ovs_bridge.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import pytest
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from tests.network.constants import BRCNV
 from tests.network.utils import vm_for_brcnv_tests
@@ -12,7 +13,7 @@ from utilities.network import (
     get_vmi_ip_v4_by_name,
     network_nad,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 OVS_BR = "test-ovs-br"
 SEC_IFACE_SUBNET = "10.0.200"
@@ -123,7 +124,11 @@ def vma_with_ovs_based_l2(
 
 @pytest.fixture()
 def running_vma_with_ovs_based_l2(vma_with_ovs_based_l2):
-    return running_vm(vm=vma_with_ovs_based_l2, wait_for_cloud_init=True)
+    vma_with_ovs_based_l2.vmi.wait_for_condition(
+        condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+        status=VirtualMachineInstance.Condition.Status.TRUE,
+    )
+    return vma_with_ovs_based_l2
 
 
 @pytest.fixture()
@@ -160,7 +165,11 @@ def vmb_with_ovs_based_l2(
 
 @pytest.fixture()
 def running_vmb_with_ovs_based_l2(vmb_with_ovs_based_l2):
-    return running_vm(vm=vmb_with_ovs_based_l2, wait_for_cloud_init=True)
+    vmb_with_ovs_based_l2.vmi.wait_for_condition(
+        condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+        status=VirtualMachineInstance.Condition.Status.TRUE,
+    )
+    return vmb_with_ovs_based_l2
 
 
 @pytest.mark.ipv4

--- a/tests/network/l2_bridge/utils.py
+++ b/tests/network/l2_bridge/utils.py
@@ -4,6 +4,7 @@ import re
 import time
 
 from ocp_resources.resource import ResourceEditor
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.network.utils import update_cloud_init_extra_user_data
@@ -27,7 +28,6 @@ from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
     migrate_vm_and_verify,
-    running_vm,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -104,7 +104,11 @@ def create_vm_with_secondary_interface_on_setup(
         cloud_init_data=cloud_init_data,
         client=client,
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.vmi.wait_for_condition(
+            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+            status=VirtualMachineInstance.Condition.Status.TRUE,
+        )
         yield vm
 
 
@@ -243,7 +247,11 @@ def create_vm_for_hot_plug(
         client=client,
         cloud_init_data=cloud_init_data,
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.vmi.wait_for_condition(
+            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
+            status=VirtualMachineInstance.Condition.Status.TRUE,
+        )
         yield vm
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
