### PR TITLE
WIP: [WIP][Observability] Mark arm64 tests

### DIFF
--- a/tests/observability/metrics/test_cdi_metrics.py
+++ b/tests/observability/metrics/test_cdi_metrics.py
@@ -4,6 +4,8 @@ from tests.observability.metrics.utils import expected_metric_labels_and_values,
 from tests.observability.utils import validate_metrics_value
 from utilities.constants import CDI_OPERATOR
 
+pytestmark = [pytest.mark.arm64]
+
 
 @pytest.mark.polarion("CNV-10557")
 def test_kubevirt_cdi_clone_pods_high_restart(

--- a/tests/observability/metrics/test_cnao_metrics.py
+++ b/tests/observability/metrics/test_cnao_metrics.py
@@ -6,6 +6,8 @@ from tests.observability.metrics.constants import (
 )
 from tests.observability.utils import validate_metrics_value
 
+pytestmark = pytest.mark.arm64
+
 
 class TestSSPMetrics:
     @pytest.mark.parametrize(

--- a/tests/observability/metrics/test_cpu_usage_metrics.py
+++ b/tests/observability/metrics/test_cpu_usage_metrics.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TestCpuUsageMetrics:
+    @pytest.mark.arm64
     @pytest.mark.parametrize(
         "query",
         [

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -45,6 +45,7 @@ def fedora_vm_without_name_in_label(
         yield vm
 
 
+@pytest.mark.arm64
 class TestVmiNodeCpuAffinityLinux:
     @pytest.mark.parametrize(
         "golden_image_data_volume_scope_class, vm_from_template_scope_class",
@@ -84,6 +85,7 @@ class TestVmiNodeCpuAffinityWindows:
         )
 
 
+@pytest.mark.arm64
 class TestVmNameInLabel:
     @pytest.mark.polarion("CNV-8582")
     def test_vm_name_in_virt_launcher_label(self, fedora_vm_without_name_in_label):
@@ -101,6 +103,7 @@ class TestVmNameInLabel:
         )
 
 
+@pytest.mark.arm64
 class TestVirtHCOSingleStackIpv6:
     @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11740")

--- a/tests/observability/metrics/test_instance_type_metrics.py
+++ b/tests/observability/metrics/test_instance_type_metrics.py
@@ -22,6 +22,8 @@ from utilities.constants import (
 )
 from utilities.virt import migrate_vm_and_verify, running_vm
 
+pytestmark = pytest.mark.arm64
+
 
 @pytest.fixture(scope="class")
 def migrated_instance_type_vm(prometheus, rhel_vm_with_cluster_instance_type_and_preference):

--- a/tests/observability/metrics/test_key_metrics.py
+++ b/tests/observability/metrics/test_key_metrics.py
@@ -9,7 +9,7 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_VMI_VCPU_WAIT_SECONDS_TOTAL,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 STRESS_NG = "stress-ng --cpu 8 --io 2 --vm 2 --vm-bytes 128M --timeout 60s &>1 &"
 STORAGE_WRITE = "for i in {1..10}; do head -c 10M </dev/urandom > randfile$i; done"
 STORAGE_READ = "for i in {1..20}; do cat /etc/hosts; done"

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -143,6 +143,7 @@ def test_cnv_installation_with_hco_cr_metrics(
     )
 
 
+@pytest.mark.arm64
 class TestVMIMetricsLinuxVms:
     @pytest.mark.polarion("CNV-8262")
     def test_vmi_domain_total_memory_bytes(
@@ -232,6 +233,7 @@ class TestVMIMetricsWindowsVms:
         )
 
 
+@pytest.mark.arm64
 class TestMemoryDeltaFromRequestedBytes:
     @pytest.mark.polarion("CNV-11632")
     def test_metric_kubevirt_memory_delta_from_requested_bytes_working_set(
@@ -278,6 +280,7 @@ class TestMemoryDeltaFromRequestedBytes:
         )
 
 
+@pytest.mark.arm64
 class TestKubeDaemonsetStatusNumberReady:
     @pytest.mark.polarion("CNV-11727")
     def test_kube_daemonset_status_number_ready(self, prometheus, virt_handler_pods_count):
@@ -288,6 +291,7 @@ class TestKubeDaemonsetStatusNumberReady:
         )
 
 
+@pytest.mark.arm64
 class TestKubevirtApiRequestDeprecatedTotal:
     @pytest.mark.polarion("CNV-11739")
     def test_metric_kubevirt_api_request_deprecated_total(self, prometheus, generated_api_deprecated_requests):
@@ -298,6 +302,7 @@ class TestKubevirtApiRequestDeprecatedTotal:
         )
 
 
+@pytest.mark.arm64
 class TestAllocatableNodes:
     @pytest.mark.polarion("CNV-11818")
     def test_metirc_kubevirt_allocatable_nodes(self, prometheus, allocatable_nodes):

--- a/tests/observability/metrics/test_metrics_cpu.py
+++ b/tests/observability/metrics/test_metrics_cpu.py
@@ -6,7 +6,7 @@ from tests.observability.metrics.utils import (
     wait_for_metric_vmi_request_cpu_cores_output,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 
 @pytest.mark.usefixtures("initial_metric_cpu_value_zero")

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -22,6 +22,8 @@ from utilities.constants import MIGRATION_POLICY_VM_LABEL, TIMEOUT_2MIN, TIMEOUT
 from utilities.infra import get_node_selector_dict, get_pods
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
+pytestmark = pytest.mark.arm64
+
 
 def delete_failed_migration_target_pod(admin_client, namespace, vm_name):
     """

--- a/tests/observability/metrics/test_network_metrics.py
+++ b/tests/observability/metrics/test_network_metrics.py
@@ -5,6 +5,8 @@ from tests.observability.metrics.utils import (
     validate_vmi_network_receive_and_transmit_packets_total,
 )
 
+pytestmark = pytest.mark.arm64
+
 
 @pytest.mark.parametrize(
     "vm_for_test",

--- a/tests/observability/metrics/test_prometheus_service_monitor.py
+++ b/tests/observability/metrics/test_prometheus_service_monitor.py
@@ -3,6 +3,8 @@ from ocp_resources.service_monitor import ServiceMonitor
 
 from utilities.constants import VIRT_OPERATOR
 
+pytestmark = pytest.mark.arm64
+
 
 @pytest.fixture()
 def kubevirt_prometheus_service_monitor_list(admin_client):

--- a/tests/observability/metrics/test_recording_rules.py
+++ b/tests/observability/metrics/test_recording_rules.py
@@ -3,7 +3,7 @@ from ocp_resources.resource import Resource
 
 from utilities.constants import KUBEVIRT_VIRT_OPERATOR_UP, VIRT_API, VIRT_CONTROLLER, VIRT_HANDLER, VIRT_OPERATOR
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 virt_label_dict = {
     VIRT_API: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_API}",

--- a/tests/observability/metrics/test_ssp_metrics.py
+++ b/tests/observability/metrics/test_ssp_metrics.py
@@ -15,6 +15,8 @@ from utilities.constants import (
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.virt import VirtualMachineForTests
 
+pytestmark = pytest.mark.arm64
+
 KUBEVIRT_SSP_OPERATOR_UP = "kubevirt_ssp_operator_up"
 KUBEVIRT_SSP_TEMPLATE_VALIDATOR_UP = "kubevirt_ssp_template_validator_up"
 KUBEVIRT_SSP_COMMON_TEMPLATES_RESTORED_INCREASE = "kubevirt_ssp_common_templates_restored_increase"

--- a/tests/observability/metrics/test_total_created_vms.py
+++ b/tests/observability/metrics/test_total_created_vms.py
@@ -4,6 +4,8 @@ from tests.observability.metrics.constants import KUBEVIRT_VM_CREATED_TOTAL_STR
 from tests.observability.metrics.utils import wait_for_expected_metric_value_sum
 from utilities.constants import RHEL_WITH_INSTANCETYPE_AND_PREFERENCE
 
+pytestmark = pytest.mark.arm64
+
 
 class TestTotalCreatedInstanceType:
     @pytest.mark.polarion("CNV-10771")

--- a/tests/observability/metrics/test_version_metrics.py
+++ b/tests/observability/metrics/test_version_metrics.py
@@ -6,6 +6,8 @@ from tests.observability.metrics.constants import GO_VERSION_STR, KUBE_VERSION_S
 from tests.observability.metrics.utils import assert_virtctl_version_equal_metric_output
 from utilities.infra import run_virtctl_command
 
+pytestmark = pytest.mark.arm64
+
 
 @pytest.fixture()
 def virtctl_go_kube_server_version():

--- a/tests/observability/metrics/test_virt_resource_mutation_metrics.py
+++ b/tests/observability/metrics/test_virt_resource_mutation_metrics.py
@@ -26,7 +26,7 @@ from utilities.constants import (
     VIRTCTL_CLI_DOWNLOADS,
 )
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 LOGGER = logging.getLogger(__name__)
 
 COMPONENT_CONFIG = {

--- a/tests/observability/metrics/test_vm_template_metrics.py
+++ b/tests/observability/metrics/test_vm_template_metrics.py
@@ -4,7 +4,7 @@ from pytest_testconfig import config as py_config
 from tests.observability.metrics import utils
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 METRIC_QUERY = 'kubevirt_vmi_phase_count{{os="{os_name}", flavor="{flavor}", workload="{workload}"}}'
 SUM_QUERY = f"sum({METRIC_QUERY})"
 

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -44,6 +44,8 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.arm64
+
 
 def get_last_transition_time(vm):
     for condition in vm.instance.get("status", {}).get("conditions"):

--- a/tests/observability/network/test_cnao_observability.py
+++ b/tests/observability/network/test_cnao_observability.py
@@ -8,6 +8,8 @@ from tests.observability.metrics.constants import (
 from tests.observability.utils import validate_metrics_value
 from utilities.constants import CLUSTER_NETWORK_ADDONS_OPERATOR, TIMEOUT_5MIN
 
+pytestmark = pytest.mark.arm64
+
 
 @pytest.mark.usefixtures("disabled_virt_operator", "invalid_cnao_operator")
 class TestCnaoDown:

--- a/tests/observability/runbook_url/test_runbook_url.py
+++ b/tests/observability/runbook_url/test_runbook_url.py
@@ -8,6 +8,8 @@ from utilities.constants import CNV_PROMETHEUS_RULES
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.arm64
+
 
 def get_downstream_runbook_url(alert_name):
     return f"https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/{alert_name}.md"

--- a/tests/observability/storage/test_hpp_observability.py
+++ b/tests/observability/storage/test_hpp_observability.py
@@ -10,7 +10,10 @@ from utilities.constants import (
 )
 from utilities.monitoring import validate_alerts
 
-pytestmark = [pytest.mark.usefixtures("skip_if_hpp_not_exist", "hpp_condition_available_scope_module")]
+pytestmark = [
+    pytest.mark.usefixtures("skip_if_hpp_not_exist", "hpp_condition_available_scope_module"),
+    pytest.mark.arm64,
+]
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/observability/test_healthy_cluster_no_alerts.py
+++ b/tests/observability/test_healthy_cluster_no_alerts.py
@@ -3,6 +3,8 @@ import pytest
 from tests.observability.constants import SSP_ALERTS_LIST, VIRT_ALERTS_LIST
 from tests.observability.utils import verify_no_listed_alerts_on_cluster
 
+pytestmark = pytest.mark.arm64
+
 
 @pytest.mark.polarion("CNV-7610")
 @pytest.mark.order(0)

--- a/tests/observability/virt/test_virt_controller_ready.py
+++ b/tests/observability/virt/test_virt_controller_ready.py
@@ -3,6 +3,8 @@ import pytest
 from tests.observability.utils import validate_metrics_value
 from utilities.constants import VIRT_CONTROLLER
 
+pytestmark = pytest.mark.arm64
+
 
 @pytest.mark.usefixtures("disabled_virt_operator")
 class TestVirtControllerReady:

--- a/tests/observability/virt/test_virt_metrics_alerts.py
+++ b/tests/observability/virt/test_virt_metrics_alerts.py
@@ -15,7 +15,7 @@ from utilities.monitoring import validate_alerts
 
 VIRT_CONTROLLER_REST_ERRORS_HIGH = "VirtControllerRESTErrorsHigh"
 
-pytestmark = pytest.mark.usefixtures("initial_virt_operator_replicas")
+pytestmark = [pytest.mark.usefixtures("initial_virt_operator_replicas"), pytest.mark.arm64]
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
##### Short description:
Mark Arm64 tests.
##### More details:
arm windows VM is not supported in 4.19.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added ARM64-specific markers to numerous test modules and classes to enable filtering and categorization for ARM64 architecture environments.
  - No changes were made to test logic, parameters, or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->