### PR TITLE
[Chaos] Refactor chaos_worker_background_process

### DIFF
--- a/containers/utility/Dockerfile
+++ b/containers/utility/Dockerfile
@@ -6,4 +6,4 @@ RUN if [ "$TARGETARCH" = "s390x" ] ; then \
     else \
       yum install epel-release centos-release-nfv-openvswitch -y ; \
     fi ; \
-    yum update -y && yum install iproute tcpdump qemu-img NetworkManager xfreerdp xauth xorg-x11-server-Xvfb which nftables stress-ng nmap -y && yum install --nogpgcheck openvswitch3.1 -y && yum clean all
+    yum update -y && yum install iproute tcpdump qemu-img NetworkManager xfreerdp xauth xorg-x11-server-Xvfb which nftables stress-ng procps-ng nmap -y && yum install --nogpgcheck openvswitch3.1 -y && yum clean all

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -534,7 +534,7 @@ BASE_EXCEPTIONS_DICT: dict[type[Exception], list[str]] = {
 }
 
 # Container images
-NET_UTIL_CONTAINER_IMAGE = "quay.io/openshift-cnv/qe-cnv-tests-net-util-container:centos-stream-9"
+NET_UTIL_CONTAINER_IMAGE = "quay.io/qwang1/qe-cnv-tests-net-util-container:centos-stream-9"
 
 
 OC_ADM_LOGS_COMMAND = "oc adm node-logs"

--- a/utilities/manifests/utility-daemonset.yaml
+++ b/utilities/manifests/utility-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - /bin/bash
             - -c
             - echo ok > /tmp/healthy && sleep INF
-          image: quay.io/openshift-cnv/qe-cnv-tests-net-util-container:centos-stream-9
+          image: quay.io/qwang1/qe-cnv-tests-net-util-container:centos-stream-9
           imagePullPolicy: IfNotPresent
           name: utility
           readinessProbe:
@@ -48,11 +48,11 @@ spec:
             timeoutSeconds: 1
           resources:
             limits:
-              cpu: 100m
-              memory: 50Mi
+              cpu: 2000m
+              memory: 2Gi
             requests:
-              cpu: 100m
-              memory: 50Mi
+              cpu: 2000m
+              memory: 2Gi
           securityContext:
             privileged: true
             runAsUser: 0


### PR DESCRIPTION
##### Short description:
1. Replaced multiprocessing with threading to avoid pickling issues on macOS and Windows.
2. Increased the utility pod’s resource limits to prevent pod restarts or stress processes being killed by the OOM killer during load injection.
3. Improved the stress-ng command by using stronger stressors and redirecting output to a log file for easier analysis.


##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chaos testing capabilities with new background thread fixtures and utilities for running and monitoring commands inside utility pods.
  * Improved process detection and asynchronous command execution within pods for more robust test scenarios.

* **Bug Fixes**
  * Updated resource limits for utility daemonset containers to prevent resource exhaustion during intensive operations.

* **Chores**
  * Changed utility container image references to a new repository path.
  * Added installation of an additional system package to the utility container for improved process management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->