### PR TITLE
Update vm_from_custom_data_import_cron to use flat vm

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -16,10 +16,14 @@ from tests.infrastructure.golden_images.constants import (
     CUSTOM_DATA_SOURCE_NAME,
     DEFAULT_FEDORA_REGISTRY_URL,
 )
-from tests.infrastructure.golden_images.update_boot_source.utils import (
-    template_labels,
+from utilities.constants import (
+    BIND_IMMEDIATE_ANNOTATION,
+    TIMEOUT_1MIN,
+    TIMEOUT_2MIN,
+    TIMEOUT_5MIN,
+    TIMEOUT_10MIN,
+    Images,
 )
-from utilities.constants import BIND_IMMEDIATE_ANNOTATION, TIMEOUT_1MIN, TIMEOUT_2MIN, TIMEOUT_5MIN, TIMEOUT_10MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import create_ns
 from utilities.ssp import (
@@ -32,7 +36,7 @@ from utilities.storage import (
     DATA_IMPORT_CRON_SUFFIX,
     data_volume_template_with_source_ref_dict,
 )
-from utilities.virt import DV_DISK, VirtualMachineForTests, VirtualMachineForTestsFromTemplate, running_vm
+from utilities.virt import DV_DISK, VirtualMachineForTests, running_vm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -157,12 +161,12 @@ def reconciled_custom_data_source(custom_data_source_scope_function):
 
 @pytest.fixture()
 def vm_from_custom_data_import_cron(custom_data_source_scope_function, namespace, unprivileged_client):
-    with VirtualMachineForTestsFromTemplate(
+    with VirtualMachineForTests(
         name=f"{custom_data_source_scope_function.name}-vm",
         namespace=namespace.name,
         client=unprivileged_client,
-        labels=template_labels(os="fedora40"),
-        data_source=custom_data_source_scope_function,
+        memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        data_volume_template=data_volume_template_with_source_ref_dict(data_source=custom_data_source_scope_function),
     ) as vm:
         running_vm(vm=vm)
         yield vm


### PR DESCRIPTION
##### Short description:
Update `test_custom_data_import_cron_via_hco` to use flat VM instead of template

##### More details:
This test verifies the functionality of using a custom DataImportCron, which can also be validated when working with a flat VM. To improve clarity and reduce dependencies, it's better to focus the test on the specific feature itself, rather than relying on the presence of a template with a specific label.

##### What this PR does / why we need it:
Remove use of templates in non-templates related test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test setup to use a different virtual machine class and revised parameters for improved consistency in test fixtures. No changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->