### PR TITLE
feat: mark virt-cluster (compute) tests as s390x-compatible

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ markers =
     # Cluster markers
     ## Architecture support
     arm64: Tests that can run on ARM-based cluster
+    s390x: Tests that can run on s390x-based cluster
 
     ## Hardware requirements
     special_infra: Tests that requires special infrastructure. e.g. sriov, gpu etc.

--- a/tests/deprecated_api/test_deprecation_audit_logs.py
+++ b/tests/deprecated_api/test_deprecation_audit_logs.py
@@ -107,6 +107,7 @@ def deprecated_apis_calls(audit_logs):
 
 @pytest.mark.polarion("CNV-6679")
 @pytest.mark.order("last")
+@pytest.mark.s390x
 def test_deprecated_apis_in_audit_logs(deprecated_apis_calls):
     LOGGER.info(f"Test deprecated API calls, max version for deprecation check: {DEPRECATED_API_MAX_VERSION}")
     if deprecated_apis_calls:

--- a/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
+++ b/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
@@ -14,6 +14,7 @@ pytestmark = [
         "updated_namespace_with_aaq_label",
     ),
     pytest.mark.arm64,
+    pytest.mark.s390x,
 ]
 
 

--- a/tests/virt/cluster/aaq/test_acrq.py
+++ b/tests/virt/cluster/aaq/test_acrq.py
@@ -12,6 +12,7 @@ TESTS_ACRQ_CLASS_NAME = "TestApplicationAwareClusterResourceQuota"
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.usefixtures(
     "enabled_aaq_in_hco_scope_package",
     "enabled_acrq_support",

--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -43,6 +43,7 @@ pytestmark = [
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.usefixtures(
     "application_aware_resource_quota",
     "first_pod_for_aaq_test",
@@ -92,6 +93,7 @@ class TestARQCanManagePods:
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.usefixtures(
     "application_aware_resource_quota",
     "vm_for_aaq_test",

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -28,7 +28,7 @@ from utilities.virt import (
 LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestCommonTemplatesCentos"
 
-
+@pytest.mark.s390x
 class TestCommonTemplatesCentos:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")
     @pytest.mark.polarion("CNV-5337")

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -28,6 +28,7 @@ from utilities.virt import (
 LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestCommonTemplatesCentos"
 
+
 @pytest.mark.s390x
 class TestCommonTemplatesCentos:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")

--- a/tests/virt/cluster/common_templates/custom_namespace/test_custom_namespace.py
+++ b/tests/virt/cluster/common_templates/custom_namespace/test_custom_namespace.py
@@ -22,6 +22,7 @@ TESTS_CLASS_NAME = "TestCustomNamespace"
 
 
 @pytest.mark.usefixtures("base_templates", "opt_in_custom_template_namespace")
+@pytest.mark.s390x
 class TestCustomNamespace:
     @pytest.mark.polarion("CNV-8144")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::test_base_templates_exist_in_custom_namespace")

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -80,6 +80,7 @@ HYPERV_DICT = {
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestCommonTemplatesFedora:
     @pytest.mark.sno
     @pytest.mark.ibm_bare_metal

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -90,6 +90,7 @@ def custom_template_from_base_template(request, namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestBaseCustomTemplates:
     @pytest.mark.parametrize(
         "custom_template_from_base_template, vm_name",

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -188,6 +188,7 @@ def verify_annotations_match(obj_annotations, expected):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-1069")
+@pytest.mark.s390x
 def test_base_templates_annotations(base_templates, common_templates_expected_list):
     """
     Check all CNV templates exists, by label: template.kubevirt.io/type=base
@@ -216,14 +217,14 @@ def test_base_templates_annotations(base_templates, common_templates_expected_li
             "rhel8",
             "rhel-8.1",
             "minimum",
-            marks=pytest.mark.polarion("CNV-3620"),
+            marks=[pytest.mark.polarion("CNV-3620"), pytest.mark.s390x],
             id="test_rhel8_minimum_memory",
         ),
         pytest.param(
             "rhel9",
             "rhel-9.0",
             "minimum",
-            marks=pytest.mark.polarion("CNV-6989"),
+            marks=[pytest.mark.polarion("CNV-6989"), pytest.mark.s390x],
             id="test_rhel9_minimum_memory",
         ),
         pytest.param(
@@ -237,14 +238,14 @@ def test_base_templates_annotations(base_templates, common_templates_expected_li
             "rhel8",
             "rhel-8.1",
             "maximum",
-            marks=pytest.mark.polarion("CNV-3623"),
+            marks=[pytest.mark.polarion("CNV-3623"), pytest.mark.s390x],
             id="test_rhel8_maximum_memory",
         ),
         pytest.param(
             "rhel9",
             "rhel-9.0",
             "maximum",
-            marks=pytest.mark.polarion("CNV-6988"),
+            marks=[pytest.mark.polarion("CNV-6988"), pytest.mark.s390x],
             id="test_rhel9_maximum_memory",
         ),
     ],
@@ -354,6 +355,7 @@ def test_validate_windows_min_max_memory(
 
 
 @pytest.mark.polarion("CNV-5002")
+@pytest.mark.s390x
 def test_common_templates_golden_images_params(base_templates):
     unmatched_templates = {}
     for template in base_templates:
@@ -387,6 +389,7 @@ def test_common_templates_golden_images_params(base_templates):
 
 
 @pytest.mark.polarion("CNV-5599")
+@pytest.mark.s390x
 def test_provide_support_annotations(base_templates, templates_provider_support_dict):
     """Verify provider, provider-support-level and provider-url annotations"""
 
@@ -404,6 +407,7 @@ def test_provide_support_annotations(base_templates, templates_provider_support_
 
 
 @pytest.mark.polarion("CNV-6874")
+@pytest.mark.s390x
 def test_vm_annotations_in_template(base_templates):
     """Verify template VM object has os, workload and flavor annotations which match corresponding template labels"""
 
@@ -473,6 +477,7 @@ def test_vm_annotations_in_template(base_templates):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vmi_annotations(data_volume_scope_function, vm_from_template_with_existing_dv):
     """Verify that VM annotations are copied to the VMI object.
     For this test the underlying OS is not important; using Cirros to reduce runtime.
@@ -543,6 +548,7 @@ def test_hyperv_features_exist_in_windows_templates(os_base_templates):
     ],
     indirect=["os_base_templates"],
 )
+@pytest.mark.s390x
 def test_suggested_image_annotation_exists(os_base_templates, annotation_list):
     failed_templates_dict = {}
     for template in os_base_templates:

--- a/tests/virt/cluster/common_templates/general/test_diskless_vm.py
+++ b/tests/virt/cluster/common_templates/general/test_diskless_vm.py
@@ -31,7 +31,7 @@ SMALL_VM_IMAGE = f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}"
                 "diskless_vm": True,
                 "start_vm": False,
             },
-            marks=(pytest.mark.polarion("CNV-4696"), pytest.mark.gating()),
+            marks=(pytest.mark.polarion("CNV-4696"), pytest.mark.gating(), pytest.mark.s390x),
         ),
         pytest.param(
             {

--- a/tests/virt/cluster/common_templates/general/test_template_validator.py
+++ b/tests/virt/cluster/common_templates/general/test_template_validator.py
@@ -12,7 +12,7 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from tests.os_params import RHEL_LATEST_LABELS
 from utilities.constants import Images
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -39,6 +39,7 @@ TESTS_CLASS_NAME = "TestCommonTemplatesRhel"
 
 class TestCommonTemplatesRhel:
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")
@@ -54,6 +55,7 @@ class TestCommonTemplatesRhel:
         golden_image_vm_object_from_template_multi_rhel_os_multi_storage_scope_class.create(wait=True)
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::start_vm", depends=[f"{TESTS_CLASS_NAME}::create_vm"])
@@ -66,6 +68,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
@@ -79,6 +82,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-3318")
@@ -104,6 +108,7 @@ class TestCommonTemplatesRhel:
         assert_linux_efi(vm=vm)
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])
     @pytest.mark.polarion("CNV-3306")
@@ -115,6 +120,7 @@ class TestCommonTemplatesRhel:
         assert label == vm.name, f"Wrong domain label: {label}"
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(
@@ -129,6 +135,7 @@ class TestCommonTemplatesRhel:
         ), "Failed to login via SSH"
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(
@@ -142,6 +149,7 @@ class TestCommonTemplatesRhel:
         ), "qemu guest agent package is not installed"
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent"])
     @pytest.mark.polarion("CNV-3513")
@@ -151,6 +159,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent"])
     @pytest.mark.polarion("CNV-4195")
@@ -169,6 +178,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent"])
     @pytest.mark.polarion("CNV-4550")
@@ -181,6 +191,7 @@ class TestCommonTemplatesRhel:
             )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent"])
     @pytest.mark.polarion("CNV-6531")
@@ -194,6 +205,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-3671")
@@ -201,6 +213,7 @@ class TestCommonTemplatesRhel:
         check_machine_type(vm=golden_image_vm_object_from_template_multi_rhel_os_multi_storage_scope_class)
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-4201")
@@ -215,6 +228,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-5916")
@@ -224,6 +238,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.smoke
     @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-3038")
@@ -238,6 +253,7 @@ class TestCommonTemplatesRhel:
         validate_libvirt_persistent_domain(vm=vm)
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.polarion("CNV-5902")
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::migrate_vm_and_verify"])
     def test_pause_unpause_after_migrate(
@@ -253,6 +269,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.polarion("CNV-6007")
     @pytest.mark.dependency(
         depends=[
@@ -280,6 +297,7 @@ class TestCommonTemplatesRhel:
         assert_linux_efi(vm=vm)
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])

--- a/tests/virt/cluster/general/test_cpu_allocation_ratio.py
+++ b/tests/virt/cluster/general/test_cpu_allocation_ratio.py
@@ -95,6 +95,7 @@ def limit_range_for_cpu_allocation_test(namespace):
 
 
 @pytest.mark.polarion("CNV-10521")
+@pytest.mark.s390x
 def test_inspect_cpu_allocation_ratio_pod(
     hco_cr_with_vmi_cpu_allocation_ratio,
     vm_for_test_cpu_allocation_ratio,
@@ -116,6 +117,7 @@ def test_inspect_cpu_allocation_ratio_pod(
 
 
 @pytest.mark.polarion("CNV-11294")
+@pytest.mark.s390x
 def test_limitrange_default_cpu_not_override_vm_cpu(
     limit_range_for_cpu_allocation_test,
     vmi_cpu_allocation_from_kubevirt,

--- a/tests/virt/cluster/general/test_smbios.py
+++ b/tests/virt/cluster/general/test_smbios.py
@@ -37,11 +37,13 @@ def smbios_defaults(cnv_current_version):
 
 
 @pytest.mark.polarion("CNV-4346")
+@pytest.mark.s390x
 def test_cm_smbios_defaults(smbios_from_kubevirt_config, smbios_defaults):
     check_smbios_defaults(smbios_defaults=smbios_defaults, cm_values=smbios_from_kubevirt_config)
 
 
 @pytest.mark.polarion("CNV-4325")
+@pytest.mark.s390x
 def test_vm_smbios_default_values(smbios_from_kubevirt_config, configmap_smbios_vm):
     check_vm_xml_smbios(
         vm=configmap_smbios_vm,

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -83,6 +83,7 @@ def added_vm_evictionstrategy(request, vm_from_template_scope_class):
 
 @pytest.mark.polarion("CNV-10085")
 @pytest.mark.post_upgrade
+@pytest.mark.s390x
 def test_evictionstrategy_not_in_templates(base_templates):
     templates_with_evictionstrategy = [
         template.name
@@ -97,6 +98,7 @@ def test_evictionstrategy_not_in_templates(base_templates):
 @pytest.mark.gating
 @pytest.mark.post_upgrade
 @pytest.mark.polarion("CNV-10086")
+@pytest.mark.s390x
 def test_evictionstrategy_in_kubevirt(sno_cluster, kubevirt_config_scope_module):
     assert EVICTIONSTRATEGY in kubevirt_config_scope_module, f"{EVICTIONSTRATEGY} not present in Kubevirt"
     default_evictionstrategy_value = kubevirt_config_scope_module[EVICTIONSTRATEGY]
@@ -126,6 +128,7 @@ def test_evictionstrategy_in_kubevirt(sno_cluster, kubevirt_config_scope_module)
     indirect=True,
 )
 @pytest.mark.usefixtures("cluster_cpu_model_scope_class")
+@pytest.mark.s390x
 class TestEvictionStrategy:
     @pytest.mark.polarion("CNV-10087")
     def test_hco_evictionstrategy_livemigrate_vm_no_evictionstrategy(

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -112,6 +112,7 @@ def vm_re_migrated_after_updating_migration_policy(vm_for_migration_policy_test,
 
 @pytest.mark.rwx_default_storage
 @pytest.mark.arm64
+@pytest.mark.s390x
 class TestMigrationPolicies:
     @pytest.mark.gating
     @pytest.mark.parametrize(

--- a/tests/virt/cluster/operator_tests/test_critical_pods.py
+++ b/tests/virt/cluster/operator_tests/test_critical_pods.py
@@ -42,6 +42,7 @@ def virt_pods(request, admin_client, hco_namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_kubevirt_pods_are_critical(virt_pods):
     """
     Positive: ensure infra pods are critical

--- a/tests/virt/cluster/operator_tests/test_ssp_custom_resources.py
+++ b/tests/virt/cluster/operator_tests/test_ssp_custom_resources.py
@@ -32,6 +32,7 @@ def pods_list_with_given_prefix(request, admin_client, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-3737")
+@pytest.mark.s390x
 def test_verify_ssp_cr_conditions(ssp_resource_scope_function):
     LOGGER.info("Check SSP CR conditions.")
     resource_conditions = {
@@ -55,6 +56,7 @@ def test_verify_ssp_cr_conditions(ssp_resource_scope_function):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_priority_class_value(pods_list_with_given_prefix):
     verify_pods_priority_class_value(pods=pods_list_with_given_prefix, expected_value="system-cluster-critical")
 
@@ -95,6 +97,7 @@ def virt_template_validator_without_podantiaffinity(
 
 
 @pytest.mark.polarion("CNV-8660")
+@pytest.mark.s390x
 def test_podantiaffinity(
     virt_template_validator_pods,
     pods_with_same_node,

--- a/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
+++ b/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
@@ -79,6 +79,7 @@ def hotplugged_vm_with_cpu_auto_limits(vm_auto_resource_limits, unprivileged_cli
     ],
     indirect=["resource_quota_for_auto_resource_limits_test", "vm_auto_resource_limits"],
 )
+@pytest.mark.s390x
 def test_auto_limits_set_one_resource(
     resource_quota_for_auto_resource_limits_test,
     vm_auto_resource_limits,
@@ -110,6 +111,7 @@ def test_auto_limits_set_one_resource(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_with_limits_overrides_global_vlaues(
     resource_quota_for_auto_resource_limits_test,
     vm_auto_resource_limits,

--- a/tests/virt/cluster/service_account/test_service_account.py
+++ b/tests/virt/cluster/service_account/test_service_account.py
@@ -9,7 +9,7 @@ from pyhelper_utils.shell import run_ssh_commands
 
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]
 
 
 @pytest.fixture(scope="module")

--- a/tests/virt/cluster/strict_reconcile/test_strict_reconcile.py
+++ b/tests/virt/cluster/strict_reconcile/test_strict_reconcile.py
@@ -217,6 +217,7 @@ def verify_reconciled_secret_resource(resource, resource_dict):
         ),
     ],
 )
+@pytest.mark.s390x
 def test_strict_reconcile_resources(admin_client, hco_namespace, resource_type, managed_resource_name):
     """Test that virt-operator strictly reconciles managed KubeVirt resources successfully"""
     for resource in resource_type.get(

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -167,6 +167,7 @@ def fedora_target_vm_instance(fedora_target_vm):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_clone_vm_two_pvc_disks(
     vm_with_dv_for_cloning,
     files_created_on_pvc_disks,
@@ -188,6 +189,7 @@ def test_clone_vm_two_pvc_disks(
     indirect=True,
 )
 @pytest.mark.polarion("CNV-10766")
+@pytest.mark.s390x
 def test_clone_vm_with_instance_type_and_preference(
     rhel_vm_with_instancetype_and_preference_for_cloning,
     cloning_job_scope_function,
@@ -254,6 +256,7 @@ def test_clone_windows_vm(
     indirect=True,
 )
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.usefixtures(
     "fedora_vm_for_cloning",

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_manifest.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_manifest.py
@@ -65,6 +65,7 @@ def vmsnapshot_created(fedora_vm_for_cloning):
 @pytest.mark.usefixtures(
     "fedora_vm_for_cloning",
 )
+@pytest.mark.s390x
 class TestVMCloneVirtctlManifest:
     @pytest.mark.parametrize(
         "virtctl_cloning_manifest",

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
@@ -30,6 +30,7 @@ LOGGER = logging.getLogger(__name__)
         ),
     ],
 )
+@pytest.mark.s390x
 def test_cloning_job_if_source_not_exist_negative(namespace, cloning_job_bad_params):
     with VirtualMachineClone(
         name="clone-job-negative-test",

--- a/tests/virt/cluster/vm_lifecycle/test_restart.py
+++ b/tests/virt/cluster/vm_lifecycle/test_restart.py
@@ -32,6 +32,7 @@ def vm_to_restart(unprivileged_client, namespace):
 
 
 @pytest.mark.polarion("CNV-1497")
+@pytest.mark.s390x
 def test_vm_restart(vm_to_restart):
     LOGGER.info("VM is running: Restarting VM")
     vm_to_restart.restart(wait=True)

--- a/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
@@ -247,6 +247,7 @@ def verify_changes(vm, os):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestRestartPersistenceLinux:
     @pytest.mark.parametrize(
         "changed_os_preferences, restarted_persistence_vm",

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -209,6 +209,7 @@ def shutdown_vm_guest_os(vm):
     indirect=True,
 )
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.gating
 class TestRunStrategyBaseActions:
     @pytest.mark.parametrize(
@@ -245,6 +246,7 @@ class TestRunStrategyBaseActions:
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestRunStrategyAdvancedActions:
     @pytest.mark.polarion("CNV-5054")
     def test_run_strategy_shutdown(

--- a/tests/virt/node/cpu_sockets_threads/test_cpu_support_sockets_threads.py
+++ b/tests/virt/node/cpu_sockets_threads/test_cpu_support_sockets_threads.py
@@ -7,7 +7,7 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
 def check_vm_dumpxml(vm, cores=None, sockets=None, threads=None):

--- a/tests/virt/node/general/test_cloud_init_disk_vm.py
+++ b/tests/virt/node/general/test_cloud_init_disk_vm.py
@@ -18,6 +18,7 @@ def vm_with_cloud_init_disk(namespace):
 
 
 @pytest.mark.polarion("CNV-10555")
+@pytest.mark.s390x
 def test_vm_with_cloud_init_disk_logging_no_disk_capacity(vm_with_cloud_init_disk):
     assert "No disk capacity" not in vm_with_cloud_init_disk.vmi.virt_launcher_pod.log(container="compute"), (
         "Error msg 'No disk capacity' logged in virt-launcher pod"

--- a/tests/virt/node/general/test_cloud_init_vm.py
+++ b/tests/virt/node/general/test_cloud_init_vm.py
@@ -7,7 +7,7 @@ import pytest
 from utilities.constants import CLOUD_INIT_NO_CLOUD
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.fixture()

--- a/tests/virt/node/general/test_container_disk_vm.py
+++ b/tests/virt/node/general/test_container_disk_vm.py
@@ -4,6 +4,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.smoke
 @pytest.mark.polarion("CNV-5501")
 def test_container_disk_vm(

--- a/tests/virt/node/general/test_custom_selinux_policy.py
+++ b/tests/virt/node/general/test_custom_selinux_policy.py
@@ -4,6 +4,7 @@ from utilities.infra import ExecCommandOnPod
 
 
 @pytest.mark.polarion("CNV-9918")
+@pytest.mark.s390x
 def test_customselinuxpolicy(workers_utility_pods, schedulable_nodes):
     nodes = []
     for node in schedulable_nodes:

--- a/tests/virt/node/general/test_disk_io_option.py
+++ b/tests/virt/node/general/test_disk_io_option.py
@@ -80,6 +80,7 @@ def disk_options_vm(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestRHELIOOptions:
     @pytest.mark.parametrize(
         "disk_options_vm, expected_disk_io_option",

--- a/tests/virt/node/general/test_linux_label.py
+++ b/tests/virt/node/general/test_linux_label.py
@@ -16,5 +16,6 @@ def assert_linux_label_was_added_in_nodes(nodes):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-5758")
+@pytest.mark.s390x
 def test_linux_label_was_added(schedulable_nodes):
     assert_linux_label_was_added_in_nodes(nodes=schedulable_nodes)

--- a/tests/virt/node/general/test_networkinterfacemultiqueue_feature.py
+++ b/tests/virt/node/general/test_networkinterfacemultiqueue_feature.py
@@ -106,6 +106,7 @@ def network_interface_multiqueue_vm(
     indirect=True,
 )
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.sno
 @pytest.mark.usefixtures("golden_image_data_volume_scope_class")
 class TestLatestRHEL:

--- a/tests/virt/node/general/test_rhel_rhsm_update.py
+++ b/tests/virt/node/general/test_rhel_rhsm_update.py
@@ -64,6 +64,7 @@ def registered_rhsm(rhsm_vm):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 # We add this marker to allow us to exclude this test when running on external cluster like IBM Cloud
 # which can't access Redhat internal service, like "subscription.rhsm.stage.redhat.com"
 # and we don't have any external alternative for it.

--- a/tests/virt/node/general/test_static_ssh_key_injection.py
+++ b/tests/virt/node/general/test_static_ssh_key_injection.py
@@ -18,6 +18,7 @@ NAME = "static-access-creds-injection"
 
 pytestmark = pytest.mark.s390x
 
+
 @pytest.fixture(scope="class")
 def ssh_secret(namespace):
     with Secret(

--- a/tests/virt/node/general/test_static_ssh_key_injection.py
+++ b/tests/virt/node/general/test_static_ssh_key_injection.py
@@ -16,6 +16,7 @@ from utilities.virt import VirtualMachineForTests, running_vm
 
 NAME = "static-access-creds-injection"
 
+pytestmark = pytest.mark.s390x
 
 @pytest.fixture(scope="class")
 def ssh_secret(namespace):

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -138,7 +138,7 @@ class TestCPUHotPlug:
                 "vm_name": "rhel-latest-memory-hotplug-vm",
             },
             id="RHEL-VM",
-            marks=[pytest.mark.s390x]
+            marks=[pytest.mark.s390x],
         ),
         pytest.param(
             {

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -138,6 +138,7 @@ class TestCPUHotPlug:
                 "vm_name": "rhel-latest-memory-hotplug-vm",
             },
             id="RHEL-VM",
+            marks=[pytest.mark.s390x]
         ),
         pytest.param(
             {

--- a/tests/virt/node/hyperv_support/test_hyperv_feature_gate.py
+++ b/tests/virt/node/hyperv_support/test_hyperv_feature_gate.py
@@ -2,6 +2,7 @@ import pytest
 
 
 @pytest.mark.polarion("CNV-5949")
+@pytest.mark.s390x
 def test_hypervstrictcheck_feature_gate_present(kubevirt_feature_gates):
     """
     This test will ensure that 'HypervStrictCheck' feature gate enabled by default.

--- a/tests/virt/node/log_verbosity/test_log_verbosity.py
+++ b/tests/virt/node/log_verbosity/test_log_verbosity.py
@@ -15,6 +15,8 @@ from utilities.infra import get_pods
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.s390x
+
 
 def assert_log_verbosity_level_in_virt_pods(virt_pods_list):
     failed_log_verbosity_level_pods = [

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -97,6 +97,7 @@ def migrated_vm_with_policy(migration_policy_with_bandwidth, vm_for_migration_pr
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestProgressOfMigrationInVirtLauncher:
     @pytest.mark.polarion("CNV-9057")
     def test_virt_launcher_log_verbosity(

--- a/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
+++ b/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
@@ -31,7 +31,7 @@ from utilities.virt import (
     start_and_fetch_processid_on_windows_vm,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.rwx_default_storage]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.rwx_default_storage, pytest.mark.s390x]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -42,6 +42,7 @@ def vm_with_common_cpu_model_scope_function(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_with_odf_cephfs_storage_class_migrates(
     skip_test_if_no_odf_cephfs_sc,
     golden_image_data_volume_scope_function,

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -122,12 +122,14 @@ def drained_node_with_hotplugged_vm(admin_client, hotplugged_vm):
 class TestPostCopyMigration:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::migrate_vm")
     @pytest.mark.polarion("CNV-11421")
+    @pytest.mark.s390x
     def test_migrate_vm(self, hotplugged_vm, vm_background_process_id, migrated_hotplugged_vm):
         assert_migration_post_copy_mode(vm=hotplugged_vm)
         assert_same_pid_after_migration(orig_pid=vm_background_process_id, vm=hotplugged_vm)
 
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::node_drain", depends=[f"{TESTS_CLASS_NAME}::migrate_vm"])
     @pytest.mark.polarion("CNV-11422")
+    @pytest.mark.s390x
     def test_node_drain(self, admin_client, hotplugged_vm, vm_background_process_id, drained_node_with_hotplugged_vm):
         assert_migration_post_copy_mode(vm=hotplugged_vm)
         assert_same_pid_after_migration(orig_pid=vm_background_process_id, vm=hotplugged_vm)

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -89,6 +89,7 @@ def get_disk_usage(ssh_exec):
     indirect=True,
 )
 @pytest.mark.rwx_default_storage
+@pytest.mark.s390x
 def test_fedora_vm_load_migration(vm_with_fio, running_fio_in_vm):
     LOGGER.info("Test migrate VM with disk load")
     migrate_vm_and_verify(vm=vm_with_fio, check_ssh_connectivity=True)

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -66,6 +66,7 @@ class TestMigrationVMWithMemoryLoad:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_fedora_vm_migrate_with_memory_load(
         self,
         vm_with_memory_load,

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -53,6 +53,7 @@ def unscheduled_node_vm(
     indirect=True,
 )
 @pytest.mark.polarion("CNV-4157")
+@pytest.mark.s390x
 def test_schedule_vm_on_cordoned_node(nodes, data_volume_scope_function, unscheduled_node_vm):
     """Test VM scheduling on a node under maintenance.
     1. Cordon the Node

--- a/tests/virt/node/node_labeller/test_node_labeller_annotation.py
+++ b/tests/virt/node/node_labeller/test_node_labeller_annotation.py
@@ -48,6 +48,7 @@ def labelled_worker_node1(worker1_supported_cpu_models_labels, worker_node1):
         yield {worker_node1: updated_label}
 
 
+@pytest.mark.s390x
 class TestNodeLabellerSkipAnnotation:
     @pytest.mark.polarion("CNV-7744")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::test_node_labeller_added_skip_node_annotation")

--- a/tests/virt/node/owner_references/test_vm_owner_references.py
+++ b/tests/virt/node/owner_references/test_vm_owner_references.py
@@ -27,6 +27,7 @@ def fedora_vm(unprivileged_client, namespace):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-1275")
+@pytest.mark.s390x
 def test_owner_references_on_vm(fedora_vm):
     """
     Check the Owner References is fill with right data

--- a/tests/virt/node/rng/test_rng.py
+++ b/tests/virt/node/rng/test_rng.py
@@ -23,6 +23,7 @@ def rng_vm(unprivileged_client, namespace):
 
 
 @pytest.mark.polarion("CNV-791")
+@pytest.mark.s390x
 def test_vm_with_rng(rng_vm):
     """
     Test VM with RNG

--- a/tests/virt/node/workload_density/test_free_page_reporting.py
+++ b/tests/virt/node/workload_density/test_free_page_reporting.py
@@ -10,6 +10,8 @@ from utilities.virt import (
     running_vm,
 )
 
+pytestmark = pytest.mark.s390x
+
 
 def assert_vmi_free_page_reporting(vm, expected_free_page_reporting):
     actual_free_page_reporting = vm.privileged_vmi.xml_dict["domain"]["devices"]["memballoon"]["@freePageReporting"]

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -174,6 +174,7 @@ def pages_to_scan_initial_value(worker_node1, workers_utility_pods):
     "vms_for_ksm_test",
     "ksm_override_annotation_added_to_worker1",
 )
+@pytest.mark.s390x
 class TestKernelSamepageMerging:
     @pytest.mark.polarion("CNV-10522")
     @pytest.mark.dependency(name="test_ksm_activated_when_node_under_pressure")


### PR DESCRIPTION
Add a marker to identify tests compatible with the s390x architecture. This helps avoid false negatives when running the test suite on s390x, where certain features are not supported, such as:

- Windows VMS
- Tablet device
- CPU Hotplug

To run the tests effectively on s390x, use:  "pytest -m s390x"

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added support for the s390x architecture across a wide range of test suites and test cases.
  - Many existing tests and test classes are now marked to run on s390x-based clusters, expanding platform coverage.
  - Select tests and parameterized cases have been updated to include the new s390x marker for targeted execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->