### PR TITLE
[IUO]Update 4.18.8 csv permissions

### DIFF
--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/csv-permissions.yaml
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/csv-permissions.yaml
@@ -3436,6 +3436,7 @@ ssp-operator:
     - servicemonitors
     verbs:
     - create
+    - delete
     - list
     - update
     - watch


### PR DESCRIPTION
##### Short description:
ssp operator added deleted permission for servicemonitors
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64253