### PR TITLE
Add ClusterUserDefinedNetwork CR and replace NADs in localnet test

### DIFF
--- a/tests/network/libs/cluster_user_defined_network.py
+++ b/tests/network/libs/cluster_user_defined_network.py
@@ -1,0 +1,91 @@
+from dataclasses import asdict, dataclass
+from enum import Enum
+
+from ocp_resources.cluster_user_defined_network import ClusterUserDefinedNetwork as Cudn
+
+from tests.network.libs.apimachinery import dict_normalization_for_dataclass
+from tests.network.libs.label_selector import LabelSelector
+
+
+@dataclass
+class Access:
+    id: int
+
+
+@dataclass
+class Vlan:
+    class Mode(Enum):
+        ACCESS = "Access"
+
+    access: Access
+    mode: str
+
+
+@dataclass
+class Ipam:
+    class Mode(Enum):
+        DISABLED = "Disabled"
+
+    mode: str
+
+
+@dataclass
+class Localnet:
+    class Role(Enum):
+        SECONDARY = "Secondary"
+
+    role: str
+    physicalNetworkName: str  # noqa: N815
+    vlan: Vlan
+    ipam: Ipam
+
+
+@dataclass
+class Network:
+    class Topology(Enum):
+        LOCALNET = "Localnet"
+
+    topology: str
+    localnet: Localnet
+
+
+class ClusterUserDefinedNetwork(Cudn):
+    """
+    ClusterUserDefinedNetwork object.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        namespace_selector: LabelSelector,
+        network: Network,
+    ):
+        """
+        Create and manage ClusterUserDefinedNetwork
+
+        API reference:
+        https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/#clusteruserdefinednetwork
+
+        Args:
+            name (str): Name of the ClusterUserDefinedNetwork object.
+            namespace_selector (NamespaceSelector): NamespaceSelector Label selector for which namespace network should
+                be available for.
+            network (Network): Network is the user-defined-network spec.
+        """
+        super().__init__(
+            name=name,
+            namespace_selector=asdict(namespace_selector, dict_factory=dict_normalization_for_dataclass),
+            network=asdict(network, dict_factory=dict_normalization_for_dataclass),
+        )
+
+    class Status:
+        class Condition:
+            class Type(str, Enum):
+                NETWORK_CREATED = "NetworkCreated"
+
+    def wait_for_status_success(self) -> None:
+        self.wait_for_condition(
+            condition=ClusterUserDefinedNetwork.Status.Condition.Type.NETWORK_CREATED.value,
+            status=ClusterUserDefinedNetwork.Condition.Status.TRUE,
+        )
+        self.logger.info(f"{self.kind}/{self.name} configured successfully")

--- a/tests/network/libs/label_selector.py
+++ b/tests/network/libs/label_selector.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class LabelSelector:
+    matchLabels: dict[str, str] | None = None  # noqa: N815

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -1,12 +1,14 @@
-from libs.net import netattachdef
 from libs.net.vmspec import add_network_interface, add_volume_disk
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import CloudInitNoCloud, Interface, Metadata, Multus, Network
 from libs.vm.vm import BaseVirtualMachine, cloudinitdisk_storage
 from tests.network.libs import cloudinit
+from tests.network.libs import cluster_user_defined_network as libcudn
+from tests.network.libs.label_selector import LabelSelector
 
 NETWORK_NAME = "localnet-network"
+LOCALNET_TEST_LABEL = {"test": "localnet"}
 
 
 def localnet_vm(namespace: str, name: str, network: str, cidr: str) -> BaseVirtualMachine:
@@ -31,8 +33,7 @@ def localnet_vm(namespace: str, name: str, network: str, cidr: str) -> BaseVirtu
     spec = base_vmspec()
     spec.template.metadata = spec.template.metadata or Metadata()
     spec.template.metadata.labels = spec.template.metadata.labels or {}
-    localnet_test_label = {"test": "localnet"}
-    spec.template.metadata.labels.update(localnet_test_label)
+    spec.template.metadata.labels.update(LOCALNET_TEST_LABEL)
     vmi_spec = spec.template.spec
 
     vmi_spec = add_network_interface(
@@ -51,24 +52,40 @@ def localnet_vm(namespace: str, name: str, network: str, cidr: str) -> BaseVirtu
     )
     vmi_spec = add_volume_disk(vmi_spec=vmi_spec, volume=volume, disk=disk)
 
-    vmi_spec.affinity = new_pod_anti_affinity(label=next(iter(localnet_test_label.items())))
+    vmi_spec.affinity = new_pod_anti_affinity(label=next(iter(LOCALNET_TEST_LABEL.items())))
     vmi_spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].namespaceSelector = {}
 
     return fedora_vm(namespace=namespace, name=name, spec=spec)
 
 
-def localnet_nad(namespace: str, name: str, vlan_id: int) -> netattachdef.NetworkAttachmentDefinition:
-    return netattachdef.NetworkAttachmentDefinition(
-        namespace=namespace,
-        name=name,
-        config=netattachdef.NetConfig(
-            NETWORK_NAME,
-            [
-                netattachdef.CNIPluginOvnK8sConfig(
-                    topology=netattachdef.CNIPluginOvnK8sConfig.Topology.LOCALNET.value,
-                    netAttachDefName=f"{namespace}/{name}",
-                    vlanID=vlan_id,
-                )
-            ],
-        ),
+def localnet_cudn(
+    name: str, match_labels: dict[str, str], vlan_id: int, physical_network_name: str
+) -> libcudn.ClusterUserDefinedNetwork:
+    """
+    Create a ClusterUserDefinedNetwork resource configured for localnet with the specified VLAN ID.
+
+    The function creates a CUDN with:
+    - IPAM disabled
+    - VLAN access mode with the specified VLAN ID
+    - Localnet configuration with secondary role
+    - Network topology set to LOCALNET
+
+    Args:
+        name (str): The name of the CUDN resource.
+        match_labels (dict[str, str]): Labels for namespace selection.
+        vlan_id (int): The VLAN ID to configure for the network.
+        physical_network_name (str): The name of the physical network to associate with the localnet configuration.
+
+    Returns:
+        ClusterUserDefinedNetwork: The configured CUDN object ready for creation.
+    """
+    ipam = libcudn.Ipam(mode=libcudn.Ipam.Mode.DISABLED.value)
+    vlan = libcudn.Vlan(mode=libcudn.Vlan.Mode.ACCESS.value, access=libcudn.Access(id=vlan_id))
+    localnet = libcudn.Localnet(
+        role=libcudn.Localnet.Role.SECONDARY.value, physicalNetworkName=physical_network_name, vlan=vlan, ipam=ipam
+    )
+    network = libcudn.Network(topology=libcudn.Network.Topology.LOCALNET.value, localnet=localnet)
+
+    return libcudn.ClusterUserDefinedNetwork(
+        name=name, namespace_selector=LabelSelector(matchLabels=match_labels), network=network
     )


### PR DESCRIPTION
##### Short description:
Add ClusterUserDefinedNetwork CR and replace NADs in localnet test
##### More details:
Add ClusterUserDefinedNetwork CR and replace NADs in localnet test
    
    Introduces the new ClusterUserDefinedNetwork custom resource and updates
    the localnet test lane to use it instead of NetworkAttachmentDefinitions (NADs).
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for cluster user-defined networks (CUDN) in network-related tests.
  - Added new test helpers and data structures for defining and managing CUDN resources.
  - Added a new label selector utility for namespace selection in tests.
- **Refactor**
  - Migrated network attachment mechanisms in tests from NetworkAttachmentDefinition (NAD) to CUDN.
  - Updated virtual machine and namespace fixtures to use label-based selection with CUDN.
  - Replaced inline test labels with a centralized constant for consistency.
- **Chores**
  - Centralized test labels into a reusable constant for consistency across tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->