### PR TITLE
Include rhel.10.s390x in rhel preference list

### DIFF
--- a/tests/infrastructure/instance_types/vm_preference_list.py
+++ b/tests/infrastructure/instance_types/vm_preference_list.py
@@ -22,6 +22,7 @@ VM_PREFERENCES_LIST = {
         "rhel.9.arm64",
         "rhel.9.s390x",
         "rhel.10.arm64",
+        "rhel.10.s390x",
         "rhel.7.desktop",
         "rhel.8.desktop",
         "rhel.9.desktop",


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://github.com/kubevirt/common-instancetypes/pull/374


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for the "rhel.10.s390x" instance type in the RHEL VM preferences test list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->