### PR TITLE
utilities, virt: Add typing to the 'migrate_vm_and_verify' helper

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1702,12 +1702,12 @@ def wait_for_cloud_init_complete(vm, timeout=TIMEOUT_4MIN):
 
 
 def migrate_vm_and_verify(
-    vm,
-    timeout=TIMEOUT_12MIN,
-    wait_for_interfaces=True,
-    check_ssh_connectivity=False,
-    wait_for_migration_success=True,
-):
+    vm: VirtualMachine,
+    timeout: int = TIMEOUT_12MIN,
+    wait_for_interfaces: bool = True,
+    check_ssh_connectivity: bool = False,
+    wait_for_migration_success: bool = True,
+) -> VirtualMachineInstanceMigration | None:
     """
     create a migration instance. You may choose to wait for migration
     success or not.
@@ -1746,6 +1746,7 @@ def migrate_vm_and_verify(
         wait_for_interfaces=wait_for_interfaces,
         check_ssh_connectivity=check_ssh_connectivity,
     )
+    return None
 
 
 def wait_for_migration_finished(vm, migration, timeout=TIMEOUT_12MIN):


### PR DESCRIPTION
##### What this PR does / why we need it:

When using the helper from typed covered locations, mypy is complaining with `Call to untyped function "migrate_vm_and_verify" in typed context [no-untyped-call]` error.

mypy insisted to to expose the function problematic behavior of
returning different things per the input.
Follow up changes should take care of this odd behavior.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved code clarity by adding type annotations to internal functions. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->