### PR TITLE
 Fix fedora image on s390x

### DIFF
--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -84,7 +84,7 @@ virt-install \
   --graphics none \
   --network default \
   --noautoconsole \
-  --wait 30 \
+  --wait 60 \
   --import
 
 # Prepare VM image

--- a/containers/fedora/user-data
+++ b/containers/fedora/user-data
@@ -22,7 +22,8 @@ write_files:
         WantedBy=cloud-init.service
 runcmd:
   - systemctl daemon-reload
-  - dnf install -y tcpdump qemu-guest-agent iperf3 dmidecode nginx lldpad kernel-modules nmap dhcp-server dhcp-relay sshpass podman ethtool libibverbs dpdk stress-ng iotop fio
+  - dnf install -y tcpdump qemu-guest-agent iperf3 nginx lldpad kernel-modules nmap dhcp-server dhcp-relay sshpass podman ethtool libibverbs stress-ng iotop fio
+  - if [ $(uname -m) != "s390x" ]; then dnf install -y dmidecode dpdk; fi
   - dnf autoremove
   - dnf clean all
   - rpm -q kernel-core | sort | head -1 | xargs rpm -e
@@ -32,4 +33,5 @@ runcmd:
   - systemctl enable nginx
   - systemctl enable sshd
   - grubby --args="net.ifnames=0" --update-kernel=ALL
+  - if [ $(uname -m) == "s390x" ]; then zipl; fi
   - shutdown


### PR DESCRIPTION
##### Short description:

In addition to the grubby command to add kernel parameters, need run 'zipl' on s390x to update boot device.

When running s390x vm on x86, would timeout frequently (30 mins).  Updating to 60 mins.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the wait time for the virtual machine import process to improve reliability during setup.

- **New Features**
  - Introduced architecture-specific package installation and bootloader update steps to better support different machine types during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->