### PR TITLE
tests, net, l2_bridge: Use `wait_for_agent_connected()` method

### DIFF
--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -4,7 +4,6 @@ import shlex
 from ipaddress import ip_interface
 
 import pytest
-from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pyhelper_utils.shell import run_ssh_commands
 
 from tests.network.constants import DHCP_IP_RANGE_END, DHCP_IP_RANGE_START
@@ -323,10 +322,7 @@ def l2_bridge_running_vm_a(namespace, worker_node1, l2_bridge_all_nads, unprivil
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
     ) as vm:
         vm.start(wait=True)
-        vm.vmi.wait_for_condition(
-            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
-            status=VirtualMachineInstance.Condition.Status.TRUE,
-        )
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -352,10 +348,7 @@ def l2_bridge_running_vm_b(namespace, worker_node2, l2_bridge_all_nads, unprivil
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
     ) as vm:
         vm.start(wait=True)
-        vm.vmi.wait_for_condition(
-            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
-            status=VirtualMachineInstance.Condition.Status.TRUE,
-        )
+        vm.wait_for_agent_connected()
         yield vm
 
 

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -1,7 +1,6 @@
 import time
 
 import pytest
-from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from libs.net import netattachdef
 from tests.network.constants import IPV4_ADDRESS_SUBNET_PREFIX
@@ -404,10 +403,7 @@ def mac_addresses_before_restart(running_vm_for_nic_hot_plug, hot_plugged_interf
 @pytest.fixture()
 def mac_addresses_after_restart(running_vm_for_nic_hot_plug, hot_plugged_interface_name):
     running_vm_for_nic_hot_plug.restart(wait=True)
-    running_vm_for_nic_hot_plug.vmi.wait_for_condition(
-        condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
-        status=VirtualMachineInstance.Condition.Status.TRUE,
-    )
+    running_vm_for_nic_hot_plug.wait_for_agent_connected()
 
     return get_primary_and_hot_plugged_mac_addresses(
         vm=running_vm_for_nic_hot_plug,

--- a/tests/network/l2_bridge/test_ovs_bridge.py
+++ b/tests/network/l2_bridge/test_ovs_bridge.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 
 import pytest
-from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from tests.network.constants import BRCNV
 from tests.network.utils import vm_for_brcnv_tests
@@ -124,10 +123,7 @@ def vma_with_ovs_based_l2(
 
 @pytest.fixture()
 def running_vma_with_ovs_based_l2(vma_with_ovs_based_l2):
-    vma_with_ovs_based_l2.vmi.wait_for_condition(
-        condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
-        status=VirtualMachineInstance.Condition.Status.TRUE,
-    )
+    vma_with_ovs_based_l2.wait_for_agent_connected()
     return vma_with_ovs_based_l2
 
 
@@ -165,10 +161,7 @@ def vmb_with_ovs_based_l2(
 
 @pytest.fixture()
 def running_vmb_with_ovs_based_l2(vmb_with_ovs_based_l2):
-    vmb_with_ovs_based_l2.vmi.wait_for_condition(
-        condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
-        status=VirtualMachineInstance.Condition.Status.TRUE,
-    )
+    vmb_with_ovs_based_l2.wait_for_agent_connected()
     return vmb_with_ovs_based_l2
 
 

--- a/tests/network/l2_bridge/utils.py
+++ b/tests/network/l2_bridge/utils.py
@@ -4,7 +4,6 @@ import re
 import time
 
 from ocp_resources.resource import ResourceEditor
-from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.network.utils import update_cloud_init_extra_user_data
@@ -105,10 +104,7 @@ def create_vm_with_secondary_interface_on_setup(
         client=client,
     ) as vm:
         vm.start(wait=True)
-        vm.vmi.wait_for_condition(
-            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
-            status=VirtualMachineInstance.Condition.Status.TRUE,
-        )
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -248,10 +244,7 @@ def create_vm_for_hot_plug(
         cloud_init_data=cloud_init_data,
     ) as vm:
         vm.start(wait=True)
-        vm.vmi.wait_for_condition(
-            condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
-            status=VirtualMachineInstance.Condition.Status.TRUE,
-        )
+        vm.wait_for_agent_connected()
         yield vm
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

Replaces the helper that waits for the agent connected condition.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Simplified the logic for waiting on VM agent connections in test fixtures, improving test readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->