### PR TITLE
net,hotplug: adjust tests to VMRolloutStrategy

### DIFF
--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -1,11 +1,14 @@
+import logging
 from collections.abc import Callable
 from typing import Any, Final
 
 from kubernetes.dynamic.client import ResourceField
-from timeout_sampler import TimeoutExpiredError, retry
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from libs.vm.spec import Devices, Interface, Network, SpecDisk, VMISpec, Volume
 from libs.vm.vm import BaseVirtualMachine
+
+LOGGER = logging.getLogger(__name__)
 
 LOOKUP_IFACE_STATUS_TIMEOUT_SEC: Final[int] = 30
 RETRY_INTERVAL_SEC: Final[int] = 5
@@ -20,24 +23,31 @@ class VMInterfaceStatusNotFoundError(Exception):
     pass
 
 
+class VMInterfaceStatusStillExistsError(Exception):
+    pass
+
+
 def _default_interface_predicate(interface: ResourceField) -> bool:
     return "guest-agent" in interface["infoSource"] and interface[IP_ADDRESS]
 
 
 def lookup_iface_status(
-    vm: BaseVirtualMachine, iface_name: str, predicate: Callable[[Any], bool] = _default_interface_predicate
+    vm: BaseVirtualMachine,
+    iface_name: str,
+    predicate: Callable[[Any], bool] = _default_interface_predicate,
+    wait_timeout: int = LOOKUP_IFACE_STATUS_TIMEOUT_SEC,
 ) -> ResourceField:
     """
-    Returns the network interface status requested if found, otherwise raises VMInterfaceStatusNotFoundError.
-    The interface status information is expected to be sourced from the guest-agent with an IP address.
+    Awaits and returns the network interface status requested if found and the predicate function,
+    otherwise raises VMInterfaceStatusNotFoundError.
 
     Args:
         vm (BaseVirtualMachine): VM in which to search for the network interface.
         iface_name (str): The name of the requested interface.
         predicate (Callable[[dict[str, Any]], bool]): A function that takes a network interface as an argument
-            and returns a boolean value. This function should define the condition that
-            the interface needs to meet. By default, this looks for condition
-            "guest-agent" in interface["infoSource"] and interface[IP_ADDRESS]
+            and returns a boolean value. this function should define the condition that
+            the interface needs to meet.
+        wait_timeout (int): lookup operation timeout
 
     Returns:
         iface (ResourceField): The requested interface.
@@ -45,25 +55,28 @@ def lookup_iface_status(
     Raises:
         VMInterfaceStatusNotFoundError: If the requested interface was not found in the vmi status.
     """
+    sampler = TimeoutSampler(
+        wait_timeout=wait_timeout,
+        sleep=RETRY_INTERVAL_SEC,
+        func=_lookup_iface_status,
+        vm=vm,
+        iface_name=iface_name,
+        predicate=predicate,
+    )
     try:
-        return _lookup_iface_status(
-            vm=vm,
-            iface_name=iface_name,
-            predicate=predicate,
-        )
+        for iface in sampler:
+            if iface:
+                return iface
     except TimeoutExpiredError:
         raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
 
 
-@retry(
-    wait_timeout=LOOKUP_IFACE_STATUS_TIMEOUT_SEC,
-    sleep=RETRY_INTERVAL_SEC,
-    exceptions_dict={VMInterfaceStatusNotFoundError: []},
-)
-def _lookup_iface_status(vm: BaseVirtualMachine, iface_name: str, predicate: Callable[[Any], bool]) -> ResourceField:
+def _lookup_iface_status(
+    vm: BaseVirtualMachine, iface_name: str, predicate: Callable[[Any], bool]
+) -> ResourceField | None:
     """
     Returns the interface requested if found and the predicate function (to which the interface is
-    sent) returns True. Else, raise VMInterfaceStatusNotFoundError.
+    sent) Else, returns None.
 
     Args:
         vm (BaseVirtualMachine): VM in which to search for the network interface.
@@ -73,15 +86,12 @@ def _lookup_iface_status(vm: BaseVirtualMachine, iface_name: str, predicate: Cal
             the interface needs to meet.
 
     Returns:
-        iface (ResourceField): The requested interface.
-
-    Raises:
-        VMInterfaceStatusNotFoundError: If the requested interface was not found in the VM.
+        iface (ResourceField) | None: The requested interface or None
     """
     for iface in vm.vmi.interfaces:
         if iface.name == iface_name and predicate(iface):
             return iface
