### PR TITLE
 [main][storage] fix invalid substring sc naming 

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -119,7 +119,7 @@ def hotplug_volume_scope_class(
 
 @pytest.fixture(scope="class")
 def param_substring_scope_class(storage_class_name_scope_class):
-    return storage_class_name_scope_class[0:3]
+    return storage_class_name_scope_class[0:3].strip("-")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### Short description:
small fix for fixture "param_substring_scope_class" 

##### More details:
small fix for "param_substring_scope_class"  where some SC e.g "sp-balanced-storage: can be fetched with "-"
which cause some failure with naming 
sp-balanced-storage

##### What this PR does / why we need it:
to fix some test related to this fixture for instance: test_hotplug_volume_with_serial 

##### Which issue(s) this PR fixes:
dv naming issue 
here is example where dv fails due to naming caused by the SC name "sp-"

faild due to wrong naming in "message":"DataVolume.cdi.kubevirt.io \\"blank-dv-sp-\\" is invalid: metadata.name: Invalid value: \\"blank-dv-sp-\

##### Special notes for reviewer:

blank-dv-sp-\\" is invalid: metadata.name: Invalid value: \\"blank-dv-sp-\\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')","reason":"Invalid","details":{"name":"blank-dv-sp-","group":"cdi.kubevirt.io","kind":"DataVolume","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \\"blank-dv-sp-\\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, \'-\' or \'.\', and must start and end with an alphanumeric character (e.g. \'example.com\', regex used for validation is \'[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\')","field":"metadata.name"}]},"code":422}\n'


##### jira-ticket:
https://issues.redhat.com/browse/CNV-63567
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated the logic for extracting substrings in a test fixture to improve test accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->