### PR TITLE
github-action, component-builder: Change current workflow to check-only

### DIFF
--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -1,8 +1,10 @@
-name: "Component Builder Check"
+name: "Component Builder Publish"
 on:
-  pull_request:
+  push:
     paths:
       - 'containers/fedora/**'
+    branches:
+      - 'main'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -41,5 +43,19 @@ jobs:
         working-directory: ./containers/fedora
         env:
           PYTHONPATH: ${{ github.workspace }}
-          NO_SECRETS: "true"
+          ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
+          ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
         run: ./build.sh
+      - name: Logging to quay.io
+        run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+      - name: Tag & Push image to staging
+        env:
+          local_repository: "localhost/fedora"
+          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          remote_tag: "${{ env.FEDORA_VERSION }}-dev"
+        run: |
+          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
+          podman push "${remote_repository}":"${arch_tag}"
+          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag}"
+          podman manifest push "${remote_repository}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -43,3 +43,20 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           NO_SECRETS: "true"
         run: ./build.sh
+      - name: Save container image as tarball
+        env:
+          local_repository: "localhost/fedora"
+          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+        run: |
+          mkdir -p artifacts
+          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
+          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image.tar"
+      - name: Upload container image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fedora-container-image
+          path: artifacts/fedora-image.tar
+          retention-days: 5
+          compression-level: 0

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -49,11 +49,17 @@ if [ "$FULL_EMULATION" = "true" ]; then
     VIRT_TYPE="qemu"
 fi
 
-set +x
-FEDORA_PASSWORD=$(uv run get_fedora_password.py)
-PASSWORD_PLACEHOLDER="CHANGE_ME"
-sed -i "s/password: $PASSWORD_PLACEHOLDER/password: $FEDORA_PASSWORD/" user-data
-set -x
+# When no secrets are available, the password cannot be computed.
+# Running such an option can be useful on CI when the build is validated.
+if [ "${NO_SECRETS}" != "true" ]; then
+    set +x
+    FEDORA_PASSWORD=$(uv run get_fedora_password.py)
+    PASSWORD_PLACEHOLDER="CHANGE_ME"
+    sed -i "s/password: $PASSWORD_PLACEHOLDER/password: $FEDORA_PASSWORD/" user-data
+    set -x
+else
+    echo "NO_SECRETS set: skipping Fedora password injection"
+fi
 
 echo "Create cloud-init user data ISO"
 cloud-localds $CLOUD_INIT_ISO user-data


### PR DESCRIPTION
##### What this PR does / why we need it:

The existing workflow to build the Fedora image has a flaw: The event is 'pull_request_target' which runs in the context of the target branch and therefore does not include the changes a PR introduces.

In order to run the changes in the PR, the event must be changed to 'pull_request'. However, this event is restricting access to the secrets which are needed to 1) generate the password and 2) push the image to the registry (quay).

The solution is to convert the current workflow to a build-only check, i.e. to check that the image can be built, but without publishing the image to the registry.
The publish itself to the registry is kept by introducing another workflow with a 'push' event. It is triggered post merge to persist the image.
At this stage, it is still pushing to the staging repo but in the future it should be change to the production one.

---

A user can download the artifact and load the image into the local image storage.

Steps:
1. Access the action workflow on github: https://github.com/RedHatQE/openshift-virtualization-tests/actions/workflows/component-builder.yml
2. Click on the relevant run, e.g. : https://github.com/RedHatQE/openshift-virtualization-tests/actions/runs/15147820347
3. On the bottom of the page, click on the artifact to download.
4. Once on the local storage, extract the tar file from the zip.
5. Load the image into the local image storage using `podman`:
`podman load -i fedora-image.tar`

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a new workflow to automate building and publishing Fedora-based container images for staging.
  - Updated an existing workflow to perform build checks only, without publishing images or requiring secret credentials.
- **New Features**
  - Enabled container image building and publishing via a new automated workflow.
- **Refactor**
  - Improved build script to optionally skip secret-dependent steps, allowing builds without credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->