### PR TITLE
tests, net, host-network: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/host_network/vlan/conftest.py
+++ b/tests/network/host_network/vlan/conftest.py
@@ -24,7 +24,7 @@ from utilities.network import (
     network_device,
     network_nad,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 LOGGER = logging.getLogger(__name__)
 
@@ -162,7 +162,9 @@ def dhcp_server_vm(namespace, worker_node1, dhcp_br_nad, unprivileged_client):
 
 @pytest.fixture(scope="module")
 def running_dhcp_server_vm(dhcp_server_vm):
-    return running_vm(vm=dhcp_server_vm, wait_for_cloud_init=True)
+    dhcp_server_vm.start(wait=True)
+    dhcp_server_vm.wait_for_agent_connected()
+    return dhcp_server_vm
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved the setup process for the DHCP server VM in test fixtures to ensure more explicit and reliable VM startup and agent connection during network-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->