### PR TITLE
tests, net, network-policy: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/network_policy/test_network_policy.py
+++ b/tests/network/network_policy/test_network_policy.py
@@ -11,7 +11,7 @@ from pyhelper_utils.shell import run_ssh_commands
 
 from utilities.constants import PORT_80
 from utilities.infra import create_ns, get_node_selector_dict
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 PORT_81 = 81
 CURL_TIMEOUT = 5
@@ -104,12 +104,14 @@ def network_policy_vmb(namespace_2, worker_node1, unprivileged_client):
 
 @pytest.fixture(scope="module")
 def running_network_policy_vma(network_policy_vma):
-    return running_vm(vm=network_policy_vma)
+    network_policy_vma.wait_for_agent_connected()
+    return network_policy_vma
 
 
 @pytest.fixture(scope="module")
 def running_network_policy_vmb(network_policy_vmb):
-    return running_vm(vm=network_policy_vmb)
+    network_policy_vmb.wait_for_agent_connected()
+    return network_policy_vmb
 
 
 @pytest.mark.order(before="test_network_policy_allow_http80")


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of network policy VM test fixtures by ensuring agent connectivity is explicitly verified before running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->