### PR TITLE
[Virt] Removes EFI boot for cloning tests on s390x

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,8 +103,10 @@ from utilities.constants import (
     POD_SECURITY_NAMESPACE_LABELS,
     PREFERENCE_STR,
     RHEL9_PREFERENCE,
+    RHEL9_PREFERENCE_S390X,
     RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
     RHSM_SECRET_NAME,
+    S390X,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
@@ -145,6 +147,7 @@ from utilities.infra import (
     get_hyperconverged_resource,
     get_infrastructure,
     get_node_selector_dict,
+    get_nodes_cpu_architecture,
     get_nodes_cpu_model,
     get_nodes_with_label,
     get_pods,
@@ -2492,13 +2495,15 @@ def vm_for_test(request, namespace, unprivileged_client):
 
 @pytest.fixture(scope="class")
 def rhel_vm_with_instancetype_and_preference_for_cloning(namespace, unprivileged_client):
+    cluster_arch = get_nodes_cpu_architecture()
+    rhel9_preference = RHEL9_PREFERENCE_S390X if cluster_arch == S390X else RHEL9_PREFERENCE
     with VirtualMachineForCloning(
         name=RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
         image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
         namespace=namespace.name,
         client=unprivileged_client,
         vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
-        vm_preference=VirtualMachineClusterPreference(name=RHEL9_PREFERENCE),
+        vm_preference=VirtualMachineClusterPreference(name=rhel9_preference),
         os_flavor=OS_FLAVOR_RHEL,
     ) as vm:
         running_vm(vm=vm)

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -13,8 +13,8 @@ from tests.virt.cluster.vm_cloning.utils import (
     assert_target_vm_has_new_pvc_disks,
     check_if_files_present_after_cloning,
 )
-from utilities.constants import RHEL_WITH_INSTANCETYPE_AND_PREFERENCE, Images
-from utilities.infra import get_artifactory_config_map, get_artifactory_secret
+from utilities.constants import RHEL_WITH_INSTANCETYPE_AND_PREFERENCE, Images, S390X
+from utilities.infra import get_artifactory_config_map, get_artifactory_secret, get_nodes_cpu_architecture
 from utilities.storage import (
     add_dv_to_vm,
     check_disk_count_in_vm,
@@ -76,6 +76,12 @@ def dv_template_for_vm_cloning(
 
 @pytest.fixture()
 def vm_with_dv_for_cloning(request, namespace, dv_template_for_vm_cloning, storage_class_for_snapshot):
+    cluster_arch = get_nodes_cpu_architecture()
+    smm_enabled = True
+    efi_params = {"secureBoot": True}
+    if cluster_arch == S390X:
+        smm_enabled = False
+        efi_params = None
     with VirtualMachineForCloning(
         name=request.param["vm_name"],
         namespace=namespace.name,
@@ -83,8 +89,8 @@ def vm_with_dv_for_cloning(request, namespace, dv_template_for_vm_cloning, stora
         memory_requests=request.param["memory_requests"],
         cpu_cores=request.param.get("cpu_cores", 1),
         os_flavor=request.param["vm_name"].split("-")[0],
-        smm_enabled=True,
-        efi_params={"secureBoot": True},
+        smm_enabled=smm_enabled,
+        efi_params=efi_params,
     ) as vm:
         # Add second DV when needed
         if request.param.get("dv_extra"):

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -680,6 +680,7 @@ OUTDATED = "Outdated"
 
 RHEL_WITH_INSTANCETYPE_AND_PREFERENCE = "rhel-with-instancetype-and-preference"
 RHEL9_PREFERENCE = "rhel.9"
+RHEL9_PREFERENCE_S390X = "rhel.9.s390x"
 U1_SMALL = "u1.small"
 PROMETHEUS_K8S = "prometheus-k8s"
 INSTANCE_TYPE_STR = "instance_type"


### PR DESCRIPTION
##### Short description:
Adds support of test on s390x by changing to bios boots  for vm cloning tests
##### More details:

##### What this PR does / why we need it:
Allows `tests/virt/cluster/vm_cloning/test_vm_cloning.py` to be run on s390x arch
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
