### PR TITLE
Storage: fix import, fix collection

### DIFF
--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -9,12 +9,14 @@ from utilities.storage import data_volume
 def fedora_dv_with_filesystem_volume_mode(
     namespace,
     storage_class_with_filesystem_volume_mode,
+    fedora_latest_os_params,
 ):
     yield from create_fedora_dv(
         namespace=namespace.name,
         name="fedora-fs",
         storage_class=storage_class_with_filesystem_volume_mode,
         volume_mode=DataVolume.VolumeMode.FILE,
+        fedora_latest_os_params=fedora_latest_os_params,
     )
 
 
@@ -22,12 +24,14 @@ def fedora_dv_with_filesystem_volume_mode(
 def fedora_dv_with_block_volume_mode(
     namespace,
     storage_class_with_block_volume_mode,
+    fedora_latest_os_params,
 ):
     yield from create_fedora_dv(
         namespace=namespace.name,
         name="fedora-block",
         storage_class=storage_class_with_block_volume_mode,
         volume_mode=DataVolume.VolumeMode.BLOCK,
+        fedora_latest_os_params=fedora_latest_os_params,
     )
 
 

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -599,9 +599,11 @@ def fedora_latest_os_params():
     """This fixture is needed as during collection pytest_testconfig is empty.
     os_params or any globals using py_config in conftest cannot be used.
     """
-    latest_fedora_dict = py_config["latest_fedora_os_dict"]
-    return {
-        "fedora_image_path": f"{get_test_artifact_server_url()}{latest_fedora_dict['image_path']}",
-        "fedora_dv_size": latest_fedora_dict["dv_size"],
-        "fedora_template_labels": latest_fedora_dict["template_labels"],
-    }
+    if latest_fedora_dict := py_config.get("latest_fedora_os_dict"):
+        return {
+            "fedora_image_path": f"{get_test_artifact_server_url()}{latest_fedora_dict['image_path']}",
+            "fedora_dv_size": latest_fedora_dict["dv_size"],
+            "fedora_template_labels": latest_fedora_dict["template_labels"],
+        }
+
+    raise ValueError("Failed to get latest Fedora OS parameters")

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -61,6 +61,7 @@ from utilities.storage import (
     create_cirros_dv_for_snapshot_dict,
     data_volume,
     get_downloaded_artifact,
+    get_test_artifact_server_url,
     sc_volume_binding_mode_is_wffc,
     write_file,
 )
@@ -591,3 +592,16 @@ def storage_class_name_scope_module(storage_class_matrix__module__):
 @pytest.fixture(scope="session")
 def cluster_csi_drivers_names():
     yield [csi_driver.name for csi_driver in list(CSIDriver.get())]
+
+
+@pytest.fixture(scope="session")
+def fedora_latest_os_params():
+    """This fixture is needed as during collection pytest_testconfig is empty.
+    os_params or any globals using py_config in conftest cannot be used.
+    """
+    latest_fedora_dict = py_config["latest_fedora_os_dict"]
+    return {
+        "fedora_image_path": f"{get_test_artifact_server_url()}{latest_fedora_dict['image_path']}",
+        "fedora_dv_size": latest_fedora_dict["dv_size"],
+        "fedora_template_labels": latest_fedora_dict["template_labels"],
+    }

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -23,7 +23,6 @@ from ocp_resources.virtual_machine import VirtualMachine
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.os_params import FEDORA_LATEST
 from utilities.constants import (
     CDI_UPLOADPROXY,
     TIMEOUT_2MIN,
@@ -44,7 +43,6 @@ from utilities.storage import (
     create_dv,
     create_vm_from_dv,
     get_containers_for_pods_with_pvc,
-    get_test_artifact_server_url,
 )
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
@@ -420,6 +418,7 @@ def create_fedora_dv(
     namespace,
     name,
     storage_class,
+    fedora_latest_os_params,
     access_modes=None,
     volume_mode=None,
     client=None,
@@ -428,7 +427,7 @@ def create_fedora_dv(
     with create_dv(
         dv_name=f"dv-{name}",
         namespace=namespace,
-        url=f"{get_test_artifact_server_url()}{FEDORA_LATEST.get('image_path')}",
+        url=fedora_latest_os_params["fedora_image_path"],
         size=dv_size,
         storage_class=storage_class,
         access_modes=access_modes,


### PR DESCRIPTION
Fixing the issue:
```
uv run pytest --collect-only tests/storage
...
15:41:05  ImportError while loading conftest '/openshift-virtualization-tests/tests/storage/conftest.py'.
15:41:05  tests/storage/conftest.py:32: in <module>
15:41:05      from tests.storage.utils import (
15:41:05  tests/storage/utils.py:26: in <module>
15:41:05      from tests.os_params import FEDORA_LATEST
15:41:05  tests/os_params.py:7: in <module>
15:41:05      RHEL_LATEST = py_config["latest_rhel_os_dict"]
15:41:05                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15:41:05  E   KeyError: 'latest_rhel_os_dict'
15:41:05  DEBUG Command exited with code: 4
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Tests**
  - Added a new fixture to provide Fedora OS parameters for testing.
  - Updated existing test fixtures to accept and use the new Fedora OS parameters.
  - Improved test setup for Fedora image handling by centralizing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->