### PR TITLE
tests, net, owners: Add 'rnetser' to the sig-network approvers

### DIFF
--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -1,6 +1,7 @@
 root-approvers: False
 approvers:
   - EdDev
+  - rnetser
 reviewers:
   - yossisegev
   - Anatw


### PR DESCRIPTION
##### What this PR does / why we need it:

The sig-network has only a single approver and the bot logic mandates an approve from the list even is a root approver adds it.

Therefore, adding rnetser explicitly to the list.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new approver to the network tests ownership list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->