### PR TITLE
Add Quarentine support (cherrypick) cnv 4.18

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,7 @@ import traceback
 from typing import Any
 
 import pytest
+import pytest_html
 import shortuuid
 from _pytest.config import Config
 from _pytest.nodes import Collector, Node
@@ -28,7 +29,7 @@ from pytest_testconfig import config as py_config
 
 import utilities.infra
 from utilities.bitwarden import get_cnv_tests_secret_by_name
-from utilities.constants import TIMEOUT_5MIN, NamespacesNames
+from utilities.constants import QUARANTINED, TIMEOUT_5MIN, NamespacesNames
 from utilities.data_collector import (
     collect_default_cnv_must_gather_with_vm_gather,
     get_data_collector_dir,
@@ -86,7 +87,11 @@ NAMESPACE_COLLECTION = {
     "network": ["openshift-nmstate"],
     "virt": [],
 }
-MUST_GATHER_IGNORE_EXCEPTION_LIST = [MissingEnvironmentVariableError, StorageSanityError, ConflictError]
+MUST_GATHER_IGNORE_EXCEPTION_LIST = [
+    MissingEnvironmentVariableError,
+    StorageSanityError,
+    ConflictError,
+]
 INSPECT_BASE_COMMAND = "oc adm inspect"
 
 
@@ -110,7 +115,9 @@ def pytest_addoption(parser):
         help="Run OCP or CNV or EUS upgrade tests",
     )
     install_upgrade_group.addoption(
-        "--upgrade_custom", choices=["cnv", "ocp"], help="Run OCP or CNV upgrade tests with custom lanes"
+        "--upgrade_custom",
+        choices=["cnv", "ocp"],
+        help="Run OCP or CNV upgrade tests with custom lanes",
     )
 
     # CNV upgrade options
@@ -490,20 +497,34 @@ def pytest_report_teststatus(report, config):
     test_name = report.head_line
     when = report.when
     call_str = "call"
+
     if report.passed:
         if when == call_str:
             BASIC_LOGGER.info(f"\nTEST: {test_name} STATUS: \033[0;32mPASSED\033[0m")
+        return None
 
-    elif report.skipped:
-        BASIC_LOGGER.info(f"\nTEST: {test_name} STATUS: \033[1;33mSKIPPED\033[0m")
+    if report.skipped:
+        quarantined = getattr(report, QUARANTINED, False)
+        test_xfailed = getattr(report, "wasxfail", False)
 
-    elif report.failed:
+        skip_type = QUARANTINED.upper() if quarantined else "XFAILED" if test_xfailed else "SKIPPED"
+        BASIC_LOGGER.info(f"\nTEST: {test_name} STATUS: \033[1;33m{skip_type}\033[0m")
+
+        if quarantined:
+            return QUARANTINED, report.wasxfail, (QUARANTINED, {"yellow": True})
+        return None
+
+    if report.failed:
         if when != call_str:
             BASIC_LOGGER.info(f"\nTEST: {test_name} [{when}] STATUS: \033[0;31mERROR\033[0m")
+            return None
         else:
             BASIC_LOGGER.info(f"\nTEST: {test_name} STATUS: \033[0;31mFAILED\033[0m")
