### PR TITLE
Modify must gather verification

### DIFF
--- a/tests/install_upgrade_operators/must_gather/utils.py
+++ b/tests/install_upgrade_operators/must_gather/utils.py
@@ -81,7 +81,7 @@ def compare_resource_contents(resource, file_content, checks):
 
         for part in check:
             oc_part = getattr(oc_part, part)
-            file_part = file_part[part]
+            file_part = file_part.get(part)
         with ResourceFieldEqBugWorkaround():
             if oc_part != file_part:
                 raise ResourceMismatch(


### PR DESCRIPTION
##### Short description:
If there's a resource without an attribute, we may fail like istio-cni net-attach-def and spec

In this case we should validate the must gather collected well, and None == None

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when comparing resources by preventing errors if expected data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->