### PR TITLE
[CNV-64474] Adjust Observability and IUO bugs IDs to 4.19.z fixVersion

### DIFF
--- a/tests/install_upgrade_operators/strict_reconciliation/conftest.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/conftest.py
@@ -209,11 +209,11 @@ def updated_resource_labels(ocp_resource_by_name):
 
 
 @pytest.fixture(scope="package")
-def is_jira_59518_open():
-    return is_jira_open(jira_id="CNV-59518")
+def is_jira_64473_open():
+    return is_jira_open(jira_id="CNV-64473")
 
 
 @pytest.fixture()
-def skip_if_hco_bearer_token_bug_open(is_jira_59518_open, ocp_resource_by_name):
-    if is_jira_59518_open and ocp_resource_by_name.name == HCO_BEARER_AUTH:
-        pytest.skip(f"{HCO_BEARER_AUTH} resource labels doesn't reconcile due to 59518 bug")
+def skip_if_hco_bearer_token_bug_open(is_jira_64473_open, ocp_resource_by_name):
+    if is_jira_64473_open and ocp_resource_by_name.name == HCO_BEARER_AUTH:
+        pytest.skip(f"{HCO_BEARER_AUTH} resource labels doesn't reconcile due to 64473 bug")

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -1060,14 +1060,14 @@ def windows_vm_for_test(namespace, unprivileged_client):
 
 @pytest.fixture(scope="session")
 def memory_metric_has_bug():
-    return is_jira_open(jira_id="CNV-59679")
+    return is_jira_open(jira_id="CNV-64560")
 
 
 @pytest.fixture()
 def xfail_if_memory_metric_has_bug(memory_metric_has_bug, cnv_vmi_monitoring_metrics_matrix__function__):
     if cnv_vmi_monitoring_metrics_matrix__function__ in METRICS_WITH_WINDOWS_VM_BUGS and memory_metric_has_bug:
         pytest.xfail(
-            f"Bug (CNV-59679), Metric: {cnv_vmi_monitoring_metrics_matrix__function__} not showing "
+            f"Bug (CNV-64560), Metric: {cnv_vmi_monitoring_metrics_matrix__function__} not showing "
             "any value for windows vm"
         )
 

--- a/tests/observability/metrics/test_instance_type_metrics.py
+++ b/tests/observability/metrics/test_instance_type_metrics.py
@@ -74,7 +74,7 @@ def running_rhel_vm_with_instance_type_and_preference(
 
 class TestInstanceType:
     @pytest.mark.polarion("CNV-10181")
-    @pytest.mark.jira("CNV-60672", run=False)
+    @pytest.mark.jira("CNV-64561", run=False)
     def test_verify_instancetype_labels(
         self,
         prometheus,
@@ -87,7 +87,7 @@ class TestInstanceType:
         )
 
     @pytest.mark.polarion("CNV-10182")
-    @pytest.mark.jira("CNV-60672", run=False)
+    @pytest.mark.jira("CNV-64561", run=False)
     def test_verify_migrated_instancetype_labels(
         self,
         prometheus,
@@ -146,7 +146,7 @@ class TestInstanceType:
 )
 class TestInstanceTypeLabling:
     @pytest.mark.polarion("CNV-10183")
-    @pytest.mark.jira("CNV-60672", run=False)
+    @pytest.mark.jira("CNV-64561", run=False)
     def test_kubevirt_vmi_phase_count_cloned_instance_types(
         self,
         prometheus,
@@ -163,7 +163,7 @@ class TestInstanceTypeLabling:
         )
 
     @pytest.mark.polarion("CNV-10797")
-    @pytest.mark.jira("CNV-60672", run=False)
+    @pytest.mark.jira("CNV-64561", run=False)
     def test_cnv_vmi_status_running_count_cloned_instance_types(
         self,
         prometheus,

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -128,7 +128,7 @@ class TestVMIMetricsWindowsVms:
         )
 
     @pytest.mark.polarion("CNV-11860")
-    @pytest.mark.jira("CNV-59552")
+    @pytest.mark.jira("CNV-64562")
     def test_vmi_used_memory_bytes_windows(
         self,
         prometheus,

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -80,7 +80,7 @@ class TestKubevirtVmiMigrationMetrics:
             ),
         ],
     )
-    @pytest.mark.jira("CNV-57777", run=False)
+    @pytest.mark.jira("CNV-64563", run=False)
     def test_kubevirt_vmi_migration_metrics(
         self,
         prometheus,


### PR DESCRIPTION
##### Short description:

There are 4.20 bugs being referenced on cnv-4.19 branch that is provoking tox check to fail. This PR is updating these IDs to the recently created cloned ones pointing to `CNV v4.19.z` version:

https://issues.redhat.com/browse/CNV-59679 --> https://issues.redhat.com/browse/CNV-64560
https://issues.redhat.com/browse/CNV-60672 --> https://issues.redhat.com/browse/CNV-64561
https://issues.redhat.com/browse/CNV-59552 --> https://issues.redhat.com/browse/CNV-64562
https://issues.redhat.com/browse/CNV-57777 --> https://issues.redhat.com/browse/CNV-64563
https://issues.redhat.com/browse/CNV-59518 --> https://issues.redhat.com/browse/CNV-64473

##### More details:

Check run locally and passed:
```
$ uv run pyutils-jira --config-file-path ~/jira.cfg --target-versions "vfuture,4.19.0,4.19.1,4.19.z"
2025-07-02T13:54:07.748668 apps.jira_utils.jira_information ERROR Following Jira ids failed jira version/statuscheck: 
	/home/rlobillo/repo/openshift-virtualization-tests/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py: CNV-48348 target version: 4.20.0, does not match expected version ['vfuture', '4.19.0', '4.19.1', '4.19.z'].
```
NOTE: https://issues.redhat.com/browse/CNV-48458 is out of scope of this PR.

##### What this PR does / why we need it:

We need tox to pass in cnv-4.19 branch when the target-version does not include 4.20.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64474