### PR TITLE
fix: skip tablet tests on s390x architecture

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ markers =
     # Cluster markers
     ## Architecture support
     arm64: Tests that can run on ARM-based cluster
+    skip_s390x: Tests that are disabled on s390x-based cluster
 
     ## Hardware requirements
     special_infra: Tests that requires special infrastructure. e.g. sriov, gpu etc.

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -48,6 +48,7 @@ def check_vm_system_tablet_device(vm, expected_device):
     ],
     indirect=True,
 )
+@pytest.mark.skip_s390x()
 class TestRHELTabletDevice:
     @pytest.mark.parametrize(
         "golden_image_vm_instance_from_template_multi_storage_dv_scope_class_vm_scope_function",
@@ -162,6 +163,7 @@ class TestRHELTabletDevice:
     ],
     indirect=True,
 )
+@pytest.mark.skip_s390x()
 class TestRHELTabletDeviceNegative:
     @pytest.mark.parametrize(
         "golden_image_vm_object_from_template_multi_storage_dv_scope_class_vm_scope_function",


### PR DESCRIPTION
Tablet-related tests are not required on the s390x architecture, as the tablet device is not supported on this platform.

To exclude these tests, the change proposes the use of a skip_s390x marker. For example, a test suite can be run with the following expression:

-m "tier2 and virt and not special_infra and not skip_s390x"

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE