### PR TITLE
Add rhel 8/9 to instance_type_rhel_os_matrix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -647,6 +647,9 @@ def pytest_sessionstart(session):
         # Update OS matrix list with the latest OS if running with os_group
         if session.config.getoption("latest_rhel"):
             py_config["rhel_os_matrix"] = [utilities.infra.generate_latest_os_dict(os_list=py_config["rhel_os_matrix"])]
+            py_config["instance_type_rhel_os_matrix"] = [
+                utilities.infra.generate_latest_os_dict(os_list=py_config["instance_type_rhel_os_matrix"])
+            ]
         if session.config.getoption("latest_windows"):
             py_config["windows_os_matrix"] = [
                 utilities.infra.generate_latest_os_dict(os_list=py_config["windows_os_matrix"])

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -410,8 +410,23 @@ centos_os_matrix = [
 
 instance_type_rhel_os_matrix = [
     {
+        "rhel-8": {
+            DV_SIZE_STR: Images.Rhel.DEFAULT_DV_SIZE,
+            INSTANCE_TYPE_STR: "u1.medium",
+            PREFERENCE_STR: "rhel.8",
+            DATA_SOURCE_NAME: "rhel8",
+        }
+    },
+    {
+        "rhel-9": {
+            DV_SIZE_STR: Images.Rhel.DEFAULT_DV_SIZE,
+            INSTANCE_TYPE_STR: "u1.medium",
+            PREFERENCE_STR: "rhel.9",
+            DATA_SOURCE_NAME: "rhel9",
+        }
+    },
+    {
         "rhel-10": {
-            OS_VERSION_STR: "10",
             DV_SIZE_STR: Images.Rhel.DEFAULT_DV_SIZE,
             INSTANCE_TYPE_STR: "u1.medium",
             PREFERENCE_STR: "rhel.10",

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture(scope="class")
+def skip_if_rhel8(instance_type_rhel_os_matrix__module__):
+    current_rhel_name = [*instance_type_rhel_os_matrix__module__][0]
+    if current_rhel_name == "rhel-8":
+        pytest.xfail("EFI is not enabled by default before RHEL9")

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -37,9 +37,9 @@ TESTS_MIGRATE_VM = f"{TESTS_CLASS_MIGRATION}::test_migrate_vm"
 class TestVMCreationAndValidation:
     @pytest.mark.dependency(name=TEST_CREATE_VM_TEST_NAME)
     @pytest.mark.polarion("CNV-11710")
-    def test_create_vm(self, golden_image_vm_with_instance_type, instance_type_rhel_os_matrix__class__):
+    def test_create_vm(self, golden_image_vm_with_instance_type, instance_type_rhel_os_matrix__module__):
         golden_image_vm_with_instance_type.create(wait=True)
-        os_param_dict = instance_type_rhel_os_matrix__class__[[*instance_type_rhel_os_matrix__class__][0]]
+        os_param_dict = instance_type_rhel_os_matrix__module__[[*instance_type_rhel_os_matrix__module__][0]]
         assert golden_image_vm_with_instance_type.instance.spec.instancetype.name == os_param_dict[INSTANCE_TYPE_STR]
         assert golden_image_vm_with_instance_type.instance.spec.preference.name == os_param_dict[PREFERENCE_STR]
 
@@ -68,6 +68,7 @@ class TestVMCreationAndValidation:
         )
 
 
+@pytest.mark.usefixtures("skip_if_rhel8")
 @pytest.mark.sno
 class TestVMFeatures:
     @pytest.mark.dependency(depends=[TEST_START_VM_TEST_NAME])


### PR DESCRIPTION
##### Short description:
Add rhel-8 and rhel-9 to testing matrix

##### More details:
 - Added rhel-8 and rhel-9 to instance_type_rhel_os_matrix
 - Added code to `_update_os_related_config()` so when calling the test with --latest-rhel only rhel-10 will be used, which is important since this is marked as gating
 -  Added skip to EFI related tests since rhel-8 does not support them by default.

##### What this PR does / why we need it:
Add coverage for rhel8 and rhel9

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-54690


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RHEL 8 and RHEL 9 in instance type and OS matrix configurations.
* **Bug Fixes**
  * Improved handling of the latest RHEL option to ensure instance type OS matrix is updated correctly.
* **Tests**
  * Enhanced test coverage for RHEL 8 and RHEL 9.
  * Updated test fixtures and parameters for improved accuracy.
  * Added logic to automatically skip certain tests for RHEL 8 where EFI is not enabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->