### PR TITLE
Remove IUO bugs on 4.20

### DIFF
--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -21,7 +21,7 @@ pytestmark = [pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
 @pytest.fixture()
 def crds(admin_client):
     crds_to_check = []
-    bug_status = is_jira_open(jira_id="CNV-58119")
+    bug_status = is_jira_open(jira_id="CNV-64424")
     for crd in CustomResourceDefinition.get(dyn_client=admin_client):
         if bug_status and crd.name in MTV_VOLUME_POPULATOR_CRDS:
             continue

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -87,7 +87,7 @@ def test_default_featuregates_by_resource(
     if isinstance(expected, list):
         assert sorted(expected) == sorted(resource_object_value_by_key), error_message
     else:
-        if is_jira_open(jira_id="CNV-63030"):
-            LOGGER.warning("Applying workaround: removed ‘autoResourceLimits’ due to open Jira CNV-63030")
+        if is_jira_open(jira_id="CNV-64431"):
+            LOGGER.warning("Applying workaround: removed ‘autoResourceLimits’ due to open Jira CNV-64431")
             resource_object_value_by_key.pop("autoResourceLimits", None)
         assert expected == resource_object_value_by_key, error_message

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -10,7 +10,6 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     get_random_minutes_hours_fields_from_data_import_schedule,
     get_templates_by_type_from_hco_status,
 )
-from tests.install_upgrade_operators.utils import is_rhel10_beta_resource_and_63351_bug_open
 from utilities.constants import (
     COMMON_TEMPLATES_KEY_NAME,
     HCO_OPERATOR,
@@ -47,7 +46,6 @@ def image_stream_names(admin_client, golden_images_namespace):
     return [
         image_stream.name
         for image_stream in ImageStream.get(dyn_client=admin_client, namespace=golden_images_namespace.name)
-        if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=image_stream.name)
     ]
 
 

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -15,7 +15,6 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     COMMON_TEMPLATE,
     get_templates_by_type_from_hco_status,
 )
-from tests.install_upgrade_operators.utils import is_rhel10_beta_resource_and_63351_bug_open
 from utilities.constants import (
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
@@ -48,12 +47,7 @@ def get_templates_resources_names_dict(templates):
 
 def verify_resource_not_in_ns(resource_type, namespace, dyn_client):
     resources = resource_type.get(dyn_client=dyn_client, namespace=namespace)
-    # skipping rhel10-beta-guest image stream if jira is open
-    resources_names = {
-        resource.name
-        for resource in resources
-        if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=resource.name)
-    }
+    resources_names = {resource.name for resource in resources}
     assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
 
 
@@ -142,12 +136,11 @@ def updated_common_template_custom_ns(
     ):
         yield
     for data_source in get_data_sources_managed_by_data_import_cron(namespace=golden_images_namespace.name):
-        if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=data_source.name):
-            data_source.wait_for_condition(
-                condition=DataSource.Condition.READY,
-                status=DataSource.Condition.Status.TRUE,
-                timeout=TIMEOUT_10MIN,
-            )
+        data_source.wait_for_condition(
+            condition=DataSource.Condition.READY,
+            status=DataSource.Condition.Status.TRUE,
+            timeout=TIMEOUT_10MIN,
+        )
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.jira("CNV-63031", run=False)
+@pytest.mark.jira("CNV-64433", run=False)
 @pytest.mark.polarion("CNV-7603")
 def test_same_random_minute_after_delete_hco_pod(
     admin_client,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -4,7 +4,6 @@ from deepdiff import DeepDiff
 from tests.install_upgrade_operators.strict_reconciliation.utils import (
     validate_related_objects,
 )
-from tests.install_upgrade_operators.utils import is_rhel10_beta_resource_and_63351_bug_open
 from utilities.constants import ALL_HCO_RELATED_OBJECTS
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
@@ -14,9 +13,7 @@ class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
     def test_no_new_hco_related_objects(self, hco_status_related_objects):
         actual_related_objects = {
-            related_object["name"]: related_object["kind"]
-            for related_object in hco_status_related_objects
-            if not is_rhel10_beta_resource_and_63351_bug_open(resource_name=related_object["name"])
+            related_object["name"]: related_object["kind"] for related_object in hco_status_related_objects
         }
         expected_related_objects = {
             object_name: object_kind

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -2,7 +2,6 @@ import importlib
 import inspect
 import logging
 import re
-from functools import cache
 
 from benedict import benedict
 from kubernetes.dynamic import DynamicClient
@@ -23,7 +22,7 @@ from utilities.constants import (
     TIMEOUT_30MIN,
     TIMEOUT_40MIN,
 )
-from utilities.infra import get_subscription, is_jira_open
+from utilities.infra import get_subscription
 
 LOGGER = logging.getLogger(__name__)
 
@@ -278,8 +277,3 @@ def get_resource_key_value(resource, key_name):
         resource.instance.to_dict()["spec"],
         keypath_separator=KEY_PATH_SEPARATOR,
     ).get(key_name)
-
-
-@cache
-def is_rhel10_beta_resource_and_63351_bug_open(resource_name):
-    return resource_name.startswith("rhel10-beta") and is_jira_open(jira_id="CNV-63351")


### PR DESCRIPTION
##### Short description:

Upgrading the main branch to point to 4.20 is not allowed on https://github.com/RedHatQE/openshift-virtualization-tests/pull/1295 due an error in tox while checking IUO bugs that does not exist in 4.20. Clones in 4.20 versions were created in Jira when needed. CNV-58119 was fixed already in 4.20 so its condition is removed from code.

##### More details:

These bugs in 4.19 that were cloned to 4.20:

https://issues.redhat.com/browse/CNV-63031 to https://issues.redhat.com/browse/CNV-64433
https://issues.redhat.com/browse/CNV-58119 to https://issues.redhat.com/browse/CNV-64424
https://issues.redhat.com/browse/CNV-63030 to https://issues.redhat.com/browse/CNV-64431

This bug https://issues.redhat.com/browse/CNV-63351 wasn't cloned as the fix already landed the main branch.

##### What this PR does / why we need it:

It's composed by 3 commits:

- Revert of https://github.com/RedHatQE/openshift-virtualization-tests/pull/1181
- Replacing the bug ids by their clones in 4.20

It's manually checked that these 4 bugs are not blocking the check anymore:

```
$ uv run pyutils-jira --config-file-path ~/jira.cfg --target-versions "vfuture,4.20.0"
2025-06-26T14:18:36.905034 apps.jira_utils.jira_information ERROR Following Jira ids failed jira version/statuscheck: 
	/home/rlobillo/repo/openshift-virtualization-tests/tests/network/connectivity/test_ovs_linux_bridge.py: CNV-58529 target version: 4.19.z, does not match expected version ['vfuture', '4.20.0'].
	/home/rlobillo/repo/openshift-virtualization-tests/tests/network/connectivity/test_pod_network.py: CNV-58529 target version: 4.19.z, does not match expected version ['vfuture', '4.20.0'].
```
Note: CNV-58529 is out of the scope of this PR.


##### Which issue(s) this PR fixes:
NONE
##### Special notes for reviewer:
NONE
##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Jira issue references in several tests to reflect current tracking IDs.
  * Removed filtering logic and related function for handling "rhel10-beta" resources, resulting in more inclusive test coverage.
  * Simplified test fixtures and resource checks by eliminating conditional skips based on removed Jira-related logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->