### PR TITLE
tests, net, localnet: Refactor the fixtures to express better the action

### DIFF
--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -9,6 +9,8 @@ from libs.net.traffic_generator import Client, Server
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cluster_user_defined_network as libcudn
 from tests.network.localnet.liblocalnet import (
+    LOCALNET_BR_EX_NETWORK,
+    LOCALNET_OVS_BRIDGE_NETWORK,
     LOCALNET_TEST_LABEL,
     create_traffic_client,
     create_traffic_server,
@@ -21,8 +23,6 @@ from utilities.constants import (
 )
 from utilities.infra import create_ns
 
-LOCALNET_BR_EX_NETWORK = "localnet-br-ex-network"
-LOCALNET_OVS_BRIDGE_NETWORK = "localnet-ovs-network"
 NNCP_INTERFACE_TYPE_OVS_BRIDGE = "ovs-bridge"
 
 
@@ -116,26 +116,26 @@ def vm_localnet_2(
 
 
 @pytest.fixture(scope="module")
-def server_client_localnet_vms(
+def localnet_running_vms(
     vm_localnet_1: BaseVirtualMachine, vm_localnet_2: BaseVirtualMachine
 ) -> tuple[BaseVirtualMachine, BaseVirtualMachine]:
-    server_vm, client_vm = run_vms(vms=(vm_localnet_1, vm_localnet_2))
-    return (server_vm, client_vm)
+    vm1, vm2 = run_vms(vms=(vm_localnet_1, vm_localnet_2))
+    return vm1, vm2
 
 
 @pytest.fixture()
-def localnet_server(server_client_localnet_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[Server]:
-    with create_traffic_server(vm=server_client_localnet_vms[0]) as server:
+def localnet_server(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[Server]:
+    with create_traffic_server(vm=localnet_running_vms[0]) as server:
         assert server.is_running()
         yield server
 
 
 @pytest.fixture()
-def localnet_client(server_client_localnet_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[Client]:
+def localnet_client(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[Client]:
     with create_traffic_client(
-        server_vm=server_client_localnet_vms[0],
-        client_vm=server_client_localnet_vms[1],
-        network_name=LOCALNET_BR_EX_NETWORK,
+        server_vm=localnet_running_vms[0],
+        client_vm=localnet_running_vms[1],
+        spec_logical_network=LOCALNET_BR_EX_NETWORK,
     ) as client:
         assert client.is_running()
         yield client
@@ -229,30 +229,30 @@ def vm_ovs_bridge_localnet_2(
 
 
 @pytest.fixture(scope="module")
-def ovs_bridge_server_client_localnet_vms(
+def ovs_bridge_localnet_running_vms(
     vm_ovs_bridge_localnet_1: BaseVirtualMachine, vm_ovs_bridge_localnet_2: BaseVirtualMachine
 ) -> Generator[tuple[BaseVirtualMachine, BaseVirtualMachine]]:
-    server_vm, client_vm = run_vms(vms=(vm_ovs_bridge_localnet_1, vm_ovs_bridge_localnet_2))
-    yield (server_vm, client_vm)
+    vm1, vm2 = run_vms(vms=(vm_ovs_bridge_localnet_1, vm_ovs_bridge_localnet_2))
+    yield vm1, vm2
 
 
 @pytest.fixture()
 def localnet_ovs_bridge_server(
-    ovs_bridge_server_client_localnet_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
+    ovs_bridge_localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
 ) -> Generator[Server]:
-    with create_traffic_server(vm=ovs_bridge_server_client_localnet_vms[0]) as server:
+    with create_traffic_server(vm=ovs_bridge_localnet_running_vms[0]) as server:
         assert server.is_running()
         yield server
 
 
 @pytest.fixture()
 def localnet_ovs_bridge_client(
-    ovs_bridge_server_client_localnet_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
+    ovs_bridge_localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
 ) -> Generator[Client]:
     with create_traffic_client(
-        server_vm=ovs_bridge_server_client_localnet_vms[0],
-        client_vm=ovs_bridge_server_client_localnet_vms[1],
-        network_name=LOCALNET_OVS_BRIDGE_NETWORK,
+        server_vm=ovs_bridge_localnet_running_vms[0],
+        client_vm=ovs_bridge_localnet_running_vms[1],
+        spec_logical_network=LOCALNET_OVS_BRIDGE_NETWORK,
     ) as client:
         assert client.is_running()
         yield client

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -8,7 +8,8 @@ from tests.network.libs import cloudinit
 from tests.network.libs import cluster_user_defined_network as libcudn
 from tests.network.libs.label_selector import LabelSelector
 
-NETWORK_NAME = "localnet-network"
+LOCALNET_BR_EX_NETWORK = "localnet-br-ex-network"
+LOCALNET_OVS_BRIDGE_NETWORK = "localnet-ovs-network"
 LOCALNET_TEST_LABEL = {"test": "localnet"}
 _IPERF_SERVER_PORT = 5201
 
@@ -26,10 +27,12 @@ def create_traffic_server(vm: BaseVirtualMachine) -> Server:
     return Server(vm=vm, port=_IPERF_SERVER_PORT)
 
 
-def create_traffic_client(server_vm: BaseVirtualMachine, client_vm: BaseVirtualMachine, network_name: str) -> Client:
+def create_traffic_client(
+    server_vm: BaseVirtualMachine, client_vm: BaseVirtualMachine, spec_logical_network: str
+) -> Client:
     return Client(
         vm=client_vm,
-        server_ip=lookup_iface_status(vm=server_vm, iface_name=network_name)[IP_ADDRESS],
+        server_ip=lookup_iface_status(vm=server_vm, iface_name=spec_logical_network)[IP_ADDRESS],
         server_port=_IPERF_SERVER_PORT,
     )
 


### PR DESCRIPTION
##### What this PR does / why we need it:

The fixture that is running the VMs is renamed to express that it does exactly that.
The fixture that is migrating a VM is changed to depend on an additional fixture that assures connectivity.

The change expresses better that there is no meaning to "client" and "server" VMs.

In addition, constants have been moved in order to use them outside the fixtures files.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
