### PR TITLE
Update assert_vm_not_error_status: Wait for VM status to populate before asserting error state

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1573,16 +1573,23 @@ def get_rhel_os_dict(rhel_version):
     raise KeyError(f"Failed to extract {rhel_version} from system_rhel_os_matrix")
 
 
-def assert_vm_not_error_status(vm: VirtualMachineForTests) -> None:
-    status = vm.instance.get("status")
-    printable_status = status.get("printableStatus")
-    error_list = VM_ERROR_STATUSES.copy()
-    vm_devices = vm.instance.spec.template.spec.domain.devices
-    if vm_devices.gpus:
-        error_list.remove(VirtualMachine.Status.ERROR_UNSCHEDULABLE)
-    assert printable_status not in error_list, (
-        f"VM {vm.name} error printable status: {printable_status}\nVM status:\n{status}"
-    )
+def assert_vm_not_error_status(vm: VirtualMachineForTests, timeout: int = TIMEOUT_5SEC) -> None:
+    try:
+        for status in TimeoutSampler(
+            wait_timeout=timeout, sleep=TIMEOUT_1SEC, func=lambda: vm.instance.get("status", {})
+        ):
+            if status:
+                printable_status = status.get("printableStatus")
+                error_list = VM_ERROR_STATUSES.copy()
+                if vm.instance.spec.template.spec.domain.devices.gpus:
+                    error_list.remove(VirtualMachine.Status.ERROR_UNSCHEDULABLE)
+                assert printable_status not in error_list, (
+                    f"VM {vm.name} error printable status: {printable_status}\nVM status:\n{status}"
+                )
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"VM {vm.name} status did not populate within {timeout}")
+        raise
 
 
 def wait_for_running_vm(


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved virtual machine status verification by waiting for status availability before proceeding.
- **New Features**
  - Introduced a customizable timeout for virtual machine status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->