### PR TITLE
Refactor storage class tests: remove redundant different storage cover

### DIFF
--- a/tests/infrastructure/golden_images/conftest.py
+++ b/tests/infrastructure/golden_images/conftest.py
@@ -6,8 +6,6 @@ import pytest
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.storage_class import StorageClass
 
-from utilities.constants import HOSTPATH_CSI_BASIC, StorageClassNames
-
 
 @pytest.fixture()
 def updated_default_storage_class_scope_function(
@@ -42,29 +40,3 @@ def latest_fedora_release_version(downloaded_latest_libosinfo_db):
         raise FileNotFoundError("No fedora files were found in osinfo db")
     latest_fedora_os_file = list_of_fedora_os_files[-1]
     return re.findall(r"\d+", latest_fedora_os_file.name)[0]
-
-
-@pytest.fixture(scope="session")
-def fail_if_no_ceph_rbd_virtualization_sc(cluster_storage_classes_names):
-    """
-    Fail the test if no NFS storage class is available
-    """
-    if StorageClassNames.CEPH_RBD_VIRTUALIZATION not in cluster_storage_classes_names:
-        pytest.fail(
-            f"Test failed: {StorageClassNames.CEPH_RBD_VIRTUALIZATION} storage class is not deployed. "
-            f"Available storage classes: {cluster_storage_classes_names}. "
-            "Ensure the correct storage class is configured before running tests."
-        )
-
-
-@pytest.fixture(scope="session")
-def fail_if_no_hostpath_csi_basic_sc(cluster_storage_classes_names):
-    """
-    Fail the test if no CSI basic storage class is available
-    """
-    if HOSTPATH_CSI_BASIC not in cluster_storage_classes_names:
-        pytest.fail(
-            f"Test failed: {HOSTPATH_CSI_BASIC} basic storage class is not deployed. "
-            f"Available storage classes: {cluster_storage_classes_names}. "
-            "Ensure the correct CSI storage class is configured before running tests."
-        )

--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -1,12 +1,10 @@
 import pytest
-from ocp_resources.datavolume import DataVolume
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.template import Template
 from pytest_testconfig import config as py_config
 
 from tests.infrastructure.golden_images.constants import PVC_NOT_FOUND_ERROR
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS, FEDORA_LATEST_OS
-from utilities.constants import HOSTPATH_CSI_BASIC, StorageClassNames
 from utilities.virt import VirtualMachineForTestsFromTemplate, running_vm
 
 pytestmark = pytest.mark.post_upgrade
@@ -141,38 +139,6 @@ def test_vm_from_golden_image_cluster_default_storage_class(
 )
 def test_vm_with_existing_dv(data_volume_scope_function, vm_from_template_with_existing_dv):
     vm_from_template_with_existing_dv.ssh_exec.executor().is_connective()
-
-
-@pytest.mark.parametrize(
-    "golden_image_data_volume_scope_function, vm_from_golden_image",
-    [
-        pytest.param(
-            {
-                "dv_name": FEDORA_LATEST_OS,
-                "image": FEDORA_LATEST["image_path"],
-                "storage_class": HOSTPATH_CSI_BASIC,
-                "dv_size": FEDORA_LATEST["dv_size"],
-            },
-            {
-                "updated_storage_class_params": {
-                    "storage_class": StorageClassNames.CEPH_RBD_VIRTUALIZATION,
-                    "access_mode": DataVolume.AccessMode.RWX,
-                    "volume_mode": DataVolume.VolumeMode.BLOCK,
-                },
-            },
-            marks=pytest.mark.polarion("CNV-5529"),
-        ),
-    ],
-    indirect=True,
-)
-def test_vm_dv_with_different_sc(
-    fail_if_no_hostpath_csi_basic_sc,
-    fail_if_no_ceph_rbd_virtualization_sc,
-    golden_image_data_volume_scope_function,
-    vm_from_golden_image,
-):
-    # VM cloned PVC storage class is different from the original golden image storage class
-    vm_from_golden_image.ssh_exec.executor().is_connective()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
##### Short description:
Remove old `test_vm_dv_with_different_sc` test and include it under `test_vm_pref_storage_class`

##### More details:
The original test verified that a VM could be created with a data source using a different storage class than the original PVC. However, this functionality is already covered by other tests.

To reduce redundancy, we are removing the redundant test and integrating the core logic into the existing `test_vm_pref_storage_class`. This is done by enhancing it with `running_vm` to preserve the intended validation.

##### What this PR does / why we need it:
Minimize number of tests by removing redundant tests

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-57583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed a test case that verified VM connectivity when using different storage classes for data volumes.
  - Updated tests to use dynamic storage class configuration via fixtures instead of hardcoded values.
  - Added a fixture to ensure required storage classes are available before running tests.
  - Improved test reliability and maintainability by refactoring fixture usage and parameterization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->