### PR TITLE
Update qe-cnv-tests-fedora image for s390x built from current changes on PR #1148

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -135,7 +135,9 @@ class ArchImages:
 
         Fedora = Fedora(
             FEDORA41_IMG="Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2",
-            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41",
+            # TODO: Replace with quay.io/openshift-cnv/qe-cnv-tests-fedora-s390x:41 once changes discussed at
+            # https://github.com/RedHatQE/openshift-virtualization-tests/pull/1148#issuecomment-3003921765 are done.
+            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41-s390x",
             DISK_DEMO="fedora-cloud-registry-disk-demo",
         )
         Fedora.LATEST_RELEASE_STR = Fedora.FEDORA41_IMG


### PR DESCRIPTION
As we plan to improvise the code to build the image as given here https://github.com/RedHatQE/openshift-virtualization-tests/pull/1148#issuecomment-3003921765, till all those changes are done, to unblock s390x tests needing the qe-cnv-tests-fedora image, we point to image which is built from current changes on the PR #1148

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
@rnetser As discussed, created the PR.

cc: @stesrn @nestoracunablanco

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
