### PR TITLE
tests, net, nmstate: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/nmstate/conftest.py
+++ b/tests/network/nmstate/conftest.py
@@ -8,7 +8,7 @@ from tests.network.utils import wait_for_address_on_iface
 from utilities.constants import LINUX_BRIDGE, NMSTATE_HANDLER
 from utilities.infra import get_daemonset_by_name, get_node_pod, get_node_selector_dict, name_prefix
 from utilities.network import network_device
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,12 +58,14 @@ def nmstate_vmb(schedulable_nodes, worker_node2, namespace, unprivileged_client)
 
 @pytest.fixture(scope="module")
 def running_nmstate_vma(nmstate_vma):
-    return running_vm(vm=nmstate_vma)
+    nmstate_vma.wait_for_agent_connected()
+    return nmstate_vma
 
 
 @pytest.fixture(scope="module")
 def running_nmstate_vmb(nmstate_vmb):
-    return running_vm(vm=nmstate_vmb)
+    nmstate_vmb.wait_for_agent_connected()
+    return nmstate_vmb
 
 
 @pytest.fixture(scope="module")

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -25,7 +25,7 @@ from utilities.network import (
     network_device,
     network_nad,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 LOGGER = logging.getLogger(__name__)
 BRIDGE_NAME = "br-nmstate"
@@ -152,12 +152,14 @@ def nmstate_linux_bridge_attached_vmb(
 
 @pytest.fixture(scope="class")
 def nmstate_linux_bridge_attached_running_vma(nmstate_linux_bridge_attached_vma):
-    return running_vm(vm=nmstate_linux_bridge_attached_vma, wait_for_cloud_init=True)
+    nmstate_linux_bridge_attached_vma.wait_for_agent_connected()
+    return nmstate_linux_bridge_attached_vma
 
 
 @pytest.fixture(scope="class")
 def nmstate_linux_bridge_attached_running_vmb(nmstate_linux_bridge_attached_vmb):
-    return running_vm(vm=nmstate_linux_bridge_attached_vmb, wait_for_cloud_init=True)
+    nmstate_linux_bridge_attached_vmb.wait_for_agent_connected()
+    return nmstate_linux_bridge_attached_vmb
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved reliability of virtual machine instance readiness checks by directly verifying agent connection status.
- **Tests**
  - Updated test fixtures to ensure virtual machines are fully connected before proceeding with network-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->