### PR TITLE
[IUO]Quarantine free memory bytes metric test

### DIFF
--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -36,6 +36,7 @@ from utilities.constants import (
     CAPACITY,
     LIVE_MIGRATE,
     MIGRATION_POLICY_VM_LABEL,
+    QUARANTINED,
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_30SEC,
@@ -467,6 +468,13 @@ class TestVmFreeMemoryBytes:
             working_set=True,
         )
 
+    @pytest.mark.xfail(
+        reason=(
+            f"{QUARANTINED}: The memory rss value from BMs reported in metric is less than 5% from expected. "
+            f"tracked in CNV-64128"
+        ),
+        run=False,
+    )
     @pytest.mark.polarion("CNV-11693")
     def test_metric_kubevirt_vm_container_free_memory_bytes_based_on_rss(
         self,


### PR DESCRIPTION
##### Short description:
Quarantine kubevirt_vm_container_free_memory_bytes_based_on_rss test duo flakiness.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Marked a specific VM metrics test to be skipped due to a known issue affecting memory metrics on bare metal systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->