+            return None
+    return None
 
 
+@pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """
     incremental tests implementation
@@ -511,6 +532,18 @@ def pytest_runtest_makereport(item, call):
     if call.excinfo is not None and "incremental" in item.keywords:
         parent = item.parent
         parent._previousfailed = item
+
+    outcome = yield
+    report = outcome.get_result()
+
+    if report.when == "setup" and hasattr(report, "wasxfail") and QUARANTINED in report.wasxfail:
+        setattr(report, QUARANTINED, True)
+
+        extras = getattr(report, "extras", [])
+        if match := re.search(r"CNV-\d+", report.wasxfail):
+            extras = getattr(report, "extras", [])
+            extras.append(pytest_html.extras.url(f"https://issues.redhat.com/browse/{match.group(0)}"))
+            report.extras = extras
 
 
 def pytest_fixture_setup(fixturedef, request):
@@ -743,7 +776,8 @@ def pytest_exception_interact(node: Item | Collector, call: CallInfo[Any], repor
             try:
                 collection_dir = os.path.join(get_data_collector_dir(), "pytest_exception_interact")
                 collect_default_cnv_must_gather_with_vm_gather(
-                    since_time=calculate_must_gather_timer(test_start_time=test_start_time), target_dir=collection_dir
+                    since_time=calculate_must_gather_timer(test_start_time=test_start_time),
+                    target_dir=collection_dir,
                 )
                 if inspect_str:
                     target_dir = os.path.join(collection_dir, "inspect_collection")
@@ -760,3 +794,17 @@ def pytest_exception_interact(node: Item | Collector, call: CallInfo[Any], repor
                     )
             except Exception as current_exception:
                 LOGGER.warning(f"Failed to collect logs: {test_name}: {current_exception} {traceback.format_exc()}")
+
+
+@pytest.mark.optionalhook
+def pytest_html_results_table_header(cells):
+    cells.insert(2, f"<th>{QUARANTINED.title()} Reason</th>")
+
+
+@pytest.mark.optionalhook
+def pytest_html_results_table_row(report, cells):
+    if getattr(report, QUARANTINED, False) and "reason" in report.wasxfail:
+        cells.insert(2, f"<th>{report.wasxfail}</th>")
+
+    else:
+        cells.insert(2, "<th></th>")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ dependencies = [
   "xmltodict>=0.14.2",
   "openshift-python-wrapper~=4.18.0",
   "marshmallow~=3.26.1",
-  "python-simple-logger>=2.0.13",
   "pytest-html>=4.1.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ dependencies = [
   "xmltodict>=0.14.2",
   "openshift-python-wrapper~=4.18.0",
   "marshmallow~=3.26.1",
+  "python-simple-logger>=2.0.13",
+  "pytest-html>=4.1.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pytest.ini
+++ b/pytest.ini
@@ -62,6 +62,10 @@ markers =
     # cluster_health_check
     cluster_health_check: cluster health check tests
 
+# pytest-html configuration
+generate_report_on_test = True
+render_collapsed = all
+
 addopts =
     -p no:logging
     --basetemp=/tmp/pytest

--- a/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
+++ b/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
@@ -8,7 +8,12 @@ import pytest
 from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
 
-from utilities.constants import OS_FLAVOR_WINDOWS, TIMEOUT_5MIN, TIMEOUT_35MIN
+from utilities.constants import (
+    OS_FLAVOR_WINDOWS,
+    QUARANTINED,
+    TIMEOUT_5MIN,
+    TIMEOUT_35MIN,
+)
 from utilities.virt import get_windows_os_dict, vm_instance_from_template
 
 LOGGER = logging.getLogger(__name__)
@@ -76,7 +81,8 @@ def rdp_pod(workers_utility_pods, rdp_vm):
     indirect=True,
 )
 @pytest.mark.xfail(
-    reason="RDP test case must be fixed and implement a reliable client; tracked in CNV-43997", run=False
+    reason=f"{QUARANTINED}: RDP test case must be fixed and implement a reliable client; tracked in CNV-43997",
+    run=False,
 )
 def test_rdp_for_exposed_win_vm_as_node_port_svc(
     rdp_vm,

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -250,6 +250,7 @@ PODS_TO_COLLECT_INFO = [
 ]
 WORKERS_TYPE = "WORKERS_TYPE"
 FILTER_BY_OS_OPTION = f"filter-by-os=linux/{AMD_64}"
+QUARANTINED = "quarantined"
 
 # Kernel Device Driver
 # Compute: GPU Devices are bound to this Kernel Driver for GPU Passthrough.

--- a/uv.lock
+++ b/uv.lock
@@ -789,6 +789,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-dependency" },
+    { name = "pytest-html" },
     { name = "pytest-jira" },
     { name = "pytest-order" },
     { name = "pytest-progress" },
@@ -841,6 +842,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-dependency", specifier = ">=0.6.0" },
+    { name = "pytest-html", specifier = ">=4.1.1" },
     { name = "pytest-jira", specifier = "~=0.3.21" },
     { name = "pytest-order", specifier = ">=1.3.0" },
     { name = "pytest-progress", specifier = ">=1.3.0" },
@@ -1205,6 +1207,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7e/3b/317cc04e77d707d338540ca67b619df8f247f3f4c9f40e67bf5ea503ad94/pytest-dependency-0.6.0.tar.gz", hash = "sha256:934b0e6a39d95995062c193f7eaeed8a8ffa06ff1bcef4b62b0dc74a708bacc1", size = 19499, upload-time = "2023-12-31T20:38:54.991Z" }
 
 [[package]]
+name = "pytest-html"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pytest" },
+    { name = "pytest-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ab/4862dcb5a8a514bd87747e06b8d55483c0c9e987e1b66972336946e49b49/pytest_html-4.1.1.tar.gz", hash = "sha256:70a01e8ae5800f4a074b56a4cb1025c8f4f9b038bba5fe31e3c98eb996686f07", size = 150773, upload-time = "2023-11-07T15:44:28.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c7/c160021cbecd956cc1a6f79e5fe155f7868b2e5b848f1320dad0b3e3122f/pytest_html-4.1.1-py3-none-any.whl", hash = "sha256:c8152cea03bd4e9bee6d525573b67bbc6622967b72b9628dda0ea3e2a0b5dd71", size = 23491, upload-time = "2023-11-07T15:44:27.149Z" },
+]
+
+[[package]]
 name = "pytest-jira"
 version = "0.3.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1217,6 +1233,18 @@ dependencies = [
     { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/88/238f28f46dd237ee32f2c232b08a4bed8c8b430f3b900e34a43e0b344105/pytest-jira-0.3.22.zip", hash = "sha256:f1649cd1823a57c2663f60150beb964ae109d560572dc67e6ebb243e6352260b", size = 34684, upload-time = "2025-04-15T15:08:38.207Z" }
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952, upload-time = "2024-02-12T19:38:44.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428, upload-time = "2024-02-12T19:38:42.531Z" },
+]
 
 [[package]]
 name = "pytest-mock"


### PR DESCRIPTION
Added support for marking and handling quarantined tests, including custom status reporting and display in HTML test reports.
HTML test reports now include a "Quarantined Reason" column for better visibility of quarantined tests.

cherrypicks https://github.com/RedHatQE/openshift-virtualization-tests/pull/1128