-    raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
+    return None
 
 
 def lookup_primary_network(vm: BaseVirtualMachine) -> Network:

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -155,9 +155,6 @@ def hot_plugged_interface_name_on_vm_created_with_secondary_interface(
         hot_plugged_interface_name=hot_plugged_interface_name,
         net_attach_def_name=network_attachment_definition_for_hot_plug.name,
     )
-    # In order to complete the interface hot-plug, and have the interface available in the guest VM -
-    # the VM must be migrated.
-    migrate_vm_and_verify(vm=running_vm_with_secondary_and_hot_plugged_interfaces)
 
     return hot_plugged_interface_name
 
@@ -173,14 +170,6 @@ def hot_plugged_second_interface_with_address(
         ipv4_address=f"{IPV4_ADDRESS_SUBNET_PREFIX}.{next(index_number)}",
         vmi_interface=hot_plugged_interface_name_on_vm_created_with_secondary_interface,
     )
-
-
-@pytest.fixture()
-def migrated_vm_with_hot_plugged_interface_attached(running_vm_for_nic_hot_plug):
-    # In order to complete the interface hot-plug, and have the interface available in the guest VM -
-    # the VM must be migrated.
-    migrate_vm_and_verify(vm=running_vm_for_nic_hot_plug)
-    return running_vm_for_nic_hot_plug
 
 
 @pytest.fixture()
@@ -358,7 +347,7 @@ def hot_unplugged_additional_interface(
         vm=running_vm_with_secondary_and_hot_plugged_interfaces,
         hot_plugged_interface_name=hot_plugged_interface_name_on_vm_created_with_secondary_interface,
     )
-    migrate_vm_and_verify(vm=running_vm_with_secondary_and_hot_plugged_interfaces)
+
     return hot_plugged_interface_name_on_vm_created_with_secondary_interface
 
 
@@ -416,7 +405,6 @@ def hot_unplug_secondary_interface_from_setup(
         vm=running_vm_with_secondary_and_hot_plugged_interfaces,
         hot_plugged_interface_name=network_attachment_definition_for_hot_plug.name,
     )
-    migrate_vm_and_verify(vm=running_vm_with_secondary_and_hot_plugged_interfaces)
 
 
 @pytest.fixture()
