### PR TITLE
Add an option to pass data-collector output dir

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -225,6 +225,10 @@ def pytest_addoption(parser):
         action="store_true",
     )
     data_collector_group.addoption(
+        "--data-collector-output-dir",
+        help="Must-gather/alert output dir if `--data-collector` is set and will overwrite `CNV_TESTS_CONTAINER` env.",
+    )
+    data_collector_group.addoption(
         "--pytest-log-file",
         help="Path to pytest log file",
         default="pytest-tests.log",
@@ -569,7 +573,7 @@ def pytest_runtest_setup(item):
     if item.config.getoption("--data-collector"):
         # before the setup work starts, insert current epoch time into the database
         try:
-            db = Database()
+            db = Database(base_dir=item.config.getoption("--data-collector-output-dir"))
             db.insert_test_start_time(
                 test_name=f"{item.fspath}::{item.name}",
                 start_time=int(datetime.datetime.now().strftime("%s")),
@@ -647,7 +651,7 @@ def pytest_sessionstart(session):
                 utilities.infra.generate_latest_os_dict(os_list=py_config["fedora_os_matrix"])
             ]
 
-    data_collector_dict = set_data_collector_values()
+    data_collector_dict = set_data_collector_values(base_dir=session.config.getoption("data_collector_output_dir"))
     shutil.rmtree(
         data_collector_dict["data_collector_base_directory"],
         ignore_errors=True,
@@ -716,7 +720,7 @@ def pytest_sessionfinish(session, exitstatus):
     reporter = session.config.pluginmanager.get_plugin("terminalreporter")
     reporter.summary_stats()
     if session.config.getoption("--data-collector"):
-        db = Database()
+        db = Database(base_dir=session.config.getoption("--data-collector-output-dir"))
         file_path = db.database_file_path
         LOGGER.info(f"Removing database file path {file_path}")
         os.remove(file_path)
@@ -777,7 +781,7 @@ def pytest_exception_interact(node: Item | Collector, call: CallInfo[Any], repor
             LOGGER.warning(f"Must-gather collection would be skipped for exception: {call.excinfo.type}")
         else:
             try:
-                db = Database()
+                db = Database(base_dir=node.config.getoption("--data-collector-output-dir"))
                 test_start_time = db.get_test_start_time(test_name=test_name)
             except Exception as db_exception:
                 test_start_time = 0

--- a/conftest.py
+++ b/conftest.py
@@ -300,6 +300,11 @@ def pytest_cmdline_main(config):
                 f" Provided images: {eus_ocp_images}"
             )
 
+    if config.getoption("data_collector_output_dir") and not config.getoption("data_collector"):
+        raise ValueError(
+            "Data will not be collected because `--data-collector-output-dir` is set without `--data-collector`"
+        )
+
     # Default value is set as this value is used to set test name in
     # tests.upgrade_params.UPGRADE_TEST_DEPENDENCY_NODE_ID which is needed for pytest dependency marker
     py_config["upgraded_product"] = upgrade_option or config.getoption("--upgrade_custom") or "cnv"

--- a/docs/RUNNING_TESTS.md
+++ b/docs/RUNNING_TESTS.md
@@ -220,18 +220,21 @@ uv run pytest <test_to_run> -o log_cli=true
 ```
 
 ### Must-gather and data collection
-openshift-virtualization-tests would collect must-gather data, pexpect logs, alert data for failure analysis, when --data-collector argument is passed.
-Logs will be available under tests-collected-info/ folder for local runs and /data/tests-collected-info for containerized runs.
+When you pass the `--data-collector` flag, **openshift-virtualization-tests** will gather must-gather archives, pexpect logs, and alert data for failure analysis. By default, collected logs land in:
+
+- `tests-collected-info/` for local runs
+- `/data/tests-collected-info/` for containerized runs (i.e., when you’ve exported the `CNV_TESTS_CONTAINER` environment variable)
 
 ```bash
 uv run pytest <test_to_run> --data-collector
 ```
 
-Logs will be available under tests-collected-info/ folder for local runs and /data/tests-collected-info for containerized runs.
-To overwite the default path, use the --data-collector-path argument.
+If you need to override the default output directory, use --data-collector-output-dir:
 
 ```bash
-uv run pytest <test_to_run> --data-collector --data-collector-output-dir=<path>
+uv run pytest <test_to_run> \
+  --data-collector \
+  --data-collector-output-dir=<path/to/your/dir>
 ```
 
 To skip must-gather collection on a given module or test, skip_must_gather_collection can be used:

--- a/docs/RUNNING_TESTS.md
+++ b/docs/RUNNING_TESTS.md
@@ -227,6 +227,13 @@ Logs will be available under tests-collected-info/ folder for local runs and /da
 uv run pytest <test_to_run> --data-collector
 ```
 
+Logs will be available under tests-collected-info/ folder for local runs and /data/tests-collected-info for containerized runs.
+To overwite the default path, use the --data-collector-path argument.
+
+```bash
+uv run pytest <test_to_run> --data-collector --data-collector-output-dir=<path>
+```
+
 To skip must-gather collection on a given module or test, skip_must_gather_collection can be used:
 
 ```bash

--- a/utilities/database.py
+++ b/utilities/database.py
@@ -23,8 +23,10 @@ class CnvTestTable(Base):
 
 
 class Database:
-    def __init__(self, database_file_name: str = CNV_TEST_DB, verbose: bool = True) -> None:
-        self.database_file_path = f"{get_data_collector_base()}{database_file_name}"
+    def __init__(
+        self, database_file_name: str = CNV_TEST_DB, verbose: bool = True, base_dir: str | None = None
+    ) -> None:
+        self.database_file_path = f"{get_data_collector_base(base_dir=base_dir)}{database_file_name}"
         self.connection_string = f"sqlite:///{self.database_file_path}"
         self.verbose = verbose
         self.engine = create_engine(url=self.connection_string, echo=self.verbose)


### PR DESCRIPTION
##### Short description:
Add an option to set data-collector output dir:
        1. Dir is set by passing --data-collector-output-dir.
        2. A "/data" prefix when running in a CNV tests container
            (i.e., when `CNV_TESTS_CONTAINER` environment variable is set).
        3. The current working directory.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to specify a custom output directory for data collection.
  - Data collection and database operations now use the user-specified directory when provided.

- **Enhancements**
  - Improved flexibility in configuring where collected data and database files are stored.

- **Documentation**
  - Updated test running guide with details on log locations and usage of the new output directory option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->