### PR TITLE
WIP: add test for common instance types using deprecated fields

### DIFF
--- a/tests/infrastructure/instance_types/test_common_vm_instancetype.py
+++ b/tests/infrastructure/instance_types/test_common_vm_instancetype.py
@@ -1,9 +1,11 @@
 import pytest
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
+from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
 )
 
-from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_label
+from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_label, verify_no_deprecated_field_in_api
 from utilities.constants import VIRT_OPERATOR, Images
 from utilities.virt import VirtualMachineForTests, running_vm
 
@@ -48,3 +50,14 @@ def test_common_instancetype_owner(base_vm_cluster_instancetypes):
         ):
             failed_ins_type.append(vm_cluster_instancetype.name)
     assert not failed_ins_type, f"The following instance types do no have {VIRT_OPERATOR} owner: {failed_ins_type}"
+
+
+@pytest.mark.post_upgrade
+@pytest.mark.polarion("CNV-11951")
+def test_common_instancetype_deprecated_fields(admin_client, base_vm_cluster_instancetypes):
+    vm_instancetype_crd = CustomResourceDefinition(
+        name=f"virtualmachineinstancetypes.{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}"
+    )
+    verify_no_deprecated_field_in_api(
+        crd_to_test=vm_instancetype_crd, cluster_resources_list=base_vm_cluster_instancetypes
+    )

--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -1,9 +1,11 @@
 import pytest
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
+from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
 )
 
-from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_label
+from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_label, verify_no_deprecated_field_in_api
 from tests.infrastructure.instance_types.vm_preference_list import VM_PREFERENCES_LIST
 from utilities.constants import VIRT_OPERATOR, Images
 from utilities.virt import VirtualMachineForTests, running_vm
@@ -131,3 +133,12 @@ def test_common_preference_owner(base_vm_cluster_preferences):
         ):
             failed_preferences.append(vm_cluster_preference.name)
     assert not failed_preferences, f"The following preferences do no have {VIRT_OPERATOR} owner: {failed_preferences}"
+
+
+@pytest.mark.post_upgrade
+@pytest.mark.polarion("CNV-11952")
+def test_common_preference_deprecated_fields(admin_client, base_vm_cluster_preferences):
+    vm_preference_crd = CustomResourceDefinition(
+        name=f"virtualmachineclusterpreferences.{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}"
+    )
+    verify_no_deprecated_field_in_api(crd_to_test=vm_preference_crd, cluster_resources_list=base_vm_cluster_preferences)


### PR DESCRIPTION
##### Short description:
Add a test to verify the resources we deploy with common instance types aren't using any deprecated fields

##### More details:
The `VirtualMachineInstancetype` and `VirtualMachinePreference` resources have reached a stage where some of their fields are deprecated.
Since changes in the KubeVirt repository are not directly linked, and are instead being used through the common-instancetypes repository, we should ensure that we are not using any deprecated fields.

##### What this PR does / why we need it:
Verify we aren't using fields which are deprecated

##### Special notes for reviewer:
A similar PR has been created in the common instance types repository, and we're currently discussing where this test should reside, possibly in both repositories.
https://github.com/kubevirt/common-instancetypes/pull/382
 
##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-52023


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify that deprecated fields are not present in VM instance type and preference APIs after upgrade.
- **Chores**
  - Introduced utility functions to detect usage of deprecated fields in API schemas and resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->