### PR TITLE
Fix TestVmiNetworkMetricsLinux tests flakiness

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -110,7 +110,7 @@ from utilities.infra import (
     unique_name,
 )
 from utilities.monitoring import get_metrics_value
-from utilities.network import get_ip_from_vm_or_virt_handler_pod, ping
+from utilities.network import assert_ping_successful, get_ip_from_vm_or_virt_handler_pod, ping
 from utilities.ssp import verify_ssp_pod_is_running
 from utilities.storage import (
     create_dv,
@@ -674,7 +674,11 @@ def memory_cached_sum_from_vm_console(vm_for_test):
 
 @pytest.fixture()
 def generated_network_traffic(vm_for_test):
-    run_vm_commands(vms=[vm_for_test], commands=[f"ping -c 20 {vm_for_test.privileged_vmi.interfaces[0]['ipAddress']}"])
+    assert_ping_successful(
+        src_vm=vm_for_test,
+        dst_ip=vm_for_test.privileged_vmi.interfaces[0]["ipAddress"],
+        count=20,
+    )
 
 
 @pytest.fixture()

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -956,9 +956,8 @@ def compare_network_traffic_bytes_and_metrics(
     )
     for entry in metric_result:
         entry_value = entry.get("value")[1]
-        if is_domifstat_compared_prometheus_values(
-            prometheus_metric_packets_value=int(entry_value),
-            domifstat_network_packets_received=int(packet_received[f"{entry.get('metric').get('type')}_bytes"]),
+        if math.isclose(
+            int(entry_value), int(packet_received[f"{entry.get('metric').get('type')}_bytes"]), rel_tol=0.02
         ):
             rx_tx_indicator = True
         else:
@@ -982,7 +981,7 @@ def validate_network_traffic_metrics_value(prometheus: Prometheus, vm: VirtualMa
         for sample in samples:
             if sample:
                 match_counter += 1
-                if match_counter > 5:
+                if match_counter >= 3:
                     return
             else:
                 match_counter = 0
@@ -990,12 +989,6 @@ def validate_network_traffic_metrics_value(prometheus: Prometheus, vm: VirtualMa
     except TimeoutExpiredError:
         LOGGER.error("Metric value and domistat value not correlate.")
         raise
-
-
-def is_domifstat_compared_prometheus_values(
-    prometheus_metric_packets_value: int, domifstat_network_packets_received: int
-) -> float:
-    return prometheus_metric_packets_value / domifstat_network_packets_received > 0.98
 
 
 def validate_vmi_network_receive_and_transmit_packets_total(
@@ -1014,6 +1007,7 @@ def validate_vmi_network_receive_and_transmit_packets_total(
     sample_value = None
     packets_kind = metric_dict["packets_kind"]
     metric_packets_value = None
+    values_comparing_history = {}
     try:
         match_counter = 0
         for sample in samples:
@@ -1022,16 +1016,24 @@ def validate_vmi_network_receive_and_transmit_packets_total(
                     prometheus=prometheus, metrics_name=f"{metric_dict['metric_name']}{{name='{vm.name}'}}"
                 )
                 sample_value = sample[packets_kind]
-                if is_domifstat_compared_prometheus_values(
-                    domifstat_network_packets_received=int(sample_value),
-                    prometheus_metric_packets_value=int(metric_packets_value),
-                ):
+                values_comparing_history[datetime.now()] = (
+                    f"Packet kind {packets_kind} value from vm: {sample_value}, "
+                    f"metric value for packet kind: {metric_packets_value}"
+                )
+                if math.isclose(int(sample_value), int(metric_packets_value), rel_tol=0.02):
                     match_counter += 1
-                    if match_counter > 5:
+                    LOGGER.info(
+                        f"Packet kind {packets_kind} and metric value for packet kind match for {match_counter} times"
+                    )
+                    if match_counter >= 3:
+                        LOGGER.info(f"Packet kind {packets_kind} and metric value for packet kind match!")
                         return
+                else:
+                    match_counter = 0
     except TimeoutExpiredError:
         LOGGER.error(
-            f"Expected metric packets value for {packets_kind}: {sample_value}, actual: {metric_packets_value}"
+            f"Expected metric packets value for {packets_kind}: {sample_value}, actual: {metric_packets_value} \n "
+            f"History : {values_comparing_history}"
         )
         raise
 


### PR DESCRIPTION
##### Short description:
Fixing the tests that failed under TestVmiNetworkMetricsLinux.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-63491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified network metric comparison logic using a standardized 2% tolerance for value matching.
  - Simplified and removed custom comparison functions, leveraging built-in methods for improved clarity.
  - Reduced the number of consecutive successful matches required for validation, making tests more responsive.
  - Enhanced logging for better visibility into metric comparison attempts and results.

- **Tests**
  - Improved network connectivity checks in test fixtures for more explicit and reliable assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->