### PR TITLE
tests, net, service-mesh: Drop usage of 'running_vm'

### DIFF
--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -36,7 +36,7 @@ from tests.network.utils import (
 )
 from utilities.constants import PORT_80, TIMEOUT_4MIN, TIMEOUT_10SEC
 from utilities.infra import add_scc_to_service_account, create_ns, label_project, unique_name
-from utilities.virt import running_vm, vm_console_run_commands, wait_for_console
+from utilities.virt import vm_console_run_commands, wait_for_console
 
 LOGGER = logging.getLogger(__name__)
 
@@ -235,7 +235,8 @@ def vm_fedora_with_service_mesh_annotation(
             service_name=vm_name,
             port=SERVICE_MESH_PORT,
         )
-        running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 
@@ -254,7 +255,8 @@ def outside_mesh_vm_fedora_with_service_mesh_annotation(
             service_name=vm_name,
             port=SERVICE_MESH_PORT,
         )
-        running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
         yield vm
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

`running_vm` is performing multiple checks to assure correct VM start. However, these checks are not required for the network tests.

For the network tests, a successful VM start is one that:
- Reaches ready status (i.e. a VMI in running phase).
- Reaches `AgentConnected` condition status (i.e. cloud-init stage succeeded based on the Fedora image setup).

This is an optimization to reduce observed flakiness on VM startup and simplify the overall maintenance (e.g. the use of a common helper that covers many aspects of a VM startup cycle forces all its users to the same logic, even though that logic is not of interest).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated VM startup procedure in test fixtures to use explicit start and agent connection steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->