### PR TITLE
Update Cirros image to Fedora into test_clone.py

### DIFF
--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -1,34 +1,8 @@
 import pytest
 from ocp_resources.datavolume import DataVolume
 
-from tests.storage.utils import create_cirros_dv, create_fedora_dv
+from tests.storage.utils import create_fedora_dv
 from utilities.storage import data_volume
-
-
-@pytest.fixture(scope="module")
-def cirros_dv_with_filesystem_volume_mode(
-    namespace,
-    storage_class_with_filesystem_volume_mode,
-):
-    yield from create_cirros_dv(
-        namespace=namespace.name,
-        name="cirros-fs",
-        storage_class=storage_class_with_filesystem_volume_mode,
-        volume_mode=DataVolume.VolumeMode.FILE,
-    )
-
-
-@pytest.fixture(scope="module")
-def cirros_dv_with_block_volume_mode(
-    namespace,
-    storage_class_with_block_volume_mode,
-):
-    yield from create_cirros_dv(
-        namespace=namespace.name,
-        name="cirros-block",
-        storage_class=storage_class_with_block_volume_mode,
-        volume_mode=DataVolume.VolumeMode.BLOCK,
-    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from ocp_resources.datavolume import DataVolume
 
-from tests.storage.utils import create_cirros_dv
+from tests.storage.utils import create_cirros_dv, create_fedora_dv
 from utilities.storage import data_volume
 
 
@@ -26,6 +26,32 @@ def cirros_dv_with_block_volume_mode(
     yield from create_cirros_dv(
         namespace=namespace.name,
         name="cirros-block",
+        storage_class=storage_class_with_block_volume_mode,
+        volume_mode=DataVolume.VolumeMode.BLOCK,
+    )
+
+
+@pytest.fixture(scope="module")
+def fedora_dv_with_filesystem_volume_mode(
+    namespace,
+    storage_class_with_filesystem_volume_mode,
+):
+    yield from create_fedora_dv(
+        namespace=namespace.name,
+        name="fedora-fs",
+        storage_class=storage_class_with_filesystem_volume_mode,
+        volume_mode=DataVolume.VolumeMode.FILE,
+    )
+
+
+@pytest.fixture(scope="module")
+def fedora_dv_with_block_volume_mode(
+    namespace,
+    storage_class_with_block_volume_mode,
+):
+    yield from create_fedora_dv(
+        namespace=namespace.name,
+        name="fedora-block",
         storage_class=storage_class_with_block_volume_mode,
         volume_mode=DataVolume.VolumeMode.BLOCK,
     )

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from ocp_resources.datavolume import DataVolume
 
-from tests.os_params import WINDOWS_11, WINDOWS_11_TEMPLATE_LABELS
+from tests.os_params import FEDORA_LATEST, WINDOWS_11, WINDOWS_11_TEMPLATE_LABELS
 from tests.storage.utils import (
     assert_pvc_snapshot_clone_annotation,
     assert_use_populator,
@@ -53,7 +53,7 @@ def create_vm_from_clone_dv_template(
         namespace=namespace_name,
         os_flavor=OS_FLAVOR_FEDORA,
         client=client,
-        memory_requests=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
         data_volume_template=data_volume_template_dict(
             target_dv_name=dv_name,
             target_dv_namespace=namespace_name,
@@ -114,7 +114,7 @@ def test_successful_clone_of_large_image(
         pytest.param(
             {
                 "dv_name": "dv-source",
-                "image": f"{Images.Fedora.DIR}/{Images.Fedora.FEDORA41_IMG}",
+                "image": FEDORA_LATEST["image_path"],
                 "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(
@@ -199,7 +199,7 @@ def test_successful_vm_from_cloned_dv_windows(
         pytest.param(
             {
                 "dv_name": "dv-source",
-                "image": f"{Images.Fedora.DIR}/{Images.Fedora.FEDORA41_IMG}",
+                "image": FEDORA_LATEST["image_path"],
                 "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(pytest.mark.polarion("CNV-4035")),
@@ -239,7 +239,7 @@ def test_disk_image_after_clone(
         pytest.param(
             {
                 "dv_name": "dv-source-fedora",
-                "image": f"{Images.Fedora.DIR}/{Images.Fedora.FEDORA41_IMG}",
+                "image": FEDORA_LATEST["image_path"],
                 "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(pytest.mark.polarion("CNV-3545"), pytest.mark.gating()),

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -16,7 +16,7 @@ from tests.storage.utils import (
     create_windows_vm_validate_guest_agent_info,
 )
 from utilities.constants import (
-    OS_FLAVOR_CIRROS,
+    OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
     TIMEOUT_1MIN,
     TIMEOUT_10MIN,
@@ -51,9 +51,9 @@ def create_vm_from_clone_dv_template(
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace_name,
-        os_flavor=OS_FLAVOR_CIRROS,
+        os_flavor=OS_FLAVOR_FEDORA,
         client=client,
-        memory_requests=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        memory_requests=Images.Fedora.DEFAULT_MEMORY_SIZE,
         data_volume_template=data_volume_template_dict(
             target_dv_name=dv_name,
             target_dv_namespace=namespace_name,
@@ -114,8 +114,8 @@ def test_successful_clone_of_large_image(
         pytest.param(
             {
                 "dv_name": "dv-source",
-                "image": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                "image": f"{Images.Fedora.DIR}/{Images.Fedora.FEDORA41_IMG}",
+                "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(
                 pytest.mark.polarion("CNV-2148"),
@@ -140,7 +140,9 @@ def test_successful_vm_restart_with_cloned_dv(
         storage_class=data_volume_multi_storage_scope_function.storage_class,
     ) as cdv:
         cdv.wait_for_dv_success(timeout=TIMEOUT_10MIN)
-        with create_vm_from_dv(dv=cdv) as vm_dv:
+        with create_vm_from_dv(
+            dv=cdv, vm_name="fedora-vm", os_flavor=OS_FLAVOR_FEDORA, memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE
+        ) as vm_dv:
             restart_vm_wait_for_running_vm(vm=vm_dv, wait_for_interfaces=False)
             check_disk_count_in_vm(vm=vm_dv)
 
@@ -197,8 +199,8 @@ def test_successful_vm_from_cloned_dv_windows(
         pytest.param(
             {
                 "dv_name": "dv-source",
-                "image": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                "image": f"{Images.Fedora.DIR}/{Images.Fedora.FEDORA41_IMG}",
+                "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(pytest.mark.polarion("CNV-4035")),
         )
@@ -236,9 +238,9 @@ def test_disk_image_after_clone(
     [
         pytest.param(
             {
-                "dv_name": "dv-source-cirros",
-                "image": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                "dv_name": "dv-source-fedora",
+                "image": f"{Images.Fedora.DIR}/{Images.Fedora.FEDORA41_IMG}",
+                "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(pytest.mark.polarion("CNV-3545"), pytest.mark.gating()),
         ),
@@ -269,7 +271,9 @@ def test_successful_snapshot_clone(
     ) as cdv:
         cdv.wait_for_dv_success()
         if OS_FLAVOR_WINDOWS not in data_volume_snapshot_capable_storage_scope_function.url.split("/")[-1]:
-            with create_vm_from_dv(dv=cdv) as vm_dv:
+            with create_vm_from_dv(
+                dv=cdv, vm_name="fedora-vm", os_flavor=OS_FLAVOR_FEDORA, memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE
+            ) as vm_dv:
                 check_disk_count_in_vm(vm=vm_dv)
         pvc = cdv.pvc
         assert_use_populator(
@@ -287,14 +291,14 @@ def test_clone_from_fs_to_block_using_dv_template(
     skip_test_if_no_block_sc,
     unprivileged_client,
     namespace,
-    cirros_dv_with_filesystem_volume_mode,
+    fedora_dv_with_filesystem_volume_mode,
     storage_class_with_block_volume_mode,
 ):
     create_vm_from_clone_dv_template(
         vm_name="vm-5607",
         dv_name="dv-5607",
         namespace_name=namespace.name,
-        source_dv=cirros_dv_with_filesystem_volume_mode,
+        source_dv=fedora_dv_with_filesystem_volume_mode,
         client=unprivileged_client,
         volume_mode=DataVolume.VolumeMode.BLOCK,
         storage_class=storage_class_with_block_volume_mode,
@@ -308,7 +312,7 @@ def test_clone_from_block_to_fs_using_dv_template(
     skip_test_if_no_block_sc,
     unprivileged_client,
     namespace,
-    cirros_dv_with_block_volume_mode,
+    fedora_dv_with_block_volume_mode,
     storage_class_with_filesystem_volume_mode,
     default_fs_overhead,
 ):
@@ -316,12 +320,12 @@ def test_clone_from_block_to_fs_using_dv_template(
         vm_name="vm-5608",
         dv_name="dv-5608",
         namespace_name=namespace.name,
-        source_dv=cirros_dv_with_block_volume_mode,
+        source_dv=fedora_dv_with_block_volume_mode,
         client=unprivileged_client,
         volume_mode=DataVolume.VolumeMode.FILE,
         # add fs overhead and round up the result
         size=overhead_size_for_dv(
-            image_size=int(cirros_dv_with_block_volume_mode.size[:-2]),
+            image_size=int(fedora_dv_with_block_volume_mode.size[:-2]),
             overhead_value=default_fs_overhead,
         ),
         storage_class=storage_class_with_filesystem_volume_mode,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -114,7 +114,7 @@ def test_successful_clone_of_large_image(
         pytest.param(
             {
                 "dv_name": "dv-source",
-                "image": FEDORA_LATEST["image_path"],
+                "image": FEDORA_LATEST.get("image_path"),
                 "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(
@@ -199,7 +199,7 @@ def test_successful_vm_from_cloned_dv_windows(
         pytest.param(
             {
                 "dv_name": "dv-source",
-                "image": FEDORA_LATEST["image_path"],
+                "image": FEDORA_LATEST.get("image_path"),
                 "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(pytest.mark.polarion("CNV-4035")),
@@ -239,7 +239,7 @@ def test_disk_image_after_clone(
         pytest.param(
             {
                 "dv_name": "dv-source-fedora",
-                "image": FEDORA_LATEST["image_path"],
+                "image": FEDORA_LATEST.get("image_path"),
                 "dv_size": Images.Fedora.DEFAULT_DV_SIZE,
             },
             marks=(pytest.mark.polarion("CNV-3545"), pytest.mark.gating()),

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -23,6 +23,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.os_params import FEDORA_LATEST
 from utilities.constants import (
     CDI_UPLOADPROXY,
     TIMEOUT_2MIN,
@@ -43,6 +44,7 @@ from utilities.storage import (
     create_dv,
     create_vm_from_dv,
     get_containers_for_pods_with_pvc,
+    get_test_artifact_server_url,
 )
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
@@ -426,7 +428,7 @@ def create_fedora_dv(
     with create_dv(
         dv_name=f"dv-{name}",
         namespace=namespace,
-        url=get_http_image_url(image_directory=Images.Fedora.DIR, image_name=Images.Fedora.FEDORA41_IMG),
+        url=f"{get_test_artifact_server_url()}{FEDORA_LATEST['image_path']}",
         size=dv_size,
         storage_class=storage_class,
         access_modes=access_modes,

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -428,7 +428,7 @@ def create_fedora_dv(
     with create_dv(
         dv_name=f"dv-{name}",
         namespace=namespace,
-        url=f"{get_test_artifact_server_url()}{FEDORA_LATEST['image_path']}",
+        url=f"{get_test_artifact_server_url()}{FEDORA_LATEST.get('image_path')}",
         size=dv_size,
         storage_class=storage_class,
         access_modes=access_modes,

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -414,6 +414,29 @@ def create_cirros_dv(
         yield dv
 
 
+def create_fedora_dv(
+    namespace,
+    name,
+    storage_class,
+    access_modes=None,
+    volume_mode=None,
+    client=None,
+    dv_size=Images.Fedora.DEFAULT_DV_SIZE,
+):
+    with create_dv(
+        dv_name=f"dv-{name}",
+        namespace=namespace,
+        url=get_http_image_url(image_directory=Images.Fedora.DIR, image_name=Images.Fedora.FEDORA41_IMG),
+        size=dv_size,
+        storage_class=storage_class,
+        access_modes=access_modes,
+        volume_mode=volume_mode,
+        client=client,
+    ) as dv:
+        dv.wait_for_dv_success()
+        yield dv
+
+
 def check_snapshot_indication(snapshot, is_online):
     snapshot_indications = snapshot.instance.status.indications
     online = "Online"


### PR DESCRIPTION
##### Short description:
Change image use from Cirros to Fedora into test `tests/storage/cdi_clone/test_clone.py`
##### More details:

##### What this PR does / why we need it:
It makes use of Fedora image in order to create VMs into test_clone.py tests as well as all the changes related to it. 
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: https://issues.redhat.com/browse/CNV-38648


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added new test fixtures for Fedora-based DataVolumes with both filesystem and block volume modes.
	- Updated test cases to use Fedora images, data volumes, and memory sizes instead of Cirros.
	- Introduced a utility for creating Fedora DataVolumes in test setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->