### PR TITLE
WIP: update global_config file to add fedora 42 os metrics for amd64

### DIFF
--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -372,13 +372,13 @@ windows_os_matrix = [
 
 fedora_os_matrix = [
     {
-        "fedora-41": {
-            IMAGE_NAME_STR: Images.Fedora.FEDORA41_IMG,
-            IMAGE_PATH_STR: os.path.join(Images.Fedora.DIR, Images.Fedora.FEDORA41_IMG),
+        "fedora-42": {
+            IMAGE_NAME_STR: Images.Fedora.FEDORA42_IMG,
+            IMAGE_PATH_STR: os.path.join(Images.Fedora.DIR, Images.Fedora.FEDORA42_IMG),
             DV_SIZE_STR: Images.Fedora.DEFAULT_DV_SIZE,
             LATEST_RELEASE_STR: True,
             TEMPLATE_LABELS_STR: {
-                OS_STR: "fedora41",
+                OS_STR: "fedora42",
                 WORKLOAD_STR: Template.Workload.SERVER,
                 FLAVOR_STR: Template.Flavor.SMALL,
             },

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -97,8 +97,8 @@ class ArchImages:
             DEFAULT_CPU_THREADS = 2
 
         class Fedora:
-            FEDORA41_IMG = "Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2"
-            FEDORA_CONTAINER_IMAGE = "quay.io/openshift-cnv/qe-cnv-tests-fedora:41"
+            FEDORA42_IMG = "Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2"
+            FEDORA_CONTAINER_IMAGE = "quay.io/openshift-cnv/qe-cnv-tests-fedora:42"
             DISK_DEMO = "fedora-cloud-registry-disk-demo"
             DIR = f"{BASE_IMAGES_DIR}/fedora-images"
             DEFAULT_DV_SIZE = "10Gi"


### PR DESCRIPTION
##### Short description:
update global_config file to add fedora 42 os metrics
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-61426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Fedora OS references from version 41 to version 42, including image names and labels, to reflect the latest release in the supported OS matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->