### PR TITLE
[Chaos][GPFS] Add GPFS mark for skipping ODF cases in GPFS clusters

### DIFF
--- a/tests/chaos/standard/test_standard.py
+++ b/tests/chaos/standard/test_standard.py
@@ -15,11 +15,11 @@ from utilities.virt import VirtualMachineForTests, running_vm
 
 pytestmark = [
     pytest.mark.chaos,
-    pytest.mark.gpfs,
     pytest.mark.usefixtures("chaos_namespace", "cluster_monitoring_process", "skip_on_aws_cluster"),
 ]
 
 
+@pytest.mark.gpfs
 @pytest.mark.parametrize(
     "chaos_vms_list_rhel9, pod_deleting_process",
     [
@@ -53,6 +53,7 @@ def test_pod_delete_openshift_apiserver(
         running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 
 
+@pytest.mark.gpfs
 @pytest.mark.parametrize(
     "rebooted_control_plane_node",
     [
@@ -115,6 +116,7 @@ def test_odf_storage_outage(
     chaos_vm_rhel9_with_dv.wait_for_specific_status(status=VirtualMachine.Status.RUNNING, timeout=TIMEOUT_2MIN)
 
 
+@pytest.mark.gpfs
 @pytest.mark.parametrize(
     "chaos_worker_background_process",
     [
@@ -150,6 +152,7 @@ def test_host_io_stress(
     assert chaos_worker_background_process.exitcode == 0, "Background process execution failed"
 
 
+@pytest.mark.gpfs
 @pytest.mark.usefixtures("deleted_pod_by_name_prefix")
 @pytest.mark.parametrize("chaos_vms_instancetype_list", [pytest.param({"number_of_vms": 3})], indirect=True)
 class TestVMInstanceTypeOperationsPodDelete:


### PR DESCRIPTION
So all chaos cases suitable for running with GPFS can be selected by `-m gpfs`

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test marker application to ensure specific tests are correctly identified for targeted test runs. No changes to test behavior or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->