### PR TITLE
Refactor vm_from_golden_image to use VirtualMachineForTests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1376,6 +1376,15 @@ def skip_test_if_no_ocs_sc(ocs_storage_class):
 
 
 @pytest.fixture(scope="session")
+def fail_test_if_no_ocs_sc(ocs_storage_class):
+    """
+    Fail test if no OCS storage class available
+    """
+    if not ocs_storage_class:
+        pytest.fail("Failing test, OCS storage class is not deployed")
+
+
+@pytest.fixture(scope="session")
 def hyperconverged_ovs_annotations_enabled_scope_session(
     admin_client,
     hco_namespace,

--- a/tests/infrastructure/golden_images/conftest.py
+++ b/tests/infrastructure/golden_images/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.storage_class import StorageClass
 
-from utilities.constants import HOSTPATH_CSI_BASIC, StorageClassNames
+from utilities.constants import HOSTPATH_CSI_BASIC
 
 
 @pytest.fixture()
@@ -42,19 +42,6 @@ def latest_fedora_release_version(downloaded_latest_libosinfo_db):
         raise FileNotFoundError("No fedora files were found in osinfo db")
     latest_fedora_os_file = list_of_fedora_os_files[-1]
     return re.findall(r"\d+", latest_fedora_os_file.name)[0]
-
-
-@pytest.fixture(scope="session")
-def fail_if_no_ceph_rbd_virtualization_sc(cluster_storage_classes_names):
-    """
-    Fail the test if no NFS storage class is available
-    """
-    if StorageClassNames.CEPH_RBD_VIRTUALIZATION not in cluster_storage_classes_names:
-        pytest.fail(
-            f"Test failed: {StorageClassNames.CEPH_RBD_VIRTUALIZATION} storage class is not deployed. "
-            f"Available storage classes: {cluster_storage_classes_names}. "
-            "Ensure the correct storage class is configured before running tests."
-        )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
##### Short description:
Change vm_from_golden_image to use `VirtualMachineForTests` instead of `DataVolumeTemplatesVirtualMachine`

##### More details:
- `vm_from_golden_image` now uses `VirtualMachineForTests`
- vm storage class is changed to use `ocs_storage_class` instead of `CEPH_RBD_VIRTUALIZATION` -- this will help in the future in case the storage class name will be changed
- Remove `running_vm` from the fixture and move it to the test -- in `test_vm_dv_with_different_sc` the function `is_connective` is already doing the same, and in `test_vm_from_golden_image_missing_default_storage_class` it is not executed

##### What this PR does / why we need it:
Reduce use of templates when creating a VM.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-57583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new test fixture to ensure tests fail if a required storage class is missing.
	- Simplified and unified virtual machine creation and data volume template handling in golden image tests.
	- Updated test parameterization to use clearer flags and removed unnecessary complexity.
	- Removed obsolete storage class check fixture to streamline test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->