### PR TITLE
[virt] fix vm cloning test

### DIFF
--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
@@ -16,12 +16,16 @@ LOGGER = logging.getLogger(__name__)
             marks=pytest.mark.polarion("CNV-10302"),
             id="VirtualMachine_as_source",
         ),
-        pytest.param(  # TODO: this won't be backported to 4.19; need to remove test after 4.19 branch created
+        pytest.param(
             {
                 "source_name": "non-existing-vm-snapshot",
                 "source_kind": "VirtualMachineSnapshot",
             },
-            marks=[pytest.mark.polarion("CNV-10303"), pytest.mark.jira("CNV-42213", run=False)],
+            marks=[
+                pytest.mark.polarion("CNV-10303"),
+                # TODO: this won't be backported to 4.19; need to remove test after 4.19 branch created
+                pytest.mark.jira("CNV-42213", run=False),
+            ],
             id="VirtualMachineSnapshot_as_source",
         ),
     ],

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
@@ -2,35 +2,10 @@ import logging
 
 import pytest
 from ocp_resources.virtual_machine_clone import VirtualMachineClone
-from timeout_sampler import retry
 
-from utilities.constants import TIMEOUT_1SEC, TIMEOUT_10SEC
+from tests.virt.cluster.vm_cloning.utils import wait_cloning_job_source_not_exist_reason
 
 LOGGER = logging.getLogger(__name__)
-
-
-class VirtualMachineCloneConditionRunningError(Exception):
-    pass
-
-
-@retry(
-    wait_timeout=TIMEOUT_10SEC,
-    sleep=TIMEOUT_1SEC,
-    exceptions_dict={VirtualMachineCloneConditionRunningError: []},
-)
-def wait_cloning_job_source_not_exist_reason(vmc: VirtualMachineClone) -> bool:
-    vmc_source = vmc.instance.spec.source
-    expected_reason = f"Source doesnt exist: {vmc_source.kind} {vmc.namespace}/{vmc_source.name}"
-    current_reason = [
-        condition.reason
-        for condition in vmc.instance.status.conditions
-        if condition.type == VirtualMachineClone.Condition.READY
-    ][0]
-    if current_reason == expected_reason:
-        return True
-    raise VirtualMachineCloneConditionRunningError(
-        f'VMClone error reason is "{current_reason}" expected is "{expected_reason}"'
-    )
 
 
 @pytest.mark.parametrize(
@@ -41,7 +16,7 @@ def wait_cloning_job_source_not_exist_reason(vmc: VirtualMachineClone) -> bool:
             marks=pytest.mark.polarion("CNV-10302"),
             id="VirtualMachine_as_source",
         ),
