### PR TITLE
tests, net, upgrade: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/upgrade/conftest.py
+++ b/tests/network/upgrade/conftest.py
@@ -9,7 +9,7 @@ from utilities.constants import (
 )
 from utilities.infra import create_ns, get_node_selector_dict
 from utilities.network import cloud_init, network_nad
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 NAD_MAC_SPOOF_NAME = "brspoofupgrade"
 
@@ -72,12 +72,16 @@ def vmb_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macsp
 
 @pytest.fixture(scope="session")
 def running_vma_upgrade_mac_spoof(vma_upgrade_mac_spoof):
-    return running_vm(vm=vma_upgrade_mac_spoof)
+    vma_upgrade_mac_spoof.wait_for_ready_status(status=True)
+    vma_upgrade_mac_spoof.wait_for_agent_connected()
+    return vma_upgrade_mac_spoof
 
 
 @pytest.fixture(scope="session")
 def running_vmb_upgrade_mac_spoof(vmb_upgrade_mac_spoof):
-    return running_vm(vm=vmb_upgrade_mac_spoof)
+    vmb_upgrade_mac_spoof.wait_for_ready_status(status=True)
+    vmb_upgrade_mac_spoof.wait_for_agent_connected()
+    return vmb_upgrade_mac_spoof
 
 
 @pytest.fixture(scope="session")
@@ -104,5 +108,6 @@ def running_vm_with_bridge(
         body=fedora_vm_body(name=name),
         eviction_strategy=ES_NONE,
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by explicitly starting virtual machines and verifying agent connectivity before running upgrade tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->