### PR TITLE
[Virt] Add suffix for s390x template names for Common templates tests

### DIFF
--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -97,7 +97,8 @@ class TestBaseCustomTemplates:
         [
             pytest.param(
                 {
-                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
+                    "base_template_name": 
+                        f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "fedora-custom-template-for-test",
                 },
                 "vm-from-custom-template",
@@ -105,7 +106,8 @@ class TestBaseCustomTemplates:
             ),
             pytest.param(
                 {
-                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
+                    "base_template_name": 
+                        f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "fedora-custom-template-disks-wildcard",
                     "validation_rule": {
                         "name": "volumes-validation",
@@ -143,7 +145,8 @@ class TestBaseCustomTemplates:
         [
             pytest.param(
                 {
-                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
+                    "base_template_name": 
+                        f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "custom-fedora-template-core-validation",
                     "validation_rule": {
                         "name": "minimal-required-cpu-core",

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -5,6 +5,7 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.template import Template
 from pytest_testconfig import py_config
 
+from tests.virt.cluster.common_templates.utils import get_template_arch_suffix
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_OS
 from utilities.constants import NamespacesNames
 from utilities.virt import (
@@ -96,7 +97,7 @@ class TestBaseCustomTemplates:
         [
             pytest.param(
                 {
-                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}",
+                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "fedora-custom-template-for-test",
                 },
                 "vm-from-custom-template",
@@ -104,7 +105,7 @@ class TestBaseCustomTemplates:
             ),
             pytest.param(
                 {
-                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}",
+                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "fedora-custom-template-disks-wildcard",
                     "validation_rule": {
                         "name": "volumes-validation",
@@ -142,7 +143,7 @@ class TestBaseCustomTemplates:
         [
             pytest.param(
                 {
-                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}",
+                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "custom-fedora-template-core-validation",
                     "validation_rule": {
                         "name": "minimal-required-cpu-core",

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -5,8 +5,8 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.template import Template
 from pytest_testconfig import py_config
 
-from tests.virt.cluster.common_templates.utils import get_template_arch_suffix
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_OS
+from tests.virt.cluster.common_templates.utils import get_template_arch_suffix
 from utilities.constants import NamespacesNames
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -97,8 +97,7 @@ class TestBaseCustomTemplates:
         [
             pytest.param(
                 {
-                    "base_template_name": 
-                        f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
+                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "fedora-custom-template-for-test",
                 },
                 "vm-from-custom-template",
@@ -106,8 +105,7 @@ class TestBaseCustomTemplates:
             ),
             pytest.param(
                 {
-                    "base_template_name": 
-                        f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
+                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "fedora-custom-template-disks-wildcard",
                     "validation_rule": {
                         "name": "volumes-validation",
@@ -145,8 +143,7 @@ class TestBaseCustomTemplates:
         [
             pytest.param(
                 {
-                    "base_template_name": 
-                        f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
+                    "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}{get_template_arch_suffix()}",
                     "new_template_name": "custom-fedora-template-core-validation",
                     "validation_rule": {
                         "name": "minimal-required-cpu-core",

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -142,7 +142,7 @@ def get_centos_templates_list(cluster_arch):
 
 @pytest.fixture()
 def common_templates_expected_list(nodes):
-    node_cpu_arch = infra.get_nodes_cpu_architecture(nodes = nodes)
+    node_cpu_arch = infra.get_nodes_cpu_architecture(nodes=nodes)
     common_templates_list = get_rhel_templates_list(cluster_arch=node_cpu_arch)
     common_templates_list += get_fedora_templates_list(cluster_arch=node_cpu_arch)
     common_templates_list += get_windows_templates_list(cluster_arch=node_cpu_arch)

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -142,7 +142,7 @@ def get_centos_templates_list(cluster_arch):
 
 @pytest.fixture()
 def common_templates_expected_list(nodes):
-    node_cpu_arch = infra.get_nodes_cpu_architecture(nodes)
+    node_cpu_arch = infra.get_nodes_cpu_architecture(nodes = nodes)
     common_templates_list = get_rhel_templates_list(cluster_arch=node_cpu_arch)
     common_templates_list += get_fedora_templates_list(cluster_arch=node_cpu_arch)
     common_templates_list += get_windows_templates_list(cluster_arch=node_cpu_arch)

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -17,8 +17,9 @@ from pytest_testconfig import config as py_config
 
 from tests.os_params import FEDORA_LATEST_LABELS
 from tests.virt.cluster.common_templates.constants import HYPERV_FEATURES_LABELS_VM_YAML
+from tests.virt.cluster.common_templates.utils import get_template_arch_suffix
 from utilities import infra
-from utilities.constants import DATA_SOURCE_NAME, DATA_SOURCE_NAMESPACE, S390X, S390X_TEMPLATE_SUFFIX, Images
+from utilities.constants import DATA_SOURCE_NAME, DATA_SOURCE_NAMESPACE, S390X, Images
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
@@ -96,7 +97,7 @@ def get_rhel_templates_list(cluster_arch):
         LOGGER.info("RHEL 7 not supported on s390x: removing RHEL 7 templates")
         rhel_major_releases_list.remove("7")
     return [
-        f"rhel{release}-{workload}-{flavor}{S390X_TEMPLATE_SUFFIX if cluster_arch == S390X else ''}"
+        f"rhel{release}-{workload}-{flavor}{get_template_arch_suffix()}"
         for release in rhel_major_releases_list
         for flavor in LINUX_FLAVORS_LIST
         for workload in LINUX_WORKLOADS_LIST
@@ -105,7 +106,7 @@ def get_rhel_templates_list(cluster_arch):
 
 def get_fedora_templates_list(cluster_arch):
     return [
-        f"fedora-{workload}-{flavor}{S390X_TEMPLATE_SUFFIX if cluster_arch == S390X else ''}"
+        f"fedora-{workload}-{flavor}{get_template_arch_suffix()}"
         for flavor in FEDORA_FLAVORS_LIST
         for workload in LINUX_WORKLOADS_LIST
     ]
@@ -133,7 +134,7 @@ def get_windows_templates_list(cluster_arch):
 def get_centos_templates_list(cluster_arch):
     centos_releases_list = ["-stream9"]
     return [
-        f"centos{release}-{workload}-{flavor}{S390X_TEMPLATE_SUFFIX if cluster_arch == S390X else ''}"
+        f"centos{release}-{workload}-{flavor}{get_template_arch_suffix()}"
         for release in centos_releases_list
         for flavor in LINUX_FLAVORS_LIST
         for workload in [Template.Workload.SERVER, Template.Workload.DESKTOP]

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -141,8 +141,8 @@ def get_centos_templates_list(cluster_arch):
 
 
 @pytest.fixture()
-def common_templates_expected_list():
-    node_cpu_arch = infra.get_nodes_cpu_architecture()
+def common_templates_expected_list(nodes):
+    node_cpu_arch = infra.get_nodes_cpu_architecture(nodes)
     common_templates_list = get_rhel_templates_list(cluster_arch=node_cpu_arch)
     common_templates_list += get_fedora_templates_list(cluster_arch=node_cpu_arch)
     common_templates_list += get_windows_templates_list(cluster_arch=node_cpu_arch)

--- a/tests/virt/cluster/common_templates/utils.py
+++ b/tests/virt/cluster/common_templates/utils.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import shlex
+import os
 from datetime import datetime, timedelta, timezone
 
 import bitmath
@@ -14,6 +15,9 @@ from tests.virt.cluster.common_templates.constants import HYPERV_FEATURES_LABELS
 from utilities.constants import (
     OS_FLAVOR_RHEL,
     OS_FLAVOR_WINDOWS,
+    S390X,
+    S390X_TEMPLATE_SUFFIX,
+    X86_64,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_15SEC,
     TIMEOUT_90SEC,
@@ -618,3 +622,9 @@ def assert_windows_efi(vm):
         tcp_timeout=TCP_TIMEOUT_30SEC,
     )[0]
     assert "\\EFI\\Microsoft\\Boot\\bootmgfw.efi" in out, f"EFI boot not found in path. bcdedit output:\n{out}"
+
+def get_template_arch_suffix():
+    if os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", X86_64) == S390X:
+        return S390X_TEMPLATE_SUFFIX
+    else:
+        return ''

--- a/tests/virt/cluster/common_templates/utils.py
+++ b/tests/virt/cluster/common_templates/utils.py
@@ -1,8 +1,8 @@
 import json
 import logging
+import os
 import re
 import shlex
-import os
 from datetime import datetime, timedelta, timezone
 
 import bitmath
@@ -17,10 +17,10 @@ from utilities.constants import (
     OS_FLAVOR_WINDOWS,
     S390X,
     S390X_TEMPLATE_SUFFIX,
-    X86_64,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_15SEC,
     TIMEOUT_90SEC,
+    X86_64,
 )
 from utilities.infra import (
     get_linux_guest_agent_version,
@@ -623,8 +623,9 @@ def assert_windows_efi(vm):
     )[0]
     assert "\\EFI\\Microsoft\\Boot\\bootmgfw.efi" in out, f"EFI boot not found in path. bcdedit output:\n{out}"
 
+
 def get_template_arch_suffix():
     if os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", X86_64) == S390X:
         return S390X_TEMPLATE_SUFFIX
     else:
-        return ''
+        return ""

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -166,6 +166,11 @@ Images = get_test_images_arch_class()
 # Virtctl constants
 VIRTCTL = "virtctl"
 VIRTCTL_CLI_DOWNLOADS = f"{VIRTCTL}-clidownloads-kubevirt-hyperconverged"
+
+AMD_64 = "amd64"
+ARM_64 = "arm64"
+S390X = "s390x"
+
 #  Network constants
 SRIOV = "sriov"
 IP_FAMILY_POLICY_PREFER_DUAL_STACK = "PreferDualStack"
@@ -363,6 +368,7 @@ DATA_SOURCE_NAME = "DATA_SOURCE_NAME"
 DATA_SOURCE_NAMESPACE = "DATA_SOURCE_NAMESPACE"
 SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME = "dataImportCronTemplates"
 COMMON_TEMPLATES_KEY_NAME = "commonTemplates"
+S390X_TEMPLATE_SUFFIX = f"-{S390X}"
 
 KUBEVIRT_HYPERCONVERGED_PROMETHEUS_RULE = "kubevirt-hyperconverged-prometheus-rule"
 HYPERCONVERGED_CLUSTER_OPERATOR_METRICS = "hyperconverged-cluster-operator-metrics"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -167,10 +167,6 @@ Images = get_test_images_arch_class()
 VIRTCTL = "virtctl"
 VIRTCTL_CLI_DOWNLOADS = f"{VIRTCTL}-clidownloads-kubevirt-hyperconverged"
 
-AMD_64 = "amd64"
-ARM_64 = "arm64"
-S390X = "s390x"
-
 #  Network constants
 SRIOV = "sriov"
 IP_FAMILY_POLICY_PREFER_DUAL_STACK = "PreferDualStack"


### PR DESCRIPTION
##### Short description:
Adds support of test on s390x by adding correct template names for `virt/cluster/commontemplate/general` tests
##### More details:
- checks node arch
- Adds "-s390x" suffix to common templates when run on s390x
##### What this PR does / why we need it:
Allows virt/cluster/commontemplate/general to be run against s390x arch
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced test coverage to dynamically handle template lists based on cluster CPU architecture, including architecture-specific template naming and restrictions.  
- **New Features**
  - Added support for the s390x CPU architecture in template selections and constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->