### PR TITLE
Add arm64 marker for RHEL10 instancetype tests

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 from typing import Any
 
 import pytest_testconfig
@@ -65,6 +66,11 @@ rhel_os_matrix = [
 
 latest_rhel_os_dict = get_latest_os_dict_list(os_list=[rhel_os_matrix])[0]
 
+# Modify instance_type_rhel_os_matrix for arm64
+instance_type_rhel_os_matrix = deepcopy(config["instance_type_rhel_os_matrix"])  # noqa: F821
+for os_matrix_dict in instance_type_rhel_os_matrix:
+    for os_params in os_matrix_dict.values():
+        os_params[PREFERENCE_STR] += f".{ARM_64}"
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -30,6 +30,7 @@ TESTS_CLASS_MIGRATION = "TestVMMigrationAndState"
 TESTS_MIGRATE_VM = f"{TESTS_CLASS_MIGRATION}::test_migrate_vm"
 
 
+@pytest.mark.arm64
 @pytest.mark.smoke
 @pytest.mark.gating
 @pytest.mark.sno
@@ -114,12 +115,11 @@ class TestVMFeatures:
         check_vm_xml_smbios(vm=golden_image_vm_with_instance_type, cm_values=smbios_from_kubevirt_config)
 
 
+@pytest.mark.arm64
 class TestVMMigrationAndState:
     @pytest.mark.polarion("CNV-11714")
     @pytest.mark.dependency(name=TESTS_MIGRATE_VM, depends=[TEST_START_VM_TEST_NAME])
-    def test_migrate_vm(
-        self, skip_if_no_common_modern_cpu, skip_access_mode_rwo_scope_class, golden_image_vm_with_instance_type
-    ):
+    def test_migrate_vm(self, skip_access_mode_rwo_scope_class, golden_image_vm_with_instance_type):
         migrate_vm_and_verify(vm=golden_image_vm_with_instance_type, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=golden_image_vm_with_instance_type)
 
@@ -144,6 +144,7 @@ class TestVMMigrationAndState:
         )
 
 
+@pytest.mark.arm64
 @pytest.mark.smoke
 @pytest.mark.gating
 @pytest.mark.sno


### PR DESCRIPTION
##### Short description:
Arm support for RHEL10 instancetype tests
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added ARM64-specific markers to several test classes and methods to improve ARM64 architecture test coverage.
  - Simplified a test method signature by removing an unused parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->