### PR TITLE
Add preference linux-virtiotransitional

### DIFF
--- a/tests/infrastructure/instance_types/vm_preference_list.py
+++ b/tests/infrastructure/instance_types/vm_preference_list.py
@@ -42,5 +42,5 @@ VM_PREFERENCES_LIST = {
         "windows.2k25.virtio",
     ],
     "network": ["centos.stream9.dpdk", "rhel.8.dpdk", "rhel.9.dpdk"],
-    "generic": ["legacy", "linux.efi", "linux"],
+    "generic": ["legacy", "linux.efi", "linux", "linux.virtiotransitional"],
 }


### PR DESCRIPTION
##### Short description:
Add preference linux-virtiotransitional to the preference list

##### What this PR does / why we need it:
Fix failing test due to missing preference


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added test coverage for the new "linux.virtiotransitional" VM preference type in the generic category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->