### PR TITLE
tests, net, owners: Add 'root-approvers: False'

### DIFF
--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -1,3 +1,4 @@
+root-approvers: False
 approvers:
   - EdDev
 reviewers:


### PR DESCRIPTION
##### What this PR does / why we need it:

The `root-approvers: False` option enables sig-network to approve and own their codebase.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

While this step increases sig independence, it is not a hard requirement at the current time, because root maintainers are very responsive and add valuable reviews. The seek to balance between the two is a never ending endeavor.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to disable root approvers for the network tests directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->