### PR TITLE
[Install] Add missing resources to expected resources

### DIFF
--- a/tests/install_upgrade_operators/product_install/constants.py
+++ b/tests/install_upgrade_operators/product_install/constants.py
@@ -35,6 +35,7 @@ CLUSTER_RESOURCE_WHITE_LIST = {
         "template:view",
         "kubevirt-hyperconverged-",
         "olm.og.openshift-cnv-",
+        "kubevirt-ipam-controller-manager-role",
     ],
     "ClusterRoleBinding": [
         "hostpath-provisioner-operator-service-system:auth-delegator",
@@ -55,7 +56,7 @@ CLUSTER_RESOURCE_WHITE_LIST = {
         "kubevirt-apiserver",
         "template-validator",
         "kubevirt-hyperconverged-",
-        "olm.og.openshift-cnv-",
+        "olm.og.openshift-cnv-kubevirt-ipam-controller-manager-rolebinding",
     ],
     "Namespace": ["openshift-cnv", "openshift-virtualization-os-images"],
     "Project": ["openshift-cnv", "openshift-virtualization-os-images"],
@@ -76,6 +77,8 @@ CLUSTER_RESOURCE_WHITE_LIST = {
         "virt-api-mutator",
         "kubemacpool-mutator",
         "cdi-api-datavolume-mutate",
+        "cdi-api-pvc-mutate",
+        "kubevirt-ipam-controller-mutating-webhook-configuration",
     ],
     "SecurityContextConstraints": [
         "linux-bridge",
@@ -102,10 +105,11 @@ NAMESPACED_RESOURCE_WHITE_LIST = {
     },
     "openshift-config-managed": {"ConfigMap": ["grafana-dashboard-kubevirt-top-consumers"]},
     "openshift-storage": {
-        "Pod": ["csi-addons"],
+        "Pod": ["csi-addons", "storageclient"],
         "EndpointSlice": ["csi-addons"],
         "PodMetrics": ["csi-addons"],
         "ReplicaSet": ["csi-addons"],
+        "Job": ["storageclient"],
     },
     "openshift-console": {
         "ReplicaSet": ["console"],


### PR DESCRIPTION
##### Short description:
Install test is failing because it doesn't take into consideration new resources added in 4.19.0:

##### More details:

cluster scoped:
```
{
  "ClusterRole": [
    "kubevirt-ipam-controller-manager-role"
  ],
  "ClusterRoleBinding": [
    "kubevirt-ipam-controller-manager-rolebinding"
  ],
  "MutatingWebhookConfiguration": [
    "cdi-api-pvc-mutate",
    "kubevirt-ipam-controller-mutating-webhook-configuration"
  ]
}
```
namespaced scoped:
```
{
  "openshift-storage": {
    "Job": [
      "storageclient-737342087af10580-status-reporter-29125664"
    ],
    "Pod": [
      "storageclient-737342087af10580-status-reporter-29125664-qtpf7"
    ]
  }
}
```

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-61975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated resource whitelists in test configurations to include additional resource names for improved coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->