### PR TITLE
[WIP]Test for kubevirt_rest_client_requests_total

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -25,7 +25,6 @@ from tests.observability.metrics.constants import (
     BINDING_TYPE,
     CNV_VMI_STATUS_RUNNING_COUNT,
     KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_VERB_AND_RESOURCE,
-    KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART,
     KUBEVIRT_CONSOLE_ACTIVE_CONNECTIONS_BY_VMI,
     KUBEVIRT_VM_CREATED_TOTAL_STR,
     KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE,
@@ -1164,5 +1163,5 @@ def created_fake_data_volume_resource(namespace, admin_client):
 
 
 @pytest.fixture()
-def metric_cdi_import_pods_high_restart_initial_value(prometheus):
-    return int(get_metrics_value(prometheus=prometheus, metrics_name=KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART))
+def metric_initial_value(request, prometheus):
+    return int(get_metrics_value(prometheus=prometheus, metrics_name=request.param))

--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -81,3 +81,6 @@ KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART = "kubevirt_cdi_import_pods_high_restart"
 BINDING_NAME = "binding_name"
 BINDING_TYPE = "binding_type"
 RSS_MEMORY_COMMAND = shlex.split("bash -c \"cat /sys/fs/cgroup/memory.stat | grep '^anon ' | awk '{print $2}'\"")
+KUBEVIRT_REST_CLIENT_REQUESTS_TOTAL_WITH_VERB_AND_RESOURCE = (
+    "kubevirt_rest_client_requests_total{verb='DELETE', resource='virtualmachineinstances'}"
+)

--- a/tests/observability/metrics/test_cdi_metrics.py
+++ b/tests/observability/metrics/test_cdi_metrics.py
@@ -69,12 +69,14 @@ def test_kubevirt_cdi_operator_up(
     )
 
 
-@pytest.mark.polarion("CNV-10019")
-def test_kubevirt_cdi_import_pods_high_restart(
-    prometheus, metric_cdi_import_pods_high_restart_initial_value, created_fake_data_volume_resource
-):
+@pytest.mark.parametrize(
+    "metric_initial_value",
+    [pytest.param(KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART, marks=pytest.mark.polarion("CNV-10019"))],
+    indirect=True,
+)
+def test_kubevirt_cdi_import_pods_high_restart(prometheus, metric_initial_value, created_fake_data_volume_resource):
     validate_metrics_value(
         prometheus=prometheus,
         metric_name=KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART,
-        expected_value=str(metric_cdi_import_pods_high_restart_initial_value + 1),
+        expected_value=str(metric_initial_value + 1),
     )

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -15,6 +15,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.observability.metrics.constants import (
     KUBEVIRT_CONSOLE_ACTIVE_CONNECTIONS_BY_VMI,
+    KUBEVIRT_REST_CLIENT_REQUESTS_TOTAL_WITH_VERB_AND_RESOURCE,
     KUBEVIRT_VM_DISK_ALLOCATED_SIZE_BYTES,
     KUBEVIRT_VMI_MEMORY_AVAILABLE_BYTES,
     KUBEVIRT_VMSNAPSHOT_PERSISTENTVOLUMECLAIM_LABELS,
@@ -593,4 +594,23 @@ class TestVmVnicInfo:
             prometheus=prometheus,
             vnic_info_to_compare=vnic_info_from_vm_or_vmi,
             metric_name=query.format(vm_name=running_metric_vm.name),
+        )
+
+
+class TestRestClientRequestsTotal:
+    @pytest.mark.parametrize(
+        "metric_initial_value",
+        [
+            pytest.param(
+                KUBEVIRT_REST_CLIENT_REQUESTS_TOTAL_WITH_VERB_AND_RESOURCE, marks=pytest.mark.polarion("CNV-12012")
+            )
+        ],
+        indirect=True,
+    )
+    def test_kubevirt_rest_client_requests_total(self, prometheus, metric_initial_value, running_metric_vm):
+        running_metric_vm.delete(wait=True)
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_REST_CLIENT_REQUESTS_TOTAL_WITH_VERB_AND_RESOURCE,
+            expected_value=str(metric_initial_value + 1),
         )


### PR DESCRIPTION
##### Short description:
test for kubevirt_rest_client_requests_total metric.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-54804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new test to verify that deleting a running virtual machine correctly increments the related Prometheus metric.

* **Refactor**
  * Improved test parametrization by generalizing the fixture for retrieving initial metric values, allowing for more flexible and reusable metric tests.

* **Tests**
  * Updated existing metric tests to use the new generalized fixture for initial metric values.
  * Introduced a new constant for a specific Prometheus metric used in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->