@@ -502,13 +490,13 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
     )
     def test_basic_connectivity_of_hot_plugged_interface(
         self,
-        migrated_vm_with_hot_plugged_interface_attached,
+        running_vm_for_nic_hot_plug,
         running_utility_vm_for_connectivity_check,
         hot_plugged_interface_with_address,
         network_attachment_definition_for_hot_plug,
     ):
         assert_ping_successful(
-            src_vm=migrated_vm_with_hot_plugged_interface_attached,
+            src_vm=running_vm_for_nic_hot_plug,
             dst_ip=get_vmi_ip_v4_by_name(
                 vm=running_utility_vm_for_connectivity_check,
                 name=network_attachment_definition_for_hot_plug.name,
@@ -523,12 +511,13 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
     )
     def test_basic_connectivity_of_hot_plugged_interface_after_second_migration(
         self,
+        running_vm_for_nic_hot_plug,
         running_utility_vm_for_connectivity_check,
         network_attachment_definition_for_hot_plug,
-        migrated_vm_with_hot_plugged_interface_attached,
     ):
+        migrate_vm_and_verify(vm=running_vm_for_nic_hot_plug)
         assert_ping_successful(
-            src_vm=migrated_vm_with_hot_plugged_interface_attached,
+            src_vm=running_vm_for_nic_hot_plug,
             dst_ip=get_vmi_ip_v4_by_name(
                 vm=running_utility_vm_for_connectivity_check,
                 name=network_attachment_definition_for_hot_plug.name,

--- a/tests/network/l2_bridge/utils.py
+++ b/tests/network/l2_bridge/utils.py
@@ -6,6 +6,7 @@ import time
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from libs.net.vmspec import lookup_iface_status, wait_for_missing_iface_status
 from tests.network.utils import update_cloud_init_extra_user_data
 from utilities import console
 from utilities.constants import (
@@ -14,6 +15,7 @@ from utilities.constants import (
     NODE_TYPE_WORKER_LABEL,
     SRIOV,
     TIMEOUT_1MIN,
+    TIMEOUT_2MIN,
     TIMEOUT_5SEC,
 )
 from utilities.infra import get_pod_by_name_prefix
@@ -23,11 +25,7 @@ from utilities.network import (
     get_vmi_ip_v4_by_name,
     network_device,
 )
-from utilities.virt import (
-    VirtualMachineForTests,
-    fedora_vm_body,
-    migrate_vm_and_verify,
-)
+from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 LOGGER = logging.getLogger(__name__)
 
@@ -125,12 +123,22 @@ def hot_plug_interface(
 
     update_hot_plug_config_in_vm(vm=vm, interfaces=interfaces, networks=networks)
 
+    lookup_iface_status(
+        vm=vm,
+        iface_name=hot_plugged_interface_name,
+        predicate=lambda interface: "guest-agent" in interface["infoSource"],
+        timeout=TIMEOUT_2MIN,
+    )
+
 
 def hot_unplug_interface(vm, hot_plugged_interface_name):
     interfaces = vm.get_interfaces()
     unplugged_interface = next(interface for interface in interfaces if interface["name"] == hot_plugged_interface_name)
     unplugged_interface.update(dict(state="absent"))
+
     update_hot_plug_config_in_vm(vm=vm, interfaces=interfaces)
+
+    wait_for_missing_iface_status(vm=vm, iface_name=hot_plugged_interface_name)
 
 
 def update_hot_plug_config_in_vm(vm, interfaces, networks=None):
@@ -207,7 +215,6 @@ def hot_plug_interface_and_set_address(
         sriov=sriov,
     )
     wait_for_interface_hot_plug_completion(vmi=vm.vmi, interface_name=hot_plugged_interface_name)
-    migrate_vm_and_verify(vm=vm)
 
     set_secondary_static_ip_address(
         vm=vm,


### PR DESCRIPTION
##### Short description: 

Starting from 4.20 the migration logic is an encapsulated detail and there is no need to follow it for hot-plug\unplug. The only thing to monitor to meet success of hot-plug\unplug process is waiting for the interface is presented (or not presented if hot-unplug) in VMI status.

There  was also refactored `lookup_iface_status` to accept an optional `wait_timeout`
parameter with a default value.  `LOOKUP_IFACE_STATUS_TIMEOUT_SEC` is not suitable for the hot-plug issue. The change improves flexibility for callers who need to override the default timeout without changing internal
logic or duplicating code.

  **Depends on:**  https://github.com/RedHatQE/openshift-virtualization-tests/pull/1333

#####  jira-ticket: https://issues.redhat.com/browse/CNV-63872
##### epic: https://issues.redhat.com/browse/CNV-57367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Made VM migration steps explicit within tests rather than implicit in fixtures.
  * Improved test stability by explicitly waiting for network interface status changes after hot-plug and hot-unplug operations.
* **New Features**
  * Added functionality to wait for network interface removal within a timeout period.
* **Bug Fixes**
  * Replaced implicit VM migration verification with explicit interface status polling to enhance reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->