### PR TITLE
Add nightly channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,12 @@ Currently, automation supports ocp upgrades using stable, ci, nightly and rc ima
 #### CNV upgrade
 Parameters:
 
-| Parameter Name  |      Requirement      |  Default Value  |    Possible Value     |
-|:----------------|:---------------------:|:---------------:|:---------------------:|
-| `--cnv-version` |     **Required**      |        -        |         4.Y.z         |
-| `--cnv-image`   |     **Required**      |        -        |     -image path-      |
-| `--cnv-source`  |     **Optional**      |      osbs       | osbs, fbc, production |
-| `--cnv-channel` |     **Optional**      |     stable      |   stable, candidate   |
+| Parameter Name  |      Requirement      |  Default Value  |       Possible Value       |
+|:----------------|:---------------------:|:---------------:|:--------------------------:|
+| `--cnv-version` |     **Required**      |        -        |           4.Y.z            |
+| `--cnv-image`   |     **Required**      |        -        |        -image path-        |
+| `--cnv-source`  |     **Optional**      |      osbs       |   osbs, fbc, production    |
+| `--cnv-channel` |     **Optional**      |     stable      | stable, candidate, nightly |
 
 Command to run entire upgrade test suite for cnv upgrade, including pre and post upgrade validation:
 

--- a/conftest.py
+++ b/conftest.py
@@ -127,7 +127,7 @@ def pytest_addoption(parser):
         "--cnv-channel",
         help="Subscription channel for CNV index image",
         default="stable",
-        choices=["stable", "candidate"],
+        choices=["stable", "candidate", "nightly"],
     )
 
     # OCP upgrade options

--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -5,7 +5,7 @@ pytestmark = pytest.mark.sno
 
 @pytest.mark.polarion("CNV-7169")
 def test_channels_in_manifest(kubevirt_package_manifest_channels):
-    expected_channels = {"stable", "candidate", "dev-preview"}
+    expected_channels = {"stable", "dev-preview"}
     missing_channels = expected_channels - {channel.name for channel in kubevirt_package_manifest_channels}
     assert not missing_channels, f"Missing channels: {missing_channels}"
 


### PR DESCRIPTION
##### Short description:
Atm it possible to run upgrade/t2 against nightly builds. So for now, we should enable those

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
stable/dev-preview must be present always.
Candidate/nightly are deployment dependent

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation to include "nightly" as a valid value for the `--cnv-channel` parameter and improved table formatting.

- **New Features**
  - Added support for "nightly" as an option for the `--cnv-channel` command-line parameter.

- **Tests**
  - Updated tests to reflect current subscription channels, removing "candidate" and including "dev-preview".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->