### PR TITLE
 Add test to validate openshift.io/required-scc annotation for all HCO deployments

### DIFF
--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Test to verify all HCO deployments have 'openshift.io/required-scc' annotation.
+"""
+
+import pytest
+from ocp_resources.deployment import Deployment
+
+from utilities.constants import ALL_CNV_DEPLOYMENTS_NO_HPP_POOL
+
+REQUIRED_SCC_ANNOTATION = "openshift.io/required-scc"
+REQUIRED_SCC_VALUE = "restricted-v2"
+
+
+@pytest.fixture(scope="module")
+def required_scc_deployment_check(admin_client, hco_namespace):
+    missing_required_scc_annotation = []
+    incorrect_required_scc_annotation_value = {}
+
+    for dp in (
+        Deployment(client=admin_client, name=name, namespace=hco_namespace.name)
+        for name in ALL_CNV_DEPLOYMENTS_NO_HPP_POOL
+    ):
+        scc = dp.instance.spec.template.metadata.annotations.get(REQUIRED_SCC_ANNOTATION)
+
+        if scc is None:
+            missing_required_scc_annotation.append(dp.name)
+        elif scc != REQUIRED_SCC_VALUE:
+            incorrect_required_scc_annotation_value[dp.name] = scc
+
+    return {
+        "missing_required_scc_annotation": missing_required_scc_annotation,
+        "incorrect_required_scc_annotation_value": incorrect_required_scc_annotation_value,
+    }
+
+
+@pytest.mark.polarion("CNV-11964")
+def test_deployments_missing_required_scc_annotation(required_scc_deployment_check):
+    assert not required_scc_deployment_check["missing_required_scc_annotation"], (
+        f"Deployments missing {REQUIRED_SCC_ANNOTATION} annotation: "
+        f"{required_scc_deployment_check['missing_required_scc_annotation']}"
+    )
+
+
+@pytest.mark.polarion("CNV-11965")
+def test_deployments_with_incorrect_required_scc(required_scc_deployment_check):
+    assert not required_scc_deployment_check["incorrect_required_scc_annotation_value"], (
+        f"Deployments incorrect {REQUIRED_SCC_ANNOTATION} annotation : "
+        f"{required_scc_deployment_check['incorrect_required_scc_annotation_value']}"
+    )


### PR DESCRIPTION

##### Short description:
Refer : https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3284

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-60087


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated tests to ensure all HyperConverged Operator deployments have the correct security context constraint annotation, improving security compliance and reporting any missing or incorrect annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->