### PR TITLE
feat: mark some s390x compute tests as working

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ markers =
     # Cluster markers
     ## Architecture support
     arm64: Tests that can run on ARM-based cluster
+    s390x: Tests that can run on s390x-based cluster
 
     ## Hardware requirements
     special_infra: Tests that requires special infrastructure. e.g. sriov, gpu etc.

--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -43,6 +43,7 @@ pytestmark = [
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.usefixtures(
     "application_aware_resource_quota",
     "first_pod_for_aaq_test",

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -183,6 +183,7 @@ class TestCommonTemplatesCentos:
             vm=golden_image_vm_object_from_template_multi_centos_multi_storage_scope_class
         ), "Guest agent stopped responding"
 
+    @pytest.mark.s390x
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])
     @pytest.mark.polarion("CNV-5351")
     def test_vm_deletion(self, golden_image_vm_object_from_template_multi_centos_multi_storage_scope_class):

--- a/tests/virt/cluster/common_templates/custom_namespace/test_custom_namespace.py
+++ b/tests/virt/cluster/common_templates/custom_namespace/test_custom_namespace.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.post_upgrade
 TESTS_CLASS_NAME = "TestCustomNamespace"
 
 
+@pytest.mark.s390x
 @pytest.mark.usefixtures("base_templates", "opt_in_custom_template_namespace")
 class TestCustomNamespace:
     @pytest.mark.polarion("CNV-8144")

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -260,6 +260,7 @@ class TestCommonTemplatesFedora:
             vm=golden_image_vm_object_from_template_multi_fedora_os_multi_storage_scope_class
         ), "Guest agent stopped responding"
 
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.ibm_bare_metal
     @pytest.mark.ocp_interop

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -202,6 +202,7 @@ def test_base_templates_annotations(base_templates, common_templates_expected_li
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("os_type", "osinfo_filename", "memory_test"),
     [
@@ -278,7 +279,7 @@ def test_validate_rhel_min_max_memory(
         osinfo_filename=osinfo_filename,
     )
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("osinfo_filename", "os_template", "memory_test"),
     [
@@ -353,6 +354,7 @@ def test_validate_windows_min_max_memory(
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-5002")
 def test_common_templates_golden_images_params(base_templates):
     unmatched_templates = {}
@@ -386,6 +388,7 @@ def test_common_templates_golden_images_params(base_templates):
     assert not unmatched_templates, f"The following templates fail on golden images verification: {unmatched_templates}"
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-5599")
 def test_provide_support_annotations(base_templates, templates_provider_support_dict):
     """Verify provider, provider-support-level and provider-url annotations"""
@@ -403,6 +406,7 @@ def test_provide_support_annotations(base_templates, templates_provider_support_
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-6874")
 def test_vm_annotations_in_template(base_templates):
     """Verify template VM object has os, workload and flavor annotations which match corresponding template labels"""
@@ -517,6 +521,7 @@ def test_hyperv_features_exist_in_windows_templates(os_base_templates):
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "annotation_list, os_base_templates",
     [

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -279,6 +279,7 @@ def test_validate_rhel_min_max_memory(
         osinfo_filename=osinfo_filename,
     )
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     ("osinfo_filename", "os_template", "memory_test"),

--- a/tests/virt/cluster/common_templates/general/test_diskless_vm.py
+++ b/tests/virt/cluster/common_templates/general/test_diskless_vm.py
@@ -31,7 +31,7 @@ SMALL_VM_IMAGE = f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}"
                 "diskless_vm": True,
                 "start_vm": False,
             },
-            marks=(pytest.mark.polarion("CNV-4696"), pytest.mark.gating()),
+            marks=(pytest.mark.polarion("CNV-4696"), pytest.mark.gating(), pytest.mark.s390x),
         ),
         pytest.param(
             {

--- a/tests/virt/cluster/common_templates/general/test_template_validator.py
+++ b/tests/virt/cluster/common_templates/general/test_template_validator.py
@@ -20,6 +20,7 @@ LOGGER = logging.getLogger(__name__)
 FAILED_VM_IMAGE = f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}"
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "golden_image_data_volume_multi_storage_scope_function,"
     "golden_image_vm_object_from_template_multi_storage_scope_function",

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -279,6 +279,7 @@ class TestCommonTemplatesRhel:
         assert_vm_xml_efi(vm=vm, secure_boot_enabled=False)
         assert_linux_efi(vm=vm)
 
+    @pytest.mark.s390x
     @pytest.mark.arm64
     @pytest.mark.sno
     @pytest.mark.smoke

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -149,6 +149,7 @@ class TestRHELTabletDevice:
         )
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "golden_image_data_volume_multi_storage_scope_class",
     [

--- a/tests/virt/cluster/general/test_smbios.py
+++ b/tests/virt/cluster/general/test_smbios.py
@@ -36,6 +36,7 @@ def smbios_defaults(cnv_current_version):
     return smbios_defaults
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-4346")
 def test_cm_smbios_defaults(smbios_from_kubevirt_config, smbios_defaults):
     check_smbios_defaults(smbios_defaults=smbios_defaults, cm_values=smbios_from_kubevirt_config)

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -81,6 +81,7 @@ def added_vm_evictionstrategy(request, vm_from_template_scope_class):
     restart_vm_wait_for_running_vm(vm=vm_from_template_scope_class, wait_for_interfaces=True)
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-10085")
 @pytest.mark.post_upgrade
 def test_evictionstrategy_not_in_templates(base_templates):
@@ -94,6 +95,7 @@ def test_evictionstrategy_not_in_templates(base_templates):
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.post_upgrade
 @pytest.mark.polarion("CNV-10086")

--- a/tests/virt/cluster/operator_tests/test_critical_pods.py
+++ b/tests/virt/cluster/operator_tests/test_critical_pods.py
@@ -30,6 +30,7 @@ def virt_pods(request, admin_client, hco_namespace):
     yield pods_list
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "virt_pods",
     [

--- a/tests/virt/cluster/operator_tests/test_ssp_custom_resources.py
+++ b/tests/virt/cluster/operator_tests/test_ssp_custom_resources.py
@@ -31,6 +31,7 @@ def pods_list_with_given_prefix(request, admin_client, hco_namespace):
     return pods_list_by_prefix
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-3737")
 def test_verify_ssp_cr_conditions(ssp_resource_scope_function):
     LOGGER.info("Check SSP CR conditions.")
@@ -44,6 +45,7 @@ def test_verify_ssp_cr_conditions(ssp_resource_scope_function):
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "pods_list_with_given_prefix",
     [
@@ -94,6 +96,7 @@ def virt_template_validator_without_podantiaffinity(
     ]
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-8660")
 def test_podantiaffinity(
     virt_template_validator_pods,

--- a/tests/virt/cluster/strict_reconcile/test_strict_reconcile.py
+++ b/tests/virt/cluster/strict_reconcile/test_strict_reconcile.py
@@ -175,6 +175,7 @@ def verify_reconciled_secret_resource(resource, resource_dict):
         )
 
 
+@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.parametrize(
     ("resource_type", "managed_resource_name"),

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
@@ -8,6 +8,7 @@ from tests.virt.cluster.vm_cloning.utils import wait_cloning_job_source_not_exis
 LOGGER = logging.getLogger(__name__)
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "cloning_job_bad_params",
     [

--- a/tests/virt/node/efi_secureboot/test_vm_with_efi_secureboot.py
+++ b/tests/virt/node/efi_secureboot/test_vm_with_efi_secureboot.py
@@ -14,6 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-4465")
+@pytest.mark.s390x
 def test_efi_secureboot_with_smm_disabled(namespace, unprivileged_client):
     """Test that EFI secureBoot VM with SMM disabled, does not get created"""
     with pytest.raises(UnprocessibleEntityError):

--- a/tests/virt/node/general/test_custom_selinux_policy.py
+++ b/tests/virt/node/general/test_custom_selinux_policy.py
@@ -3,6 +3,7 @@ import pytest
 from utilities.infra import ExecCommandOnPod
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-9918")
 def test_customselinuxpolicy(workers_utility_pods, schedulable_nodes):
     nodes = []

--- a/tests/virt/node/general/test_linux_label.py
+++ b/tests/virt/node/general/test_linux_label.py
@@ -14,6 +14,7 @@ def assert_linux_label_was_added_in_nodes(nodes):
     assert not no_os_labels_nodes, f"Following Nodes {no_os_labels_nodes} does not have Linux label."
 
 
+@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-5758")
 def test_linux_label_was_added(schedulable_nodes):

--- a/tests/virt/node/general/test_static_ssh_key_injection.py
+++ b/tests/virt/node/general/test_static_ssh_key_injection.py
@@ -77,6 +77,7 @@ class TestVMWithStaticKeyInjection:
     def test_static_ssh_key_injection(self, vm_with_ssh_secret):
         running_vm(vm=vm_with_ssh_secret)
 
+    @pytest.mark.s390x
     @pytest.mark.polarion("CNV-6061")
     def test_ssh_access_is_successful_with_updated_secret(self, ssh_secret, vm_with_ssh_secret):
         with ResourceEditor(

--- a/tests/virt/node/log_verbosity/test_log_verbosity.py
+++ b/tests/virt/node/log_verbosity/test_log_verbosity.py
@@ -45,6 +45,7 @@ def virt_component_pods_in_first_node(worker_node1, virt_component_pods):
     return [pod for pod in virt_component_pods if pod.node.name == worker_node1.name]
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "updated_log_verbosity_config",
     [
@@ -61,6 +62,7 @@ def test_component_log_verbosity(updated_log_verbosity_config, virt_component_po
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "updated_log_verbosity_config",
     [

--- a/tests/virt/node/node_labeller/cpu_features/test_node_feature_discovery.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_node_feature_discovery.py
@@ -74,6 +74,7 @@ def node_label_checker(node_label_dict, label_list, dict_key):
 
 
 @pytest.mark.polarion("CNV-2797")
+@pytest.mark.s390x
 def test_obsolete_cpus_in_node_labels(nodes_labels_dict, kubevirt_config):
     """
     Test obsolete CPUs. Obsolete CPUs don't appear in node labels.
@@ -111,6 +112,7 @@ def test_hardware_required_node_labels(nodes_labels_dict):
     assert any(test_dict.values()), f"KVM info not found in labels\n{test_dict}"
 
 
+@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-6088")
 def test_hardware_non_required_node_labels(nodes_labels_dict):
@@ -130,6 +132,7 @@ def test_hardware_non_required_node_labels(nodes_labels_dict):
     assert not any(test_dict.values()), f"Some nodes have non required KVM labels: {test_dict}"
 
 
+@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-6103")
 def test_updated_obsolete_cpus_in_node_labels(updated_kubevirt_cpus, nodes_labels_dict, kubevirt_config):

--- a/tests/virt/node/node_labeller/test_node_labeller_annotation.py
+++ b/tests/virt/node/node_labeller/test_node_labeller_annotation.py
@@ -48,6 +48,7 @@ def labelled_worker_node1(worker1_supported_cpu_models_labels, worker_node1):
         yield {worker_node1: updated_label}
 
 
+@pytest.mark.s390x
 class TestNodeLabellerSkipAnnotation:
     @pytest.mark.polarion("CNV-7744")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::test_node_labeller_added_skip_node_annotation")


### PR DESCRIPTION
##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
NONE
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added support for running tests on the s390x architecture by marking relevant test classes and functions.
  - Introduced a new marker to identify tests compatible with s390x-based clusters.
  - Extended architecture coverage across various test suites, including cluster, node, operator, and template-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->