### PR TITLE
[Virt] Swap to correct device for s390x when mounting device in tests/virt/cluster/service_account/test_service_account.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ from utilities.constants import (
     RHEL9_PREFERENCE,
     RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
     RHSM_SECRET_NAME,
+    S390X,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
@@ -1197,6 +1198,10 @@ def modern_cpu_for_migration(cluster_common_modern_node_cpu, host_cpu_model, nod
             cluster_cpu=cluster_common_modern_node_cpu, host_cpu_model=host_cpu_model
         )
     )
+
+@pytest.fixture(scope="session")
+def is_s390x_cluster(nodes_cpu_architecture):
+    return nodes_cpu_architecture == S390X
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1199,6 +1199,7 @@ def modern_cpu_for_migration(cluster_common_modern_node_cpu, host_cpu_model, nod
         )
     )
 
+
 @pytest.fixture(scope="session")
 def is_s390x_cluster(nodes_cpu_architecture):
     return nodes_cpu_architecture == S390X

--- a/tests/virt/cluster/service_account/test_service_account.py
+++ b/tests/virt/cluster/service_account/test_service_account.py
@@ -31,7 +31,7 @@ def service_account_vm(namespace, service_account, unprivileged_client):
         running_vm(vm=vm)
         yield vm
 
-
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-1000")
 def test_vm_with_specified_service_account(is_s390x_cluster, service_account_vm):
     """

--- a/tests/virt/cluster/service_account/test_service_account.py
+++ b/tests/virt/cluster/service_account/test_service_account.py
@@ -4,11 +4,9 @@ Check VM with Service Account
 
 import pytest
 from kubernetes.client.rest import ApiException
-from ocp_resources.node import Node
 from ocp_resources.service_account import ServiceAccount
 from pyhelper_utils.shell import run_ssh_commands
 
-from utilities.constants import S390X
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]


### PR DESCRIPTION
##### Short description:
Swaps to correct device `/dev/vdb` when mounting for the s390x image in test case `tests/virt/cluster/service_account/test_service_account.py`

##### More details:

##### What this PR does / why we need it:
Allows test `tests/virt/cluster/service_account/test_service_account.py` to be run correctly on s390x arch
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now adapt to architecture-specific device naming so VM validation runs correctly on s390x and other architectures.
  * Added an automatic cluster-architecture detection fixture to streamline running tests across different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->