### PR TITLE
network tests: add hardware markers wherever there is special_infra

### DIFF
--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -28,12 +28,7 @@ from utilities.network import (
 )
 from utilities.virt import migrate_vm_and_verify
 
-pytestmark = [
-    pytest.mark.special_infra,
-    pytest.mark.usefixtures(
-        "label_schedulable_nodes",
-    ),
-]
+pytestmark = pytest.mark.usefixtures("label_schedulable_nodes")
 
 HOT_PLUG_STR = "hot-plug"
 TEST_BASIC_HOT_PLUGGED_INTERFACE_CONNECTIVITY = "test_basic_connectivity_of_hot_plugged_interface"
@@ -574,6 +569,8 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
         assert mac_addresses_after_restart == mac_addresses_before_restart
 
     @pytest.mark.ipv4
+    @pytest.mark.special_infra
+    @pytest.mark.jumbo_frame
     @pytest.mark.polarion("CNV-10135")
     def test_connectivity_of_hot_plugged_jumbo_interface(
         self,


### PR DESCRIPTION
##### What this PR does / why we need it:
We strive to remove special_infra marker for all tests, this PR adds the use of available network hardware markers wherever there is a special_infra marker and guarantees an interchangeability. New markers are not needed in this case, we already have sriov and jumbo_frame.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
After this PR we will have an interchangeability of `special_infra` marker and network hardware markers:
```
$ pytest --collect-only -m special_infra tests/network/
.....
collected 201 items / 150 deselected / 51 selected                                                                                                                          

<Dir openshift-virtualization-tests>
  <Package tests>
    <Package network>
      <Package checkup_framework>
        <Module test_checkup_framework.py>
          <Function test_disconnected_network_sriov_job_failure>
          <Class TestCheckupLatencySriovNetwork>
            <Function test_basic_configmap_sriov_network>
            <Function test_basic_configmap_sriov_network_on_same_node>
            <Function test_two_configmaps_and_jobs_with_success_sriov_network>
            <Function test_concurrent_checkup_jobs_sriov_network>
            <Function test_job_failure_sriov_network_nonexistent_configmap_env>
            <Function test_job_failure_sriov_network>
            <Function test_configmap_error_job_failure_sriov_network_nonexistent_nad>
            <Function test_configmap_error_job_failure_sriov_network_nonexistent_namespace>
            <Function test_configmap_error_job_failure_sriov_network_one_second_timeout>
            <Function test_configmap_error_job_failure_sriov_network_zero_milliseconds>
            <Function test_configmap_error_job_failure_sriov_network_nonexistent_node>
      <Package jumbo_frame>
        <Module test_bond.py>
          <Class TestBondJumboFrame>
            <Function test_connectivity_over_linux_bond_large_mtu[#linux-bridge#]>
            <Function test_negative_mtu_linux_bond[#linux-bridge#]>
            <Function test_connectivity_over_linux_bond_large_mtu[#ovs-bridge#]>
            <Function test_negative_mtu_linux_bond[#ovs-bridge#]>
        <Module test_bridge.py>
          <Class TestJumboFrameBridge>
            <Function test_connectivity_over_linux_bridge_large_mtu[#linux-bridge#]>
            <Function test_negative_mtu_linux_bridge[#linux-bridge#]>
            <Function test_connectivity_over_linux_bridge_large_mtu[#ovs-bridge#]>
            <Function test_negative_mtu_linux_bridge[#ovs-bridge#]>
        <Module test_pod_network_ovn.py>
          <Class TestJumboPodNetworkOnly>
            <Function test_jumbo_traffic_over_pod_network_separate_nodes>
            <Function test_jumbo_traffic_over_pod_network_same_node>
            <Function test_jumbo_negative_traffic_over_pod_network_with_oversized_traffic>
          <Class TestJumboPodNetworkAndSecondary>
            <Function test_jumbo_traffic_over_pod_network_while_secondary_traffic_flows>
      <Package l2_bridge>
        <Module test_bridge_nic_hot_plug.py>
          <Class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface>
            <Function test_vmi_spec_updated_with_hot_plugged_interface>
            <Function test_multiple_interfaces_hot_plugged>
            <Function test_basic_connectivity_of_hot_plugged_interface>
            <Function test_basic_connectivity_of_hot_plugged_interface_after_second_migration>
            <Function test_mac_of_hot_plugged_interface_from_kubemacpool>
            <Function test_primary_interface_not_modified_after_hot_plug>
            <Function test_connectivity_of_hot_plugged_jumbo_interface>
            <Function test_hot_plug_flat_overlay_network>
            <Function test_mac_of_hot_plugged_interface_returned_to_kubemacpool_after_vm_delete>
            <Function test_connectivity_of_hot_plugged_sriov_interface>
          <Class TestHotPlugInterfaceToVmWithSecondaryInterface>
            <Function test_basic_connectivity_vm_with_secondary_and_hot_plugged_interfaces[eth2]>
            <Function test_basic_connectivity_vm_with_secondary_and_hot_plugged_interfaces[eth1]>
            <Function test_hot_unplugged_interface_removed_from_vmi_spec>
            <Function test_basic_connectivity_vm_with_secondary_after_hot_unplug>
            <Function test_mac_of_hot_plugged_interface_returned_to_kubemacpool_after_hot_unplug>
            <Function test_hot_unplug_secondary_interface_from_setup>
      <Package sriov>
        <Module test_sriov.py>
          <Class TestPingConnectivity>
            <Function test_sriov_basic_connectivity>
            <Function test_sriov_custom_mtu_connectivity>
            <Function test_sriov_basic_connectivity_vlan>
            <Function test_sriov_no_connectivity_no_vlan_to_vlan>
            <Function test_sriov_interfaces_post_reboot[1]>
            <Function test_sriov_interfaces_post_reboot[2]>
            <Function test_sriov_interfaces_post_reboot[3]>
            <Function test_sriov_interfaces_post_reboot[4]>
            <Function test_sriov_interfaces_post_reboot[5]>
          <Class TestSriovLiveMigration>
            <Function test_sriov_migration>
          <Class TestSriovDpdk>
            <Function test_sriov_dpdk_testpmd>
.....
```
and 
```
$ pytest --collect-only -m 'jumbo_frame or sriov' tests/network/
.....
collected 201 items / 150 deselected / 51 selected                                                                                                                          

<Dir openshift-virtualization-tests>
  <Package tests>
    <Package network>
      <Package checkup_framework>
        <Module test_checkup_framework.py>
          <Function test_disconnected_network_sriov_job_failure>
          <Class TestCheckupLatencySriovNetwork>
            <Function test_basic_configmap_sriov_network>
            <Function test_basic_configmap_sriov_network_on_same_node>
            <Function test_two_configmaps_and_jobs_with_success_sriov_network>
            <Function test_concurrent_checkup_jobs_sriov_network>
            <Function test_job_failure_sriov_network_nonexistent_configmap_env>
            <Function test_job_failure_sriov_network>
            <Function test_configmap_error_job_failure_sriov_network_nonexistent_nad>
            <Function test_configmap_error_job_failure_sriov_network_nonexistent_namespace>
            <Function test_configmap_error_job_failure_sriov_network_one_second_timeout>
            <Function test_configmap_error_job_failure_sriov_network_zero_milliseconds>
            <Function test_configmap_error_job_failure_sriov_network_nonexistent_node>
      <Package jumbo_frame>
        <Module test_bond.py>
          <Class TestBondJumboFrame>
            <Function test_connectivity_over_linux_bond_large_mtu[#linux-bridge#]>
            <Function test_negative_mtu_linux_bond[#linux-bridge#]>
            <Function test_connectivity_over_linux_bond_large_mtu[#ovs-bridge#]>
            <Function test_negative_mtu_linux_bond[#ovs-bridge#]>
        <Module test_bridge.py>
          <Class TestJumboFrameBridge>
            <Function test_connectivity_over_linux_bridge_large_mtu[#linux-bridge#]>
            <Function test_negative_mtu_linux_bridge[#linux-bridge#]>
            <Function test_connectivity_over_linux_bridge_large_mtu[#ovs-bridge#]>
            <Function test_negative_mtu_linux_bridge[#ovs-bridge#]>
        <Module test_pod_network_ovn.py>
          <Class TestJumboPodNetworkOnly>
            <Function test_jumbo_traffic_over_pod_network_separate_nodes>
            <Function test_jumbo_traffic_over_pod_network_same_node>
            <Function test_jumbo_negative_traffic_over_pod_network_with_oversized_traffic>
          <Class TestJumboPodNetworkAndSecondary>
            <Function test_jumbo_traffic_over_pod_network_while_secondary_traffic_flows>
      <Package l2_bridge>
        <Module test_bridge_nic_hot_plug.py>
          <Class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface>
            <Function test_vmi_spec_updated_with_hot_plugged_interface>
            <Function test_multiple_interfaces_hot_plugged>
            <Function test_basic_connectivity_of_hot_plugged_interface>
            <Function test_basic_connectivity_of_hot_plugged_interface_after_second_migration>
            <Function test_mac_of_hot_plugged_interface_from_kubemacpool>
            <Function test_primary_interface_not_modified_after_hot_plug>
            <Function test_connectivity_of_hot_plugged_jumbo_interface>
            <Function test_hot_plug_flat_overlay_network>
            <Function test_mac_of_hot_plugged_interface_returned_to_kubemacpool_after_vm_delete>
            <Function test_connectivity_of_hot_plugged_sriov_interface>
          <Class TestHotPlugInterfaceToVmWithSecondaryInterface>
            <Function test_basic_connectivity_vm_with_secondary_and_hot_plugged_interfaces[eth2]>
            <Function test_basic_connectivity_vm_with_secondary_and_hot_plugged_interfaces[eth1]>
            <Function test_hot_unplugged_interface_removed_from_vmi_spec>
            <Function test_basic_connectivity_vm_with_secondary_after_hot_unplug>
            <Function test_mac_of_hot_plugged_interface_returned_to_kubemacpool_after_hot_unplug>
            <Function test_hot_unplug_secondary_interface_from_setup>
      <Package sriov>
        <Module test_sriov.py>
          <Class TestPingConnectivity>
            <Function test_sriov_basic_connectivity>
            <Function test_sriov_custom_mtu_connectivity>
            <Function test_sriov_basic_connectivity_vlan>
            <Function test_sriov_no_connectivity_no_vlan_to_vlan>
            <Function test_sriov_interfaces_post_reboot[1]>
            <Function test_sriov_interfaces_post_reboot[2]>
            <Function test_sriov_interfaces_post_reboot[3]>
            <Function test_sriov_interfaces_post_reboot[4]>
            <Function test_sriov_interfaces_post_reboot[5]>
          <Class TestSriovLiveMigration>
            <Function test_sriov_migration>
          <Class TestSriovDpdk>
            <Function test_sriov_dpdk_testpmd>
.....
```
 
##### jira-ticket: https://issues.redhat.com/browse/CNV-62769


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated test markers to include additional scenarios for jumbo frame support and special infrastructure conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->