### PR TITLE
 tests, net, secondary dns: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/secondary_network_dns/test_secondary_network_dns.py
+++ b/tests/network/secondary_network_dns/test_secondary_network_dns.py
@@ -275,7 +275,8 @@ def kubernetes_secondary_dns_vm(
         cloud_init_data=cloud_init_data,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
     ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 

--- a/tests/network/secondary_network_dns/test_secondary_network_dns.py
+++ b/tests/network/secondary_network_dns/test_secondary_network_dns.py
@@ -34,7 +34,7 @@ from utilities.network import (
     network_device,
     network_nad,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 pytestmark = pytest.mark.usefixtures(
     "enabled_kube_secondary_dns_feature_gate",


### PR DESCRIPTION
`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:

Reaches ready status (i.e. a VMI in running phase).
Reaches AgentConnected condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).
This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated the VM startup process in test cases to explicitly start the VM and wait for agent connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->