### PR TITLE
tests, net, libs, nncp:  Assure NNCP resource exists, status & conditions absense is treated correctly.

### DIFF
--- a/tests/network/libs/nodenetworkconfigurationpolicy.py
+++ b/tests/network/libs/nodenetworkconfigurationpolicy.py
@@ -129,7 +129,7 @@ class NodeNetworkConfigurationPolicy(Nncp):
 
         conditions = (
             condition
-            for condition in self.instance.status.conditions
+            for condition in self.instance.get("status", {}).get("conditions", {})
             if condition["status"] == Resource.Condition.Status.TRUE
         )
 

--- a/tests/network/libs/nodenetworkconfigurationpolicy.py
+++ b/tests/network/libs/nodenetworkconfigurationpolicy.py
@@ -101,6 +101,7 @@ class NodeNetworkConfigurationPolicy(Nncp):
             name=name,
             desired_state=asdict(desired_state, dict_factory=dict_normalization_for_dataclass),
             node_selector=node_selector,
+            wait_for_resource=True,
         )
 
     @property


### PR DESCRIPTION
##### What this PR does / why we need it:

Currently, the default resource deployment is not waiting for the
resource to appear. We are interested for the NNCP resources to assure
that the resource exists before we continue.

This change assures that the `self.instance` exists and with it the
`status`.

On NNCP resource creation, the status and/or conditions may not yet be
populated. Assure such scenarios are treated.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
