### PR TITLE
deprecate feature gate DeployKubeSecondaryDNS

### DIFF
--- a/tests/network/secondary_network_dns/test_secondary_network_dns.py
+++ b/tests/network/secondary_network_dns/test_secondary_network_dns.py
@@ -37,7 +37,7 @@ from utilities.network import (
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 pytestmark = pytest.mark.usefixtures(
-    "enabled_kube_secondary_dns_feature_gate",
+    "enabled_kube_secondary_dns",
     "exposed_kubernetes_secondary_dns_service",
 )
 
@@ -147,10 +147,10 @@ def network_security_rule_for_virtual_workers(
 
 
 @pytest.fixture(scope="module")
-def enabled_kube_secondary_dns_feature_gate(hyperconverged_resource_scope_module):
+def enabled_kube_secondary_dns(hyperconverged_resource_scope_module):
     with ResourceEditorValidateHCOReconcile(
         patches={
-            hyperconverged_resource_scope_module: {"spec": {"featureGates": {"deployKubeSecondaryDNS": True}}},
+            hyperconverged_resource_scope_module: {"spec": {"deployKubeSecondaryDNS": True}},
         },
         list_resource_reconcile=[NetworkAddonsConfig],
         wait_for_reconcile_post_update=True,
@@ -180,7 +180,7 @@ def available_kubernetes_secondary_dns_service_port_number(
 @pytest.fixture(scope="module")
 def created_dns_nodeport_service(
     hco_namespace,
-    enabled_kube_secondary_dns_feature_gate,
+    enabled_kube_secondary_dns,
     available_kubernetes_secondary_dns_service_port_number,
     kubernetes_secondary_dns_deployment,
 ):


### PR DESCRIPTION
##### Short description:
deprecate feature gate DeployKubeSecondaryDNS and change it to spec

##### More details:
DeployKubeSecondaryDNS feature gate is deprecated and moved to spec - https://issues.redhat.com/browse/CNV-51993

##### What this PR does / why we need it:
Fix test_kubernetes_secondary_dns_basic_nslookup test

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-53053


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed and simplified test fixture for improved clarity and consistency in secondary DNS network tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->