### PR TITLE
tests, net, migration: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -13,7 +13,6 @@ from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
     migrate_vm_and_verify,
-    running_vm,
     vm_console_run_commands,
     wait_for_console,
 )
@@ -33,7 +32,8 @@ def running_vm_static(
         body=fedora_vm_body(name=name),
         client=unprivileged_client,
     ) as vm:
-        running_vm(vm=vm, check_ssh_connectivity=False)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -51,7 +51,8 @@ def running_vm_for_migration(
         client=unprivileged_client,
         cpu_model=cpu_for_migration,
     ) as vm:
-        running_vm(vm=vm, check_ssh_connectivity=False)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -37,8 +37,6 @@ from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
     migrate_vm_and_verify,
-    restart_vm_wait_for_running_vm,
-    running_vm,
 )
 
 PING_LOG = "ping.log"
@@ -181,17 +179,20 @@ def brcnv_vm_for_migration(
 
 @pytest.fixture(scope="module")
 def running_vma(vma):
-    return running_vm(vm=vma, wait_for_cloud_init=True)
+    vma.wait_for_agent_connected()
+    return vma
 
 
 @pytest.fixture(scope="module")
 def running_vmb(vmb):
-    return running_vm(vm=vmb, wait_for_cloud_init=True)
+    vmb.wait_for_agent_connected()
+    return vmb
 
 
 @pytest.fixture()
 def restarted_vmb(running_vmb):
-    restart_vm_wait_for_running_vm(vm=running_vmb, check_ssh_connectivity=False)
+    running_vmb.restart(wait=True)
+    running_vmb.wait_for_agent_connected()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test fixtures to start and check VM readiness using direct method calls instead of utility functions.
	- Improved clarity and maintainability of VM startup and connectivity checks in migration-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->