### PR TITLE
Change RHEL Image name into test_import_http.py

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -666,7 +666,7 @@ def test_vm_from_dv_on_different_node(
     data_volume_multi_storage_scope_function.wait_for_dv_success(timeout=TIMEOUT_12MIN)
     with create_vm_from_dv(
         dv=data_volume_multi_storage_scope_function,
-        vm_name=Images.Rhel.RHEL8_2_IMG,
+        vm_name="rhel_vm",
         os_flavor=OS_FLAVOR_RHEL,
         node_selector=get_node_selector_dict(node_selector=nodes[0].name),
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,


### PR DESCRIPTION
##### Short description:
Update RHEL image name into test `tests/storage/test_import_http.py`
##### More details:
Suggestion coming from CherryPick PR, see comment: https://github.com/RedHatQE/openshift-virtualization-tests/pull/1201#pullrequestreview-2930085266
##### What this PR does / why we need it:
Change image name for `RHEL8_2_IMG` to other name
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

