### PR TITLE
Updated node T2 gating tests which didn't require a change with s390x tag

### DIFF
--- a/tests/virt/node/general/test_disk_io_option.py
+++ b/tests/virt/node/general/test_disk_io_option.py
@@ -66,6 +66,7 @@ def disk_options_vm(
 
 
 @pytest.mark.gating
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "golden_image_data_volume_scope_class,",
     [

--- a/tests/virt/node/general/test_static_ssh_key_injection.py
+++ b/tests/virt/node/general/test_static_ssh_key_injection.py
@@ -69,6 +69,7 @@ def vm_with_ssh_secret(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestVMWithStaticKeyInjection:
     """
     Test VM with static key injection.


### PR DESCRIPTION
##### Short description:
Added s390x marker for the Initial tests in T2 node gating set, which are working for s390x, without any change.

##### jira-ticket:
NONE
