### PR TITLE
tests, net, macspoof: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/macspoof/conftest.py
+++ b/tests/network/macspoof/conftest.py
@@ -17,7 +17,7 @@ from utilities.network import (
     network_device,
     network_nad,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 ETH1_INTERFACE_NAME = "eth1"
 BRIDGE_NAME = "br1macspoof"
@@ -149,12 +149,14 @@ def linux_bridge_attached_vmb(
 
 @pytest.fixture(scope="class")
 def linux_bridge_attached_running_vma(linux_bridge_attached_vma):
-    return running_vm(vm=linux_bridge_attached_vma, wait_for_cloud_init=True)
+    linux_bridge_attached_vma.wait_for_agent_connected()
+    return linux_bridge_attached_vma
 
 
 @pytest.fixture(scope="class")
 def linux_bridge_attached_running_vmb(linux_bridge_attached_vmb):
-    return running_vm(vm=linux_bridge_attached_vmb, wait_for_cloud_init=True)
+    linux_bridge_attached_vmb.wait_for_agent_connected()
+    return linux_bridge_attached_vmb
 
 
 @pytest.fixture(scope="class")
@@ -211,4 +213,4 @@ def vms_without_mac_spoof(
         vm.start(wait=True)
 
     for vm in stopped_vms:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.wait_for_agent_connected()


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test fixtures to directly wait for VM agent connectivity, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->