### PR TITLE
Add support to overwrite data_collector_base_directory via ENV

### DIFF
--- a/utilities/data_collector.py
+++ b/utilities/data_collector.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shlex
+from pathlib import Path
 
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import get_client
@@ -17,9 +18,33 @@ LOGGER = logging.getLogger(__name__)
 BASE_DIRECTORY_NAME = "tests-collected-info"
 
 
-def get_data_collector_base():
-    return f"{'/data/' if os.environ.get('CNV_TESTS_CONTAINER') else ''}"
+def get_data_collector_base() -> str:
+    """
+    Determine the base directory for data collection, with the following priority:
 
+    1. The `DATA_COLLECTOR_DIR_OVERWRITE` environment variable, if set.
+    2. A "/data/" prefix when running in a CNV tests container (i.e., when the
+       `CNV_TESTS_CONTAINER` environment variable is truthy).
+    3. The current working directory (empty string).
+
+    The returned path is always normalized and guaranteed to end with a trailing slash.
+    """
+    # 1. Check for explicit override
+    override = os.getenv("DATA_COLLECTOR_DIR_OVERWRITE")
+    if override:
+        base = Path(override)
+    else:
+        # 2. Use "/data/" prefix if in test container, otherwise empty
+        prefix = Path("/data") if os.getenv("CNV_TESTS_CONTAINER") else Path()
+        base = prefix
+
+    # Normalize path (expand user, remove redundant separators) without requiring existence
+    # This will also collapse any '.' or '..' segments
+    normalized = base.expanduser().resolve(strict=False)
+
+    # Convert to POSIX string and ensure trailing slash
+    path_str = normalized.as_posix().rstrip("/") + "/"
+    return path_str
 
 def get_data_collector_base_directory() -> str:
     return py_config["data_collector"]["data_collector_base_directory"]

--- a/utilities/data_collector.py
+++ b/utilities/data_collector.py
@@ -46,6 +46,7 @@ def get_data_collector_base() -> str:
     path_str = normalized.as_posix().rstrip("/") + "/"
     return path_str
 
+
 def get_data_collector_base_directory() -> str:
     return py_config["data_collector"]["data_collector_base_directory"]
 


### PR DESCRIPTION
##### Short description:

With openshift-ci we need more options for the data directory, the easiest way is to allow overwriting the value from environment variable.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the method for determining the base directory path for data collection, improving flexibility and ensuring consistent path formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->