### PR TITLE
Add io2 storage class to default storage class of ARM64 config

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -44,11 +44,20 @@ storage_class_matrix = [
             "default": True,
         }
     },
+    {
+        StorageClassNames.IO2_CSI: {
+            "volume_mode": DataVolume.VolumeMode.BLOCK,
+            "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": True,
+        }
+    },
     {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES},
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.TRIDENT_CSI_NFS
-storage_class_for_storage_migration_b = StorageClassNames.TRIDENT_CSI_NFS
+storage_class_for_storage_migration_a = StorageClassNames.IO2_CSI
+storage_class_for_storage_migration_b = StorageClassNames.IO2_CSI
 
 rhel_os_matrix = [
     {

--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -36,7 +36,7 @@ storage_class_matrix = [
             "access_mode": DataVolume.AccessMode.RWX,
             "snapshot": True,
             "online_resize": True,
-            "wffc": False,
+            "wffc": True,
         }
     },
 ]


### PR DESCRIPTION
io2 storage class as one of the storage class with ARM64 AWS cluster. This PR adds the io2 storage class to default set of storage class in the configuration file.
Volume binding mode for this io2 storage class is WFFC so the same is updated as "WFFC: True" in AWS and ARM64 config file

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
"NONE"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated storage class configurations to enhance capabilities and adjust migration defaults.
  - Enabled Wait For First Consumer (WFFC) for a specific storage class in AWS-related settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->