### PR TITLE
Remove use of templates on vm_from_golden_image_multi_storage

### DIFF
--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -1,57 +1,17 @@
 import pytest
-from ocp_resources.resource import ResourceEditor
-from ocp_resources.template import Template
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from pytest_testconfig import config as py_config
 
 from tests.infrastructure.golden_images.constants import PVC_NOT_FOUND_ERROR
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS, FEDORA_LATEST_OS
-from utilities.constants import HOSTPATH_CSI_BASIC, Images
+from utilities.constants import HOSTPATH_CSI_BASIC, U1_SMALL, Images
 from utilities.storage import data_volume_template_with_source_ref_dict
-from utilities.virt import VirtualMachineForTests, VirtualMachineForTestsFromTemplate, running_vm
+from utilities.virt import VirtualMachineForTests, running_vm
 
 pytestmark = pytest.mark.post_upgrade
 
 
 NON_EXISTING_DV_NAME = "non-existing-dv"
-
-
-class DataVolumeTemplatesVirtualMachine(VirtualMachineForTestsFromTemplate):
-    def __init__(
-        self,
-        name,
-        namespace,
-        client,
-        labels,
-        data_source,
-        updated_storage_class_params=None,
-        updated_source_pvc_name=None,
-        use_full_storage_api=False,
-    ):
-        super().__init__(
-            name=name,
-            namespace=namespace,
-            client=client,
-            labels=labels,
-            data_source=data_source,
-            use_full_storage_api=use_full_storage_api,
-        )
-        self.data_source = data_source
-        self.updated_storage_class_params = updated_storage_class_params
-        self.updated_source_pvc_name = updated_source_pvc_name
-
-    def to_dict(self):
-        super().to_dict()
-        vm_datavolumetemplates_storage_spec = self.res["spec"]["dataVolumeTemplates"][0]["spec"]["storage"]
-        if self.updated_storage_class_params:
-            # Update SC params
-            vm_datavolumetemplates_storage_spec["storageClassName"] = self.updated_storage_class_params["storage_class"]
-            vm_datavolumetemplates_storage_spec["volumeMode"] = self.updated_storage_class_params["volume_mode"]
-            vm_datavolumetemplates_storage_spec["accessModes"] = [self.updated_storage_class_params["access_mode"]]
-
-        if self.updated_source_pvc_name:
-            ResourceEditor(
-                patches={self.data_source: {"spec": {"source": {"pvc": {"name": self.updated_source_pvc_name}}}}}
-            ).update()
 
 
 @pytest.fixture()
@@ -61,13 +21,14 @@ def vm_from_golden_image_multi_storage(
     namespace,
     golden_image_data_source_multi_storage_scope_function,
 ):
-    with DataVolumeTemplatesVirtualMachine(
+    with VirtualMachineForTests(
         name="vm-from-golden-image",
         namespace=namespace.name,
         client=unprivileged_client,
-        labels=Template.generate_template_labels(**FEDORA_LATEST_LABELS),
-        data_source=golden_image_data_source_multi_storage_scope_function,
-        use_full_storage_api=request.param.get("use_full_storage_api"),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=golden_image_data_source_multi_storage_scope_function,
+        ),
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -96,16 +57,13 @@ def vm_from_golden_image(
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_multi_storage_scope_function, vm_from_golden_image_multi_storage",
+    "golden_image_data_volume_multi_storage_scope_function",
     [
         pytest.param(
             {
                 "dv_name": FEDORA_LATEST_OS,
                 "image": FEDORA_LATEST["image_path"],
                 "dv_size": FEDORA_LATEST["dv_size"],
-            },
-            {
-                "use_full_storage_api": True,
             },
             marks=pytest.mark.polarion("CNV-5582"),
         ),


### PR DESCRIPTION
##### Short description:
Remove the use of VirtualMachineForTestsFromTemplate when testing DataSources with different storage classes on VM

##### More details:
When running `test_vm_from_golden_image_cluster_default_storage_class` the VM creation fixture uses a template to create the VM. there is no need for a template to be used since we are testing the `DataSources` and `DataVolumeTemplates` section of the creation on different storage classes

##### What this PR does / why we need it:
Remove use of `VirtualMachineForTestsFromTemplate` if not needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Simplified and streamlined test setup for data volume templates by removing custom subclasses and using standard test classes and helper functions. Test logic and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->