### PR TITLE
Fix TestMigrationMetrics test class

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -15,6 +15,7 @@ from ocp_resources.pod_metrics import PodMetrics
 from ocp_resources.resource import Resource, ResourceEditor, get_client
 from ocp_resources.storage_class import StorageClass
 from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 from pyhelper_utils.shell import run_command, run_ssh_commands
@@ -1192,6 +1193,7 @@ def vm_with_node_selector_vmim(vm_with_node_selector):
         namespace=vm_with_node_selector.namespace,
         vmi_name=vm_with_node_selector.vmi.name,
     ) as vmim:
+        vmim.wait_for_status(status=VirtualMachineInstance.Status.SCHEDULING)
         yield vmim
 
 

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -16,7 +16,7 @@ from tests.observability.metrics.utils import (
     timestamp_to_seconds,
     wait_for_non_empty_metrics_value,
 )
-from tests.observability.utils import validate_metrics_value
+from tests.observability.utils import validate_metrics_value, validate_metrics_value_greater_than_zero
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,10 +32,8 @@ class TestMigrationMetrics:
         initial_migration_metrics_values,
         vm_with_node_selector_vmim,
     ):
-        validate_metrics_value(
-            prometheus=prometheus,
-            metric_name=KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE,
-            expected_value=str(initial_migration_metrics_values[KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE] + 1),
+        validate_metrics_value_greater_than_zero(
+            prometheus=prometheus, metric_name=f"sum({KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE})"
         )
 
     @pytest.mark.polarion("CNV-8481")
@@ -47,10 +45,8 @@ class TestMigrationMetrics:
         initial_migration_metrics_values,
         vm_migration_metrics_vmim,
     ):
-        validate_metrics_value(
-            prometheus=prometheus,
-            metric_name=f"max_over_time({KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE}[5m])",
-            expected_value=f"{initial_migration_metrics_values[KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE] + 1}",
+        validate_metrics_value_greater_than_zero(
+            prometheus=prometheus, metric_name=f"sum({KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE})"
         )
 
 

--- a/tests/observability/utils.py
+++ b/tests/observability/utils.py
@@ -26,8 +26,8 @@ def validate_metrics_value(
         prometheus=prometheus,
         metrics_name=metric_name,
     )
+    sample = None
     try:
-        sample = None
         for sample in samples:
             if sample:
                 LOGGER.info(f"metric: {metric_name} value is: {sample}, the expected value is {expected_value}")
@@ -35,7 +35,30 @@ def validate_metrics_value(
                     LOGGER.info("Metrics value matches the expected value!")
                     return
     except TimeoutExpiredError:
-        LOGGER.info(f"Metrics value: {sample}, expected: {expected_value}")
+        LOGGER.error(f"Metrics value: {sample}, expected: {expected_value}")
+        raise
+
+
+def validate_metrics_value_greater_than_zero(
+    prometheus: Prometheus, metric_name: str, timeout: int = TIMEOUT_4MIN
+) -> None:
+    samples = TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=TIMEOUT_15SEC,
+        func=get_metrics_value,
+        prometheus=prometheus,
+        metrics_name=metric_name,
+    )
+    sample = None
+    try:
+        for sample in samples:
+            if sample:
+                LOGGER.info(f"metric: {metric_name} value is: {sample}")
+                if int(sample) > 0:
+                    LOGGER.info(f"Metric value: {sample} and greater than 0")
+                    return
+    except TimeoutExpiredError:
+        LOGGER.error(f"Metrics value: {sample}")
         raise
 
 


### PR DESCRIPTION
##### Short description:
The tests failed in the last observability lane run. The metric have more than one entry, when migrating several times it can use different virt-contoller so instead checking only the first entry I am summing the values and make sure it is greater than 0.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging in metric validation to provide clearer information when timeouts occur.
- **Tests**
	- Updated test methods to use a refined metric validation approach with enhanced logging and flexible checking options.
	- Adjusted test fixtures by removing explicit waits to improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->