### PR TITLE
[IUO]Allow istio-cni differences for node must gather

### DIFF
--- a/tests/install_upgrade_operators/must_gather/utils.py
+++ b/tests/install_upgrade_operators/must_gather/utils.py
@@ -171,7 +171,7 @@ def compare_node_data(file_content, cmd_output, compare_method):
     else:
         raise NotImplementedError(f"{compare_method} not implemented")
 
-    if any(line.startswith(("- ", "+ ")) for line in diff):
+    if any(line.startswith(("- ", "+ ")) and "istio-cni" not in line for line in diff):
         raise NodeResourceException(diff)
 
 


### PR DESCRIPTION
##### Short description:
istio-cni is getting validated every 50 min,
So the timestamp is updated every 50 min for the ls command.

The must gather might be collected before this update, which may lead to a race condition and a failure.

We should not fail upon this scenario.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to ignore differences related to "istio-cni" when comparing node data, reducing unnecessary exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->