### PR TITLE
 [VIRT] Update for descheduler test - use PSI metrics

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -762,6 +762,8 @@ def get_inspect_command_namespace_string(node: Node, test_name: str) -> str:
                 namespaces_to_collect.append(NamespacesNames.NVIDIA_GPU_OPERATOR)
             if "swap" in all_markers:
                 namespaces_to_collect.append(NamespacesNames.WASP)
+            if "descheduler" in all_markers:
+                namespaces_to_collect.append(NamespacesNames.OPENSHIFT_KUBE_DESCHEDULER_OPERATOR)
         namespace_str = " ".join([f"namespace/{namespace}" for namespace in namespaces_to_collect])
     return namespace_str
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -45,6 +45,7 @@ markers =
     service_mesh: Tests that require the service mesh operator to be installed
     jumbo_frame: Tests that require network configurations supporting jumbo frames
     rwx_default_storage: Tests that require RWX storage
+    descheduler: Tests that require kube-descheduler on nodes
 
     ## Resources requirements
     high_resource_vm: Tests that create VM using a lot of resources (like Windows OS VMs, hight performance VMs, etc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,7 +157,6 @@ from utilities.infra import (
     name_prefix,
     run_virtctl_command,
     scale_deployment_replicas,
-    verify_image_info,
     wait_for_pods_deletion,
 )
 from utilities.network import (
@@ -2269,19 +2268,6 @@ def common_vm_preference_param_dict(request):
     if request.param.get("cpu_spread_option"):
         common_preference_dict.setdefault("cpu", {}).update({"spreadOption": request.param.get("cpu_spread_option")})
     return common_preference_dict
-
-
-@pytest.fixture(scope="session")
-def ocp_qe_art_image_url(ocp_current_version, nodes_cpu_architecture, generated_pulled_secret):
-    ocp_qe_image = (
-        f"quay.io/openshift-qe-optional-operators/aosqe-index:v{ocp_current_version.major}.{ocp_current_version.minor}"
-    )
-    verify_image_info(
-        image_url=ocp_qe_image,
-        generated_pulled_secret=generated_pulled_secret,
-        nodes_cpu_architecture=nodes_cpu_architecture,
-    )
-    return ocp_qe_image
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2913,15 +2913,6 @@ def machine_config_pools():
 
 
 @pytest.fixture(scope="session")
-def active_machine_config_pools(machine_config_pools):
-    return [
-        machine_config_pool
-        for machine_config_pool in machine_config_pools
-        if machine_config_pool.instance.status.machineCount > 0
-    ]
-
-
-@pytest.fixture(scope="session")
 def nmstate_namespace(admin_client):
     nmstate_ns = Namespace(name="openshift-nmstate")
     assert nmstate_ns.exists, "Namespace openshift-nmstate doesn't exist"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2913,6 +2913,15 @@ def machine_config_pools():
 
 
 @pytest.fixture(scope="session")
+def active_machine_config_pools(machine_config_pools):
+    return [
+        machine_config_pool
+        for machine_config_pool in machine_config_pools
+        if machine_config_pool.instance.status.machineCount > 0
+    ]
+
+
+@pytest.fixture(scope="session")
 def nmstate_namespace(admin_client):
     nmstate_ns = Namespace(name="openshift-nmstate")
     assert nmstate_ns.exists, "Namespace openshift-nmstate doesn't exist"

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -431,15 +431,6 @@ def eus_applied_all_icsp(
     )
 
 
-@pytest.fixture(scope="session")
-def active_machine_config_pools(machine_config_pools):
-    return [
-        machine_config_pool
-        for machine_config_pool in machine_config_pools
-        if machine_config_pool.instance.status.machineCount > 0
-    ]
-
-
 @pytest.fixture()
 def machine_config_pools_conditions(active_machine_config_pools):
     return get_machine_config_pools_conditions(machine_config_pools=active_machine_config_pools)

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -431,6 +431,15 @@ def eus_applied_all_icsp(
     )
 
 
+@pytest.fixture(scope="session")
+def active_machine_config_pools(machine_config_pools):
+    return [
+        machine_config_pool
+        for machine_config_pool in machine_config_pools
+        if machine_config_pool.instance.status.machineCount > 0
+    ]
+
+
 @pytest.fixture()
 def machine_config_pools_conditions(active_machine_config_pools):
     return get_machine_config_pools_conditions(machine_config_pools=active_machine_config_pools)

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -3,6 +3,7 @@ import shlex
 from multiprocessing import Manager, cpu_count
 from multiprocessing.dummy import Pool
 
+import bitmath
 import pytest
 from bitmath import parse_string_unsafe
 from ocp_resources.datavolume import DataVolume
@@ -18,7 +19,11 @@ from tests.virt.node.gpu.constants import (
 from tests.virt.node.gpu.utils import (
     wait_for_manager_pods_deployed,
 )
-from tests.virt.utils import check_node_for_missing_mdev_bus, patch_hco_cr_with_mdev_permitted_hostdevices
+from tests.virt.utils import (
+    check_node_for_missing_mdev_bus,
+    get_allocatable_memory_per_node,
+    patch_hco_cr_with_mdev_permitted_hostdevices,
+)
 from utilities.constants import AMD, INTEL, NamespacesNames
 from utilities.exceptions import UnsupportedGPUDeviceError
 from utilities.infra import exit_pytest_execution, label_nodes
@@ -30,6 +35,7 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture(scope="session", autouse=True)
 def virt_special_infra_sanity(
     request,
+    admin_client,
     junitxml_plugin,
     is_psi_cluster,
     schedulable_nodes,
@@ -39,6 +45,7 @@ def virt_special_infra_sanity(
     workers,
     nodes_cpu_virt_extension,
     workers_utility_pods,
+    allocatable_memory_per_node_scope_session,
 ):
     """Performs verification that cluster has all required capabilities based on collected tests."""
 
@@ -106,6 +113,7 @@ def virt_special_infra_sanity(
         descheduler_deployment = Deployment(
             name="descheduler-operator",
             namespace=NamespacesNames.OPENSHIFT_KUBE_DESCHEDULER_OPERATOR,
+            client=admin_client,
         )
         if not descheduler_deployment.exists or descheduler_deployment.instance.status.readyReplicas == 0:
             failed_verifications_list.append("kube-descheduler operator is not working on the cluster")
@@ -114,6 +122,15 @@ def virt_special_infra_sanity(
         for pod in _workers_utility_pods:
             if "psi=1" not in pod.execute(command=shlex.split("cat /proc/cmdline")):
                 failed_verifications_list.append(f"Node {pod.node.name} does not have psi=1 kernel argument")
+
+    def _verify_if_1tb_memory_or_more_node(_memory_per_node):
+        """
+        Descheduler tests should run on nodes with less than 1Tb of memory.
+        """
+        upper_memory_limit = bitmath.TiB(value=1)
+        for node, memory in _memory_per_node.items():
+            if memory >= upper_memory_limit:
+                failed_verifications_list.append(f"Cluster has node with more than 1Tb of memory: {node.name}")
 
     skip_virt_sanity_check = "--skip-virt-sanity-check"
     failed_verifications_list = []
@@ -139,6 +156,7 @@ def virt_special_infra_sanity(
         if any(item.get_closest_marker("descheduler") for item in request.session.items):
             _verify_descheduler_operator_installed()
             _verify_psi_kernel_argument(_workers_utility_pods=workers_utility_pods)
+            _verify_if_1tb_memory_or_more_node(_memory_per_node=allocatable_memory_per_node_scope_session)
     else:
         LOGGER.warning(f"Skipping virt special infra sanity because {skip_virt_sanity_check} was passed")
 
@@ -250,3 +268,8 @@ def non_existent_mdev_bus_nodes(workers_utility_pods, vgpu_ready_nodes):
                 "namespace the nvidia-vgpu-manager-daemonset Pod is Running."
             )
         )
+
+
+@pytest.fixture(scope="session")
+def allocatable_memory_per_node_scope_session(schedulable_nodes):
+    return get_allocatable_memory_per_node(schedulable_nodes=schedulable_nodes)

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -37,22 +37,20 @@ from utilities.virt import (
 
 LOGGER = logging.getLogger(__name__)
 
-DESCHEDULER_CATALOG_SOURCE = "descheduler-catalog"
-DESCHEDULER_OPERATOR_DEPLOYMENT_NAME = "descheduler-operator"
 
 LOCALHOST = "localhost"
 
 
 @pytest.fixture(scope="module")
-def skip_if_1tb_memory_or_more_node(allocatable_memory_per_node_scope_module):
+def xfail_if_1tb_memory_or_more_node(allocatable_memory_per_node_scope_module):
     """
     One of QE BM setups has worker with 5 TiB RAM memory while rest workers
-    has 120 GiB RAM. Test should be skipped on this cluster.
+    has 120 GiB RAM. Test should not run on this cluster.
     """
     upper_memory_limit = bitmath.TiB(value=1)
     for node, memory in allocatable_memory_per_node_scope_module.items():
         if memory >= upper_memory_limit:
-            pytest.skip(f"Cluster has node with at least {upper_memory_limit} RAM: {node.name}")
+            pytest.xfail(f"Cluster has node with at least {upper_memory_limit} RAM: {node.name}")
 
 
 @pytest.fixture(scope="module")

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -55,8 +55,9 @@ def xfail_if_1tb_memory_or_more_node(allocatable_memory_per_node_scope_module):
 
 
 @pytest.fixture(scope="module")
-def descheduler_long_lifecycle_profile():
+def descheduler_long_lifecycle_profile(admin_client):
     with create_kube_descheduler(
+        admin_client=admin_client,
         profiles=["LongLifecycle"],
         profile_customizations={
             "devLowNodeUtilizationThresholds": "High",  # underutilized <40%, overutilized >70%
@@ -68,10 +69,12 @@ def descheduler_long_lifecycle_profile():
 
 @pytest.fixture(scope="module")
 def descheduler_kubevirt_relieve_and_migrate_profile(
+    admin_client,
     schedulable_nodes,
     nodes_taints_before_descheduler_test_run,
 ):
     with create_kube_descheduler(
+        admin_client=admin_client,
         profiles=["DevKubeVirtRelieveAndMigrate"],
         profile_customizations={
             "devActualUtilizationProfile": "PrometheusCPUCombined",

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -390,7 +390,7 @@ def node_to_run_stress(schedulable_nodes, deployed_vms_for_descheduler_test):
         if vm_per_node_counters[node.name] > 0:
             return node
 
-    raise ValueError("No suitable node to drain")
+    raise ValueError("No suitable node to run stress")
 
 
 @pytest.fixture(scope="class")

--- a/tests/virt/node/descheduler/constants.py
+++ b/tests/virt/node/descheduler/constants.py
@@ -6,6 +6,5 @@ CONFIG_MAP_POLICY_YAML_FILE = "policy.yaml"
 NODE_SELECTOR_LABEL = {"descheduler": "test"}
 
 DESCHEDULER_DEPLOYMENT_NAME = "descheduler"
-DESCHEDULER_NAMESPACE_NAME = "openshift-kube-descheduler-operator"
 
 DESCHEDULER_SOFT_TAINT_KEY = "nodeutilization.descheduler.openshift.io"

--- a/tests/virt/node/descheduler/constants.py
+++ b/tests/virt/node/descheduler/constants.py
@@ -4,3 +4,8 @@ RUNNING_PING_PROCESS_NAME_IN_VM = "ping"
 CONFIG_MAP_POLICY_YAML_FILE = "policy.yaml"
 
 NODE_SELECTOR_LABEL = {"descheduler": "test"}
+
+DESCHEDULER_DEPLOYMENT_NAME = "descheduler"
+DESCHEDULER_NAMESPACE_NAME = "openshift-kube-descheduler-operator"
+
+DESCHEDULER_SOFT_TAINT_KEY = "nodeutilization.descheduler.openshift.io"

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -18,7 +18,8 @@ pytestmark = [
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
         "skip_if_1tb_memory_or_more_node",
-        "installed_descheduler",
+        "installed_descheduler_operator",
+        "descheduler_long_lifecycle_profile",
     ),
 ]
 

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -28,7 +28,7 @@ NO_MIGRATION_STORM_ASSERT_MESSAGE = "Verify no migration storm after triggered m
 
 
 @pytest.mark.parametrize(
-    "calculated_vm_deployment_for_node_drain_test",
+    "calculated_vm_deployment_for_descheduler_test",
     [pytest.param(0.50)],
     indirect=True,
 )
@@ -40,12 +40,12 @@ class TestDeschedulerEvictsVMAfterDrainUncordon:
     def test_descheduler_evicts_vm_after_drain_uncordon(
         self,
         schedulable_nodes,
-        deployed_vms_for_node_drain,
+        deployed_vms_for_descheduler_test,
         vms_started_process_for_node_drain,
         drain_uncordon_node,
     ):
         assert_vms_distribution_after_failover(
-            vms=deployed_vms_for_node_drain,
+            vms=deployed_vms_for_descheduler_test,
             nodes=schedulable_nodes,
         )
 
@@ -56,21 +56,21 @@ class TestDeschedulerEvictsVMAfterDrainUncordon:
     @pytest.mark.polarion("CNV-7316")
     def test_no_migrations_storm(
         self,
-        deployed_vms_for_node_drain,
+        deployed_vms_for_descheduler_test,
         completed_migrations,
     ):
         LOGGER.info(NO_MIGRATION_STORM_ASSERT_MESSAGE)
-        assert_vms_consistent_virt_launcher_pods(running_vms=deployed_vms_for_node_drain)
+        assert_vms_consistent_virt_launcher_pods(running_vms=deployed_vms_for_descheduler_test)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::test_no_migrations_storm"])
     @pytest.mark.polarion("CNV-8288")
     def test_running_process_after_migrations_complete(
         self,
-        deployed_vms_for_node_drain,
+        deployed_vms_for_descheduler_test,
         vms_started_process_for_node_drain,
     ):
         assert_running_process_after_failover(
-            vms_list=deployed_vms_for_node_drain,
+            vms_list=deployed_vms_for_descheduler_test,
             process_dict=vms_started_process_for_node_drain,
         )
 

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -18,7 +18,7 @@ pytestmark = [
     pytest.mark.descheduler,
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
-        "skip_if_1tb_memory_or_more_node",
+        "xfail_if_1tb_memory_or_more_node",
         "descheduler_long_lifecycle_profile",
     ),
 ]

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -19,7 +19,6 @@ pytestmark = [
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
         "skip_if_1tb_memory_or_more_node",
-        "installed_descheduler_operator",
         "descheduler_long_lifecycle_profile",
     ),
 ]

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -18,7 +18,6 @@ pytestmark = [
     pytest.mark.descheduler,
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
-        "xfail_if_1tb_memory_or_more_node",
         "descheduler_long_lifecycle_profile",
     ),
 ]

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.tier3,
+    pytest.mark.descheduler,
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
         "skip_if_1tb_memory_or_more_node",

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -11,7 +11,6 @@ pytestmark = [
     pytest.mark.descheduler,
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
-        "xfail_if_1tb_memory_or_more_node",
         "descheduler_kubevirt_relieve_and_migrate_profile",
     ),
 ]

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -1,0 +1,53 @@
+import logging
+
+import pytest
+
+from tests.virt.node.descheduler.utils import verify_at_least_one_vm_migrated, wait_for_overutilized_soft_taint
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.tier3,
+    pytest.mark.post_upgrade,
+    pytest.mark.usefixtures(
+        "skip_if_1tb_memory_or_more_node",
+        "installed_descheduler_operator",
+        "descheduler_kubevirt_releave_and_migrate_profile",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "calculated_vm_deployment_for_node_with_least_available_memory",
+    [pytest.param(0.80)],
+    indirect=True,
+)
+@pytest.mark.usefixtures(
+    "node_labeled_for_test",
+    "deployed_vms_on_labeled_node",
+    "stress_started_on_vms_for_psi_metrics",
+)
+class TestDeschedulerLoadAwareRebalancing:
+    @pytest.mark.polarion("CNV-11960")
+    def test_soft_taint_added_when_node_overloaded(
+        self,
+        node_labeled_for_test,
+    ):
+        wait_for_overutilized_soft_taint(node=node_labeled_for_test, taint_expected=True)
+
+    @pytest.mark.polarion("CNV-11961")
+    def test_rebalancing_when_node_overloaded(
+        self,
+        node_labeled_for_test,
+        migration_policy_with_allow_auto_converge,
+        deployed_vms_on_labeled_node,
+        second_node_labeled_labeled_for_migration,
+    ):
+        verify_at_least_one_vm_migrated(vms=deployed_vms_on_labeled_node, node_before=node_labeled_for_test)
+
+    @pytest.mark.polarion("CNV-11962")
+    def test_soft_taint_removed_when_node_not_overloaded(
+        self,
+        node_labeled_for_test,
+    ):
+        wait_for_overutilized_soft_taint(node=node_labeled_for_test, taint_expected=False)

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -12,7 +12,7 @@ pytestmark = [
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
         "xfail_if_1tb_memory_or_more_node",
-        "descheduler_kubevirt_releave_and_migrate_profile",
+        "descheduler_kubevirt_relieve_and_migrate_profile",
     ),
 ]
 

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -12,7 +12,6 @@ pytestmark = [
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
         "skip_if_1tb_memory_or_more_node",
-        "installed_descheduler_operator",
         "descheduler_kubevirt_releave_and_migrate_profile",
     ),
 ]

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -11,7 +11,7 @@ pytestmark = [
     pytest.mark.descheduler,
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
-        "skip_if_1tb_memory_or_more_node",
+        "xfail_if_1tb_memory_or_more_node",
         "descheduler_kubevirt_releave_and_migrate_profile",
     ),
 ]

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -19,36 +19,33 @@ pytestmark = [
 
 
 @pytest.mark.parametrize(
-    "calculated_vm_deployment_for_node_with_least_available_memory",
-    [pytest.param(0.80)],
+    "calculated_vm_deployment_for_descheduler_test",
+    [pytest.param(0.50)],
     indirect=True,
 )
 @pytest.mark.usefixtures(
-    "node_labeled_for_test",
-    "deployed_vms_on_labeled_node",
-    "stress_started_on_vms_for_psi_metrics",
+    "deployed_vms_for_descheduler_test",
 )
 class TestDeschedulerLoadAwareRebalancing:
     @pytest.mark.polarion("CNV-11960")
     def test_soft_taint_added_when_node_overloaded(
         self,
-        node_labeled_for_test,
+        node_to_run_stress,
+        stressed_vms_on_one_node,
     ):
-        wait_for_overutilized_soft_taint(node=node_labeled_for_test, taint_expected=True)
+        wait_for_overutilized_soft_taint(node=node_to_run_stress, taint_expected=True)
 
     @pytest.mark.polarion("CNV-11961")
     def test_rebalancing_when_node_overloaded(
         self,
-        node_labeled_for_test,
-        migration_policy_with_allow_auto_converge,
-        deployed_vms_on_labeled_node,
-        second_node_labeled_labeled_for_migration,
+        node_to_run_stress,
+        stressed_vms_on_one_node,
     ):
-        verify_at_least_one_vm_migrated(vms=deployed_vms_on_labeled_node, node_before=node_labeled_for_test)
+        verify_at_least_one_vm_migrated(vms=stressed_vms_on_one_node, node_before=node_to_run_stress)
 
     @pytest.mark.polarion("CNV-11962")
     def test_soft_taint_removed_when_node_not_overloaded(
         self,
-        node_labeled_for_test,
+        node_to_run_stress,
     ):
-        wait_for_overutilized_soft_taint(node=node_labeled_for_test, taint_expected=False)
+        wait_for_overutilized_soft_taint(node=node_to_run_stress, taint_expected=False)

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -8,6 +8,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.tier3,
+    pytest.mark.descheduler,
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
         "skip_if_1tb_memory_or_more_node",

--- a/tests/virt/node/descheduler/utils.py
+++ b/tests/virt/node/descheduler/utils.py
@@ -11,7 +11,6 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.virt.node.descheduler.constants import (
     DESCHEDULER_DEPLOYMENT_NAME,
-    DESCHEDULER_NAMESPACE_NAME,
     DESCHEDULER_SOFT_TAINT_KEY,
     DESCHEDULING_INTERVAL_120SEC,
     RUNNING_PING_PROCESS_NAME_IN_VM,
@@ -23,6 +22,7 @@ from utilities.constants import (
     TIMEOUT_10MIN,
     TIMEOUT_15MIN,
     TIMEOUT_20SEC,
+    NamespacesNames,
 )
 from utilities.virt import (
     VirtualMachineForTests,
@@ -314,10 +314,11 @@ def verify_at_least_one_vm_migrated(vms, node_before):
 
 
 @contextmanager
-def create_kube_descheduler(profiles, profile_customizations):
+def create_kube_descheduler(admin_client, profiles, profile_customizations):
     with KubeDescheduler(
         name="cluster",
-        namespace=DESCHEDULER_NAMESPACE_NAME,
+        namespace=NamespacesNames.OPENSHIFT_KUBE_DESCHEDULER_OPERATOR,
+        client=admin_client,
         profiles=profiles,
         descheduling_interval_seconds=DESCHEDULING_INTERVAL_120SEC,
         mode="Automatic",
@@ -326,7 +327,8 @@ def create_kube_descheduler(profiles, profile_customizations):
     ) as kd:
         deployment = Deployment(
             name=DESCHEDULER_DEPLOYMENT_NAME,
-            namespace=DESCHEDULER_NAMESPACE_NAME,
+            namespace=NamespacesNames.OPENSHIFT_KUBE_DESCHEDULER_OPERATOR,
+            client=admin_client,
         )
         deployment.wait()
         deployment.wait_for_replicas()

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -481,3 +481,29 @@ def check_node_for_missing_mdev_bus(node_and_shared_list):
                 return
     except TimeoutExpiredError:
         shared_list.append(node.name)
+
+
+def get_allocatable_memory_per_node(schedulable_nodes):
+    """
+    Gets allocatable memory for each schedulable node.
+
+    A node's allocatable memory is preferred, but if it's not set,
+    the capacity value is used as a fallback.
+
+    Args:
+        schedulable_nodes (list): List of node objects`.
+
+    Returns:
+        dict: A dictionary mapping each node to its allocatable memory.
+    """
+    nodes_memory = {}
+    for node in schedulable_nodes:
+        # memory format does not include the Bytes suffix(e.g: 23514144Ki)
+        memory = getattr(
+            node.instance.status.allocatable,
+            "memory",
+            node.instance.status.capacity.memory,
+        )
+        nodes_memory[node] = bitmath.parse_string_unsafe(s=memory).to_KiB()
+        LOGGER.info(f"Node {node.name} has {nodes_memory[node].to_GiB()} of allocatable memory")
+    return nodes_memory

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -637,6 +637,7 @@ class NamespacesNames:
     MACHINE_API_NAMESPACE = "machine-api-namespace"
     OPENSHIFT_VIRTUALIZATION_OS_IMAGES = "openshift-virtualization-os-images"
     WASP = "wasp"
+    OPENSHIFT_KUBE_DESCHEDULER_OPERATOR = "openshift-kube-descheduler-operator"
 
 
 # CNV supplemental-templates

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1549,16 +1549,6 @@ def get_nodes_cpu_architecture(nodes: list[Node]) -> str:
     return next(iter(nodes_cpu_arch))
 
 
-def verify_image_info(image_url, generated_pulled_secret, nodes_cpu_architecture):
-    LOGGER.info(f"Checking image {image_url} information.")
-    run_command(
-        command=shlex.split(
-            f"oc image info {image_url} "
-            f"--registry-config={generated_pulled_secret} --filter-by-os={nodes_cpu_architecture}"
-        ),
-    )
-
-
 @cache
 def cache_admin_client():
     return get_client()

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -14,7 +14,6 @@ from ocp_resources.cluster_operator import ClusterOperator
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.image_content_source_policy import ImageContentSourcePolicy
 from ocp_resources.image_digest_mirror_set import ImageDigestMirrorSet
-from ocp_resources.installplan import InstallPlan
 from ocp_resources.machine_config_pool import MachineConfigPool
 from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
@@ -469,20 +468,6 @@ def get_install_plan_from_subscription(subscription):
             f"Subscription: {subscription.name}, did not get updated with install plan: {pformat(subscription)}"
         )
         raise
-
-
-def wait_for_operator_install(admin_client, install_plan_name, namespace_name, subscription_name):
-    install_plan = InstallPlan(
-        client=admin_client,
-        name=install_plan_name,
-        namespace=namespace_name,
-    )
-    install_plan.wait_for_status(status=install_plan.Status.COMPLETE, timeout=TIMEOUT_5MIN)
-    wait_for_csv_successful_state(
-        admin_client=admin_client,
-        namespace_name=namespace_name,
-        subscription_name=subscription_name,
-    )
 
 
 def wait_for_csv_successful_state(admin_client, namespace_name, subscription_name):


### PR DESCRIPTION
Remove descheduler installation part - it should be a part of cluster installation for saving huge amount of time
Update virt sanity: check kube-descheduler operator installed, check psi kernel argument present on nodes

Add descheduler CPU Load rebalancing tests

Add descheduler operator namespace to data collector

Remove programmatic skip



##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced tests verifying descheduler behavior during node overload, including soft taint application, VM migration, and taint removal.
  - Added support for VM stress testing to simulate node overutilization.
  - Added new constants and configuration for descheduler namespaces and taints.
  - Added a pytest marker for descheduler-specific tests.
  - Enhanced kernel argument verification in utility pods for descheduler tests.
  - Enabled direct creation of kube descheduler instances with customizable profiles.
  - Added functionality to calculate VM CPU allocation dynamically based on node CPU capacity.
  - Added functionality to capture and restore node taints before and after descheduler tests.

- **Bug Fixes**
  - Improved cleanup and restoration of node taints after descheduler tests to maintain environment consistency.

- **Refactor**
  - Streamlined and renamed test fixtures for clarity and reuse.
  - Updated test and utility code to use new fixture and parameter names.
  - Simplified descheduler setup by removing operator installation via OLM and using direct descheduler creation.
  - Updated VM CPU allocation logic to use a percentage of node CPU capacity.
  - Removed obsolete image verification and operator installation wait utilities.

- **Tests**
  - Expanded test coverage for descheduler scenarios with improved setup for stress and migration conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->