### PR TITLE
Update assert_vm_not_error_status: Wait for VM status to populate before asserting error state (#1018)

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -61,6 +61,7 @@ from utilities.constants import (
     SSH_PORT_22,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
+    TIMEOUT_1SEC,
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
@@ -1571,16 +1572,23 @@ def get_rhel_os_dict(rhel_version):
     raise KeyError(f"Failed to extract {rhel_version} from system_rhel_os_matrix")
 
 
-def assert_vm_not_error_status(vm: VirtualMachineForTests) -> None:
-    status = vm.instance.get("status")
-    printable_status = status.get("printableStatus")
-    error_list = VM_ERROR_STATUSES.copy()
-    vm_devices = vm.instance.spec.template.spec.domain.devices
-    if vm_devices.gpus:
-        error_list.remove(VirtualMachine.Status.ERROR_UNSCHEDULABLE)
-    assert printable_status not in error_list, (
-        f"VM {vm.name} error printable status: {printable_status}\nVM status:\n{status}"
-    )
+def assert_vm_not_error_status(vm: VirtualMachineForTests, timeout: int = TIMEOUT_5SEC) -> None:
+    try:
+        for status in TimeoutSampler(
+            wait_timeout=timeout, sleep=TIMEOUT_1SEC, func=lambda: vm.instance.get("status", {})
+        ):
+            if status:
+                printable_status = status.get("printableStatus")
+                error_list = VM_ERROR_STATUSES.copy()
+                if vm.instance.spec.template.spec.domain.devices.gpus:
+                    error_list.remove(VirtualMachine.Status.ERROR_UNSCHEDULABLE)
+                assert printable_status not in error_list, (
+                    f"VM {vm.name} error printable status: {printable_status}\nVM status:\n{status}"
+                )
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"VM {vm.name} status did not populate within {timeout}")
+        raise
 
 
 def wait_for_running_vm(


### PR DESCRIPTION
cherry pick and replacement [PR](https://github.com/RedHatQE/openshift-virtualization-tests/pull/1288)

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

