### PR TITLE
[virt] drop rwo storage related skips

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -25,29 +25,29 @@ markers =
     node_remediation_ipmi_enabled: Destructive NodeHealthCheck with SNR/FAR on IPMI-enabled clusters
 
     # Cluster markers
-    ## Architecture
-    arm64: tests that can run on ARM-based cluster
+    ## Architecture support
+    arm64: Tests that can run on ARM-based cluster
 
-    ## Hardware
-    special_infra: tests that requires special infrastructure. e.g. sriov, gpu etc.
-    gpu: tests that require cluster with gpu
-    sriov: tests that require sriov net-cards on nodes
-    single_nic: tests that dont require mutli-nic nodes, required for conformance tests for new archs, platforms etc.
+    ## Hardware requirements
+    special_infra: Tests that requires special infrastructure. e.g. sriov, gpu etc.
+    gpu: Tests that require cluster with gpu cards
+    sriov: Tests that require sriov net-cards on nodes
+    single_nic: Tests that don`t require mutli-nic nodes, required for conformance tests for new archs, platforms etc.
 
-    ## Configuration
-    ipv4: IPv4 based test
-    ipv6: IPv6 based test
-    dpdk: Tests that requires dpdk
-    swap: tests that require SWAP active on nodes
-    cpu_manager: tests that require cpu manager on nodes
-    numa: tests that require numa configured on nodes
-    hugepages: tests that require nodes with hugepages
-    service_mesh: tests that require the service mesh operator to be installed
-    jumbo_frame: tests that require network configurations supporting jumbo frames
-    rwx_default_storage: tests that require RWX storage
+    ## Configuration requirements
+    ipv4: Tests that require IPv4
+    ipv6: Tests that require IPv6
+    dpdk: Tests that require dpdk
+    swap: Tests that require SWAP active on nodes
+    cpu_manager: Tests that require cpu manager on nodes
+    numa: Tests that require numa configured on nodes
+    hugepages: Tests that require nodes with hugepages
+    service_mesh: Tests that require the service mesh operator to be installed
+    jumbo_frame: Tests that require network configurations supporting jumbo frames
+    rwx_default_storage: Tests that require RWX storage
 
-    ## Resources
-    high_resource_vm: tests using VM requirening a lot of resources (like Windows OS VMs, hight performance VMs, etc)
+    ## Resources requirements
+    high_resource_vm: Tests that create VM using a lot of resources (like Windows OS VMs, hight performance VMs, etc)
 
     # CI
     smoke: Mark tests as smoke tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,6 @@ markers =
     # Data collection markers
     skip_must_gather_collection: skip must gather collection on failures
     gpu: indicates collecting relevant namespace data on failure
-    swap: indicates collecting relevant namespace data on failure
     # Test types
     destructive: Destructive tests
     sap_hana: SAP HANA tests
@@ -38,6 +37,7 @@ markers =
     jumbo_frame: tests that require network configurations supporting jumbo frames
     single_nic: tests that dont require mutli-nic nodes, required for conformance tests for new archs, platforms etc.
     arm64: tests that require ARM-based cluster supported
+    migration: tests that involve migration (e.g. live migrating VM, hotplugging CPU, etc)
     # CI
     smoke: Mark tests as smoke tests
     ci: Mark tests as CI tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,33 +11,44 @@ markers =
     order: Configure test order
     early: Run fixtures early
     redhat_internal_dependency: Tests which have a dependency on an RedHat internal resource
+
     # Data collection markers
     skip_must_gather_collection: skip must gather collection on failures
-    gpu: indicates collecting relevant namespace data on failure
+
     # Test types
     destructive: Destructive tests
     sap_hana: SAP HANA tests
     ovs_brcnv: Test functionality of existing ovs bridge with primary, secondary node ifaces
     scale: Scale tests
     longevity: Longevity (continuous) tests
-    ipv4: IPV4 based test
-    ipv6: IPV6 based test
     node_remediation: Destructive Node Remediation using NodeHealthCheck with SNR
     node_remediation_ipmi_enabled: Destructive NodeHealthCheck with SNR/FAR on IPMI-enabled clusters
+
+    # Cluster markers
+    ## Architecture
+    arm64: tests that can run on ARM-based cluster
+
+    ## Hardware
     special_infra: tests that requires special infrastructure. e.g. sriov, gpu etc.
+    gpu: tests that require cluster with gpu
+    sriov: tests that require sriov net-cards on nodes
+    single_nic: tests that dont require mutli-nic nodes, required for conformance tests for new archs, platforms etc.
+
+    ## Configuration
+    ipv4: IPv4 based test
+    ipv6: IPv6 based test
     dpdk: Tests that requires dpdk
     swap: tests that require SWAP active on nodes
-    high_resource_vm: tests using VM requirening a lot of resources (like Windows OS VMs, hight performance VMs, etc)
-    gpu: tests that require cluster with gpu
     cpu_manager: tests that require cpu manager on nodes
     numa: tests that require numa configured on nodes
-    sriov: tests that require sriov net-cards on nodes
     hugepages: tests that require nodes with hugepages
     service_mesh: tests that require the service mesh operator to be installed
     jumbo_frame: tests that require network configurations supporting jumbo frames
-    single_nic: tests that dont require mutli-nic nodes, required for conformance tests for new archs, platforms etc.
-    arm64: tests that require ARM-based cluster supported
-    migration: tests that involve migration (e.g. live migrating VM, hotplugging CPU, etc)
+    rwx_default_storage: tests that require RWX storage
+
+    ## Resources
+    high_resource_vm: tests using VM requirening a lot of resources (like Windows OS VMs, hight performance VMs, etc)
+
     # CI
     smoke: Mark tests as smoke tests
     ci: Mark tests as CI tests
@@ -46,6 +57,7 @@ markers =
     ocp_interop: Interop testing with openshift
     ibm_bare_metal: IBM BM tests
     gating: Mark tier2 tests that are part of gating job
+
     # Install and upgrade
     install: Tests that self-manage HCO/CNV installation
     upgrade: Run regular upgrade lanes with default configuration
@@ -55,6 +67,7 @@ markers =
     cnv_upgrade: Mark cnv upgrade test
     ocp_upgrade: Mark ocp upgrade test
     eus_upgrade: Mark EUS-to-EUS upgrade test
+
     # Teams
     chaos: Chaos tests
     virt: Virt tests
@@ -65,6 +78,7 @@ markers =
     sno: SingleNodeOpenShift tests
     infrastructure: Infrastructure tests
     data_protection: Data Protection tests
+
     # cluster_health_check
     cluster_health_check: cluster health check tests
 

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -146,7 +146,7 @@ class TestCommonTemplatesCentos:
             vm=golden_image_vm_object_from_template_multi_centos_multi_storage_scope_class,
         )
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-5841")
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify",

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -146,16 +146,13 @@ class TestCommonTemplatesCentos:
             vm=golden_image_vm_object_from_template_multi_centos_multi_storage_scope_class,
         )
 
+    @pytest.mark.migration
     @pytest.mark.polarion("CNV-5841")
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify",
         depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"],
     )
-    def test_migrate_vm(
-        self,
-        skip_access_mode_rwo_scope_class,
-        golden_image_vm_object_from_template_multi_centos_multi_storage_scope_class,
-    ):
+    def test_migrate_vm(self, golden_image_vm_object_from_template_multi_centos_multi_storage_scope_class):
         """Test SSH connectivity after migration"""
         migrate_vm_and_verify(
             vm=golden_image_vm_object_from_template_multi_centos_multi_storage_scope_class,

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -225,6 +225,7 @@ class TestCommonTemplatesFedora:
             vm=golden_image_vm_object_from_template_multi_fedora_os_multi_storage_scope_class,
         )
 
+    @pytest.mark.migration
     @pytest.mark.ibm_bare_metal
     @pytest.mark.ocp_interop
     @pytest.mark.polarion("CNV-5842")
@@ -232,11 +233,7 @@ class TestCommonTemplatesFedora:
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify",
         depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"],
     )
-    def test_migrate_vm(
-        self,
-        skip_access_mode_rwo_scope_class,
-        golden_image_vm_object_from_template_multi_fedora_os_multi_storage_scope_class,
-    ):
+    def test_migrate_vm(self, golden_image_vm_object_from_template_multi_fedora_os_multi_storage_scope_class):
         """Test SSH connectivity after migration"""
         vm = golden_image_vm_object_from_template_multi_fedora_os_multi_storage_scope_class
         migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)
@@ -246,7 +243,6 @@ class TestCommonTemplatesFedora:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::migrate_vm_and_verify"])
     def test_pause_unpause_after_migrate(
         self,
-        skip_access_mode_rwo_scope_class,
         golden_image_vm_object_from_template_multi_fedora_os_multi_storage_scope_class,
         ping_process_in_fedora_os,
     ):

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -225,7 +225,7 @@ class TestCommonTemplatesFedora:
             vm=golden_image_vm_object_from_template_multi_fedora_os_multi_storage_scope_class,
         )
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.ibm_bare_metal
     @pytest.mark.ocp_interop
     @pytest.mark.polarion("CNV-5842")

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -225,7 +225,7 @@ class TestCommonTemplatesRhel:
 
     @pytest.mark.arm64
     @pytest.mark.smoke
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-3038")
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify",

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -225,16 +225,13 @@ class TestCommonTemplatesRhel:
 
     @pytest.mark.arm64
     @pytest.mark.smoke
+    @pytest.mark.migration
     @pytest.mark.polarion("CNV-3038")
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify",
         depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"],
     )
-    def test_migrate_vm(
-        self,
-        skip_access_mode_rwo_scope_class,
-        golden_image_vm_object_from_template_multi_rhel_os_multi_storage_scope_class,
-    ):
+    def test_migrate_vm(self, golden_image_vm_object_from_template_multi_rhel_os_multi_storage_scope_class):
         """Test SSH connectivity after migration"""
         vm = golden_image_vm_object_from_template_multi_rhel_os_multi_storage_scope_class
         migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -133,7 +133,7 @@ class TestRHELTabletDevice:
                     "vm_dict": set_vm_tablet_device_dict({"name": "my_tablet", "type": "tablet", "bus": "usb"}),
                     "set_vm_common_cpu": True,
                 },
-                marks=[pytest.mark.polarion("CNV-5833"), pytest.mark.migration],
+                marks=[pytest.mark.polarion("CNV-5833"), pytest.mark.rwx_default_storage],
             ),
         ],
         indirect=True,

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -133,14 +133,13 @@ class TestRHELTabletDevice:
                     "vm_dict": set_vm_tablet_device_dict({"name": "my_tablet", "type": "tablet", "bus": "usb"}),
                     "set_vm_common_cpu": True,
                 },
-                marks=pytest.mark.polarion("CNV-5833"),
+                marks=[pytest.mark.polarion("CNV-5833"), pytest.mark.migration],
             ),
         ],
         indirect=True,
     )
     def test_tablet_device_migrate_vm(
         self,
-        skip_access_mode_rwo_scope_class,
         cluster_cpu_model_scope_class,
         golden_image_vm_instance_from_template_multi_storage_dv_scope_class_vm_scope_function,
     ):

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -209,7 +209,7 @@ class TestCustomWindowsOptions:
     def test_windows_custom_options_initialize_disk(self, custom_windows_vm):
         initialize_and_format_windows_drive(vm=custom_windows_vm, disk_number=1, partition_number=2, drive_letter="D")
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-7886")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::migration", depends=[f"{TESTS_CLASS_NAME}::boot"])
     def test_windows_custom_options_migration(self, custom_windows_vm):

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -209,9 +209,10 @@ class TestCustomWindowsOptions:
     def test_windows_custom_options_initialize_disk(self, custom_windows_vm):
         initialize_and_format_windows_drive(vm=custom_windows_vm, disk_number=1, partition_number=2, drive_letter="D")
 
+    @pytest.mark.migration
     @pytest.mark.polarion("CNV-7886")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::migration", depends=[f"{TESTS_CLASS_NAME}::boot"])
-    def test_windows_custom_options_migration(self, skip_access_mode_rwo_scope_class, custom_windows_vm):
+    def test_windows_custom_options_migration(self, custom_windows_vm):
         with VirtualMachineInstanceMigration(
             name="custom-windows-vm-migration",
             namespace=custom_windows_vm.namespace,

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -156,16 +156,13 @@ class TestCommonTemplatesWindows:
             cm_values=smbios_from_kubevirt_config,
         )
 
+    @pytest.mark.migration
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify",
         depends=[f"{TESTS_CLASS_NAME}::start_vm"],
     )
     @pytest.mark.polarion("CNV-3335")
-    def test_migrate_vm(
-        self,
-        skip_access_mode_rwo_scope_class,
-        golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class,
-    ):
+    def test_migrate_vm(self, golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class):
         """Test SSH connectivity after migration"""
         vm = golden_image_vm_object_from_template_multi_windows_os_multi_storage_scope_class
         migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -156,7 +156,7 @@ class TestCommonTemplatesWindows:
             cm_values=smbios_from_kubevirt_config,
         )
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify",
         depends=[f"{TESTS_CLASS_NAME}::start_vm"],

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -23,15 +23,11 @@ from utilities.virt import (
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.arm64
+pytestmark = [pytest.mark.arm64, pytest.mark.migration]
 
 
 def wait_for_vm_uid_mismatch(vmi, vmi_old_uid):
-    samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_5MIN,
-        sleep=5,
-        func=lambda: vmi.instance.metadata.uid != vmi_old_uid,
-    )
+    samples = TimeoutSampler(wait_timeout=TIMEOUT_5MIN, sleep=5, func=lambda: vmi.instance.metadata.uid != vmi_old_uid)
     for sample in samples:
         if sample:
             return
@@ -129,62 +125,38 @@ def test_evictionstrategy_in_kubevirt(sno_cluster, kubevirt_config_scope_module)
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("skip_access_mode_rwo_scope_class", "cluster_cpu_model_scope_class")
+@pytest.mark.usefixtures("cluster_cpu_model_scope_class")
 class TestEvictionStrategy:
     @pytest.mark.polarion("CNV-10087")
     def test_hco_evictionstrategy_livemigrate_vm_no_evictionstrategy(
-        self,
-        unprivileged_client,
-        vm_from_template_scope_class,
-        drained_node,
+        self, unprivileged_client, vm_from_template_scope_class, drained_node
     ):
         check_migration_process_after_node_drain(dyn_client=unprivileged_client, vm=vm_from_template_scope_class)
 
     @pytest.mark.polarion("CNV-10088")
     def test_hco_evictionstrategy_none_vm_no_evictionstrategy(
-        self,
-        vm_from_template_scope_class,
-        hco_cr_with_evictionstrategy_none,
-        vm_restarted,
-        vmi_old_uid,
-        drained_node,
+        self, vm_from_template_scope_class, hco_cr_with_evictionstrategy_none, vm_restarted, vmi_old_uid, drained_node
     ):
         assert_vm_restarts_after_node_drain(
-            source_node=drained_node,
-            vmi=vm_from_template_scope_class.vmi,
-            vmi_old_uid=vmi_old_uid,
+            source_node=drained_node, vmi=vm_from_template_scope_class.vmi, vmi_old_uid=vmi_old_uid
         )
 
     @pytest.mark.parametrize(
         "added_vm_evictionstrategy",
-        [
-            pytest.param(
-                {"evictionstrategy": "None"},
-            ),
-        ],
+        [pytest.param({"evictionstrategy": "None"})],
         indirect=True,
     )
     @pytest.mark.polarion("CNV-10073")
     def test_hco_evictionstrategy_livemigrate_vm_evictionstrategy_none(
-        self,
-        vm_from_template_scope_class,
-        added_vm_evictionstrategy,
-        vmi_old_uid,
-        drained_node,
+        self, vm_from_template_scope_class, added_vm_evictionstrategy, vmi_old_uid, drained_node
     ):
         assert_vm_restarts_after_node_drain(
-            source_node=drained_node,
-            vmi=vm_from_template_scope_class.vmi,
-            vmi_old_uid=vmi_old_uid,
+            source_node=drained_node, vmi=vm_from_template_scope_class.vmi, vmi_old_uid=vmi_old_uid
         )
 
     @pytest.mark.parametrize(
         "added_vm_evictionstrategy",
-        [
-            pytest.param(
-                {"evictionstrategy": "LiveMigrate"},
-            ),
-        ],
+        [pytest.param({"evictionstrategy": "LiveMigrate"})],
         indirect=True,
     )
     @pytest.mark.polarion("CNV-10357")

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -23,7 +23,7 @@ from utilities.virt import (
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.arm64, pytest.mark.migration]
+pytestmark = [pytest.mark.arm64, pytest.mark.rwx_default_storage]
 
 
 def wait_for_vm_uid_mismatch(vmi, vmi_old_uid):

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -110,8 +110,8 @@ def vm_re_migrated_after_updating_migration_policy(vm_for_migration_policy_test,
     migrate_vm_and_verify(vm=vm_for_migration_policy_test)
 
 
+@pytest.mark.migration
 @pytest.mark.arm64
-@pytest.mark.usefixtures("skip_access_mode_rwo_scope_class")
 class TestMigrationPolicies:
     @pytest.mark.gating
     @pytest.mark.parametrize(

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -110,7 +110,7 @@ def vm_re_migrated_after_updating_migration_policy(vm_for_migration_policy_test,
     migrate_vm_and_verify(vm=vm_for_migration_policy_test)
 
 
-@pytest.mark.migration
+@pytest.mark.rwx_default_storage
 @pytest.mark.arm64
 class TestMigrationPolicies:
     @pytest.mark.gating

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -273,7 +273,7 @@ class TestSysprep:
     def test_admin_user_locale_computer_name_after_boot(self, sysprep_vm, sysprep_vm_hostname):
         verify_changes_from_autounattend(vm=sysprep_vm, timezone=NEW_TIMEZONE, hostname=sysprep_vm_hostname)
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-6761")
     def test_migrate_vm_with_sysprep_cm(self, sysprep_vm, migrated_sysprep_vm, sysprep_vm_hostname):
         verify_changes_from_autounattend(vm=sysprep_vm, timezone=NEW_TIMEZONE, hostname=sysprep_vm_hostname)

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -273,10 +273,9 @@ class TestSysprep:
     def test_admin_user_locale_computer_name_after_boot(self, sysprep_vm, sysprep_vm_hostname):
         verify_changes_from_autounattend(vm=sysprep_vm, timezone=NEW_TIMEZONE, hostname=sysprep_vm_hostname)
 
+    @pytest.mark.migration
     @pytest.mark.polarion("CNV-6761")
-    def test_migrate_vm_with_sysprep_cm(
-        self, skip_access_mode_rwo_scope_class, sysprep_vm, migrated_sysprep_vm, sysprep_vm_hostname
-    ):
+    def test_migrate_vm_with_sysprep_cm(self, sysprep_vm, migrated_sysprep_vm, sysprep_vm_hostname):
         verify_changes_from_autounattend(vm=sysprep_vm, timezone=NEW_TIMEZONE, hostname=sysprep_vm_hostname)
 
     @pytest.mark.polarion("CNV-6762")

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -311,6 +311,6 @@ class TestRunStrategyAdvancedActions:
         ],
         indirect=True,
     )
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     def test_run_strategy_migrate_vm(self, lifecycle_vm, request_updated_vm_run_strategy, start_vm_if_not_running):
         migrate_validate_run_strategy_vm(vm=lifecycle_vm, run_strategy=request_updated_vm_run_strategy)

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -311,11 +311,6 @@ class TestRunStrategyAdvancedActions:
         ],
         indirect=True,
     )
-    def test_run_strategy_migrate_vm(
-        self,
-        skip_access_mode_rwo_scope_function,
-        lifecycle_vm,
-        request_updated_vm_run_strategy,
-        start_vm_if_not_running,
-    ):
+    @pytest.mark.migration
+    def test_run_strategy_migrate_vm(self, lifecycle_vm, request_updated_vm_run_strategy, start_vm_if_not_running):
         migrate_validate_run_strategy_vm(vm=lifecycle_vm, run_strategy=request_updated_vm_run_strategy)

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -107,7 +107,7 @@ def virt_special_infra_sanity(
             _verify_sriov(_sriov_workers=sriov_workers)
         if any(item.get_closest_marker("hugepages") for item in request.session.items):
             _verify_hugepages_1gi(_workers=workers)
-        if any(item.get_closest_marker("migration") for item in request.session.items):
+        if any(item.get_closest_marker("rwx_default_storage") for item in request.session.items):
             _verify_rwx_default_storage()
     else:
         LOGGER.warning(f"Skipping virt special infra sanity because {skip_virt_sanity_check} was passed")

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -26,20 +26,20 @@ def virt_special_infra_sanity(
     workers,
     nodes_cpu_virt_extension,
 ):
-    """Performs verification that cluster has all required capabilities for virt special_infra marked tests."""
+    """Performs verification that cluster has all required capabilities based on collected tests."""
 
     def _verify_not_psi_cluster(_is_psi_cluster):
-        LOGGER.info("Verify running on BM cluster")
+        LOGGER.info("Verifying tests run on BM cluster")
         if _is_psi_cluster:
             failed_verifications_list.append("Cluster should be BM and not PSI")
 
     def _verify_cpumanager_workers(_schedulable_nodes):
-        LOGGER.info("Verify cluster nodes have CPU Manager labels")
+        LOGGER.info("Verifing cluster nodes have CPU Manager labels")
         if not any([node.labels.cpumanager == "true" for node in _schedulable_nodes]):
             failed_verifications_list.append("Cluster does't have CPU Manager")
 
     def _verify_gpu(_gpu_nodes, _nodes_with_supported_gpus):
-        LOGGER.info("Verify cluster nodes have enough supported GPU cards")
+        LOGGER.info("Verifing cluster nodes have enough supported GPU cards")
         if not _gpu_nodes:
             failed_verifications_list.append("Cluster doesn't have any GPU nodes")
         if not _nodes_with_supported_gpus:
@@ -48,18 +48,18 @@ def virt_special_infra_sanity(
             failed_verifications_list.append(f"Cluster has only {len(_nodes_with_supported_gpus)} node with GPU")
 
     def _verfify_no_dpdk():
-        LOGGER.info("Verify cluster doesn't have DPDK enabled")
+        LOGGER.info("Verifing cluster doesn't have DPDK enabled")
         if PerformanceProfile(name="dpdk").exists:
             failed_verifications_list.append("Cluster has DPDK enabled (DPDK is incomatible with NVIDIA GPU)")
 
     def _verify_sriov(_sriov_workers):
-        LOGGER.info("Verify cluster has worker node with SR-IOV card")
+        LOGGER.info("Verifing cluster has worker node with SR-IOV card")
         if not _sriov_workers:
             failed_verifications_list.append("Cluster does not have any SR-IOV workers")
 
-    def _verify_evmcs_support(_schedulable_nodes, _nodes_cpu_virt_extension):
+    def _verify_hw_virtualization(_schedulable_nodes, _nodes_cpu_virt_extension):
         if _nodes_cpu_virt_extension:
-            LOGGER.info(f"Verify cluster nodes support {_nodes_cpu_virt_extension.upper()} cpu fixture")
+            LOGGER.info(f"Verifing cluster nodes support {_nodes_cpu_virt_extension.upper()} cpu fixture")
             for node in _schedulable_nodes:
                 if not any([
                     label == f"cpu-feature.node.kubevirt.io/{_nodes_cpu_virt_extension}" and value == "true"
@@ -74,21 +74,19 @@ def virt_special_infra_sanity(
             )
 
     def _verify_hugepages_1gi(_workers):
-        LOGGER.info("Verify cluster has 1Gi hugepages enabled")
+        LOGGER.info("Verifing cluster has 1Gi hugepages enabled")
         if not any([
             parse_string_unsafe(worker.instance.status.allocatable["hugepages-1Gi"]) >= parse_string_unsafe("1Gi")
             for worker in _workers
         ]):
             failed_verifications_list.append("Cluster does not have hugepages-1Gi")
 
-    def _verify_migration_support():
+    def _verify_rwx_default_storage():
         storage_class = py_config["default_storage_class"]
-        LOGGER.info(f"Verify default storage class {storage_class} supports RWX mode for migration")
+        LOGGER.info(f"Verifing default storage class {storage_class} supports RWX mode")
         access_modes = StorageProfile(name=storage_class).first_claim_property_set_access_modes()
         if not access_modes or access_modes[0] != DataVolume.AccessMode.RWX:
-            failed_verifications_list.append(
-                f"default storage class {storage_class} doesn't support RWX mode for migration"
-            )
+            failed_verifications_list.append(f"Default storage class {storage_class} doesn't support RWX mode")
 
     skip_virt_sanity_check = "--skip-virt-sanity-check"
     failed_verifications_list = []
@@ -97,7 +95,7 @@ def virt_special_infra_sanity(
         LOGGER.info("Verifying that cluster has all required capabilities for special_infra marked tests")
         if any(item.get_closest_marker("high_resource_vm") for item in request.session.items):
             _verify_not_psi_cluster(_is_psi_cluster=is_psi_cluster)
-            _verify_evmcs_support(
+            _verify_hw_virtualization(
                 _schedulable_nodes=schedulable_nodes, _nodes_cpu_virt_extension=nodes_cpu_virt_extension
             )
         if any(item.get_closest_marker("cpu_manager") for item in request.session.items):
@@ -110,7 +108,7 @@ def virt_special_infra_sanity(
         if any(item.get_closest_marker("hugepages") for item in request.session.items):
             _verify_hugepages_1gi(_workers=workers)
         if any(item.get_closest_marker("migration") for item in request.session.items):
-            _verify_migration_support()
+            _verify_rwx_default_storage()
     else:
         LOGGER.warning(f"Skipping virt special infra sanity because {skip_virt_sanity_check} was passed")
 

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -110,7 +110,7 @@ def test_pc_q35_vm_machine_type(vm, expected):
     indirect=True,
 )
 @pytest.mark.arm64
-@pytest.mark.migration
+@pytest.mark.rwx_default_storage
 @pytest.mark.gating
 def test_migrate_vm(machine_type_from_kubevirt_config, vm):
     migrate_vm_and_verify(vm=vm)
@@ -152,7 +152,7 @@ def test_machine_type_after_vm_restart(
     ],
     indirect=True,
 )
-@pytest.mark.migration
+@pytest.mark.rwx_default_storage
 @pytest.mark.gating
 def test_machine_type_after_vm_migrate(
     machine_type_from_kubevirt_config, vm, updated_kubevirt_config_machine_type, migrated_vm

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -110,8 +110,9 @@ def test_pc_q35_vm_machine_type(vm, expected):
     indirect=True,
 )
 @pytest.mark.arm64
+@pytest.mark.migration
 @pytest.mark.gating
-def test_migrate_vm(skip_access_mode_rwo_scope_function, machine_type_from_kubevirt_config, vm):
+def test_migrate_vm(machine_type_from_kubevirt_config, vm):
     migrate_vm_and_verify(vm=vm)
 
     validate_machine_type(vm=vm, expected_machine_type=machine_type_from_kubevirt_config)
@@ -151,13 +152,10 @@ def test_machine_type_after_vm_restart(
     ],
     indirect=True,
 )
+@pytest.mark.migration
 @pytest.mark.gating
 def test_machine_type_after_vm_migrate(
-    skip_access_mode_rwo_scope_function,
-    machine_type_from_kubevirt_config,
-    vm,
-    updated_kubevirt_config_machine_type,
-    migrated_vm,
+    machine_type_from_kubevirt_config, vm, updated_kubevirt_config_machine_type, migrated_vm
 ):
     """Test machine type change in kubevirt_config; existing VM does not get new
     value after migration"""

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -172,7 +172,8 @@ class TestBitLockerVTPM:
     def test_bitlocker_encryption(self, bitlocker_encrypted_vm):
         restart_vm_wait_for_running_vm(vm=bitlocker_encrypted_vm)
 
+    @pytest.mark.migration
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::bitlocker_encryption"])
     @pytest.mark.polarion("CNV-10309")
-    def test_migrate_encrypted_vm(self, skip_access_mode_rwo_scope_function, migrated_encrypted_vm):
+    def test_migrate_encrypted_vm(self, migrated_encrypted_vm):
         restart_vm_wait_for_running_vm(vm=migrated_encrypted_vm)

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -172,7 +172,7 @@ class TestBitLockerVTPM:
     def test_bitlocker_encryption(self, bitlocker_encrypted_vm):
         restart_vm_wait_for_running_vm(vm=bitlocker_encrypted_vm)
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::bitlocker_encryption"])
     @pytest.mark.polarion("CNV-10309")
     def test_migrate_encrypted_vm(self, migrated_encrypted_vm):

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -119,8 +119,9 @@ class TestWSL2:
         verify_wsl2_guest_works(vm=windows_wsl2_vm)
         assert_windows_host_resource_usage(vm=windows_wsl2_vm)
 
+    @pytest.mark.migration
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::wsl2_guest"])
     @pytest.mark.polarion("CNV-5462")
-    def test_migration_with_wsl2_guest(self, skip_access_mode_rwo_scope_function, migrated_wsl2_vm):
+    def test_migration_with_wsl2_guest(self, migrated_wsl2_vm):
         verify_wsl2_guest_works(vm=migrated_wsl2_vm)
         assert_windows_host_resource_usage(vm=migrated_wsl2_vm)

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -119,7 +119,7 @@ class TestWSL2:
         verify_wsl2_guest_works(vm=windows_wsl2_vm)
         assert_windows_host_resource_usage(vm=windows_wsl2_vm)
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::wsl2_guest"])
     @pytest.mark.polarion("CNV-5462")
     def test_migration_with_wsl2_guest(self, migrated_wsl2_vm):

--- a/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
+++ b/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
@@ -92,9 +92,8 @@ class TestIsolateEmulatorThread:
         # even though the VM is allocated overall 3 dedicated cpus.
         validate_dedicated_emulatorthread(vm=isolated_emulatorthread_vm)
 
+    @pytest.mark.migration
     @pytest.mark.dependency(depends=[ISOLATE_EMULATOR_THREAD])
     @pytest.mark.polarion("CNV-10554")
-    def test_vm_with_isolate_emulator_thread_live_migrates(
-        self, skip_access_mode_rwo_scope_function, isolated_emulatorthread_vm
-    ):
+    def test_vm_with_isolate_emulator_thread_live_migrates(self, isolated_emulatorthread_vm):
         migrate_vm_and_verify(vm=isolated_emulatorthread_vm)

--- a/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
+++ b/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
@@ -92,7 +92,7 @@ class TestIsolateEmulatorThread:
         # even though the VM is allocated overall 3 dedicated cpus.
         validate_dedicated_emulatorthread(vm=isolated_emulatorthread_vm)
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.dependency(depends=[ISOLATE_EMULATOR_THREAD])
     @pytest.mark.polarion("CNV-10554")
     def test_vm_with_isolate_emulator_thread_live_migrates(self, isolated_emulatorthread_vm):

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -27,7 +27,7 @@ from utilities.virt import (
     restart_vm_wait_for_running_vm,
 )
 
-pytestmark = pytest.mark.migration
+pytestmark = pytest.mark.rwx_default_storage
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -27,7 +27,7 @@ from utilities.virt import (
     restart_vm_wait_for_running_vm,
 )
 
-pytestmark = pytest.mark.usefixtures("skip_access_mode_rwo_scope_module")
+pytestmark = pytest.mark.migration
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -108,7 +108,7 @@ class TestProgressOfMigrationInVirtLauncher:
             container="compute"
         ), f"Not found correct log verbosity level: {VIRT_LOG_VERBOSITY_LEVEL_6} in logs"
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-9058")
     def test_progress_of_vm_migration_in_virt_launcher_pod(
         self,

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -108,10 +108,10 @@ class TestProgressOfMigrationInVirtLauncher:
             container="compute"
         ), f"Not found correct log verbosity level: {VIRT_LOG_VERBOSITY_LEVEL_6} in logs"
 
+    @pytest.mark.migration
     @pytest.mark.polarion("CNV-9058")
     def test_progress_of_vm_migration_in_virt_launcher_pod(
         self,
-        skip_access_mode_rwo_scope_function,
         updated_log_verbosity_config,
         vm_for_migration_progress_test,
         source_pod_log_verbosity_test,

--- a/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
+++ b/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
@@ -31,7 +31,7 @@ from utilities.virt import (
     start_and_fetch_processid_on_windows_vm,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.migration]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.rwx_default_storage]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
+++ b/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
@@ -31,7 +31,7 @@ from utilities.virt import (
     start_and_fetch_processid_on_windows_vm,
 )
 
-pytestmark = pytest.mark.post_upgrade
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.migration]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -142,11 +142,7 @@ def test_node_drain_using_console_fedora(
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures(
-    "cluster_cpu_model_scope_class",
-    "skip_access_mode_rwo_scope_class",
-    "golden_image_data_volume_multi_storage_scope_class",
-)
+@pytest.mark.usefixtures("cluster_cpu_model_scope_class", "golden_image_data_volume_multi_storage_scope_class")
 @pytest.mark.ibm_bare_metal
 class TestNodeMaintenanceRHEL:
     @pytest.mark.polarion("CNV-2292")
@@ -208,11 +204,7 @@ class TestNodeMaintenanceRHEL:
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures(
-    "skip_access_mode_rwo_scope_class",
-    "cluster_modern_cpu_model_scope_class",
-    "golden_image_data_volume_multi_storage_scope_class",
-)
+@pytest.mark.usefixtures("cluster_modern_cpu_model_scope_class", "golden_image_data_volume_multi_storage_scope_class")
 @pytest.mark.ibm_bare_metal
 class TestNodeCordonAndDrain:
     @pytest.mark.polarion("CNV-2048")

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -27,7 +27,7 @@ from utilities.virt import (
     start_and_fetch_processid_on_windows_vm,
 )
 
-pytestmark = [pytest.mark.migration, pytest.mark.usefixtures("created_post_copy_migration_policy")]
+pytestmark = [pytest.mark.rwx_default_storage, pytest.mark.usefixtures("created_post_copy_migration_policy")]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -27,7 +27,7 @@ from utilities.virt import (
     start_and_fetch_processid_on_windows_vm,
 )
 
-pytestmark = pytest.mark.usefixtures("skip_access_mode_rwo_scope_module", "created_post_copy_migration_policy")
+pytestmark = [pytest.mark.migration, pytest.mark.usefixtures("created_post_copy_migration_policy")]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -88,7 +88,7 @@ def get_disk_usage(ssh_exec):
     ],
     indirect=True,
 )
-@pytest.mark.migration
+@pytest.mark.rwx_default_storage
 def test_fedora_vm_load_migration(vm_with_fio, running_fio_in_vm):
     LOGGER.info("Test migrate VM with disk load")
     migrate_vm_and_verify(vm=vm_with_fio, check_ssh_connectivity=True)

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -88,7 +88,8 @@ def get_disk_usage(ssh_exec):
     ],
     indirect=True,
 )
-def test_fedora_vm_load_migration(skip_access_mode_rwo_scope_function, vm_with_fio, running_fio_in_vm):
+@pytest.mark.migration
+def test_fedora_vm_load_migration(vm_with_fio, running_fio_in_vm):
     LOGGER.info("Test migrate VM with disk load")
     migrate_vm_and_verify(vm=vm_with_fio, check_ssh_connectivity=True)
     get_disk_usage(ssh_exec=vm_with_fio.ssh_exec)

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -17,7 +17,7 @@ from utilities.virt import migrate_vm_and_verify
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.usefixtures("skip_access_mode_rwo_scope_module")
+pytestmark = pytest.mark.migration
 
 
 @pytest.fixture()

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -17,7 +17,7 @@ from utilities.virt import migrate_vm_and_verify
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.migration
+pytestmark = pytest.mark.rwx_default_storage
 
 
 @pytest.fixture()

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -32,6 +32,7 @@ def unscheduled_node_vm(
 
 
 @pytest.mark.gating
+@pytest.mark.migration
 @pytest.mark.parametrize(
     "data_volume_scope_function, unscheduled_node_vm",
     [
@@ -52,12 +53,7 @@ def unscheduled_node_vm(
     indirect=True,
 )
 @pytest.mark.polarion("CNV-4157")
-def test_schedule_vm_on_cordoned_node(
-    skip_access_mode_rwo_scope_function,
-    nodes,
-    data_volume_scope_function,
-    unscheduled_node_vm,
-):
+def test_schedule_vm_on_cordoned_node(nodes, data_volume_scope_function, unscheduled_node_vm):
     """Test VM scheduling on a node under maintenance.
     1. Cordon the Node
     2. Once node status is 'Ready,SchedulingDisabled', start a VM (on the

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -32,7 +32,7 @@ def unscheduled_node_vm(
 
 
 @pytest.mark.gating
-@pytest.mark.migration
+@pytest.mark.rwx_default_storage
 @pytest.mark.parametrize(
     "data_volume_scope_function, unscheduled_node_vm",
     [

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -140,13 +140,9 @@ class TestWindowsGuestTools:
         LOGGER.info("Test VM with Windows guest tools")
         verify_cdrom_in_xml(vm=vm_with_guest_tools)
 
+    @pytest.mark.migration
     @pytest.mark.polarion("CNV-6518")
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vm_with_guest_tools"])
-    def test_migrate_vm_with_windows_guest_tools(
-        self,
-        skip_access_mode_rwo_scope_class,
-        vm_with_guest_tools,
-        migrated_vm_with_guest_tools,
-    ):
+    def test_migrate_vm_with_windows_guest_tools(self, vm_with_guest_tools, migrated_vm_with_guest_tools):
         LOGGER.info("Test migration of a VM with Windows guest tools")
         verify_cdrom_in_xml(vm=vm_with_guest_tools)

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -140,7 +140,7 @@ class TestWindowsGuestTools:
         LOGGER.info("Test VM with Windows guest tools")
         verify_cdrom_in_xml(vm=vm_with_guest_tools)
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-6518")
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vm_with_guest_tools"])
     def test_migrate_vm_with_windows_guest_tools(self, vm_with_guest_tools, migrated_vm_with_guest_tools):

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -191,7 +191,7 @@ class TestKernelSamepageMerging:
             initial_value=pages_to_scan_initial_value,
         )
 
-    @pytest.mark.migration
+    @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-10523")
     @pytest.mark.dependency(depends=["test_ksm_activated_when_node_under_pressure"])
     def test_migrate_vm_when_ksm_active(self, ksm_label_added_to_worker2, vms_for_ksm_test):

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -191,14 +191,10 @@ class TestKernelSamepageMerging:
             initial_value=pages_to_scan_initial_value,
         )
 
+    @pytest.mark.migration
     @pytest.mark.polarion("CNV-10523")
     @pytest.mark.dependency(depends=["test_ksm_activated_when_node_under_pressure"])
-    def test_migrate_vm_when_ksm_active(
-        self,
-        skip_access_mode_rwo_scope_function,
-        ksm_label_added_to_worker2,
-        vms_for_ksm_test,
-    ):
+    def test_migrate_vm_when_ksm_active(self, ksm_label_added_to_worker2, vms_for_ksm_test):
         migrate_vm_and_verify(vm=vms_for_ksm_test[0])
 
     @pytest.mark.polarion("CNV-10524")


### PR DESCRIPTION
##### Short description:
  - drop storage related programmatic skips
  - added new "rwx_default_storage" marker
  - added new virt sanity verification step for default storage
 
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-57837


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Reorganized and expanded test markers to include a new "rwx_default_storage" category.
	- Simplified test signatures by removing unused parameters related to storage access mode fixtures.
	- Updated test markers and decorators to categorize tests under the new "rwx_default_storage" marker.

- **Tests**
	- Added verification to ensure default storage supports RWX access mode before running migration-related tests.
	- Improved test categorization and maintainability by consistently applying the new storage-related marker across multiple test modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->