### PR TITLE
[VIRT] Add post-copy migration test to upgrade scope

### DIFF
--- a/tests/virt/constants.py
+++ b/tests/virt/constants.py
@@ -31,6 +31,9 @@ REQUESTS_INSTANCES_VMI_STR = "requests.instances/vmi"
 REQUESTS_CPU_VMI_STR = "requests.cpu/vmi"
 REQUESTS_MEMORY_VMI_STR = "requests.memory/vmi"
 
+# MigrationPolicy labels
+VM_LABEL = {"post-copy-vm": "true"}
+
 
 # BASH
 REMOVE_NEWLINE = 'tr -d "\n"'

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -9,6 +9,8 @@ from tests.utils import (
     assert_guest_os_cpu_count,
     assert_guest_os_memory_amount,
 )
+from tests.virt.constants import VM_LABEL
+from tests.virt.utils import assert_migration_post_copy_mode
 from utilities.constants import (
     REGEDIT_PROC_NAME,
     SIX_CPU_SOCKETS,
@@ -32,7 +34,6 @@ pytestmark = [pytest.mark.rwx_default_storage, pytest.mark.usefixtures("created_
 
 LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestPostCopyMigration"
-VM_LABEL = {"post-copy-vm": "true"}
 
 
 def assert_same_pid_after_migration(orig_pid, vm):
@@ -41,11 +42,6 @@ def assert_same_pid_after_migration(orig_pid, vm):
     else:
         new_pid = fetch_pid_from_linux_vm(vm=vm, process_name="ping")
     assert new_pid == orig_pid, f"PID mismatch after migration! orig_pid: {orig_pid}; new_pid: {new_pid}"
-
-
-def assert_migration_post_copy_mode(vm):
-    migration_state = vm.vmi.instance.status.migrationState
-    assert migration_state.mode == "PostCopy", f"Migration mode is not PostCopy! VMI MigrationState {migration_state}"
 
 
 @pytest.fixture(scope="module")

--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -4,12 +4,14 @@ from copy import deepcopy
 import pytest
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
+from ocp_resources.migration_policy import MigrationPolicy
 from ocp_resources.template import Template
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from pytest_testconfig import py_config
 
+from tests.virt.constants import VM_LABEL
 from tests.virt.upgrade.utils import (
     get_all_migratable_vms,
     validate_vms_pod_updated,
@@ -36,6 +38,7 @@ from utilities.storage import (
 from utilities.virt import (
     VirtualMachineForTests,
     VirtualMachineForTestsFromTemplate,
+    fedora_vm_body,
     get_base_templates_list,
     get_vm_boot_time,
     running_vm,
@@ -304,3 +307,31 @@ def linux_boot_time_before_upgrade(vms_for_upgrade):
 @pytest.fixture(scope="session")
 def windows_boot_time_before_upgrade(windows_vm):
     yield get_vm_boot_time(vm=windows_vm)
+
+
+@pytest.fixture(scope="session")
+def post_copy_migration_policy_for_upgrade():
+    with MigrationPolicy(
+        name="post-copy-migration-policy",
+        allow_auto_converge=True,
+        bandwidth_per_migration="100Mi",
+        completion_timeout_per_gb=1,
+        allow_post_copy=True,
+        vmi_selector=VM_LABEL,
+    ) as mp:
+        yield mp
+
+
+@pytest.fixture(scope="session")
+def vm_for_post_copy_upgrade(upgrade_namespace_scope_session, unprivileged_client, cpu_for_migration):
+    vm_name = "vm-for-post-copy-upgrade-test"
+    with VirtualMachineForTests(
+        name=vm_name,
+        namespace=upgrade_namespace_scope_session.name,
+        body=fedora_vm_body(name=vm_name),
+        client=unprivileged_client,
+        cpu_model=cpu_for_migration,
+        additional_labels=VM_LABEL,
+    ) as vm:
+        running_vm(vm=vm)
+        yield vm

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -491,3 +491,8 @@ def get_allocatable_memory_per_node(schedulable_nodes):
         nodes_memory[node] = bitmath.parse_string_unsafe(s=memory).to_KiB()
         LOGGER.info(f"Node {node.name} has {nodes_memory[node].to_GiB()} of allocatable memory")
     return nodes_memory
+
+
+def assert_migration_post_copy_mode(vm):
+    migration_state = vm.vmi.instance.status.migrationState
+    assert migration_state.mode == "PostCopy", f"Migration mode is not PostCopy! VMI MigrationState {migration_state}"


### PR DESCRIPTION
Add post-copy migration test to upgrade scope, it covers scenarios:
1. check post-copy migration before upgrade
2. check post-copy supported during the upgrade (new virt-handler + old virt-launcher pod)
3. check post-copy migration after the upgrade

Also this patch contains dependency fix for test_machine_type_after_upgrade

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
