### PR TITLE
WIP:  adjust dv size to fit GCP minimumSupportedPvcSize

### DIFF
--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -142,7 +142,6 @@ def cirros_dv_unprivileged(
         name=f"cirros-dv-{storage_class_name_scope_module}",
         storage_class=storage_class_name_scope_module,
         client=unprivileged_client,
-        dv_size=DEFAULT_DV_SIZE,
     )
 
 

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -542,6 +542,7 @@ def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_funct
     ],
 )
 def test_vmi_image_size(
+    xfail_test_if_gcp_sc,
     namespace,
     storage_class_matrix__module__,
     storage_class_name_scope_module,

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -228,7 +228,9 @@ def test_virtctl_image_upload_with_exist_dv_image(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-3728")
-def test_virtctl_image_upload_pvc(download_image, namespace, storage_class_name_scope_module):
+def test_virtctl_image_upload_pvc(
+    download_image, namespace, storage_class_name_scope_module, storage_profile_minimum_supported_pvc_size
+):
     """
     Check that virtctl can create a new PVC and upload an image to it
     """
@@ -237,7 +239,7 @@ def test_virtctl_image_upload_pvc(download_image, namespace, storage_class_name_
         namespace=namespace.name,
         pvc=True,
         name=pvc_name,
-        size="1Gi",
+        size=storage_profile_minimum_supported_pvc_size,
         image_path=LOCAL_PATH,
         storage_class=storage_class_name_scope_module,
         insecure=True,
@@ -283,6 +285,7 @@ def empty_pvc(
     storage_class_matrix__module__,
     storage_class_name_scope_module,
     worker_node1,
+    storage_profile_minimum_supported_pvc_size,
 ):
     with PersistentVolumeClaim(
         name="empty-pvc",
@@ -290,7 +293,7 @@ def empty_pvc(
         storage_class=storage_class_name_scope_module,
         volume_mode=storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"],
         accessmodes=storage_class_matrix__module__[storage_class_name_scope_module]["access_mode"],
-        size="1Gi",
+        size=storage_profile_minimum_supported_pvc_size,
         hostpath_node=worker_node1.name
         if sc_is_hpp_with_immediate_volume_binding(sc=storage_class_name_scope_module)
         else None,
@@ -311,6 +314,7 @@ def test_virtctl_image_upload_with_exist_pvc(
     namespace,
     storage_class_name_scope_module,
     schedulable_nodes,
+    storage_profile_minimum_supported_pvc_size,
 ):
     """
     Check that virtctl can upload an local disk image to an existing empty PVC
@@ -318,7 +322,7 @@ def test_virtctl_image_upload_with_exist_pvc(
     with virtctl_upload_dv(
         namespace=namespace.name,
         name=empty_pvc.name,
-        size="1Gi",
+        size=storage_profile_minimum_supported_pvc_size,
         pvc=True,
         image_path=LOCAL_PATH,
         storage_class=storage_class_name_scope_module,
@@ -387,6 +391,7 @@ def test_virtctl_image_upload_dv_with_exist_pvc(
     namespace,
     storage_class_name_scope_module,
     schedulable_nodes,
+    storage_profile_minimum_supported_pvc_size,
 ):
     """
     Check that virtctl fails gracefully when attempting to upload an image to a new data volume
@@ -395,7 +400,7 @@ def test_virtctl_image_upload_dv_with_exist_pvc(
     with virtctl_upload_dv(
         namespace=namespace.name,
         name=empty_pvc.name,
-        size="1Gi",
+        size=storage_profile_minimum_supported_pvc_size,
         image_path=LOCAL_PATH,
         storage_class=storage_class_name_scope_module,
         insecure=True,

--- a/tests/storage/fs_overhead/test_fs_overhead.py
+++ b/tests/storage/fs_overhead/test_fs_overhead.py
@@ -9,7 +9,6 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 
 from tests.utils import create_cirros_vm
-from utilities.constants import Images
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import virtctl_upload_dv
 
@@ -64,12 +63,13 @@ def uploaded_cirros_dv(
     downloaded_cirros_image_full_path,
     downloaded_cirros_image_scope_class,
     storage_class_with_filesystem_volume_mode,
+    storage_profile_minimum_supported_pvc_size,
 ):
     dv_name = "uploaded-dv"
     with virtctl_upload_dv(
         namespace=namespace.name,
         name=dv_name,
-        size=Images.Cirros.DEFAULT_DV_SIZE,
+        size=storage_profile_minimum_supported_pvc_size,
         image_path=downloaded_cirros_image_full_path,
         storage_class=storage_class_with_filesystem_volume_mode,
         volume_mode=DataVolume.VolumeMode.FILE,
@@ -93,10 +93,9 @@ def test_import_vm_with_specify_fs_overhead(updated_fs_overhead_20_with_hco, vm_
 
 @pytest.mark.polarion("CNV-8637")
 def test_upload_dv_with_specify_fs_overhead(
-    updated_fs_overhead_20_with_hco,
-    uploaded_cirros_dv,
+    updated_fs_overhead_20_with_hco, uploaded_cirros_dv, storage_profile_minimum_supported_pvc_size
 ):
     assert_fs_overhead_added(
         actual_size=get_pvc_size_gib(pvc=uploaded_cirros_dv.pvc),
-        requested_size=bitmath.GiB(int(Images.Cirros.DEFAULT_DV_SIZE[0])),
+        requested_size=bitmath.parse_string_unsafe(storage_profile_minimum_supported_pvc_size).to_GiB(),
     )

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -23,6 +23,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.utils import get_default_storage_profile_minimum_supported_pvc_size
 from utilities.constants import (
     CDI_UPLOADPROXY,
     TIMEOUT_2MIN,
@@ -398,17 +399,16 @@ def create_cirros_dv(
     access_modes=None,
     volume_mode=None,
     client=None,
-    dv_size=Images.Cirros.DEFAULT_DV_SIZE,
 ):
     with create_dv(
         dv_name=f"dv-{name}",
         namespace=namespace,
         url=get_http_image_url(image_directory=Images.Cirros.DIR, image_name=Images.Cirros.QCOW2_IMG),
-        size=dv_size,
         storage_class=storage_class,
         access_modes=access_modes,
         volume_mode=volume_mode,
         client=client,
+        size=get_default_storage_profile_minimum_supported_pvc_size(),
     ) as dv:
         dv.wait_for_dv_success()
         yield dv


### PR DESCRIPTION
##### Short description:
this PR is following the new  cloud providors storage class, gcp, aro, arm etcc...   that is supporting minimumSupportedPvcSize > 4Gi
there are few tests that are failing because they use dv's that are smaller than minimumSupportedPvcSize, 1Gi etc ...

##### More details:

there are many test that are failing due to small dv size, need to adjust these test accordingly to minimumSupportedPvcSize, size  changed dynamiclly + added a function that fetch the minimumSupportedPvcSize from the storage profile

https://docs.google.com/presentation/d/1wDDKB0ZGbRpObNP9hqSu2Rm8OdccRTQ1St-eNEQaFYM/edit?slide=id.g317d1609066_0_17#slide=id.g317d1609066_0_17

https://drive.google.com/file/d/1MT99MArNHn4e85APbvrawDZydQzHxslk/view

##### What this PR does / why we need it:

there are many test that are failing due to small dv size, need to adjust these test accordingly to minimumSupportedPvcSiz from storgae profile

##### Which issue(s) this PR fixes:

T2 failuers 
https://jenkins-csb-cnvqe-main.dno.corp.redhat.com/job/test-pytest-cnv-4.19-storage-gcp/5/testReport/

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-63567
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
