### PR TITLE
tests, net, ovs-bond: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/ovs_bond/conftest.py
+++ b/tests/network/ovs_bond/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from ocp_utilities.exceptions import CommandExecFailed
 
 from utilities.infra import ExecCommandOnPod, get_node_selector_dict
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,12 +41,14 @@ def ovs_bond_vmb(schedulable_nodes, namespace, unprivileged_client, node_with_bo
 
 @pytest.fixture(scope="module")
 def running_ovs_bond_vma(ovs_bond_vma):
-    return running_vm(vm=ovs_bond_vma)
+    ovs_bond_vma.wait_for_agent_connected()
+    return ovs_bond_vma
 
 
 @pytest.fixture(scope="module")
 def running_ovs_bond_vmb(ovs_bond_vmb):
-    return running_vm(vm=ovs_bond_vma)
+    ovs_bond_vmb.wait_for_agent_connected()
+    return ovs_bond_vmb
 
 
 def get_interface_by_attribute(all_connections, att):


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by explicitly waiting for virtual machine agent connections before proceeding with network bond tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->