-        pytest.param(  # TODO: this won't be backported to 4.19; need to remove test after 4.19 created
+        pytest.param(  # TODO: this won't be backported to 4.19; need to remove test after 4.19 branch created
             {
                 "source_name": "non-existing-vm-snapshot",
                 "source_kind": "VirtualMachineSnapshot",

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
@@ -1,6 +1,36 @@
+import logging
+
 import pytest
-from kubernetes.client import ApiException
 from ocp_resources.virtual_machine_clone import VirtualMachineClone
+from timeout_sampler import retry
+
+from utilities.constants import TIMEOUT_1SEC, TIMEOUT_10SEC
+
+LOGGER = logging.getLogger(__name__)
+
+
+class VirtualMachineCloneConditionRunningError(Exception):
+    pass
+
+
+@retry(
+    wait_timeout=TIMEOUT_10SEC,
+    sleep=TIMEOUT_1SEC,
+    exceptions_dict={VirtualMachineCloneConditionRunningError: []},
+)
+def wait_cloning_job_source_not_exist_reason(vmc: VirtualMachineClone) -> bool:
+    vmc_source = vmc.instance.spec.source
+    expected_reason = f"Source doesnt exist: {vmc_source.kind} {vmc.namespace}/{vmc_source.name}"
+    current_reason = [
+        condition.reason
+        for condition in vmc.instance.status.conditions
+        if condition.type == VirtualMachineClone.Condition.READY
+    ][0]
+    if current_reason == expected_reason:
+        return True
+    raise VirtualMachineCloneConditionRunningError(
+        f'VMClone error reason is "{current_reason}" expected is "{expected_reason}"'
+    )
 
 
 @pytest.mark.parametrize(
@@ -11,25 +41,21 @@ from ocp_resources.virtual_machine_clone import VirtualMachineClone
             marks=pytest.mark.polarion("CNV-10302"),
             id="VirtualMachine_as_source",
         ),
-        pytest.param(
+        pytest.param(  # TODO: this won't be backported to 4.19; need to remove test after 4.19 created
             {
                 "source_name": "non-existing-vm-snapshot",
                 "source_kind": "VirtualMachineSnapshot",
             },
-            marks=pytest.mark.polarion("CNV-10303"),
+            marks=[pytest.mark.polarion("CNV-10303"), pytest.mark.jira("CNV-42213", run=False)],
             id="VirtualMachineSnapshot_as_source",
         ),
     ],
 )
 def test_cloning_job_if_source_not_exist_negative(namespace, cloning_job_bad_params):
-    with pytest.raises(
-        ApiException,
-        match=rf".* {cloning_job_bad_params['source_kind']} {cloning_job_bad_params['source_name']} does not exist .*",
-    ):
-        with VirtualMachineClone(
-            name="clone-job-negative-test",
-            namespace=namespace.name,
-            source_name=cloning_job_bad_params["source_name"],
-            source_kind=cloning_job_bad_params["source_kind"],
-        ):
-            pytest.fail("Cloning job created with non-existing source")
+    with VirtualMachineClone(
+        name="clone-job-negative-test",
+        namespace=namespace.name,
+        source_name=cloning_job_bad_params["source_name"],
+        source_kind=cloning_job_bad_params["source_kind"],
+    ) as vmc:
+        wait_cloning_job_source_not_exist_reason(vmc=vmc)

--- a/tests/virt/cluster/vm_cloning/utils.py
+++ b/tests/virt/cluster/vm_cloning/utils.py
@@ -1,15 +1,22 @@
 import logging
 import shlex
 
+from ocp_resources.virtual_machine_clone import VirtualMachineClone
 from pyhelper_utils.shell import run_ssh_commands
+from timeout_sampler import retry
 
 from tests.virt.cluster.vm_cloning.constants import (
     ROOT_DISK_TEST_FILE_STR,
     SECOND_DISK_PATH,
     SECOND_DISK_TEST_FILE_STR,
 )
+from utilities.constants import TIMEOUT_1SEC, TIMEOUT_10SEC
 
 LOGGER = logging.getLogger(__name__)
+
+
+class VirtualMachineCloneConditionRunningError(Exception):
+    pass
 
 
 def check_if_files_present_after_cloning(vm):
@@ -38,4 +45,38 @@ def assert_target_vm_has_new_pvc_disks(source_vm, target_vm):
         f"DataVolume on VMs should be unique. \n "
         f"Source VM: {source_vm_volumes_list},\n "
         f"Target VM: {target_vm_volumes_list}"
+    )
+
+
+@retry(
+    wait_timeout=TIMEOUT_10SEC,
+    sleep=TIMEOUT_1SEC,
+    exceptions_dict={VirtualMachineCloneConditionRunningError: []},
+)
+def wait_cloning_job_source_not_exist_reason(vmc: VirtualMachineClone) -> bool:
+    """
+    Check if the VirtualMachineClone source does not exist.
+
+    Args:
+        vmc (VirtualMachineClone): The VirtualMachineClone resource to check.
+
+    Returns:
+        bool: True if the source does not exist, otherwise raises an exception.
+
+    Raises:
+        VirtualMachineCloneConditionRunningError: If the ready condition does not
+        match the expected source non-existence reason.
+    """
+    vmc_source = vmc.instance.spec.source
+    ready_reason = ""
+    expected_reason = f"Source doesnt exist: {vmc_source.kind} {vmc.namespace}/{vmc_source.name}"
+    ready_condition = [
+        condition
+        for condition in vmc.instance.status.conditions
+        if condition.type == VirtualMachineClone.Condition.READY
+    ]
+    if ready_condition and (ready_reason := ready_condition[0].reason) == expected_reason:
+        return True
+    raise VirtualMachineCloneConditionRunningError(
+        f'VMClone ready condition is "{ready_reason}" expected error is"{expected_reason}"'
     )


### PR DESCRIPTION
##### Short description:
Fixed test_cloning_job_if_source_not_exist_negative
  - now if source doesn't exist, VMClone object is still created (webhook rejecting it was removed)
  - VMClone object Ready condition has relevant err msg
  - Skip this for VMSnapshot source due to bug

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved reliability of VM cloning negative tests by waiting for specific error conditions when the source does not exist, instead of expecting immediate errors.
  - Enhanced test structure with retry logic for better error detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->