### PR TITLE
[4.18]Must gather fix flags and node role

### DIFF
--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -605,7 +605,8 @@ def collected_vm_details_must_gather_from_vm_node(
     yield collect_must_gather(
         must_gather_tmpdir=target_path,
         must_gather_image_url=must_gather_image_url,
-        flag_names=f"node-name={must_gather_vm.vmi.node.name},vms_details",
+        node_name=must_gather_vm.vmi.node.name,
+        flag_names="vms_details",
     )
     clean_up_collected_must_gather(failed=(request.session.testsfailed - before_fail_count), target_path=target_path)
 

--- a/utilities/must_gather.py
+++ b/utilities/must_gather.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shlex
 
@@ -5,11 +6,14 @@ from pyhelper_utils.shell import run_command
 
 from utilities.constants import TIMEOUT_15MIN, TIMEOUT_20MIN
 
+LOGGER = logging.getLogger(__name__)
+
 
 def run_must_gather(
     image_url: str = "",
     target_base_dir: str = "",
     script_name: str = "",
+    node_name: str = "",
     flag_names: str = "",
     timeout: str = f"{TIMEOUT_15MIN}s",
     since: str | None = None,
@@ -22,6 +26,7 @@ def run_must_gather(
             If not specified, OpenShift's default must-gather image will be used.
         target_base_dir (str, optional): path to base directory
         script_name (str, optional): must-gather script name or path
+        node_name (str, optional): node name to run the must gather pod on.
         flag_names (str, optional): comma separated list of must-gather flags
             Examples: "oc adm must-gather --image=quay.io/kubevirt/must-gather -- /usr/bin/gather --default"
 
@@ -38,17 +43,28 @@ def run_must_gather(
         base_command += f" --dest-dir={target_base_dir}"
     if image_url:
         base_command += f" --image={image_url}"
-    if script_name:
-        base_command += f" -- {script_name}"
+    if node_name:
+        base_command += f" --node-name={node_name}"
     if since:
         base_command += f" --since={since}"
     if timeout:
         base_command += f" --timeout={timeout}"
+    if script_name:
+        base_command += f" -- {script_name}"
     # flag_name must be the last argument
     if flag_names:
         flag_string = "".join([f" --{flag_name}" for flag_name in flag_names.split(",")])
         base_command += f" {flag_string}"
-    return run_command(command=shlex.split(base_command), check=False, timeout=TIMEOUT_20MIN)[1]
+    did_succeed, output, error = run_command(
+        command=shlex.split(base_command),
+        check=False,
+        timeout=TIMEOUT_20MIN,
+        log_errors=False,
+    )
+    if not did_succeed and error:
+        log_func = LOGGER.warning if "Warning" in error else LOGGER.error
+        log_func(f"must-gather raised the following error: {error}")
+    return output
 
 
 def get_must_gather_output_file(path):
@@ -69,6 +85,7 @@ def collect_must_gather(
     script_name="/usr/bin/gather",
     flag_names="",
     timeout="",
+    node_name="",
 ):
     """
     Run must gather command and puts the content in directory.
@@ -79,7 +96,7 @@ def collect_must_gather(
         script_name (str): must-gather script name or path
         flag_names (str, optional): comma separated list of must-gather flags
         timeout (str, optional): runs the debug pods for specified duration
-
+        node_name (str, optional): node name to run the debug pods on.
     Returns:
         str: output directory with must gather content
     """
@@ -87,6 +104,7 @@ def collect_must_gather(
         image_url=must_gather_image_url,
         target_base_dir=must_gather_tmpdir,
         script_name=script_name,
+        node_name=node_name,
         flag_names=flag_names,
         timeout=timeout,
     )


### PR DESCRIPTION
##### Short description:
Cherry pick from https://github.com/RedHatQE/openshift-virtualization-tests/pull/705

Fixing two issues with must gather.

##### More details:
1. Must gather collected both at failure point & IUO tests.But each time we run must-gather, it results in this message:

> error: Warning: spec.nodeSelector[node-role.kubernetes.io/master]: use "node-role.kubernetes.io/control-plane" instead

**Solution:** We should use control-plane selector.
can be done by passing specific node name/ setting up a node selector.

2. Currently, --since-time and --timeout flags are passed after "–" options seperator:

> oc adm must-gather --dest-dir=$PWD/regular --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9@sha256:520577044baddc484233e22feede7c67d72b18958ac36811367ee58c4ffe2a0f -- --since=0s --timeout=900s  /usr/bin/gather --vm-details

**Solution**: They should be passed before the "–". both for IUO tests & infra must gather collection via failure.

##### What this PR does / why we need it:
1. Infra - each must gather collected on failure prints 10000 lines of output
2. Must gather IUO tests might have false positive.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

