### PR TITLE
tests, net, sriov: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -25,12 +25,10 @@ class TestPingConnectivity:
         sriov_network,
         sriov_vm1,
         sriov_vm2,
-        running_sriov_vm1,
-        running_sriov_vm2,
     ):
         assert_ping_successful(
-            src_vm=running_sriov_vm1,
-            dst_ip=get_vmi_ip_v4_by_name(vm=running_sriov_vm2, name=sriov_network.name),
+            src_vm=sriov_vm1,
+            dst_ip=get_vmi_ip_v4_by_name(vm=sriov_vm2, name=sriov_network.name),
         )
 
     @pytest.mark.ipv4
@@ -40,13 +38,11 @@ class TestPingConnectivity:
         sriov_network,
         sriov_vm1,
         sriov_vm2,
-        running_sriov_vm1,
-        running_sriov_vm2,
         sriov_network_mtu_9000,
     ):
         assert_ping_successful(
-            src_vm=running_sriov_vm1,
-            dst_ip=get_vmi_ip_v4_by_name(vm=running_sriov_vm2, name=sriov_network.name),
+            src_vm=sriov_vm1,
+            dst_ip=get_vmi_ip_v4_by_name(vm=sriov_vm2, name=sriov_network.name),
             packet_size=MTU_9000,
         )
 
@@ -57,12 +53,10 @@ class TestPingConnectivity:
         sriov_network_vlan,
         sriov_vm3,
         sriov_vm4,
-        running_sriov_vm3,
-        running_sriov_vm4,
     ):
         assert_ping_successful(
-            src_vm=running_sriov_vm3,
-            dst_ip=get_vmi_ip_v4_by_name(vm=running_sriov_vm4, name=sriov_network_vlan.name),
+            src_vm=sriov_vm3,
+            dst_ip=get_vmi_ip_v4_by_name(vm=sriov_vm4, name=sriov_network_vlan.name),
         )
 
     @pytest.mark.ipv4
@@ -72,12 +66,10 @@ class TestPingConnectivity:
         sriov_network_vlan,
         sriov_vm1,
         sriov_vm4,
-        running_sriov_vm1,
-        running_sriov_vm4,
     ):
         assert_no_ping(
-            src_vm=running_sriov_vm1,
-            dst_ip=get_vmi_ip_v4_by_name(vm=running_sriov_vm4, name=sriov_network_vlan.name),
+            src_vm=sriov_vm1,
+            dst_ip=get_vmi_ip_v4_by_name(vm=sriov_vm4, name=sriov_network_vlan.name),
         )
 
     @pytest.mark.post_upgrade
@@ -85,7 +77,6 @@ class TestPingConnectivity:
     def test_sriov_interfaces_post_reboot(
         self,
         sriov_vm4,
-        running_sriov_vm4,
         vm4_interfaces,
         restarted_sriov_vm4,
     ):
@@ -102,13 +93,11 @@ class TestSriovLiveMigration:
         sriov_network,
         sriov_vm_migrate,
         sriov_vm2,
-        running_sriov_vm_migrate,
-        running_sriov_vm2,
     ):
         migrate_vm_and_verify(vm=sriov_vm_migrate, check_ssh_connectivity=True)
         assert_ping_successful(
-            src_vm=running_sriov_vm2,
-            dst_ip=get_vmi_ip_v4_by_name(vm=running_sriov_vm_migrate, name=sriov_network.name),
+            src_vm=sriov_vm2,
+            dst_ip=get_vmi_ip_v4_by_name(vm=sriov_vm_migrate, name=sriov_network.name),
         )
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

One usage of 'running_vm' has been left as it uses a non-Fedora guest.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Simplified and consolidated virtual machine test fixtures for SR-IOV, reducing redundancy and streamlining test setup.
	- Improved reliability of test VMs by ensuring they are started and agent connections are established before tests run.
	- Updated tests to directly use base VM fixtures, removing intermediate wrappers for clearer and more consistent test parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->