### PR TITLE
net, localnet: Mark single-nic and use 'usefixtures'

### DIFF
--- a/tests/network/localnet/test_localnet.py
+++ b/tests/network/localnet/test_localnet.py
@@ -5,7 +5,9 @@ from utilities.virt import migrate_vm_and_verify
 
 
 @pytest.mark.ipv4
+@pytest.mark.single_nic
+@pytest.mark.usefixtures("nncp_localnet")
 @pytest.mark.polarion("CNV-11775")
-def test_connectivity_over_migration_between_localnet_vms(nncp_localnet, localnet_server, localnet_client):
+def test_connectivity_over_migration_between_localnet_vms(localnet_server, localnet_client):
     migrate_vm_and_verify(vm=localnet_client.vm)
     assert is_tcp_connection(server=localnet_server, client=localnet_client)


### PR DESCRIPTION
- Mark the test as compatible with single-NIC clusters as it utilizes the br-ex bridge and doesn't require additional NICs on worker nodes.
- Refactor fixture usage by applying the NNCP fixture via @pytest.mark.usefixtures since its output is not directly consumed by the test, preventing potential confusion and accidental removal.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test configuration by applying new markers and modifying fixture usage for improved clarity and maintainability. Test logic and outcomes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->