### PR TITLE
Add s390x test marker for smoke tests

### DIFF
--- a/tests/install_upgrade_operators/csv/test_csv.py
+++ b/tests/install_upgrade_operators/csv/test_csv.py
@@ -27,6 +27,7 @@ EXPECTED_LINK_MAP = {
 @pytest.mark.polarion("CNV-4456")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_keywords(csv_scope_session):
     """
     Assert keywords. Check that each one of the expected keywords are actually there
@@ -37,6 +38,7 @@ def test_csv_keywords(csv_scope_session):
 @pytest.mark.polarion("CNV-4457")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_links(csv_scope_session):
     """
     Check links list.
@@ -53,6 +55,7 @@ def test_csv_links(csv_scope_session):
 @pytest.mark.polarion("CNV-4458")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_icon(csv_scope_session):
     """
     Assert Icon/Logo.
@@ -69,6 +72,7 @@ def test_csv_icon(csv_scope_session):
 @pytest.mark.polarion("CNV-4376")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_properties(csv_scope_session):
     """
     Asserting remaining csv properties.

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -301,6 +301,7 @@ def test_clone_from_fs_to_block_using_dv_template(
 
 @pytest.mark.polarion("CNV-5608")
 @pytest.mark.smoke()
+@pytest.mark.s390x
 def test_clone_from_block_to_fs_using_dv_template(
     skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -302,7 +302,7 @@ def test_successful_import_secure_image(internal_http_configmap, running_pod_wit
         pytest.param(
             DataVolume.ContentType.KUBEVIRT,
             Images.Cirros.RAW_IMG_XZ,
-            marks=(pytest.mark.polarion("CNV-784"), pytest.mark.smoke()),
+            marks=(pytest.mark.polarion("CNV-784"), pytest.mark.smoke(), pytest.mark.s390x()),
         ),
     ],
     ids=["import_basic_auth_archive", "import_basic_auth_kubevirt"],

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -81,7 +81,7 @@ def test_public_registry_multiple_data_volume(
         pytest.param(
             "import-public-registry-empty-content-type-dv",
             "",
-            marks=(pytest.mark.polarion("CNV-2197"), pytest.mark.smoke()),
+            marks=(pytest.mark.polarion("CNV-2197"), pytest.mark.smoke(), pytest.mark.s390x()),
         ),
         pytest.param(
             "import-public-registry-quay-dv",

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -39,6 +39,7 @@ TESTS_CLASS_NAME = "TestCommonTemplatesRhel"
 
 class TestCommonTemplatesRhel:
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")
@@ -54,6 +55,7 @@ class TestCommonTemplatesRhel:
         golden_image_vm_object_from_template_multi_rhel_os_multi_storage_scope_class.create(wait=True)
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::start_vm", depends=[f"{TESTS_CLASS_NAME}::create_vm"])
@@ -66,6 +68,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
@@ -115,6 +118,7 @@ class TestCommonTemplatesRhel:
         assert label == vm.name, f"Wrong domain label: {label}"
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(
@@ -129,6 +133,7 @@ class TestCommonTemplatesRhel:
         ), "Failed to login via SSH"
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(
@@ -224,6 +229,7 @@ class TestCommonTemplatesRhel:
         )
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.smoke
     @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-3038")
@@ -280,6 +286,7 @@ class TestCommonTemplatesRhel:
         assert_linux_efi(vm=vm)
 
     @pytest.mark.arm64
+    @pytest.mark.s390x
     @pytest.mark.sno
     @pytest.mark.smoke
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])

--- a/tests/virt/node/general/test_container_disk_vm.py
+++ b/tests/virt/node/general/test_container_disk_vm.py
@@ -4,6 +4,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.smoke
 @pytest.mark.polarion("CNV-5501")
 def test_container_disk_vm(


### PR DESCRIPTION
##### Short description:
This change adds the @pytest.mark.s390x marker to smoke test functions and methods across multiple test files. The marker is applied to annotate tests for the s390x architecture, with no modifications to test logic, parameters, or control flow in any of the affected files.

##### More details:
The marker helps identify tests relevant for the s390x environment. This is useful for running architecture-specific test suites as needed.

##### What this PR does / why we need it:
This PR adds s390x architecture-specific markers to identify tests that are relevant to the s390x platform. It allows better control over test execution when running smoke tests in s390x environments.

##### Which issue(s) this PR fixes:
NONE

##### Special notes for reviewer:

##### jira-ticket:
NONE
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
