### PR TITLE
[IUO] Add jira 63351 - rhel10-beta leftovers

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -27,7 +27,6 @@ from utilities.infra import (
     get_daemonset_by_name,
     get_deployment_by_name,
     get_pod_by_name_prefix,
-    is_jira_open,
 )
 from utilities.operator import (
     disable_default_sources_in_operatorhub,
@@ -236,10 +235,3 @@ def updated_resource(
         wait_for_reconcile_post_update=True,
     ):
         yield cr
-
-
-@pytest.fixture(scope="session")
-def rhel10_beta_resource():
-    return lambda resource_name, _open=is_jira_open(jira_id="CNV-63351"): (
-        resource_name.startswith("rhel10-beta") and _open
-    )

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -27,6 +27,7 @@ from utilities.infra import (
     get_daemonset_by_name,
     get_deployment_by_name,
     get_pod_by_name_prefix,
+    is_jira_open,
 )
 from utilities.operator import (
     disable_default_sources_in_operatorhub,
@@ -235,3 +236,8 @@ def updated_resource(
         wait_for_reconcile_post_update=True,
     ):
         yield cr
+
+
+@pytest.fixture(scope="session")
+def jira_63351_open():
+    return is_jira_open(jira_id="CNV-63351")

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -239,5 +239,7 @@ def updated_resource(
 
 
 @pytest.fixture(scope="session")
-def jira_63351_open():
-    return is_jira_open(jira_id="CNV-63351")
+def rhel10_beta_resource():
+    return lambda resource_name, _open=is_jira_open(jira_id="CNV-63351"): (
+        resource_name.startswith("rhel10-beta") and _open
+    )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -42,10 +42,11 @@ def deleted_hco_operator_pod(admin_client, hco_namespace, hyperconverged_resourc
 
 
 @pytest.fixture()
-def image_stream_names(admin_client, golden_images_namespace):
+def image_stream_names(admin_client, golden_images_namespace, jira_63351_open):
     return [
         image_stream.name
         for image_stream in ImageStream.get(dyn_client=admin_client, namespace=golden_images_namespace.name)
+        if not (image_stream.name == "rhel10-beta-guest" and jira_63351_open)
     ]
 
 

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -42,11 +42,11 @@ def deleted_hco_operator_pod(admin_client, hco_namespace, hyperconverged_resourc
 
 
 @pytest.fixture()
-def image_stream_names(admin_client, golden_images_namespace, jira_63351_open):
+def image_stream_names(admin_client, golden_images_namespace, rhel10_beta_resource):
     return [
         image_stream.name
         for image_stream in ImageStream.get(dyn_client=admin_client, namespace=golden_images_namespace.name)
-        if not (image_stream.name == "rhel10-beta-guest" and jira_63351_open)
+        if not rhel10_beta_resource(image_stream.name)
     ]
 
 

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -10,6 +10,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     get_random_minutes_hours_fields_from_data_import_schedule,
     get_templates_by_type_from_hco_status,
 )
+from tests.install_upgrade_operators.utils import is_rhel10_beta_resource_and_63351_bug_open
 from utilities.constants import (
     COMMON_TEMPLATES_KEY_NAME,
     HCO_OPERATOR,
@@ -42,11 +43,11 @@ def deleted_hco_operator_pod(admin_client, hco_namespace, hyperconverged_resourc
 
 
 @pytest.fixture()
-def image_stream_names(admin_client, golden_images_namespace, rhel10_beta_resource):
+def image_stream_names(admin_client, golden_images_namespace):
     return [
         image_stream.name
         for image_stream in ImageStream.get(dyn_client=admin_client, namespace=golden_images_namespace.name)
-        if not rhel10_beta_resource(image_stream.name)
+        if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=image_stream.name)
     ]
 
 

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -45,9 +45,12 @@ def get_templates_resources_names_dict(templates):
     return resource_dict
 
 
-def verify_resource_not_in_ns(resource_type, namespace, dyn_client):
+def verify_resource_not_in_ns(resource_type, namespace, dyn_client, jira_open=False):
     resources = resource_type.get(dyn_client=dyn_client, namespace=namespace)
-    resources_names = {resource.name for resource in resources}
+    # skipping rhel10-beta-guest image stream if jira is open
+    resources_names = {
+        resource.name for resource in resources if not (resource.name == "rhel10-beta-guest" and jira_open)
+    }
     assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
 
 
@@ -124,6 +127,7 @@ def updated_common_template_custom_ns(
     golden_images_namespace,
     hyperconverged_resource_scope_class,
     custom_golden_images_namespace,
+    jira_63351_open,
 ):
     with ResourceEditorValidateHCOReconcile(
         patches={
@@ -136,6 +140,8 @@ def updated_common_template_custom_ns(
     ):
         yield
     for data_source in get_data_sources_managed_by_data_import_cron(namespace=golden_images_namespace.name):
+        if data_source.name == "rhel10-beta" and jira_63351_open:
+            continue
         data_source.wait_for_condition(
             condition=DataSource.Condition.READY,
             status=DataSource.Condition.Status.TRUE,
@@ -198,6 +204,7 @@ class TestDefaultCommonTemplates:
         default_common_templates_related_resources,
         resource_type,
         ready_condition,
+        jira_63351_open,
     ):
         verify_resource_in_ns(
             expected_resource_names=default_common_templates_related_resources[resource_type.kind],
@@ -211,6 +218,7 @@ class TestDefaultCommonTemplates:
                 resource_type=resource_type,
                 namespace=golden_images_namespace.name,
                 dyn_client=admin_client,
+                jira_open=jira_63351_open,
             )
 
     @pytest.mark.polarion("CNV-11477")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -49,7 +49,11 @@ def get_templates_resources_names_dict(templates):
 def verify_resource_not_in_ns(resource_type, namespace, dyn_client):
     resources = resource_type.get(dyn_client=dyn_client, namespace=namespace)
     # skipping rhel10-beta-guest image stream if jira is open
-    resources_names = {resource.name for resource in resources if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=resource.name)}
+    resources_names = {
+        resource.name
+        for resource in resources
+        if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=resource.name)
+    }
     assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
 
 

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -11,11 +11,11 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
-    def test_no_new_hco_related_objects(self, hco_status_related_objects, jira_63351_open):
+    def test_no_new_hco_related_objects(self, hco_status_related_objects, rhel10_beta_resource):
         actual_related_objects = {
             related_object["name"]: related_object["kind"]
             for related_object in hco_status_related_objects
-            if not (related_object["name"] == "rhel10-beta-guest" and jira_63351_open)
+            if not rhel10_beta_resource(related_object["name"])
         }
         expected_related_objects = {
             object_name: object_kind

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -11,9 +11,11 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
-    def test_no_new_hco_related_objects(self, hco_status_related_objects):
+    def test_no_new_hco_related_objects(self, hco_status_related_objects, jira_63351_open):
         actual_related_objects = {
-            related_object["name"]: related_object["kind"] for related_object in hco_status_related_objects
+            related_object["name"]: related_object["kind"]
+            for related_object in hco_status_related_objects
+            if not (related_object["name"] == "rhel10-beta-guest" and jira_63351_open)
         }
         expected_related_objects = {
             object_name: object_kind

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -4,6 +4,7 @@ from deepdiff import DeepDiff
 from tests.install_upgrade_operators.strict_reconciliation.utils import (
     validate_related_objects,
 )
+from tests.install_upgrade_operators.utils import is_rhel10_beta_resource_and_63351_bug_open
 from utilities.constants import ALL_HCO_RELATED_OBJECTS
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
@@ -11,11 +12,11 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
-    def test_no_new_hco_related_objects(self, hco_status_related_objects, rhel10_beta_resource):
+    def test_no_new_hco_related_objects(self, hco_status_related_objects):
         actual_related_objects = {
             related_object["name"]: related_object["kind"]
             for related_object in hco_status_related_objects
-            if not rhel10_beta_resource(related_object["name"])
+            if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=related_object["name"])
         }
         expected_related_objects = {
             object_name: object_kind

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import logging
 import re
+from functools import cache
 
 from benedict import benedict
 from kubernetes.dynamic import DynamicClient
@@ -22,7 +23,7 @@ from utilities.constants import (
     TIMEOUT_30MIN,
     TIMEOUT_40MIN,
 )
-from utilities.infra import get_subscription
+from utilities.infra import get_subscription, is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
@@ -277,3 +278,8 @@ def get_resource_key_value(resource, key_name):
         resource.instance.to_dict()["spec"],
         keypath_separator=KEY_PATH_SEPARATOR,
     ).get(key_name)
+
+
+@cache
+def is_rhel10_beta_resource_and_63351_bug_open(resource_name):
+    return resource_name.startswith("rhel10-beta") and is_jira_open(jira_id="CNV-63351")


### PR DESCRIPTION
##### Short description:
After upgrade, rhel10-beta resources still exist.
Adding jira skip for this resources until resolved.


##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Should be verified on post-upgraded cluster
##### jira-ticket:
https://issues.redhat.com/browse/CNV-63465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved resource filtering in tests to exclude RHEL 10 beta resources from certain checks and readiness conditions.
- **Tests**
	- Updated test logic to selectively skip RHEL 10 beta resources, ensuring more accurate and reliable test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->