### PR TITLE
refactor: use packages module instead of specifying dnf directly

### DIFF
--- a/containers/fedora/user-data
+++ b/containers/fedora/user-data
@@ -20,9 +20,27 @@ write_files:
 
         [Install]
         WantedBy=cloud-init.service
+packages:
+  - tcpdump
+  - qemu-guest-agent
+  - iperf3
+  - dmidecode
+  - nginx
+  - lldpad
+  - kernel-modules
+  - nmap
+  - dhcp-server
+  - dhcp-relay
+  - sshpass
+  - podman
+  - ethtool
+  - libibverbs
+  - dpdk
+  - stress-ng
+  - iotop
+  - fio
 runcmd:
   - systemctl daemon-reload
-  - dnf install -y tcpdump qemu-guest-agent iperf3 dmidecode nginx lldpad kernel-modules nmap dhcp-server dhcp-relay sshpass podman ethtool libibverbs dpdk stress-ng iotop fio
   - dnf autoremove
   - dnf clean all
   - rpm -q kernel-core | sort | head -1 | xargs rpm -e


### PR DESCRIPTION
This change improves code generality by using the packages module. Architecture-specific packages can now be installed in a separate step, enhancing flexibility and maintainability.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Switched to a declarative package installation approach in system configuration and removed explicit cleanup commands. This improves configuration clarity and maintainability while preserving existing system behavior and user-visible features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->