### PR TITLE
Mark a customer-0 test

### DIFF
--- a/tests/network/ovs_bond/test_bond_link_down.py
+++ b/tests/network/ovs_bond/test_bond_link_down.py
@@ -10,6 +10,7 @@ import utilities.network
 
 
 @pytest.mark.polarion("CNV-3296")
+@pytest.mark.ovs_brcnv
 def test_connectivity_over_pod_network(
     disconnected_bond_port,
     running_ovs_bond_vma,


### PR DESCRIPTION
The setup of a bond, configured during deployment with the node's primary interface as one of its ports, is a customer-0 specific, and anyway doesn't fit for OVN-Kubernetes clusters, where the primary NIC should serve as a port of the default br-ex OVS bridge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test marker to the connectivity test for improved test categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->