### PR TITLE
Add s390x marker for tier2 IUO-OCS tests

### DIFF
--- a/tests/deprecated_api/test_deprecation_audit_logs.py
+++ b/tests/deprecated_api/test_deprecation_audit_logs.py
@@ -108,6 +108,7 @@ def deprecated_apis_calls(audit_logs):
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-6679")
 @pytest.mark.order("last")
+@pytest.mark.s390x
 def test_deprecated_apis_in_audit_logs(deprecated_apis_calls):
     LOGGER.info(f"Test deprecated API calls, max version for deprecation check: {DEPRECATED_API_MAX_VERSION}")
     if deprecated_apis_calls:

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -34,9 +34,11 @@ TESTS_MIGRATE_VM = f"{TESTS_CLASS_MIGRATION}::test_migrate_vm"
 @pytest.mark.smoke
 @pytest.mark.gating
 @pytest.mark.sno
+@pytest.mark.s390x
 class TestVMCreationAndValidation:
     @pytest.mark.dependency(name=TEST_CREATE_VM_TEST_NAME)
     @pytest.mark.polarion("CNV-11710")
+    @pytest.mark.s390x
     def test_create_vm(self, golden_image_vm_with_instance_type, instance_type_rhel_os_matrix__class__):
         golden_image_vm_with_instance_type.create(wait=True)
         os_param_dict = instance_type_rhel_os_matrix__class__[[*instance_type_rhel_os_matrix__class__][0]]
@@ -45,6 +47,7 @@ class TestVMCreationAndValidation:
 
     @pytest.mark.dependency(name=TEST_START_VM_TEST_NAME, depends=[TEST_CREATE_VM_TEST_NAME])
     @pytest.mark.polarion("CNV-11711")
+    @pytest.mark.s390x
     def test_start_vm(self, golden_image_vm_with_instance_type):
         running_vm(vm=golden_image_vm_with_instance_type)
 
@@ -116,9 +119,11 @@ class TestVMFeatures:
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 class TestVMMigrationAndState:
     @pytest.mark.polarion("CNV-11714")
     @pytest.mark.dependency(name=TESTS_MIGRATE_VM, depends=[TEST_START_VM_TEST_NAME])
+    @pytest.mark.s390x
     def test_migrate_vm(self, skip_access_mode_rwo_scope_class, golden_image_vm_with_instance_type):
         migrate_vm_and_verify(vm=golden_image_vm_with_instance_type, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=golden_image_vm_with_instance_type)

--- a/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
+++ b/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
@@ -33,6 +33,7 @@ class TestCertRotation:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_certificate_renewed_in_hco(
         self,
         hco_namespace,

--- a/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
+++ b/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
@@ -58,6 +58,7 @@ class TestDisconnectedVirtctlDownload:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_download_virtcli_binary(
         self,
         downloaded_and_extracted_virtctl_binary_for_os,
@@ -84,6 +85,7 @@ class TestDisconnectedVirtctlDownloadAndExecute:
         ],
         indirect=["downloaded_and_extracted_virtctl_binary_for_os"],
     )
+    @pytest.mark.s390x
     def test_download_and_execute_virtcli_binary_linux(self, downloaded_and_extracted_virtctl_binary_for_os, platform):
         assert os.path.exists(downloaded_and_extracted_virtctl_binary_for_os)
         # this part should only be repeated if the execution is being done on a matching platform:
@@ -94,6 +96,7 @@ class TestDisconnectedVirtctlDownloadAndExecute:
 @pytest.mark.arm64
 class TestDisconnectedVirtctlAllLinksInternal:
     @pytest.mark.polarion("CNV-6915")
+    @pytest.mark.s390x
     def test_all_links_internal(self, all_virtctl_urls, non_internal_fqdns):
         assert not non_internal_fqdns, (
             "Found virtctl URLs that do not point to the cluster internally: "

--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -37,6 +37,7 @@ def crds(admin_client):
 
 
 @pytest.mark.polarion("CNV-8263")
+@pytest.mark.s390x
 def test_crds_cluster_readers_role(crds):
     LOGGER.info(f"CRds: {crds}")
     cluster_readers = "system:cluster-readers"

--- a/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
@@ -105,6 +105,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
     ],
     indirect=["resource_crypto_policy_settings"],
 )
+@pytest.mark.s390x
 def test_default_crypto_policy(resource_crypto_policy_settings, resource_type):
     expected_result = CRYPTO_POLICY_EXPECTED_DICT[TLS_INTERMEDIATE_POLICY].get(resource_type)
     assert resource_crypto_policy_settings == expected_result, (
@@ -114,6 +115,7 @@ def test_default_crypto_policy(resource_crypto_policy_settings, resource_type):
 
 
 @pytest.mark.polarion("CNV-9266")
+@pytest.mark.s390x
 def test_default_crypto_policy_check_connectivity(
     workers, workers_utility_pods, services_to_check_connectivity, fips_enabled_cluster
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
@@ -41,6 +41,7 @@ def updated_hco_crypto_policy(
 
 
 @pytest.mark.polarion("CNV-9331")
+@pytest.mark.s390x
 def test_set_hco_crypto_policy(
     cnv_crypto_policy_matrix__function__,
     updated_hco_crypto_policy,

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.polarion("CNV-9367")
+@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):
@@ -41,6 +42,7 @@ def test_set_hco_crypto_failed_without_required_cipher(
 
 
 @pytest.mark.polarion("CNV-10551")
+@pytest.mark.s390x
 def test_set_ciphers_for_tlsv13(hyperconverged_resource_scope_function):
     error_string = r"custom ciphers cannot be selected when minTLSVersion is VersionTLS13"
     tls_custom_profile = copy.deepcopy(TLS_CUSTOM_PROFILE)

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.polarion("CNV-9367")
+@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -140,6 +140,7 @@ def updated_cr_with_custom_crypto_policy(
     ],
     indirect=["updated_cr_with_custom_crypto_policy"],
 )
+@pytest.mark.s390x
 def test_update_specific_component_crypto_policy(
     resources_dict,
     updated_cr_with_custom_crypto_policy,

--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -66,6 +66,7 @@ def csv_permissions_from_yaml(pytestconfig):
 
 
 @pytest.mark.polarion("CNV-9805")
+@pytest.mark.s390x
 def test_new_operator_in_csv(operators_from_csv):
     assert sorted(list(operators_from_csv)) == sorted(CNV_OPERATORS), (
         f"Expected cnv operators:{CNV_OPERATORS} does not match operators {operators_from_csv} "
@@ -73,6 +74,7 @@ def test_new_operator_in_csv(operators_from_csv):
 
 
 @pytest.mark.polarion("CNV-9547")
+@pytest.mark.s390x
 def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissions_from_yaml, csv_permissions):
     from_yaml = csv_permissions_from_yaml.get(cnv_operators_matrix__function__, {})
     from_csv = csv_permissions.get(cnv_operators_matrix__function__, {})
@@ -86,6 +88,7 @@ def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissio
 
 
 @pytest.mark.polarion("CNV-9548")
+@pytest.mark.s390x
 def test_global_csv_permissions(cnv_operators_matrix__function__, global_permission_from_csv):
     error_message = f"Found global permission for {cnv_operators_matrix__function__}"
     errors = {}

--- a/tests/install_upgrade_operators/csv/test_csv.py
+++ b/tests/install_upgrade_operators/csv/test_csv.py
@@ -27,6 +27,7 @@ EXPECTED_LINK_MAP = {
 @pytest.mark.polarion("CNV-4456")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_keywords(csv_scope_session):
     """
     Assert keywords. Check that each one of the expected keywords are actually there
@@ -37,6 +38,7 @@ def test_csv_keywords(csv_scope_session):
 @pytest.mark.polarion("CNV-4457")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_links(csv_scope_session):
     """
     Check links list.
@@ -53,6 +55,7 @@ def test_csv_links(csv_scope_session):
 @pytest.mark.polarion("CNV-4458")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_icon(csv_scope_session):
     """
     Assert Icon/Logo.
@@ -69,6 +72,7 @@ def test_csv_icon(csv_scope_session):
 @pytest.mark.polarion("CNV-4376")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_properties(csv_scope_session):
     """
     Asserting remaining csv properties.
@@ -96,6 +100,7 @@ def test_csv_properties(csv_scope_session):
         ),
     ],
 )
+@pytest.mark.s390x
 def test_csv_annotations(csv_scope_session, csv_annotation, expected_value):
     """
     Validates badges have been added to csv's operators.openshift.io/infrastructure-features annotation

--- a/tests/install_upgrade_operators/csv/test_csv_infrastructure_features_disconnected.py
+++ b/tests/install_upgrade_operators/csv/test_csv_infrastructure_features_disconnected.py
@@ -6,6 +6,7 @@ pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-5840")
+@pytest.mark.s390x
 def test_csv_infrastructure_features_disconnected(csv_annotation):
     """
     In the Cluster Service Version annotations for Infrastructure Feature disconnected looks like:

--- a/tests/install_upgrade_operators/csv/test_hco_api_version.py
+++ b/tests/install_upgrade_operators/csv/test_hco_api_version.py
@@ -5,6 +5,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-5832")
+@pytest.mark.s390x
 def test_hyperconverged_cr_api_version(hyperconverged_resource_scope_function):
     """
     This test will check the Hyperconverged CR's api_version for v1beta1

--- a/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
+++ b/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
@@ -7,6 +7,7 @@ pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-5884")
+@pytest.mark.s390x
 def test_hco_cr_explainable(hyperconverged_resource_scope_function):
     """
     This test case ensure that after executing 'oc explain hyperconvergeds'
@@ -51,6 +52,7 @@ def test_hco_cr_explainable(hyperconverged_resource_scope_function):
         ),
     ],
 )
+@pytest.mark.s390x
 def test_hco_cr_fields_explainable(fields, description):
     """
     This test case ensure that after executing 'oc explain hyperconvergeds.{fields}'

--- a/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
+++ b/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-4751")
+@pytest.mark.s390x
 def test_immutable_image_using_sha(kubevirt_package_manifest_current_channel):
     """
     check all images of the current channel on the kubevirt-hyperconverged Package Manifest.

--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-7169")
+@pytest.mark.s390x
 def test_channels_in_manifest(kubevirt_package_manifest_channels):
     expected_channels = {"stable", "dev-preview"}
     missing_channels = expected_channels - {channel.name for channel in kubevirt_package_manifest_channels}
@@ -11,5 +12,6 @@ def test_channels_in_manifest(kubevirt_package_manifest_channels):
 
 
 @pytest.mark.polarion("CNV-11944")
+@pytest.mark.s390x
 def test_cnv_subscription_channel(cnv_subscription_scope_session, kubevirt_package_manifest_current_channel):
     assert cnv_subscription_scope_session.instance.spec.channel == kubevirt_package_manifest_current_channel.name

--- a/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
+++ b/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
@@ -13,6 +13,7 @@ def cnv_daemonset_names(admin_client, hco_namespace):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8509")
+@pytest.mark.s390x
 def test_no_new_cnv_daemonset_added(sno_cluster, cnv_daemonset_names):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -32,6 +32,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_liveness_probe(deployment_by_name):
     """Validates various livenessProbe fields values for different deployment objects"""
     validate_liveness_probe_fields(deployment=deployment_by_name)
@@ -56,6 +57,7 @@ def test_liveness_probe(deployment_by_name):
     ],
     indirect=["deployment_by_name"],
 )
+@pytest.mark.s390x
 def test_request_param(deployment_by_name, cpu_min_value):
     """Validates resources.requests fields keys and default cpu values for different deployment objects"""
     validate_request_fields(deployment=deployment_by_name, cpu_min_value=cpu_min_value)
@@ -63,6 +65,7 @@ def test_request_param(deployment_by_name, cpu_min_value):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-7675")
+@pytest.mark.s390x
 def test_cnv_deployment_priority_class_name(
     cnv_deployment_by_name_no_hpp,
 ):
@@ -75,6 +78,7 @@ def test_cnv_deployment_priority_class_name(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8289")
+@pytest.mark.s390x
 def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added
@@ -90,6 +94,7 @@ def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8264")
+@pytest.mark.s390x
 def test_cnv_deployment_container_image(cnv_deployment_by_name):
     assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)
     assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -79,6 +79,7 @@ def resource_object_value_by_key(request):
     ],
     indirect=["resource_object_value_by_key"],
 )
+@pytest.mark.s390x
 def test_default_featuregates_by_resource(
     expected,
     resource_object_value_by_key,

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -52,6 +52,7 @@ class TestHardcodedFeatureGates:
         ],
         indirect=["updated_resource"],
     )
+    @pytest.mark.s390x
     def test_managed_cr_featuregate_reconcile(
         self,
         updated_resource,

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -42,6 +42,7 @@ def updated_fg_hco(
     ],
     indirect=["updated_fg_hco"],
 )
+@pytest.mark.s390x
 def test_enable_fg_hco(
     updated_fg_hco,
     hco_spec,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -178,6 +178,7 @@ class TestDefaultCommonTemplates:
             pytest.param("ssp_spec_templates_scope_function", marks=pytest.mark.polarion("CNV-11677")),
         ],
     )
+    @pytest.mark.s390x
     def test_custom_namespace_added_to_templates_metadata(
         self,
         request,
@@ -197,6 +198,7 @@ class TestDefaultCommonTemplates:
             pytest.param(DataSource, DataSource.Condition.READY, marks=pytest.mark.polarion("CNV-11476")),
         ],
     )
+    @pytest.mark.s390x
     def test_resources_in_custom_ns(
         self,
         admin_client,
@@ -221,6 +223,7 @@ class TestDefaultCommonTemplates:
             )
 
     @pytest.mark.polarion("CNV-11477")
+    @pytest.mark.s390x
     def test_boot_sources_not_reconciled_in_default_namespace(self, admin_client, golden_images_namespace):
         verify_resources_not_reconciled(
             resources_to_verify=[DataVolume, VolumeSnapshot],
@@ -230,6 +233,7 @@ class TestDefaultCommonTemplates:
 
 
 @pytest.mark.polarion("CNV-11631")
+@pytest.mark.s390x
 def test_non_existent_namespace(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
@@ -9,6 +9,7 @@ pytestmark = [pytest.mark.gating, pytest.mark.arm64]
 
 @pytest.mark.usefixtures("hyperconverged_spec_scope_session", "hyperconverged_status_scope_session")
 @pytest.mark.polarion("CNV-7504")
+@pytest.mark.s390x
 def test_data_import_schedule_default_in_hco_cr(
     data_import_schedule,
 ):
@@ -18,6 +19,7 @@ def test_data_import_schedule_default_in_hco_cr(
 
 
 @pytest.mark.polarion("CNV-8168")
+@pytest.mark.s390x
 def test_default_hco_cr_image_streams(
     admin_client,
     golden_images_namespace,
@@ -36,6 +38,7 @@ def test_default_hco_cr_image_streams(
 
 
 @pytest.mark.polarion("CNV-8935")
+@pytest.mark.s390x
 def test_no_data_import_template_in_hco_spec(
     hyperconverged_spec_scope_session,
 ):
@@ -45,6 +48,7 @@ def test_no_data_import_template_in_hco_spec(
 
 
 @pytest.mark.polarion("CNV-8703")
+@pytest.mark.s390x
 def test_data_import_template_defaults_hco_status(
     hyperconverged_status_scope_session,
     hyperconverged_spec_scope_session,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.mark.jira("CNV-63031", run=False)
 @pytest.mark.polarion("CNV-7603")
+@pytest.mark.s390x
 def test_same_random_minute_after_delete_hco_pod(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 class TestEnableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7626")
+    @pytest.mark.s390x
     def test_set_enable_common_boot_image_import_true_ssp_cr(
         self,
         ssp_cr_spec,
@@ -26,6 +27,7 @@ class TestEnableCommonBootImageImport:
 
 
 @pytest.mark.polarion("CNV-7778")
+@pytest.mark.s390x
 def test_enable_and_delete_spec_enable_common_boot_image_import_hco_cr(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -128,6 +128,7 @@ class TestModifyCommonTemplateSpec:
         ],
         indirect=["updated_common_template"],
     )
+    @pytest.mark.s390x
     def test_modified_common_template(self, updated_common_template, hyperconverged_status_templates_scope_function):
         template_name = updated_common_template[0]["metadata"]["name"]
         hco_template = get_template_dict_by_name(
@@ -164,6 +165,7 @@ class TestModifyCommonTemplateSpec:
         ],
         indirect=["updated_common_template"],
     )
+    @pytest.mark.s390x
     def test_common_template_modify_spec(
         self,
         updated_common_template,
@@ -249,6 +251,7 @@ class TestCommonTemplatesEnableDisable:
         ],
         indirect=["updated_common_template"],
     )
+    @pytest.mark.s390x
     def test_common_template_config_disable(
         self,
         updated_common_template,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
@@ -71,6 +71,7 @@ def updated_hco_cr_custom_template_disable(
 
 
 @pytest.mark.polarion("CNV-8731")
+@pytest.mark.s390x
 def test_custom_template_no_disable(
     updated_hco_cr_custom_template_disable,
     hyperconverged_status_templates_scope_function,
@@ -89,6 +90,7 @@ def test_custom_template_no_disable(
 
 
 @pytest.mark.polarion("CNV-8709")
+@pytest.mark.s390x
 def test_disable_template_annotation_value(admin_client, hco_namespace, editor_hyperconverged_custom_template):
     try:
         with pytest.raises(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
@@ -11,6 +11,7 @@ pytestmark = [pytest.mark.gating, pytest.mark.arm64]
 @pytest.mark.usefixtures("disabled_common_boot_image_import_hco_spec_scope_class")
 class TestDisableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7473")
+    @pytest.mark.s390x
     def test_disable_spec_verify_hco_cr_and_ssp_cr(
         self,
         ssp_cr_spec,
@@ -20,6 +21,7 @@ class TestDisableCommonBootImageImport:
         )
 
     @pytest.mark.polarion("CNV-8183")
+    @pytest.mark.s390x
     def test_image_streams_disable_feature_gate(
         self,
         golden_images_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -62,6 +62,7 @@ def updated_hco_cr_custom_template_scope_class(
 class TestCustomTemplates:
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-8707")
+    @pytest.mark.s390x
     def test_custom_template_status(self, hyperconverged_status_templates_scope_function):
         custom_template_name = CUSTOM_CRON_TEMPLATE["metadata"]["name"]
         custom_templates_name = [
@@ -77,6 +78,7 @@ class TestCustomTemplates:
 
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7884")
+    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template(
         self,
         hyperconverged_status_templates_scope_function,
@@ -89,6 +91,7 @@ class TestCustomTemplates:
 
     @pytest.mark.dependency(name="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7914")
+    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template_disable_spec(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
@@ -46,6 +46,7 @@ def json_patched_cdi(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8717")
+    @pytest.mark.s390x
     def test_cdi_json_patch(
         self,
         admin_client,
@@ -66,6 +67,7 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9707")
+    @pytest.mark.s390x
     def test_cdi_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -80,5 +82,6 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9706")
+    @pytest.mark.s390x
     def test_cdi_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT_CDI)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
@@ -51,6 +51,7 @@ def json_patched_cnao(
 )
 class TestCNAOJsonPatch:
     @pytest.mark.polarion("CNV-8715")
+    @pytest.mark.s390x
     def test_cnao_json_patch(
         self,
         admin_client,
@@ -68,6 +69,7 @@ class TestCNAOJsonPatch:
         assert not cnao_spec.get(PATH), f"Unable to replace {PATH} from CNAO via json patch. Current value: {cnao_spec}"
 
     @pytest.mark.polarion("CNV-9713")
+    @pytest.mark.s390x
     def test_cnao_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -82,5 +84,6 @@ class TestCNAOJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9712")
+    @pytest.mark.s390x
     def test_cnao_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
@@ -44,6 +44,7 @@ def json_patched_kubevirt(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8689")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch(
         self,
         admin_client,
@@ -60,6 +61,7 @@ class TestKubevirtJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-9697")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -74,6 +76,7 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9698")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch_alert(self, prometheus):
         wait_for_alert(
             prometheus=prometheus,

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
@@ -79,6 +79,7 @@ def multiple_json_patched(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestMultipleJsonPatch:
     @pytest.mark.polarion("CNV-8718")
+    @pytest.mark.s390x
     def test_multiple_json_patch(
         self,
         admin_client,
@@ -101,6 +102,7 @@ class TestMultipleJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-8720")
+    @pytest.mark.s390x
     def test_multiple_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         component_metrics_dict = {
             component: filter_metric_by_component(
@@ -120,6 +122,7 @@ class TestMultipleJsonPatch:
             )
 
     @pytest.mark.polarion("CNV-8813")
+    @pytest.mark.s390x
     def test_multiple_json_patch_alert(self, prometheus):
         for component in COMPONENT_DICT.keys():
             LOGGER.info(f"Waiting for alert: {ALERT_NAME} for component: {component}")

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -47,6 +47,7 @@ def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestSSPJsonPatch:
     @pytest.mark.polarion("CNV-8690")
+    @pytest.mark.s390x
     def test_ssp_json_patch(
         self,
         admin_client,
@@ -67,6 +68,7 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8691")
+    @pytest.mark.s390x
     def test_ssp_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -81,5 +83,6 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8714")
+    @pytest.mark.s390x
     def test_ssp_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
@@ -41,6 +41,7 @@ LOGGER = logging.getLogger(__name__)
         ),
     ],
 )
+@pytest.mark.s390x
 def test_default_workload_update_strategy(admin_client, hco_namespace, resource_name, expected):
     """Validates by default, hyperconverged's and kubevirt's spec.workloadUpdateStrategy is set to correct values"""
     LOGGER.info("Ensure HCO is is in stable condition before checking for spec.workloadUpdateStrategy")

--- a/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
@@ -65,6 +65,7 @@ class TestLauncherUpdateNegative:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_hyperconverged_reset_custom_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,

--- a/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
@@ -51,6 +51,7 @@ class TestLauncherUpdateResetFields:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_reset_custom_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,

--- a/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
@@ -60,6 +60,7 @@ class TestLauncherUpdateModifyDefault:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_modify_custom_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,
@@ -112,6 +113,7 @@ class TestLauncherUpdateModifyDefault:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_modify_all_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,

--- a/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
@@ -42,6 +42,7 @@ class TestLauncherUpdateAll:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_modify_custom_workload_update_strategy_all(
         self,
         admin_client,
@@ -162,6 +163,7 @@ class TestCustomWorkLoadStrategy:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_modify_custom_workload_update_strategy(
         self, admin_client, hco_namespace, updated_hco_cr, expected
     ):

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -78,6 +78,7 @@ class TestMustGatherCluster:
         ],
         indirect=["resource_type"],
     )
+    @pytest.mark.s390x
     def test_resource_type(
         self,
         admin_client,
@@ -95,6 +96,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2982")
+    @pytest.mark.s390x
     def test_namespace(self, hco_namespace, must_gather_for_test):
         namespace_name = hco_namespace.name
         check_resource(
@@ -106,6 +108,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-5885")
+    @pytest.mark.s390x
     def test_no_upstream_only_namespaces(self, must_gather_for_test, sriov_namespace):
         """
         After running must-gather command on the cluster, there are some upstream-only namespaces
@@ -179,6 +182,7 @@ class TestMustGatherCluster:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_pods(
         self,
         admin_client,
@@ -197,6 +201,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2727")
+    @pytest.mark.s390x
     def test_template_in_openshift_ns_data(self, admin_client, must_gather_for_test):
         template_resources = list(
             Template.get(dyn_client=admin_client, singular_name="template", namespace="openshift")
@@ -214,6 +219,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2809")
+    @pytest.mark.s390x
     def test_node_nftables(self, collected_nft_files_must_gather, nftables_from_utility_pods):
         table_not_found_errors = []
         for node_name in collected_nft_files_must_gather:
@@ -255,6 +261,7 @@ class TestMustGatherCluster:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_node_resource(
         self,
         must_gather_for_test,
@@ -273,6 +280,7 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-2801")
+    @pytest.mark.s390x
     def test_nmstate_config_data(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -287,6 +295,7 @@ class TestMustGatherCluster:
         "label_selector",
         [pytest.param({"app": "cni-plugins"}, marks=(pytest.mark.polarion("CNV-2715")))],
     )
+    @pytest.mark.s390x
     def test_logs_gathering(self, must_gather_for_test, running_hco_containers, label_selector):
         check_logs(
             cnv_must_gather=must_gather_for_test,
@@ -307,6 +316,7 @@ class TestMustGatherCluster:
         ],
         indirect=["config_map_by_name"],
     )
+    @pytest.mark.s390x
     def test_gathered_config_maps(
         self,
         must_gather_for_test,
@@ -326,6 +336,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2723")
+    @pytest.mark.s390x
     def test_apiservice_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -337,6 +348,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2726")
+    @pytest.mark.s390x
     def test_webhookconfig_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -365,11 +377,13 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-8508")
+    @pytest.mark.s390x
     def test_no_new_cnv_crds(self, kubevirt_crd_names):
         new_crds = [crd for crd in kubevirt_crd_names if crd not in ALL_CNV_CRDS]
         assert not new_crds, f"Following crds are new: {new_crds}."
 
     @pytest.mark.polarion("CNV-2724")
+    @pytest.mark.s390x
     def test_crd_resources(self, admin_client, must_gather_for_test, kubevirt_crd_by_type):
         crd_name = kubevirt_crd_by_type.name
         for version in kubevirt_crd_by_type.instance.spec.versions:
@@ -420,6 +434,7 @@ class TestMustGatherCluster:
                 )
 
     @pytest.mark.polarion("CNV-2939")
+    @pytest.mark.s390x
     def test_image_stream_tag_resources(self, admin_client, must_gather_for_test):
         resource_path = (
             f"namespaces/{NamespacesNames.OPENSHIFT}/{ImageStreamTag.ApiGroup.IMAGE_OPENSHIFT_IO}/imagestreamtags"
@@ -462,6 +477,7 @@ class TestSriovMustGather:
 
 class TestCNVCollectsLogs:
     @pytest.mark.polarion("CNV-9906")
+    @pytest.mark.s390x
     def test_kubevirt_logs_collected(self, gathered_kubevirt_logs, running_hco_containers, hco_namespace):
         LOGGER.info(f"Pod containers: {running_hco_containers}")
         check_logs(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -33,6 +33,7 @@ class TestImageGathering:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_image_gather(self, admin_client, gathered_images, resource, resource_path):
         check_list_of_resources(
             dyn_client=admin_client,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
@@ -22,6 +22,7 @@ class TestInstanceTypesAndPreferencesCollected:
         indirect=True,
     )
     @pytest.mark.polarion("CNV-9648")
+    @pytest.mark.s390x
     def test_instancestypes_collected(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -83,6 +83,7 @@ class TestMustGatherClusterWithVMs:
         ],
         indirect=["resource_type"],
     )
+    @pytest.mark.s390x
     def test_resource_type(
         self,
         admin_client,
@@ -262,6 +263,7 @@ class TestMustGatherVmDetails:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_blockjob_file_collected_from_virt_launcher(
         self,
         data_volume_scope_class,
@@ -276,6 +278,7 @@ class TestMustGatherVmDetails:
         )
 
     @pytest.mark.polarion("CNV-10243")
+    @pytest.mark.s390x
     def test_must_gather_and_vm_same_node(
         self,
         must_gather_vm,
@@ -291,6 +294,7 @@ class TestMustGatherVmDetails:
 class TestGuestConsoleLog:
     @pytest.mark.usefixtures("updated_disable_serial_console_log_false", "must_gather_vm_scope_class")
     @pytest.mark.polarion("CNV-10630")
+    @pytest.mark.s390x
     def test_guest_console_logs(
         self,
         must_gather_vm_scope_class,
@@ -305,6 +309,7 @@ class TestGuestConsoleLog:
 @pytest.mark.sno
 class TestMustGatherVmLongNameDetails:
     @pytest.mark.polarion("CNV-9233")
+    @pytest.mark.s390x
     def test_data_collected_from_virt_launcher_long(
         self,
         must_gather_long_name_vm,
@@ -330,6 +335,7 @@ class TestNoMultipleFilesCollected:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_no_multiple_empty_files_collected_from_must_gather_migrated_vm(
         self,
         skip_if_no_common_cpu,
@@ -353,6 +359,7 @@ class TestNoMultipleFilesCollected:
 @pytest.mark.sno
 class TestControllerRevisionCollected:
     @pytest.mark.polarion("CNV-10978")
+    @pytest.mark.s390x
     def test_controller_revision_collected(
         self,
         rhel_vm_with_cluster_instance_type_and_preference,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
@@ -49,6 +49,7 @@ class TestMustGatherVmDetailsWithParams:
         ],
         indirect=["collected_vm_details_must_gather_with_params"],
     )
+    @pytest.mark.s390x
     def test_must_gather_params(
         self,
         must_gather_vm,
@@ -66,6 +67,7 @@ class TestMustGatherVmDetailsWithParams:
         )
 
     @pytest.mark.polarion("CNV-9039")
+    @pytest.mark.s390x
     def test_must_gather_stopped_vm(
         self,
         must_gather_vms_from_alternate_namespace,

--- a/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
+++ b/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
@@ -45,6 +45,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_change_subscription_on_selected_node_before_workload(
         self,
         admin_client,
@@ -78,6 +79,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         indirect=True,
     )
     @pytest.mark.dependency(name="test_change_infrastructure_components_on_selected_node_before_workload")
+    @pytest.mark.s390x
     def test_change_infrastructure_components_on_selected_node_before_workload(
         self,
         admin_client,
@@ -114,6 +116,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_change_workload_components_on_selected_node_before_workload",
         depends=["test_change_infrastructure_components_on_selected_node_before_workload"],
     )
+    @pytest.mark.s390x
     def test_change_workload_components_on_selected_node_before_workload(
         self,
         admin_client,
@@ -143,6 +146,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_deploying_workloads_on_selected_nodes",
         depends=["test_change_workload_components_on_selected_node_before_workload"],
     )
+    @pytest.mark.s390x
     def test_deploying_workloads_on_selected_nodes(
         self,
         vm_placement_vm_work3,
@@ -154,6 +158,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_deploying_workloads_on_selected_nodes"],
     )
+    @pytest.mark.s390x
     def test_workload_components_selection_change_denied_with_workloads(
         self,
         nodes_labeled,
@@ -182,6 +187,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_infrastructure_components_selection_change_allowed_with_workloads",
         depends=["test_deploying_workloads_on_selected_nodes"],
     )
+    @pytest.mark.s390x
     def test_infrastructure_components_selection_change_allowed_with_workloads(
         self,
         admin_client,
@@ -221,6 +227,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_infrastructure_components_selection_change_allowed_with_workloads"],
     )
+    @pytest.mark.s390x
     def test_operator_components_selection_change_allowed_with_workloads(
         self,
         admin_client,
@@ -258,6 +265,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_infrastructure_components_selection_change_allowed_after_workloads",
         depends=["test_infrastructure_components_selection_change_allowed_with_workloads"],
     )
+    @pytest.mark.s390x
     def test_infrastructure_components_selection_change_allowed_after_workloads(
         self,
         admin_client,
@@ -297,6 +305,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_infrastructure_components_selection_change_allowed_after_workloads"],
     )
+    @pytest.mark.s390x
     def test_operator_components_selection_change_allowed_after_workloads(
         self,
         admin_client,
@@ -332,6 +341,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_infrastructure_components_selection_change_allowed_after_workloads"],
     )
+    @pytest.mark.s390x
     def test_workload_components_selection_change_allowed_after_workloads(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/node_component/test_hco_vm.py
+++ b/tests/install_upgrade_operators/node_component/test_hco_vm.py
@@ -49,6 +49,7 @@ def hco_vm(unprivileged_client, namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_remove_workload_label_from_node_while_vm_running(
     node_placement_labels, hyperconverged_with_node_placement, hco_vm
 ):

--- a/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
+++ b/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
@@ -27,6 +27,7 @@ LOGGER = logging.getLogger(__name__)
 class TestCreateHCOWithNodePlacement:
     @pytest.mark.polarion("CNV-5368")
     @pytest.mark.dependency(name="test_hco_cr_with_node_placement")
+    @pytest.mark.s390x
     def test_hco_cr_with_node_placement(
         self,
         admin_client,
@@ -63,6 +64,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5369")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_ssp_cr(
         self,
         ssp_cr_spec,
@@ -81,6 +83,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5382")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_network_addons_cr(
         self,
         network_addon_config_spec_placement,
@@ -123,6 +126,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5383")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_kubevirt_cr(
         self,
         kubevirt_hyperconverged_spec_scope_function,
@@ -158,6 +162,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5384")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_cdi_cr(
         self,
         cdi_spec,

--- a/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
+++ b/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
@@ -57,6 +57,7 @@ def pod_security_violations_apis_calls(audit_logs, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-9115")
+@pytest.mark.s390x
 def test_cnv_pod_security_violation_audit_logs(pod_security_violations_apis_calls):
     LOGGER.info("Test pod security violations API calls:")
     if pod_security_violations_apis_calls:

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -40,6 +40,7 @@ def cnv_pods_by_type_no_hpp_csi_hpp_pool(cnv_pod_priority_class_matrix__function
 
 
 @pytest.mark.polarion("CNV-7261")
+@pytest.mark.s390x
 def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
     all_pods = ALL_CNV_PODS.copy()
     all_pods.append(HPP_POOL)
@@ -53,12 +54,14 @@ def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
 
 
 @pytest.mark.polarion("CNV-7262")
+@pytest.mark.s390x
 def test_pods_priority_class_value(cnv_pods_by_type_no_hpp_csi_hpp_pool):
     validate_cnv_pods_priority_class_name_exists(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
     validate_priority_class_value(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
 
 
 @pytest.mark.polarion("CNV-7306")
+@pytest.mark.s390x
 def test_pods_resource_request(
     cnv_pods_by_type,
     pod_resource_validation_matrix__function__,
@@ -70,6 +73,7 @@ def test_pods_resource_request(
 
 
 @pytest.mark.polarion("CNV-8267")
+@pytest.mark.s390x
 def test_cnv_pod_container_image(cnv_pods_by_type):
     assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)
     assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)

--- a/tests/install_upgrade_operators/product_install/test_crds_schema.py
+++ b/tests/install_upgrade_operators/product_install/test_crds_schema.py
@@ -36,6 +36,7 @@ def crd_operator_resources(request, admin_client):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_check_crd_non_structural_schema(crd_operator_resources):
     failed_crds = [
         crd_resource.name

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
@@ -35,6 +35,7 @@ def remove_kubevirt_vm(unprivileged_client, namespace):
 
 
 @pytest.mark.polarion("CNV-3738")
+@pytest.mark.s390x
 def test_validate_default_uninstall_strategy(kubevirt_resource):
     strategy = kubevirt_resource.instance.spec.uninstallStrategy
     assert strategy == "BlockUninstallIfWorkloadsExist", (

--- a/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
@@ -88,6 +88,7 @@ def cnv_resources(hco_namespace):
 
 
 @pytest.mark.polarion("CNV-10307")
+@pytest.mark.s390x
 def test_relationship_labels_all_cnv_resources(
     ocp_resources_submodule_list, admin_client, cnv_resources, hco_namespace
 ):

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -42,6 +42,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_mismatch_relationship_labels_deployments(self, expected_label_dictionary, cnv_deployment_by_name):
         verify_component_labels_by_resource(
             component=cnv_deployment_by_name,
@@ -58,6 +59,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_mismatch_relationship_labels_daemonsets(self, expected_label_dictionary, cnv_daemonset_by_name):
         verify_component_labels_by_resource(
             component=cnv_daemonset_by_name,
@@ -74,6 +76,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_mismatch_relationship_labels_pods(self, expected_label_dictionary, cnv_pod_by_name):
         verify_component_labels_by_resource(
             component=cnv_pod_by_name,
@@ -90,6 +93,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_relationship_labels_hco_components(
         self,
         expected_label_dictionary,

--- a/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
+++ b/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
@@ -23,6 +23,7 @@ LOGGER = logging.getLogger(__name__)
         ),
     ],
 )
+@pytest.mark.s390x
 def test_hco_status_conditions(admin_client, hco_namespace, expected_condition_fields):
     """Validates hco status conditions contains expected field"""
     LOGGER.info("Check for hco to be in stable condition:")

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -35,6 +35,7 @@ def required_scc_deployment_check(admin_client, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-11964")
+@pytest.mark.s390x
 def test_deployments_missing_required_scc_annotation(required_scc_deployment_check):
     assert not required_scc_deployment_check["missing_required_scc_annotation"], (
         f"Deployments missing {REQUIRED_SCC_ANNOTATION} annotation: "
@@ -43,6 +44,7 @@ def test_deployments_missing_required_scc_annotation(required_scc_deployment_che
 
 
 @pytest.mark.polarion("CNV-11965")
+@pytest.mark.s390x
 def test_deployments_with_incorrect_required_scc(required_scc_deployment_check):
     assert not required_scc_deployment_check["incorrect_required_scc_annotation_value"], (
         f"Deployments incorrect {REQUIRED_SCC_ANNOTATION} annotation : "

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -44,6 +44,7 @@ def verify_cnv_pods_with_scc(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4438")
+@pytest.mark.s390x
 def test_openshift_io_scc_exists(cnv_pods):
     """
     Validate that Pods in openshift-cnv have 'openshift.io/scc' annotation
@@ -64,6 +65,7 @@ def pods_not_allowlisted_or_anyuid(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4211")
+@pytest.mark.s390x
 def test_pods_scc_in_allowlist(pods_not_allowlisted_or_anyuid):
     """
     Validate that Pods in openshift-cnv have SCC from a predefined allowlist

--- a/tests/install_upgrade_operators/security/scc/test_default_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_default_scc.py
@@ -16,6 +16,7 @@ def privileged_scc():
 
 
 @pytest.mark.polarion("CNV-4439")
+@pytest.mark.s390x
 def test_users_in_privileged_scc(privileged_scc):
     """
     Validate that Users in privileged SCC is not updated after installing CNV

--- a/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
+++ b/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
@@ -36,6 +36,7 @@ def vm_virt_launcher_pod(developer_vm, namespace, unprivileged_client):
 
 
 @pytest.mark.polarion("CNV-4897")
+@pytest.mark.s390x
 def test_unprivileged_client_virt_launcher(unprivileged_client, developer_vm, vm_virt_launcher_pod):
     with pytest.raises(
         ApiException,

--- a/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
+++ b/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-4296")
+@pytest.mark.s390x
 def test_selinuxlaunchertype_in_kubevirt_config(kubevirt_config):
     selinux_launcher_type = "selinuxLauncherType"
     assert selinux_launcher_type not in kubevirt_config, f"{selinux_launcher_type} is found in {kubevirt_config}"

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
@@ -237,6 +237,7 @@ class TestCRDefaultsOnStanzaDeletion:
         ],
         indirect=["deleted_stanza_on_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_certconfig_defaults_on_stanza_delete(
         self,
         deleted_stanza_on_hco_cr,
@@ -270,6 +271,7 @@ class TestCRDefaultsOnStanzaDeletion:
         ],
         indirect=["deleted_stanza_on_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_featuregates_defaults_on_stanza_delete(
         self,
         admin_client,
@@ -428,6 +430,7 @@ class TestCRDefaultsOnStanzaDeletion:
         ],
         indirect=["deleted_stanza_on_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_livemigrationconfig_defaults_on_stanza_delete(
         self,
         deleted_stanza_on_hco_cr,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
@@ -317,6 +317,7 @@ class TestOperatorsModify:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_modify_hco_cr(
         self,
         hco_cr_custom_values,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
@@ -156,6 +156,7 @@ class TestHCONonDefaultFields:
         ],
         indirect=["deleted_stanza_on_hco_cr", "reconciled_cr_post_hco_update"],
     )
+    @pytest.mark.s390x
     def test_non_default_fields_cdi(
         self,
         hco_status_related_objects_scope_function,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -92,6 +92,7 @@ def hco_with_default_cpu_model_set(
 
 
 @pytest.mark.polarion("CNV-9024")
+@pytest.mark.s390x
 def test_default_value_for_cpu_model(
     hco_spec_scope_module,
     kubevirt_hyperconverged_spec_scope_module,
@@ -119,6 +120,7 @@ def test_default_value_for_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9025")
+@pytest.mark.s390x
 def test_set_hco_default_cpu_model(
     hyperconverged_resource_scope_function,
     hco_with_default_cpu_model_set,
@@ -145,6 +147,7 @@ def test_set_hco_default_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9026")
+@pytest.mark.s390x
 def test_set_hco_default_cpu_model_with_existing_vm(
     hyperconverged_resource_scope_function,
     fedora_vm_scope_module,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
@@ -53,6 +53,7 @@ class TestNegativeFeatureGates:
         ],
         indirect=["hco_with_non_default_feature_gates"],
     )
+    @pytest.mark.s390x
     def test_invalid_featuregates_in_hco_cr(
         self,
         admin_client,
@@ -91,6 +92,7 @@ class TestNegativeFeatureGates:
         ],
         indirect=["updated_kv_with_feature_gates"],
     )
+    @pytest.mark.s390x
     def test_optional_featuregates_removed_from_kubevirt_cr(
         self,
         admin_client,
@@ -118,6 +120,7 @@ class TestHCOOptionalFeatureGatesSuite:
         [["fakeGate"]],
         indirect=["updated_cdi_with_feature_gates"],
     )
+    @pytest.mark.s390x
     def test_optional_featuregates_fake_removed_from_cdi_cr(
         self,
         updated_cdi_with_feature_gates,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -12,6 +12,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
+    @pytest.mark.s390x
     def test_no_new_hco_related_objects(self, hco_status_related_objects):
         actual_related_objects = {
             related_object["name"]: related_object["kind"]
@@ -28,6 +29,7 @@ class TestRelatedObjects:
         assert not new_related_objects, f"There are new HCO related objects:\n {new_related_objects.to_json(indent=2)}"
 
     @pytest.mark.polarion("CNV-7267")
+    @pytest.mark.s390x
     def test_hco_related_objects(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
@@ -37,6 +37,7 @@ class TestLiveMigrationConfigUpdate:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_modify_hco_cr(
         self,
         updated_hco_cr,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
@@ -118,6 +118,7 @@ class TestOperatorsDefaults:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_verify_expected_config_in_crs(
         self,
         expected,
@@ -160,6 +161,7 @@ class TestOperatorsDefaults:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_no_defaults_in_cr_for_permittedhostdevices_and_obsoletecpu(
         self,
         expected_to_be_absent,
@@ -169,6 +171,7 @@ class TestOperatorsDefaults:
         assert expected_to_be_absent not in str(cr_func_map[resource_kind_str]).lower()
 
     @pytest.mark.polarion("CNV-7312")
+    @pytest.mark.s390x
     def test_bandwidthpermigration_does_not_exist_in_hco_cr(
         self,
         hco_spec,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
@@ -109,6 +109,7 @@ class TestOperatorsModify:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_modify_cdi_cr(
         self,
         admin_client,
@@ -282,6 +283,7 @@ class TestOperatorsModify:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_modify_kubevirt_cr(
         self,
         admin_client,
@@ -370,6 +372,7 @@ class TestOperatorsModify:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_modify_cnao_cr(
         self,
         admin_client,

--- a/tests/network/bond/test_bond_modes.py
+++ b/tests/network/bond/test_bond_modes.py
@@ -195,17 +195,20 @@ def bond_resource(index_number, nodes_available_nics, worker_node1):
 
 
 @pytest.mark.polarion("CNV-4382")
+@pytest.mark.s390x
 def test_bond_created(workers_utility_pods, matrix_bond_modes_bond):
     assert_bond_validation(utility_pods=workers_utility_pods, bond=matrix_bond_modes_bond)
 
 
 @pytest.mark.polarion("CNV-4383")
+@pytest.mark.s390x
 def test_vm_started(bond_modes_vm):
     bond_modes_vm.start(wait=True)
     bond_modes_vm.wait_for_agent_connected()
 
 
 @pytest.mark.polarion("CNV-6583")
+@pytest.mark.s390x
 def test_active_backup_bond_with_fail_over_mac(
     index_number,
     worker_node1,
@@ -224,6 +227,7 @@ def test_active_backup_bond_with_fail_over_mac(
 
 
 @pytest.mark.polarion("CNV-6584")
+@pytest.mark.s390x
 def test_vm_bond_with_fail_over_mac_started(
     vm_with_fail_over_mac_bond,
 ):
@@ -232,5 +236,6 @@ def test_vm_bond_with_fail_over_mac_started(
 
 
 @pytest.mark.polarion("CNV-7263")
+@pytest.mark.s390x
 def test_bond_with_bond_port(workers_utility_pods, bond_resource):
     assert_bond_validation(utility_pods=workers_utility_pods, bond=bond_resource)

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -183,6 +183,7 @@ def ovs_linux_bond_bridge_attached_vms(ovs_linux_bond_bridge_attached_vma, ovs_l
 class TestBondConnectivity:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-3366")
+    @pytest.mark.s390x
     def test_bond(
         self,
         namespace,

--- a/tests/network/cluster_addons_operator/test_network_addons_operator.py
+++ b/tests/network/cluster_addons_operator/test_network_addons_operator.py
@@ -216,6 +216,7 @@ def net_add_op_bridge_attached_vm(namespace, net_add_op_br1test_nad):
 @pytest.mark.gating
 @pytest.mark.post_upgrade
 @pytest.mark.single_nic
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-2520")
 def test_component_installed_by_operator(network_addons_config_scope_session):
     """
@@ -237,6 +238,7 @@ def test_component_installed_by_operator(network_addons_config_scope_session):
 
 @pytest.mark.post_upgrade
 @pytest.mark.polarion("CNV-2296")
+@pytest.mark.s390x
 def test_linux_bridge_functionality(net_add_op_bridge_attached_vm):
     """
     Verify the linux-bridge component valid functionality.
@@ -248,6 +250,7 @@ def test_linux_bridge_functionality(net_add_op_bridge_attached_vm):
 
 @pytest.mark.polarion("CNV-6754")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_cnao_labels(
     admin_client,
     network_addons_config_scope_session,

--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -28,6 +28,7 @@ class TestConnectivityLinuxBridge:
         ],
     )
     @pytest.mark.ipv4
+    @pytest.mark.s390x
     def test_ipv4_linux_bridge(
         self,
         use_default_bridge,
@@ -73,6 +74,7 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11123")
     @pytest.mark.ipv4
+    @pytest.mark.s390x
     def test_positive_vlan_linux_bridge(
         self,
         nad_linux_bridge_vlan_1,
@@ -89,6 +91,7 @@ class TestConnectivityLinuxBridge:
 
     @pytest.mark.polarion("CNV-11131")
     @pytest.mark.ipv4
+    @pytest.mark.s390x
     def test_negative_vlan_linux_bridge(
         self,
         nad_linux_bridge_vlan_3,
@@ -123,6 +126,7 @@ class TestConnectivityOVSBridge:
         ],
     )
     @pytest.mark.ipv4
+    @pytest.mark.s390x
     def test_ipv4_ovs_bridge(
         self,
         use_default_bridge,
@@ -167,6 +171,7 @@ class TestConnectivityOVSBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11129")
     @pytest.mark.ipv4
+    @pytest.mark.s390x
     def test_positive_vlan_ovs_bridge(
         self,
         nad_ovs_bridge_vlan_1,
@@ -183,6 +188,7 @@ class TestConnectivityOVSBridge:
 
     @pytest.mark.polarion("CNV-11130")
     @pytest.mark.ipv4
+    @pytest.mark.s390x
     def test_negative_vlan_ovs_bridge(
         self,
         nad_ovs_bridge_vlan_3,

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -99,6 +99,7 @@ def cloud_init_ipv6_network_data(dual_stack_network_data):
 )
 @pytest.mark.gating
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_connectivity_over_pod_network(
     ip_family,
     pod_net_vma,

--- a/tests/network/dry_run/test_dry_run_kubemacpool.py
+++ b/tests/network/dry_run/test_dry_run_kubemacpool.py
@@ -114,6 +114,7 @@ def dry_run_vm_with_mac_address(
 
 
 @pytest.mark.polarion("CNV-7872")
+@pytest.mark.s390x
 def test_dry_run_mac_not_saved(
     dry_run_vma_mac_address,
     vm_with_mac_address,
@@ -128,6 +129,7 @@ def test_dry_run_mac_not_saved(
 
 
 @pytest.mark.polarion("CNV-7873")
+@pytest.mark.s390x
 def test_allocated_mac_is_unavailable_for_dry_run(dry_run_vm_with_mac_address):
     with pytest.raises(ApiException, match="Failed to allocate mac to the vm object"):
         with dry_run_vm_with_mac_address as vm:

--- a/tests/network/flat_overlay/test_flat_overlay.py
+++ b/tests/network/flat_overlay/test_flat_overlay.py
@@ -19,6 +19,7 @@ class TestFlatOverlayConnectivity:
     @pytest.mark.gating
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-10158")
+    @pytest.mark.s390x
     @pytest.mark.dependency(name="test_flat_overlay_basic_ping")
     def test_flat_overlay_basic_ping(self, flat_overlay_vma_vmb_nad, vma_flat_overlay, vmb_flat_overlay):
         assert_ping_successful(
@@ -27,6 +28,7 @@ class TestFlatOverlayConnectivity:
         )
 
     @pytest.mark.polarion("CNV-10159")
+    @pytest.mark.s390x
     @pytest.mark.dependency(name="test_flat_overlay_separate_nads", depends=["test_flat_overlay_basic_ping"])
     def test_flat_overlay_separate_nads(
         self,
@@ -48,6 +50,7 @@ class TestFlatOverlayConnectivity:
         )
 
     @pytest.mark.polarion("CNV-10160")
+    @pytest.mark.s390x
     def test_flat_overlay_separate_nads_no_connectivity(
         self,
         vma_flat_overlay,
@@ -59,6 +62,7 @@ class TestFlatOverlayConnectivity:
         )
 
     @pytest.mark.polarion("CNV-10172")
+    @pytest.mark.s390x
     def test_flat_overlay_connectivity_between_namespaces(
         self,
         flat_overlay_vma_vmb_nad,
@@ -77,6 +81,7 @@ class TestFlatOverlayConnectivity:
         )
 
     @pytest.mark.polarion("CNV-10173")
+    @pytest.mark.s390x
     def test_flat_overlay_consistent_ip(
         self,
         vmc_flat_overlay_ip_address,
@@ -92,6 +97,7 @@ class TestFlatOverlayConnectivity:
 
 class TestFlatOverlayJumboConnectivity:
     @pytest.mark.polarion("CNV-10162")
+    @pytest.mark.s390x
     def test_flat_l2_jumbo_frame_connectivity(
         self,
         flat_l2_jumbo_frame_packet_size,

--- a/tests/network/flat_overlay/test_multi_network_policy.py
+++ b/tests/network/flat_overlay/test_multi_network_policy.py
@@ -12,6 +12,7 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.mark.polarion("CNV-10644")
+@pytest.mark.s390x
 def test_positive_egress_multi_network_policy(
     vma_flat_overlay,
     vmb_flat_overlay_ip_address,
@@ -24,6 +25,7 @@ def test_positive_egress_multi_network_policy(
 
 
 @pytest.mark.polarion("CNV-10645")
+@pytest.mark.s390x
 def test_negative_ingress_multi_network_policy(
     vma_flat_overlay,
     vmb_flat_overlay_ip_address,

--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -136,6 +136,7 @@ def _assert_failure_reason_is_bridge_missing(pod, bridge):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2234")
+@pytest.mark.s390x
 def test_bridge_marker_no_device(bridge_marker_bridge_network, bridge_attached_vmi_for_bridge_marker_no_device):
     """Check that VMI fails to start when bridge device is missing."""
     with pytest.raises(TimeoutExpiredError):
@@ -150,12 +151,14 @@ def test_bridge_marker_no_device(bridge_marker_bridge_network, bridge_attached_v
 # device before attaching a VMI to it
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2235")
+@pytest.mark.s390x
 def test_bridge_marker_device_exists(bridge_device_on_all_nodes, bridge_attached_vmi_for_bridge_marker_device_exists):
     """Check that VMI successfully starts when bridge device is present."""
     bridge_attached_vmi_for_bridge_marker_device_exists.wait_until_running(timeout=_VM_RUNNING_TIMEOUT)
 
 
 @pytest.mark.polarion("CNV-2309")
+@pytest.mark.s390x
 def test_bridge_marker_devices_exist_on_different_nodes(
     bridge_networks,
     non_homogenous_bridges,

--- a/tests/network/general/test_cnv_tuning_regression.py
+++ b/tests/network/general/test_cnv_tuning_regression.py
@@ -52,6 +52,7 @@ def cnv_tuning_vm(unprivileged_client, worker_node1, linux_bridge_nad, linux_bri
 
 @pytest.mark.polarion("CNV-7287")
 @pytest.mark.ipv4
+@pytest.mark.s390x
 def test_vm_cnv_tuning_regression(cnv_tuning_vm):
     cnv_tuning_vm.start(wait=True)
     cnv_tuning_vm.wait_for_agent_connected()

--- a/tests/network/general/test_dhcp6_configurations_on_ipv4_single_stack_cluster.py
+++ b/tests/network/general/test_dhcp6_configurations_on_ipv4_single_stack_cluster.py
@@ -74,6 +74,7 @@ def listening_dhcpv6_pid_in_virt_launcher_pod(worker_node1_pod_executor, virt_la
 @pytest.mark.polarion("CNV-7407")
 @pytest.mark.ipv4
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_dhcp6_disabled_on_ipv4_single_stack_cluster(
     fail_if_not_ipv4_single_stack_cluster,
     vm_cirros,

--- a/tests/network/general/test_ip_family_services.py
+++ b/tests/network/general/test_ip_family_services.py
@@ -107,6 +107,7 @@ def expected_num_families_in_service(request, dual_stack_cluster):
 @pytest.mark.gating
 class TestServiceConfigurationViaManifest:
     @pytest.mark.polarion("CNV-5789")
+    @pytest.mark.s390x
     @pytest.mark.single_nic
     def test_service_with_configured_ip_families(
         self,
@@ -120,6 +121,7 @@ class TestServiceConfigurationViaManifest:
 
     @pytest.mark.polarion("CNV-5831")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_service_with_default_ip_family_policy(
         self,
         running_vm_for_exposure,
@@ -156,6 +158,7 @@ class TestServiceConfigurationViaVirtctl:
         indirect=["virtctl_expose_service", "expected_num_families_in_service"],
     )
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_vitrctl_expose_services(
         self,
         expected_num_families_in_service,

--- a/tests/network/general/test_network_naming.py
+++ b/tests/network/general/test_network_naming.py
@@ -13,6 +13,7 @@ def invalid_network_names():
 
 @pytest.mark.polarion("CNV-8304")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_vm_with_illegal_network_name(namespace, unprivileged_client, invalid_network_names):
     vm_name = "unsupported-network-name-vm"
 

--- a/tests/network/general/test_vm_ips_report.py
+++ b/tests/network/general/test_vm_ips_report.py
@@ -40,6 +40,7 @@ def report_masquerade_ip_vmi(unprivileged_client, namespace):
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4455")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_report_masquerade_ip(report_masquerade_ip_vmi):
     assert_ip_mismatch(vm=report_masquerade_ip_vmi)
 
@@ -47,6 +48,7 @@ def test_report_masquerade_ip(report_masquerade_ip_vmi):
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-4153")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_report_masquerade_ip_after_migration(report_masquerade_ip_vmi):
     src_node = report_masquerade_ip_vmi.instance.status.nodeName
     with VirtualMachineInstanceMigration(

--- a/tests/network/kubemacpool/test_kubemacpool.py
+++ b/tests/network/kubemacpool/test_kubemacpool.py
@@ -17,6 +17,7 @@ class TestKMPConnectivity:
     # |.......|---eth4:10.200.4.1: Automatic mac tuning network :10.200.4.2:eth4---|........|
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-2154")
+    @pytest.mark.s390x
     def test_manual_mac_from_pool(self, namespace, running_vm_a, running_vm_b):
         """Test that manually assigned mac address from pool is configured and working"""
         for vm in (running_vm_a, running_vm_b):
@@ -24,6 +25,7 @@ class TestKMPConnectivity:
         assert_ping_successful(src_vm=running_vm_a, dst_ip=running_vm_b.manual_mac_iface_config.ip_address)
 
     @pytest.mark.polarion("CNV-2156")
+    @pytest.mark.s390x
     def test_manual_mac_not_from_pool(self, running_vm_a, running_vm_b):
         """Test that manually assigned mac address out of pool is configured and working"""
         for vm in (running_vm_a, running_vm_b):
@@ -35,6 +37,7 @@ class TestKMPConnectivity:
 
     @pytest.mark.gating
     @pytest.mark.polarion("CNV-2241")
+    @pytest.mark.s390x
     def test_automatic_mac_from_pool_pod_network(self, mac_pool, running_vm_a, running_vm_b):
         """Test that automatic mac address assigned to POD's masquerade network
         from kubemacpool belongs to range and connectivity is OK"""
@@ -49,6 +52,7 @@ class TestKMPConnectivity:
 
     @pytest.mark.gating
     @pytest.mark.polarion("CNV-2155")
+    @pytest.mark.s390x
     def test_automatic_mac_from_pool(self, mac_pool, running_vm_a, running_vm_b):
         """Test that automatic mac address assigned to interface
         from kubemacpool belongs to range and connectivity is OK"""
@@ -59,6 +63,7 @@ class TestKMPConnectivity:
         assert_ping_successful(src_vm=running_vm_a, dst_ip=running_vm_b.auto_mac_iface_config.ip_address)
 
     @pytest.mark.polarion("CNV-2242")
+    @pytest.mark.s390x
     def test_automatic_mac_from_pool_tuning(self, mac_pool, running_vm_a, running_vm_b):
         """Test that automatic mac address assigned to tuning interface
         from kubemacpool is belongs to range and connectivity is OK"""
@@ -73,12 +78,14 @@ class TestKMPConnectivity:
 
     @pytest.mark.gating
     @pytest.mark.polarion("CNV-2157")
+    @pytest.mark.s390x
     def test_mac_preserved_after_shutdown(self, restarted_vmi_a, restarted_vmi_b, running_vm_a, running_vm_b):
         """Test that all macs are preserved even after VM restart"""
         kmp_utils.assert_macs_preseved(vm=running_vm_a)
         kmp_utils.assert_macs_preseved(vm=running_vm_b)
 
     @pytest.mark.polarion("CNV-5941")
+    @pytest.mark.s390x
     def test_enabled_label_ns(
         self,
         mac_pool,
@@ -91,6 +98,7 @@ class TestKMPConnectivity:
         )
 
     @pytest.mark.polarion("CNV-4217")
+    @pytest.mark.s390x
     def test_no_label_ns(
         self,
         mac_pool,
@@ -105,6 +113,7 @@ class TestKMPConnectivity:
 
 class TestNegatives:
     @pytest.mark.polarion("CNV-4199")
+    @pytest.mark.s390x
     def test_disabled_assignment_ns(
         self,
         mac_pool,
@@ -121,6 +130,7 @@ class TestNegatives:
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4405")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_kmp_down(namespace, kmp_down):
     with pytest.raises(ApiException):
         with VirtualMachineForTests(name="kmp-down-vm", namespace=namespace.name):

--- a/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
+++ b/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
@@ -51,6 +51,7 @@ class TestL2LinuxBridge:
     """
 
     @pytest.mark.polarion("CNV-2285")
+    @pytest.mark.s390x
     def test_connectivity_l2_bridge(
         self,
         configured_l2_bridge_vm_a,
@@ -66,6 +67,7 @@ class TestL2LinuxBridge:
         )
 
     @pytest.mark.polarion("CNV-2282")
+    @pytest.mark.s390x
     def test_dhcp_broadcast(
         self,
         configured_l2_bridge_vm_a,
@@ -89,6 +91,7 @@ class TestL2LinuxBridge:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-2284")
+    @pytest.mark.s390x
     def test_custom_eth_type(
         self,
         configured_l2_bridge_vm_a,
@@ -107,6 +110,7 @@ class TestL2LinuxBridge:
         assert f"Successful connections: {num_of_packets}" in out
 
     @pytest.mark.polarion("CNV-2674")
+    @pytest.mark.s390x
     def test_icmp_multicast(
         self,
         configured_l2_bridge_vm_a,

--- a/tests/network/l2_bridge/test_ovs_bridge.py
+++ b/tests/network/l2_bridge/test_ovs_bridge.py
@@ -167,6 +167,7 @@ def running_vmb_with_ovs_based_l2(vmb_with_ovs_based_l2):
 
 @pytest.mark.ipv4
 @pytest.mark.polarion("CNV-5636")
+@pytest.mark.s390x
 def test_ovs_bridge_sanity(
     hyperconverged_ovs_annotations_enabled_scope_session,
     vma_with_ovs_based_l2,

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -8,6 +8,7 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.gating
 @pytest.mark.ipv4
 @pytest.mark.single_nic
+@pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet")
 @pytest.mark.polarion("CNV-11775")
 def test_connectivity_over_migration_between_localnet_vms(localnet_server, localnet_client):
@@ -17,6 +18,7 @@ def test_connectivity_over_migration_between_localnet_vms(localnet_server, local
 
 @pytest.mark.ipv4
 @pytest.mark.single_nic
+@pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet")
 @pytest.mark.polarion("CNV-11925")
 def test_connectivity_post_migration_between_localnet_vms(migrated_localnet_vm, localnet_running_vms):

--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -7,6 +7,7 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.ipv4
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")
 @pytest.mark.polarion("CNV-11905")
+@pytest.mark.s390x
 def test_connectivity_over_migration_between_ovs_bridge_localnet_vms(
     localnet_ovs_bridge_server, localnet_ovs_bridge_client
 ):

--- a/tests/network/macspoof/test_macspoof.py
+++ b/tests/network/macspoof/test_macspoof.py
@@ -8,6 +8,7 @@ from utilities.network import assert_ping_successful
 class TestMacSpoof:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-7264")
+    @pytest.mark.s390x
     def test_macspoof_prevent_connectivity(
         self,
         linux_bridge_attached_vma,

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -84,6 +84,7 @@ def vm_console_connection_ready(running_vm_for_migration):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-6733")
+@pytest.mark.s390x
 @pytest.mark.single_nic
 def test_connectivity_after_migration(
     namespace,

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -326,6 +326,7 @@ def brcnv_migrated_vm(
 )
 @pytest.mark.ipv4
 @pytest.mark.polarion("CNV-2060")
+@pytest.mark.s390x
 def test_ping_vm_migration(
     vma,
     vmb,
@@ -339,6 +340,7 @@ def test_ping_vm_migration(
 
 @pytest.mark.ipv4
 @pytest.mark.polarion("CNV-2063")
+@pytest.mark.s390x
 def test_ssh_vm_migration(
     namespace,
     br1test_nad,
@@ -370,6 +372,7 @@ def test_cnv_bridge_ssh_vm_migration(
 @pytest.mark.post_upgrade
 @pytest.mark.ipv4
 @pytest.mark.polarion("CNV-5565")
+@pytest.mark.s390x
 def test_connectivity_after_migration_and_restart(
     namespace,
     br1test_nad,
@@ -386,6 +389,7 @@ def test_connectivity_after_migration_and_restart(
 
 
 @pytest.mark.polarion("CNV-2061")
+@pytest.mark.s390x
 def test_migration_with_masquerade(
     ip_stack_version_matrix__module__,
     admin_client,
@@ -407,6 +411,7 @@ def test_migration_with_masquerade(
 
 @pytest.mark.ipv4
 @pytest.mark.polarion("CNV-6548")
+@pytest.mark.s390x
 def test_ping_from_migrated_vm(
     br1test_nad,
     vma,

--- a/tests/network/network_policy/test_network_policy.py
+++ b/tests/network/network_policy/test_network_policy.py
@@ -117,6 +117,7 @@ def running_network_policy_vmb(network_policy_vmb):
 @pytest.mark.order(before="test_network_policy_allow_http80")
 @pytest.mark.polarion("CNV-369")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_network_policy_deny_all_http(
     deny_all_http_ports,
     network_policy_vma,
@@ -138,6 +139,7 @@ def test_network_policy_deny_all_http(
 @pytest.mark.order(before="test_network_policy_allow_all_http")
 @pytest.mark.polarion("CNV-2775")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_network_policy_allow_http80(
     allow_http80_port,
     network_policy_vma,
@@ -160,6 +162,7 @@ def test_network_policy_allow_http80(
 
 @pytest.mark.polarion("CNV-2774")
 @pytest.mark.single_nic
+@pytest.mark.s390x
 def test_network_policy_allow_all_http(
     allow_all_http_ports,
     network_policy_vma,

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -245,6 +245,7 @@ class TestConnectivityAfterNmstateChanged:
     @pytest.mark.post_upgrade
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-5780")
+    @pytest.mark.s390x
     def test_nmstate_restart_and_check_connectivity(
         self,
         nncp_ready,
@@ -281,6 +282,7 @@ class TestConnectivityAfterNmstateChanged:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-7746")
+    @pytest.mark.s390x
     def test_ssh_alive_after_restart_nmstate_handler(
         self,
         nncp_ready,
@@ -297,6 +299,7 @@ class TestConnectivityAfterNmstateChanged:
     @pytest.mark.gating
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-5839")
+    @pytest.mark.s390x
     def test_connectivity_after_nncp_change(
         self,
         nmstate_linux_bridge_attached_vma,

--- a/tests/network/ovs_bond/test_bond_link_down.py
+++ b/tests/network/ovs_bond/test_bond_link_down.py
@@ -11,6 +11,7 @@ import utilities.network
 
 @pytest.mark.polarion("CNV-3296")
 @pytest.mark.ovs_brcnv
+@pytest.mark.s390x
 def test_connectivity_over_pod_network(
     disconnected_bond_port,
     running_ovs_bond_vma,

--- a/tests/network/ovs_optin/test_ovs_optin.py
+++ b/tests/network/ovs_optin/test_ovs_optin.py
@@ -52,6 +52,7 @@ def hyperconverged_ovs_annotations_removed(
 class TestOVSOptIn:
     @pytest.mark.polarion("CNV-5520")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_ovs_installed(
         self,
         admin_client,
@@ -68,6 +69,7 @@ class TestOVSOptIn:
 
     @pytest.mark.polarion("CNV-5533")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_ovs_not_installed_annotations_removed(
         self,
         admin_client,
@@ -83,6 +85,7 @@ class TestOVSOptIn:
 
     @pytest.mark.polarion("CNV-5531")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_ovs_not_installed_annotations_disabled(
         self,
         admin_client,

--- a/tests/network/secondary_network_dns/test_secondary_network_dns.py
+++ b/tests/network/secondary_network_dns/test_secondary_network_dns.py
@@ -327,6 +327,7 @@ def kubernetes_secondary_dns_service_port_number(
 
 
 @pytest.mark.polarion("CNV-9256")
+@pytest.mark.s390x
 def test_kubernetes_secondary_dns_basic_nslookup(
     cluster_base_domain,
     exposed_kubernetes_secondary_dns_service,

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -12,6 +12,7 @@ pytestmark = pytest.mark.service_mesh
 class TestSMTrafficManagement:
     @pytest.mark.polarion("CNV-5782")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_service_mesh_traffic_management(
         self,
         traffic_management_service_mesh_convergence,
@@ -27,6 +28,7 @@ class TestSMTrafficManagement:
 
     @pytest.mark.polarion("CNV-7304")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_service_mesh_traffic_management_manipulated_rule(
         self,
         traffic_management_service_mesh_convergence,
@@ -46,6 +48,7 @@ class TestSMPeerAuthentication:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-5784")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_authentication_policy_from_mesh(
         self,
         peer_authentication_service_mesh_deployment,
@@ -60,6 +63,7 @@ class TestSMPeerAuthentication:
     @pytest.mark.polarion("CNV-7305")
     @pytest.mark.ipv4
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_authentication_policy_outside_mesh(
         self,
         outside_mesh_vm_fedora_with_service_mesh_annotation,
@@ -75,6 +79,7 @@ class TestSMPeerAuthentication:
 
     @pytest.mark.polarion("CNV-7128")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_service_mesh_inbound_traffic_blocked(
         self,
         outside_mesh_vm_fedora_with_service_mesh_annotation,

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -102,6 +102,7 @@ def client(vma_udn, vmb_udn_non_migratable):
 class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11624")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_ip_address_in_running_vm_matches_udn_subnet(self, namespaced_layer2_user_defined_network, vma_udn):
         ip = lookup_iface_status(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name)[IP_ADDRESS]
         (subnet,) = namespaced_layer2_user_defined_network.subnets
@@ -111,6 +112,7 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-11674")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_ip_address_is_preserved_after_live_migration(self, vma_udn):
         ip_before_migration = lookup_iface_status(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name)[
             IP_ADDRESS
@@ -127,6 +129,7 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-11434")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_vm_egress_connectivity(self, vmb_udn_non_migratable):
         assert lookup_iface_status(
             vm=vmb_udn_non_migratable, iface_name=lookup_primary_network(vm=vmb_udn_non_migratable).name
@@ -135,6 +138,7 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-11418")
     @pytest.mark.single_nic
+    @pytest.mark.s390x
     def test_basic_connectivity_between_udn_vms(self, vma_udn, vmb_udn_non_migratable):
         target_vm_ip = lookup_iface_status(
             vm=vmb_udn_non_migratable, iface_name=lookup_primary_network(vm=vmb_udn_non_migratable).name
@@ -144,6 +148,7 @@ class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11427")
     @pytest.mark.single_nic
     @pytest.mark.gating
+    @pytest.mark.s390x
     def test_connectivity_is_preserved_after_live_migration(self, vma_udn, server, client):
         migrate_vm_and_verify(vm=vma_udn)
         assert is_tcp_connection(server=server, client=client)

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -125,6 +125,7 @@ def test_successful_clone_of_large_image(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_successful_vm_restart_with_cloned_dv(
     namespace,
     data_volume_multi_storage_scope_function,
@@ -203,6 +204,7 @@ def test_successful_vm_from_cloned_dv_windows(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_image_after_clone(
     skip_block_volumemode_scope_function,
     unprivileged_client,
@@ -251,6 +253,7 @@ def test_disk_image_after_clone(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_successful_snapshot_clone(
     data_volume_snapshot_capable_storage_scope_function,
     cluster_csi_drivers_names,
@@ -280,6 +283,7 @@ def test_successful_snapshot_clone(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-5607")
+@pytest.mark.s390x
 def test_clone_from_fs_to_block_using_dv_template(
     skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,
@@ -301,6 +305,7 @@ def test_clone_from_fs_to_block_using_dv_template(
 
 @pytest.mark.polarion("CNV-5608")
 @pytest.mark.smoke()
+@pytest.mark.s390x
 def test_clone_from_block_to_fs_using_dv_template(
     skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -138,6 +138,7 @@ def dv_with_annotation(admin_client, namespace, linux_nad):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_delete_pvc_after_successful_import(
     data_volume_multi_storage_scope_function,
 ):
@@ -158,6 +159,7 @@ def test_delete_pvc_after_successful_import(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-876")
+@pytest.mark.s390x
 def test_invalid_url(dv_non_exist_url):
     dv_non_exist_url.wait_for_status(
         status=DataVolume.Status.IMPORT_IN_PROGRESS,
@@ -173,6 +175,7 @@ def test_invalid_url(dv_non_exist_url):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-674")
+@pytest.mark.s390x
 def test_empty_url(namespace, storage_class_name_scope_module):
     with pytest.raises(UnprocessibleEntityError):
         with create_dv(
@@ -200,6 +203,7 @@ def test_empty_url(namespace, storage_class_name_scope_module):
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2145")
+@pytest.mark.s390x
 def test_successful_import_archive(
     skip_block_volumemode_scope_module,
     running_pod_with_dv_pvc,
@@ -233,6 +237,7 @@ def test_successful_import_archive(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_successful_import_image(
     running_pod_with_dv_pvc,
     dv_from_http_import,
@@ -264,6 +269,7 @@ def test_successful_import_image(
     indirect=True,
 )
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_successful_import_secure_archive(
     skip_block_volumemode_scope_module, internal_http_configmap, running_pod_with_dv_pvc
 ):
@@ -286,6 +292,7 @@ def test_successful_import_secure_archive(
 )
 @pytest.mark.sno
 @pytest.mark.gating
+@pytest.mark.s390x
 def test_successful_import_secure_image(internal_http_configmap, running_pod_with_dv_pvc):
     assert_disk_img(pod=running_pod_with_dv_pvc)
 
@@ -307,6 +314,7 @@ def test_successful_import_secure_image(internal_http_configmap, running_pod_wit
     ],
     ids=["import_basic_auth_archive", "import_basic_auth_kubevirt"],
 )
+@pytest.mark.s390x
 def test_successful_import_basic_auth(
     namespace,
     storage_class_matrix__module__,
@@ -359,6 +367,7 @@ def test_successful_import_basic_auth(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_wrong_content_type(
     admin_client,
     dv_from_http_import,
@@ -399,6 +408,7 @@ def test_wrong_content_type(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unpack_compressed(
     admin_client,
     dv_from_http_import,
@@ -423,6 +433,7 @@ def test_unpack_compressed(
     indirect=True,
 )
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_certconfigmap(internal_http_configmap, running_pod_with_dv_pvc):
     assert_num_files_in_pod(pod=running_pod_with_dv_pvc, expected_num_of_files=1)
 
@@ -454,6 +465,7 @@ def test_certconfigmap(internal_http_configmap, running_pod_with_dv_pvc):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_certconfigmap_incorrect_cert(
     admin_client,
     https_config_map,
@@ -484,6 +496,7 @@ def test_certconfigmap_incorrect_cert(
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2815")
+@pytest.mark.s390x
 def test_certconfigmap_missing_or_wrong_cm(data_volume_multi_storage_scope_function):
     with pytest.raises(TimeoutExpiredError):
         samples = TimeoutSampler(
@@ -514,6 +527,7 @@ def test_certconfigmap_missing_or_wrong_cm(data_volume_multi_storage_scope_funct
         ),
     ],
 )
+@pytest.mark.s390x
 def test_successful_concurrent_blank_disk_import(
     dv_list_created_by_multiprocess,
     vm_list_created_by_multiprocess,
@@ -530,6 +544,7 @@ def test_successful_concurrent_blank_disk_import(
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2004")
+@pytest.mark.s390x
 def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_function):
     data_volume_multi_storage_scope_function.wait_for_dv_success(timeout=TIMEOUT_5MIN)
 
@@ -539,8 +554,8 @@ def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_funct
     ("size", "unit", "dv_name"),
     [
         pytest.param(64, "M", "cnv-1404", marks=(pytest.mark.polarion("CNV-1404"))),
-        pytest.param(1, "G", "cnv-6532", marks=(pytest.mark.polarion("CNV-6532"))),
-        pytest.param(13, "G", "cnv-6536", marks=(pytest.mark.polarion("CNV-6536"))),
+        pytest.param(6, "G", "cnv-6532", marks=(pytest.mark.polarion("CNV-6532"), pytest.mark.s390x)),
+        pytest.param(13, "G", "cnv-6536", marks=(pytest.mark.polarion("CNV-6536"), pytest.mark.s390x)),
     ],
 )
 def test_vmi_image_size(
@@ -621,12 +636,13 @@ def test_vmi_image_size(
     indirect=True,
 )
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_disk_falloc(internal_http_configmap, dv_from_http_import):
     dv_from_http_import.wait_for_dv_success()
     with create_vm_from_dv(dv=dv_from_http_import) as vm_dv:
         with console.Console(vm=vm_dv) as vm_console:
             LOGGER.info("Fill disk space.")
-            vm_console.sendline("dd if=/dev/zero of=file bs=1M")
+            vm_console.sendline("dd if=/dev/urandom of=file bs=64M")
             vm_console.expect("dd: writing 'file': No space left on device", timeout=TIMEOUT_1MIN)
 
 
@@ -714,12 +730,14 @@ def test_successful_vm_from_imported_dv_windows(
 
 @pytest.mark.polarion("CNV-4032")
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_disk_image_after_import(skip_block_volumemode_scope_module, cirros_dv_unprivileged):
     create_vm_and_verify_image_permission(dv=cirros_dv_unprivileged)
 
 
 @pytest.mark.polarion("CNV-4724")
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_dv_api_version_after_import(cirros_dv_unprivileged):
     assert (
         cirros_dv_unprivileged.api_version
@@ -728,6 +746,7 @@ def test_dv_api_version_after_import(cirros_dv_unprivileged):
 
 
 @pytest.mark.polarion("CNV-5509")
+@pytest.mark.s390x
 def test_importer_pod_annotation(dv_with_annotation, linux_nad):
     # verify "k8s.v1.cni.cncf.io/networks" can pass to the importer pod
     assert dv_with_annotation.get(f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks") == linux_nad.name

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -61,6 +61,7 @@ def test_disk_image_not_conform_to_registy_disk(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2028")
+@pytest.mark.s390x
 def test_public_registry_multiple_data_volume(
     namespace, storage_class_name_scope_function, dvs_and_vms_from_public_registry
 ):
@@ -95,6 +96,7 @@ def test_public_registry_multiple_data_volume(
         "import-public-registry-quay-dv",
     ],
 )
+@pytest.mark.s390x
 def test_public_registry_data_volume(
     namespace,
     dv_name,
@@ -125,6 +127,7 @@ def test_public_registry_data_volume(
 # we can overcome by updating to the right requested volume size and import successfully
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2024")
+@pytest.mark.s390x
 def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_scope_function):
     dv_param = {
         "dv_name": "import-public-registry-low-capacity-dv",
@@ -169,6 +172,7 @@ def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2150")
+@pytest.mark.s390x
 def test_public_registry_data_volume_archive(namespace, storage_class_name_scope_function):
     with pytest.raises(ApiException, match=r".*ContentType must be kubevirt when Source is Registry.*"):
         with create_dv(

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -54,6 +54,7 @@ def wait_for_upload_response_code(token, data, response_code, asynchronous=False
 
 
 @pytest.mark.polarion("CNV-2318")
+@pytest.mark.s390x
 def test_cdi_uploadproxy_route_owner_references(hco_namespace):
     route = Route(name=CDI_UPLOADPROXY, namespace=hco_namespace.name)
     assert route.instance
@@ -158,6 +159,7 @@ def test_cdi_uploadproxy_route_owner_references(hco_namespace):
         ),
     ],
 )
+@pytest.mark.s390x
 def test_successful_upload_with_supported_formats(
     namespace,
     tmpdir,
@@ -198,6 +200,7 @@ def test_successful_upload_with_supported_formats(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-2018")
+@pytest.mark.s390x
 def test_successful_upload_token_validity(
     namespace,
     data_volume_multi_storage_scope_function,
@@ -248,6 +251,7 @@ def test_successful_upload_token_validity(
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2011")
+@pytest.mark.s390x
 def test_successful_upload_token_expiry(namespace, data_volume_multi_storage_scope_function):
     dv = data_volume_multi_storage_scope_function
     dv.wait_for_status(status=DataVolume.Status.UPLOAD_READY, timeout=TIMEOUT_3MIN)
@@ -289,6 +293,7 @@ def _upload_image(dv_name, namespace, storage_class, local_name, size=None):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2015")
+@pytest.mark.s390x
 def test_successful_concurrent_uploads(
     upload_file_path,
     namespace,
@@ -325,6 +330,7 @@ def test_successful_concurrent_uploads(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_successful_upload_missing_file_in_transit(namespace, storage_class_matrix__class__, upload_file_path):
     dv_name = "cnv-2017"
     storage_class = [*storage_class_matrix__class__][0]
@@ -369,6 +375,7 @@ def test_successful_upload_missing_file_in_transit(namespace, storage_class_matr
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_print_response_body_on_error_upload(
     namespace,
     download_specified_image,

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -60,6 +60,7 @@ def skip_no_reencrypt_route(upload_proxy_route):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2192")
+@pytest.mark.s390x
 def test_successful_virtctl_upload_no_url(namespace, tmpdir):
     local_name = f"{tmpdir}/{Images.Cdi.QCOW2_IMG}"
     get_downloaded_artifact(remote_name=f"{Images.Cdi.DIR}/{Images.Cdi.QCOW2_IMG}", local_name=local_name)
@@ -109,6 +110,7 @@ def test_successful_virtctl_upload_no_route(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2217")
+@pytest.mark.s390x
 def test_image_upload_with_overridden_url(
     namespace,
     tmpdir,
@@ -131,6 +133,7 @@ def test_image_upload_with_overridden_url(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3031")
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_ca(
     enabled_ca,
     skip_no_reencrypt_route,
@@ -155,6 +158,7 @@ def test_virtctl_image_upload_with_ca(
 @pytest.mark.smoke
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3724")
+@pytest.mark.s390x
 def test_virtctl_image_upload_dv(
     skip_if_sc_volume_binding_mode_is_wffc,
     download_image,
@@ -195,6 +199,7 @@ def test_virtctl_image_upload_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_dv_image(
     data_volume_multi_storage_scope_function,
     storage_class_name_scope_function,
@@ -231,6 +236,7 @@ def test_virtctl_image_upload_with_exist_dv_image(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-3728")
+@pytest.mark.s390x
 def test_virtctl_image_upload_pvc(download_image, namespace, storage_class_name_scope_module):
     """
     Check that virtctl can create a new PVC and upload an image to it
@@ -252,6 +258,7 @@ def test_virtctl_image_upload_pvc(download_image, namespace, storage_class_name_
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3725")
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_dv(download_image, namespace, storage_class_name_scope_module):
     """
     Check that virtctl is able to upload a local disk image to an existing DataVolume
@@ -308,6 +315,7 @@ def empty_pvc(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3727")
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_pvc(
     empty_pvc,
     download_image,
@@ -342,6 +350,7 @@ def test_virtctl_image_upload_with_exist_pvc(
 
 
 @pytest.mark.polarion("CNV-3729")
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_pvc_image(
     download_image,
     namespace,
@@ -384,6 +393,7 @@ def test_virtctl_image_upload_with_exist_pvc_image(
 
 
 @pytest.mark.polarion("CNV-3730")
+@pytest.mark.s390x
 def test_virtctl_image_upload_dv_with_exist_pvc(
     empty_pvc,
     download_image,
@@ -447,6 +457,7 @@ def test_successful_vm_from_uploaded_dv_windows(
 
 
 @pytest.mark.polarion("CNV-4033")
+@pytest.mark.s390x
 def test_disk_image_after_upload_virtctl(
     skip_block_volumemode_scope_module,
     unprivileged_client,
@@ -487,6 +498,7 @@ def test_disk_image_after_upload_virtctl(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_print_response_body_on_error_upload_virtctl(
     namespace, download_specified_image, storage_class_name_scope_module
 ):

--- a/tests/storage/checkups/test_checkups.py
+++ b/tests/storage/checkups/test_checkups.py
@@ -25,6 +25,7 @@ LOGGER = logging.getLogger(__name__)
 )
 class TestCheckupPositive:
     @pytest.mark.polarion("CNV-10707")
+    @pytest.mark.s390x
     def test_overriden_storage_profile_claim_propertyset(
         self,
         updated_default_storage_profile,
@@ -41,6 +42,7 @@ class TestCheckupPositive:
         )
 
     @pytest.mark.polarion("CNV-10708")
+    @pytest.mark.s390x
     def test_storage_profile_missing_volume_snapshot_class(
         self,
         updated_storage_class_snapshot_clone_strategy,
@@ -58,6 +60,7 @@ class TestCheckupPositive:
         )
 
     @pytest.mark.polarion("CNV-10709")
+    @pytest.mark.s390x
     def test_ocs_rbd_non_virt_vm_exist(
         self,
         skip_if_no_ocs_rbd_non_virt_sc,
@@ -75,6 +78,7 @@ class TestCheckupPositive:
         )
 
     @pytest.mark.polarion("CNV-10712")
+    @pytest.mark.s390x
     def test_checkup_live_migration(
         self,
         default_storage_class_access_modes,

--- a/tests/storage/checkups/test_checkups_negative.py
+++ b/tests/storage/checkups/test_checkups_negative.py
@@ -21,6 +21,7 @@ MSG_UNKNOWN_PROVISIONER = "there are StorageProfiles with empty ClaimPropertySet
 )
 class TestCheckupNegative:
     @pytest.mark.polarion("CNV-10701")
+    @pytest.mark.s390x
     def test_no_default_storage_class(
         self,
         removed_default_storage_classes,
@@ -34,13 +35,14 @@ class TestCheckupNegative:
         assert_results_in_configmap(
             configmap=checkup_configmap,
             expected_failure_msg=MSG_NO_DEFAULT_STORAGE_CLASS
-            if rhel9_data_import_cron_source_format == "pvc"
+            if rhel9_data_import_cron_source_format == "snapshot"
             else "^persistentvolumeclaims.*.not found$",
             expected_result=MSG_NO_DEFAULT_STORAGE_CLASS,
             result_entry=DEFAULT_STORAGE_CLASS_ENTRY,
         )
 
     @pytest.mark.polarion("CNV-10705")
+    @pytest.mark.s390x
     def test_additional_default_storage_class(
         self,
         updated_two_default_storage_classes,
@@ -54,13 +56,14 @@ class TestCheckupNegative:
         assert_results_in_configmap(
             configmap=checkup_configmap,
             expected_failure_msg=MSG_MULTIPLE_DEFAULT_SC
-            if rhel9_data_import_cron_source_format == "pvc"
+            if rhel9_data_import_cron_source_format == "snapshot"
             else "VMI is not running",
             expected_result=MSG_MULTIPLE_DEFAULT_SC,
             result_entry=DEFAULT_STORAGE_CLASS_ENTRY,
         )
 
     @pytest.mark.polarion("CNV-10706")
+    @pytest.mark.s390x
     def test_unknown_provisioner(
         self,
         storage_class_with_unknown_provisioner,
@@ -78,6 +81,7 @@ class TestCheckupNegative:
         )
 
     @pytest.mark.polarion("CNV-10711")
+    @pytest.mark.s390x
     def test_golden_image_data_source_not_ready(
         self,
         broken_data_import_cron,

--- a/tests/storage/data_import_cron/test_data_import_cron_pvc_source.py
+++ b/tests/storage/data_import_cron/test_data_import_cron_pvc_source.py
@@ -7,6 +7,7 @@ LOGGER = logging.getLogger(__name__)
 
 class TestDataImportCronPvcSource:
     @pytest.mark.polarion("CNV-11842")
+    @pytest.mark.s390x
     def test_data_import_cron_with_pvc_source_ready(
         self, namespace, dv_source_for_data_import_cron, data_import_cron_with_pvc_source, imported_data_source
     ):
@@ -15,5 +16,6 @@ class TestDataImportCronPvcSource:
         )
 
     @pytest.mark.polarion("CNV-11858")
+    @pytest.mark.s390x
     def test_data_import_cron_vm_from_import_pvc(self, namespace, vm_for_data_source_import):
         assert vm_for_data_source_import, f"vm {vm_for_data_source_import} did not created from the imported source pvc"

--- a/tests/storage/fs_overhead/test_fs_overhead.py
+++ b/tests/storage/fs_overhead/test_fs_overhead.py
@@ -79,6 +79,7 @@ def uploaded_cirros_dv(
 
 
 @pytest.mark.polarion("CNV-8635")
+@pytest.mark.s390x
 def test_import_vm_with_specify_fs_overhead(updated_fs_overhead_20_with_hco, vm_for_fs_overhead_test):
     vm_metadata = vm_for_fs_overhead_test.data_volume_template["metadata"]
     assert_fs_overhead_added(
@@ -86,17 +87,22 @@ def test_import_vm_with_specify_fs_overhead(updated_fs_overhead_20_with_hco, vm_
             pvc=PersistentVolumeClaim(name=vm_metadata["name"], namespace=vm_metadata["namespace"])
         ),
         requested_size=bitmath.GiB(
-            int(vm_for_fs_overhead_test.data_volume_template["spec"]["storage"]["resources"]["requests"]["storage"][0])
+            int(
+                vm_for_fs_overhead_test.data_volume_template["spec"]["storage"]["resources"]["requests"][
+                    "storage"
+                ].replace("Gi", "")
+            )
         ),
     )
 
 
 @pytest.mark.polarion("CNV-8637")
+@pytest.mark.s390x
 def test_upload_dv_with_specify_fs_overhead(
     updated_fs_overhead_20_with_hco,
     uploaded_cirros_dv,
 ):
     assert_fs_overhead_added(
         actual_size=get_pvc_size_gib(pvc=uploaded_cirros_dv.pvc),
-        requested_size=bitmath.GiB(int(Images.Cirros.DEFAULT_DV_SIZE[0])),
+        requested_size=bitmath.GiB(int(Images.Cirros.DEFAULT_DV_SIZE.replace("Gi", ""))),
     )

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -221,6 +221,7 @@ def rhel9_golden_image_vm(
 
 
 @pytest.mark.polarion("CNV-10721")
+@pytest.mark.s390x
 def test_automatic_update_for_system_cached_snapshot(
     rhel9_cached_snapshot,
     disabled_common_boot_image_import_hco_spec_rhel9_scope_function,
@@ -234,6 +235,7 @@ def test_automatic_update_for_system_cached_snapshot(
 
 
 @pytest.mark.polarion("CNV-10722")
+@pytest.mark.s390x
 def test_disable_automatic_update_using_annotation(
     disabled_data_import_cron_annotation_rhel9,
     rhel9_data_import_cron,
@@ -260,5 +262,6 @@ def test_disable_automatic_update_using_annotation(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unprivileged_user_vm_snapshot_datasource(rhel9_golden_image_vm):
     running_vm(vm=rhel9_golden_image_vm)

--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -48,6 +48,7 @@ def dv_created_by_unprivileged_user_with_rolebinding(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4755")
+@pytest.mark.s390x
 def test_regular_user_cant_create_dv_in_ns(
     golden_images_namespace,
     unprivileged_client,
@@ -76,6 +77,7 @@ def test_regular_user_cant_create_dv_in_ns(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_cant_delete_dv_from_cloned_dv(
     golden_images_namespace,
     unprivileged_client,
@@ -114,6 +116,7 @@ def test_regular_user_cant_delete_dv_from_cloned_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_can_create_vm_from_cloned_dv(
     golden_image_data_volume_multi_storage_scope_function,
     golden_image_vm_instance_from_template_multi_storage_scope_function,
@@ -129,6 +132,7 @@ def test_regular_user_can_create_vm_from_cloned_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_can_list_all_pvc_in_ns(
     golden_images_namespace,
     unprivileged_client,
@@ -152,6 +156,7 @@ def test_regular_user_can_list_all_pvc_in_ns(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_cant_clone_dv_in_ns(
     unprivileged_client,
     golden_image_data_volume_scope_module,
@@ -190,6 +195,7 @@ def test_regular_user_cant_clone_dv_in_ns(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_can_create_dv_in_ns_given_proper_rolebinding(
     dv_created_by_unprivileged_user_with_rolebinding,
 ):

--- a/tests/storage/hpp/test_hostpath.py
+++ b/tests/storage/hpp/test_hostpath.py
@@ -305,6 +305,7 @@ def get_pod_and_scratch_pvc_nodes(dyn_client, namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_hostpath_pod_reference_pvc(
     namespace,
     dv_kwargs,
@@ -322,6 +323,7 @@ def test_hostpath_pod_reference_pvc(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3354")
+@pytest.mark.s390x
 def test_hpp_not_specify_node_immediate(
     skip_when_hpp_no_immediate,
     namespace,
@@ -350,6 +352,7 @@ def test_hpp_not_specify_node_immediate(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3228")
+@pytest.mark.s390x
 def test_hpp_specify_node_immediate(
     skip_when_hpp_no_immediate,
     namespace,
@@ -390,6 +393,7 @@ def test_hpp_specify_node_immediate(
         ),
     ],
 )
+@pytest.mark.s390x
 def test_hostpath_http_import_dv(
     skip_when_hpp_no_immediate,
     namespace,
@@ -416,6 +420,7 @@ def test_hostpath_http_import_dv(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3227")
+@pytest.mark.s390x
 def test_hpp_pvc_without_specify_node_waitforfirstconsumer(
     skip_when_hpp_no_waitforfirstconsumer,
     namespace,
@@ -451,6 +456,7 @@ def test_hpp_pvc_without_specify_node_waitforfirstconsumer(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3280")
+@pytest.mark.s390x
 def test_hpp_pvc_specify_node_immediate(
     skip_when_hpp_no_immediate,
     namespace,
@@ -482,6 +488,7 @@ def test_hpp_pvc_specify_node_immediate(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2771")
+@pytest.mark.s390x
 def test_hpp_upload_virtctl(
     skip_when_hpp_no_waitforfirstconsumer,
     skip_when_cdiconfig_scratch_no_hpp,
@@ -527,6 +534,7 @@ def test_hpp_upload_virtctl(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2769")
+@pytest.mark.s390x
 def test_hostpath_upload_dv_with_token(
     skip_when_cdiconfig_scratch_no_hpp,
     skip_when_hpp_no_waitforfirstconsumer,
@@ -556,6 +564,7 @@ def test_hostpath_upload_dv_with_token(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3326")
+@pytest.mark.s390x
 def test_hostpath_registry_import_dv(
     admin_client,
     skip_when_hpp_no_waitforfirstconsumer,
@@ -604,6 +613,7 @@ def test_hostpath_registry_import_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_hostpath_clone_dv_without_annotation_wffc(
     skip_when_hpp_no_waitforfirstconsumer,
     admin_client,
@@ -656,6 +666,7 @@ def test_hostpath_clone_dv_without_annotation_wffc(
 
 
 @pytest.mark.polarion("CNV-2770")
+@pytest.mark.s390x
 def test_hostpath_clone_dv_with_annotation(
     skip_when_hpp_no_immediate,
     namespace,
@@ -699,6 +710,7 @@ def test_hostpath_clone_dv_with_annotation(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8928")
+@pytest.mark.s390x
 def test_hpp_cr(hostpath_provisioner_scope_module):
     assert hostpath_provisioner_scope_module.exists
     hostpath_provisioner_scope_module.wait_for_condition(
@@ -710,6 +722,7 @@ def test_hpp_cr(hostpath_provisioner_scope_module):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-7969")
+@pytest.mark.s390x
 def test_hpp_prometheus_resources(hpp_prometheus_resources):
     non_existing_resources = []
     for rsc in hpp_prometheus_resources:
@@ -720,6 +733,7 @@ def test_hpp_prometheus_resources(hpp_prometheus_resources):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3279")
+@pytest.mark.s390x
 def test_hpp_serviceaccount(
     hpp_serviceaccount,
     hpp_daemonset_scope_module,
@@ -745,6 +759,7 @@ def test_hpp_serviceaccount(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8901")
+@pytest.mark.s390x
 def test_hpp_scc(hpp_scc, hpp_cr_suffix_scope_module):
     assert hpp_scc.exists
     assert (
@@ -755,6 +770,7 @@ def test_hpp_scc(hpp_scc, hpp_cr_suffix_scope_module):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8902")
+@pytest.mark.s390x
 def test_hpp_clusterrole_and_clusterrolebinding(
     hpp_clusterrole,
     hpp_clusterrolebinding,
@@ -776,6 +792,7 @@ def test_hpp_clusterrole_and_clusterrolebinding(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8903")
+@pytest.mark.s390x
 def test_hpp_daemonset(hpp_daemonset_scope_module):
     assert (
         hpp_daemonset_scope_module.instance.status.numberReady
@@ -785,6 +802,7 @@ def test_hpp_daemonset(hpp_daemonset_scope_module):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8904")
+@pytest.mark.s390x
 def test_hpp_operator_pod(hpp_operator_pod):
     assert hpp_operator_pod.status == Pod.Status.RUNNING, f"HPP operator pod {hpp_operator_pod.name} is not running"
 
@@ -810,6 +828,7 @@ def test_hpp_operator_recreate_after_deletion(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-6097")
+@pytest.mark.s390x
 def test_hpp_operator_scc(hpp_scc, hpp_operator_pod):
     assert hpp_scc.exists, f"scc {hpp_scc.name} is not existed"
     user_id = hpp_operator_pod.instance.spec["containers"][0]["securityContext"]["runAsUser"]
@@ -870,6 +889,7 @@ def test_hpp_operator_scc(hpp_scc, hpp_operator_pod):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_verify_hpp_res_app_label(
     hpp_resources,
     cnv_current_version,

--- a/tests/storage/hpp/test_hpp_csi_cr.py
+++ b/tests/storage/hpp/test_hpp_csi_cr.py
@@ -185,6 +185,7 @@ def vm_from_template_with_existing_dv_on_hpp_pvc(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_install_and_delete_hpp_csi_cr_basic(
     admin_client,
     hpp_csi_custom_resource,
@@ -240,6 +241,7 @@ def test_install_and_delete_hpp_csi_cr_basic(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_install_and_delete_hpp_csi_cr_with_pvc_template(
     admin_client,
     hpp_csi_custom_resource,
@@ -285,6 +287,7 @@ def test_install_and_delete_hpp_csi_cr_with_pvc_template(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_install_and_delete_hpp_csi_cr_basic_and_with_pvc_template(
     admin_client,
     hpp_csi_custom_resource,

--- a/tests/storage/hpp/test_hpp_node_placement.py
+++ b/tests/storage/hpp/test_hpp_node_placement.py
@@ -77,6 +77,7 @@ def test_create_dv_on_right_node_with_node_placement(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_on_node_without_hpp_pod_and_after_update(
     update_node_labels,
     updated_hpp_with_node_placement,
@@ -109,6 +110,7 @@ def test_create_vm_on_node_without_hpp_pod_and_after_update(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_with_dv_on_functional_after_configuring_hpp_not_to_work_on_that_same_node(
     hostpath_provisioner_scope_module,
     update_node_labels,
@@ -136,6 +138,7 @@ def test_vm_with_dv_on_functional_after_configuring_hpp_not_to_work_on_that_same
     indirect=True,
 )
 @pytest.mark.post_upgrade
+@pytest.mark.s390x
 def test_pv_stay_released_after_deleted_when_no_hpp_pod(
     hostpath_provisioner_scope_module,
     update_node_labels,

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -47,6 +47,7 @@ pytestmark = pytest.mark.usefixtures("fail_when_no_unprivileged_client_available
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unprivileged_user_clone_dv_same_namespace_positive(
     permissions_pvc_source,
     dv_cloned_by_unprivileged_user_in_the_same_namespace,
@@ -83,6 +84,7 @@ def test_unprivileged_user_clone_dv_same_namespace_positive(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_user_permissions_positive(
     unprivileged_client,
     storage_class_matrix__module__,
@@ -125,6 +127,7 @@ def test_user_permissions_positive(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_user_permissions_negative(
     storage_class_name_scope_module,
     namespace,
@@ -157,6 +160,7 @@ def test_user_permissions_negative(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unprivileged_user_clone_same_namespace_negative(
     storage_class_name_scope_module,
     namespace,
@@ -187,6 +191,7 @@ def test_unprivileged_user_clone_same_namespace_negative(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_user_permissions_only_for_dst_ns_negative(
     storage_class_name_scope_module,
     data_volume_multi_storage_scope_module,

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
@@ -83,6 +83,7 @@ def create_vm_negative(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_with_cloned_data_volume_positive(
     unprivileged_client,
     restricted_role_binding_for_vms_in_destination_namespace,
@@ -116,6 +117,7 @@ def test_create_vm_with_cloned_data_volume_positive(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_with_cloned_data_volume_grant_unprivileged_client_permissions_negative(
     namespace,
     destination_namespace,
@@ -147,6 +149,7 @@ def test_create_vm_with_cloned_data_volume_grant_unprivileged_client_permissions
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_cloned_data_volume_restricted_ns_service_account_no_clone_perm_negative(
     namespace,
     destination_namespace,
@@ -176,6 +179,7 @@ def test_create_vm_cloned_data_volume_restricted_ns_service_account_no_clone_per
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_with_cloned_data_volume_permissions_for_pods_positive(
     unprivileged_client,
     data_volume_clone_settings,

--- a/tests/storage/snapshots/test_snapshots.py
+++ b/tests/storage/snapshots/test_snapshots.py
@@ -38,6 +38,7 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.mark.polarion("CNV-5781")
+@pytest.mark.s390x
 def test_snapshot_feature_gate_present(kubevirt_feature_gates):
     """
     This test will ensure that 'Snapshot' feature gate is present in KubeVirt ConfigMap.
@@ -111,6 +112,7 @@ class TestRestoreSnapshots:
         ],
         indirect=["cirros_vm_name", "snapshots_with_content"],
     )
+    @pytest.mark.s390x
     def test_restore_snapshots(
         self,
         cirros_vm_for_snapshot,
@@ -146,6 +148,7 @@ class TestRestoreSnapshots:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_restore_snapshot_while_vm_is_running(
         self,
         cirros_vm_for_snapshot,
@@ -193,6 +196,7 @@ class TestRestoreSnapshots:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_fail_restore_vm_with_unprivileged_client(
         self,
         cirros_vm_for_snapshot,
@@ -225,6 +229,7 @@ class TestRestoreSnapshots:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_restore_same_snapshot_twice(
         self,
         cirros_vm_for_snapshot,
@@ -263,6 +268,7 @@ class TestRestoreSnapshots:
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_remove_vm_with_snapshots(
     cirros_vm_for_snapshot,
     snapshots_with_content,
@@ -284,6 +290,7 @@ def test_remove_vm_with_snapshots(
     ],
     indirect=["cirros_vm_name", "snapshots_with_content"],
 )
+@pytest.mark.s390x
 def test_remove_snapshots_while_vm_is_running(
     cirros_vm_for_snapshot,
     snapshots_with_content,
@@ -323,6 +330,7 @@ def test_remove_snapshots_while_vm_is_running(
     ],
     indirect=["namespace"],
 )
+@pytest.mark.s390x
 def test_unprivileged_client_fails_to_list_resources(namespace, unprivileged_client, resource, error_msg):
     with pytest.raises(
         ApiException,
@@ -343,6 +351,7 @@ def test_unprivileged_client_fails_to_list_resources(namespace, unprivileged_cli
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_fail_to_snapshot_with_unprivileged_client_no_permissions(
     cirros_vm_for_snapshot,
     unprivileged_client,
@@ -366,6 +375,7 @@ def test_fail_to_snapshot_with_unprivileged_client_no_permissions(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_fail_to_snapshot_with_unprivileged_client_dv_permissions(
     cirros_vm_for_snapshot,
     permissions_for_dv,

--- a/tests/storage/storage_migration/test_mtc_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_mtc_storage_class_migration.py
@@ -43,6 +43,7 @@ class TestStorageClassMigrationAtoB:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_vm_storage_class_migration_a_to_b_running_vms(
         self,
         source_storage_class,
@@ -63,6 +64,7 @@ class TestStorageClassMigrationAtoB:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_A_TO_B}::test_vm_storage_class_migration_a_to_b_running_vms"])
     @pytest.mark.polarion("CNV-11504")
+    @pytest.mark.s390x
     def test_migrate_vms_after_storage_migration(self, booted_vms_for_storage_class_migration):
         vms_failed_migration = {}
         for vm in booted_vms_for_storage_class_migration:
@@ -106,6 +108,7 @@ class TestStorageClassMigrationAtoB:
 )
 class TestStorageClassMigrationBtoA:
     @pytest.mark.polarion("CNV-11501")
+    @pytest.mark.s390x
     def test_vm_storage_class_migration_b_to_a_with_running_and_stopped_vms(
         self,
         source_storage_class,

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -166,6 +166,7 @@ def dv_of_multi_storage_cirros_vm(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_dv_delete_from_vm(
     valid_cdi_certificates,
     namespace,
@@ -185,6 +186,7 @@ def test_dv_delete_from_vm(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3667")
+@pytest.mark.s390x
 def test_upload_after_certs_renewal(
     skip_if_sc_volume_binding_mode_is_wffc,
     refresh_cdi_certificates,
@@ -227,6 +229,7 @@ def test_upload_after_certs_renewal(
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3678")
+@pytest.mark.s390x
 def test_import_clone_after_certs_renewal(
     refresh_cdi_certificates,
     data_volume_multi_storage_scope_module,
@@ -250,6 +253,7 @@ def test_import_clone_after_certs_renewal(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3977")
+@pytest.mark.s390x
 def test_upload_after_validate_aggregated_api_cert(
     skip_if_sc_volume_binding_mode_is_wffc,
     valid_aggregated_api_client_cert,
@@ -310,6 +314,7 @@ def downloaded_cirros_image(tmpdir):
 
 
 @pytest.mark.polarion("CNV-5708")
+@pytest.mark.s390x
 def test_cert_exposure_rotation(
     enabled_ca,
     updated_certconfig_in_hco_cr,

--- a/tests/storage/test_cdi_config.py
+++ b/tests/storage/test_cdi_config.py
@@ -113,6 +113,7 @@ def initial_cdi_config_from_cr(cdi):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2451")
+@pytest.mark.s390x
 def test_cdiconfig_scratchspace_fs_upload_to_block(
     available_hpp_storage_class,
     tmpdir,
@@ -139,6 +140,7 @@ def test_cdiconfig_scratchspace_fs_upload_to_block(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2478")
+@pytest.mark.s390x
 def test_cdiconfig_scratchspace_fs_import_to_block(
     available_hpp_storage_class,
     hyperconverged_resource_scope_module,
@@ -163,6 +165,7 @@ def test_cdiconfig_scratchspace_fs_import_to_block(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2214")
+@pytest.mark.s390x
 def test_cdiconfig_status_scratchspace_update_with_spec(
     available_hpp_storage_class,
     hyperconverged_resource_scope_module,
@@ -185,6 +188,7 @@ def test_cdiconfig_status_scratchspace_update_with_spec(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2440")
+@pytest.mark.s390x
 def test_cdiconfig_scratch_space_not_default(
     available_hpp_storage_class,
     hyperconverged_resource_scope_module,
@@ -210,6 +214,7 @@ def test_cdiconfig_scratch_space_not_default(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-2412")
+@pytest.mark.s390x
 def test_cdi_config_scratch_space_value_is_default(
     default_sc_as_fallback_for_scratch,
     cdi_config,
@@ -220,6 +225,7 @@ def test_cdi_config_scratch_space_value_is_default(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-2208")
+@pytest.mark.s390x
 def test_cdi_config_exists(cdi_config, upload_proxy_route):
     assert cdi_config.upload_proxy_url == upload_proxy_route.host
 
@@ -237,6 +243,7 @@ def test_different_route_for_upload_proxy(hco_namespace, cdi_config, uploadproxy
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2215")
+@pytest.mark.s390x
 def test_route_for_different_service(cdi_config, upload_proxy_route):
     with Route(namespace=upload_proxy_route.namespace, name="cdi-api", service="cdi-api") as cdi_api_route:
         assert cdi_config.upload_proxy_url != cdi_api_route.host
@@ -245,6 +252,7 @@ def test_route_for_different_service(cdi_config, upload_proxy_route):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2216")
+@pytest.mark.s390x
 def test_upload_proxy_url_overridden(cdi_config, namespace, cdi_config_upload_proxy_overridden):
     with Route(namespace=namespace.name, name="my-route", service=CDI_UPLOADPROXY) as new_route:
         assert cdi_config.upload_proxy_url != new_route.host
@@ -252,6 +260,7 @@ def test_upload_proxy_url_overridden(cdi_config, namespace, cdi_config_upload_pr
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2441")
+@pytest.mark.s390x
 def test_cdiconfig_changing_storage_class_default(
     skip_test_if_no_ocs_sc,
     available_hpp_storage_class,
@@ -286,6 +295,7 @@ def test_cdiconfig_changing_storage_class_default(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-6312")
+@pytest.mark.s390x
 def test_cdi_spec_reconciled_by_hco(initial_cdi_config_from_cr, updated_cdi_extra_non_existent_feature_gate):
     """
     Test that added feature gate on the CDI CR does not persist
@@ -320,6 +330,7 @@ def test_cdi_spec_reconciled_by_hco(initial_cdi_config_from_cr, updated_cdi_extr
         ),
     ],
 )
+@pytest.mark.s390x
 def test_cdi_tunables_in_hco_propagated_to_cr(
     hyperconverged_resource_scope_module,
     cdi,

--- a/tests/storage/test_cdi_resources.py
+++ b/tests/storage/test_cdi_resources.py
@@ -163,12 +163,14 @@ def data_volume_without_snapshot_capability_scope_function(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_verify_pod_cdi_label(cdi_resources_scope_module):
     verify_label(cdi_resources=cdi_resources_scope_module)
 
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3475")
+@pytest.mark.s390x
 def test_importer_pod_cdi_label(namespace, https_server_certificate):
     # verify "cdi.kubevirt.io" label is included in importer pod
     with import_image_to_dv(
@@ -185,6 +187,7 @@ def test_importer_pod_cdi_label(namespace, https_server_certificate):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3474")
+@pytest.mark.s390x
 def test_uploader_pod_cdi_label(unprivileged_client, namespace, storage_class_name_scope_module):
     """
     Verify "cdi.kubevirt.io" label is included in uploader pod
@@ -216,6 +219,7 @@ def test_uploader_pod_cdi_label(unprivileged_client, namespace, storage_class_na
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_cloner_pods_cdi_label(
     namespace,
     data_volume_without_snapshot_capability_scope_function,
@@ -301,6 +305,7 @@ def test_cloner_pods_cdi_label(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_verify_cdi_res_app_label(
     cdi_resources_scope_module,
     cnv_current_version,

--- a/tests/storage/test_data_import_cron.py
+++ b/tests/storage/test_data_import_cron.py
@@ -207,6 +207,7 @@ def second_object_cleanup(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-7602")
+@pytest.mark.s390x
 def test_data_import_cron_garbage_collection(
     namespace,
     second_object_cleanup,

--- a/tests/storage/test_disk_preallocation.py
+++ b/tests/storage/test_disk_preallocation.py
@@ -93,6 +93,7 @@ def cdi_preallocation_enabled(hyperconverged_resource_scope_module, cdi_config):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_preallocation_dv(
     data_volume_multi_storage_scope_function,
 ):
@@ -120,6 +121,7 @@ def test_preallocation_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_preallocation_globally_dv_spec_without_preallocation(
     cdi_preallocation_enabled,
     data_volume_multi_storage_scope_module,
@@ -149,6 +151,7 @@ def test_preallocation_globally_dv_spec_without_preallocation(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_preallocation_globally_dv_spec_with_preallocation_false(
     cdi_preallocation_enabled,
     data_volume_multi_storage_scope_function,
@@ -180,6 +183,7 @@ def test_preallocation_globally_dv_spec_with_preallocation_false(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_preallocation_for_blank_dv(
     data_volume_multi_storage_scope_function,
 ):

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -165,6 +165,7 @@ class TestHotPlugWithSerial:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6013")
     @pytest.mark.dependency(name="test_hotplug_volume_with_serial")
+    @pytest.mark.s390x
     def test_hotplug_volume_with_serial(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -176,6 +177,7 @@ class TestHotPlugWithSerial:
 
     @pytest.mark.polarion("CNV-11389")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_serial"])
+    @pytest.mark.s390x
     def test_hotplug_volume_with_serial_migrate(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -198,6 +200,7 @@ class TestHotPlugWithPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6014")
     @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
+    @pytest.mark.s390x
     def test_hotplug_volume_with_persist(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -209,6 +212,7 @@ class TestHotPlugWithPersist:
 
     @pytest.mark.polarion("CNV-11390")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
+    @pytest.mark.s390x
     def test_hotplug_volume_with_persist_migrate(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -231,6 +235,7 @@ class TestHotPlugWithSerialPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6425")
     @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
+    @pytest.mark.s390x
     def test_hotplug_volume_with_serial_and_persist(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -243,6 +248,7 @@ class TestHotPlugWithSerialPersist:
 
     @pytest.mark.polarion("CNV-6425b")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
+    @pytest.mark.s390x
     def test_hotplug_volume_with_serial_and_persist_migrate(
         self,
         blank_disk_dv_multi_storage_scope_class,

--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -87,6 +87,7 @@ def client_for_test(request, admin_client, unprivileged_client):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_virtctl_libguestfs_with_specific_user(
     client_for_test,
     virtctl_libguestfs_by_user,

--- a/tests/storage/test_local_storage.py
+++ b/tests/storage/test_local_storage.py
@@ -56,6 +56,7 @@ def local_storage_profile_claim_property_sets(local_storage_class):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_local_storage_profile_claim_property_sets(
     skip_if_no_local_storage_class,
     local_storage_class,

--- a/tests/storage/test_online_resize.py
+++ b/tests/storage/test_online_resize.py
@@ -106,7 +106,7 @@ def expand_pvc(dv, size_change):
 
 
 def get_resize_count(vm):
-    commands = shlex.split("dmesg | grep -c 'new size' || true")
+    commands = shlex.split("sudo dmesg | grep -c 'new size' || true")
     return int(run_ssh_commands(host=vm.ssh_exec, commands=commands)[0])
 
 
@@ -238,6 +238,7 @@ def skip_if_storage_for_online_resize_does_not_support_snapshots(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_sequential_disk_expand(
     cirros_dv_for_online_resize,
     cirros_vm_for_online_resize,
@@ -259,6 +260,7 @@ def test_sequential_disk_expand(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_simultaneous_disk_expand(
     cirros_dv_for_online_resize,
     second_cirros_dv_for_online_resize,
@@ -281,6 +283,7 @@ def test_simultaneous_disk_expand(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_expand_then_clone_fail(
     cirros_dv_for_online_resize,
     cirros_vm_after_expand,
@@ -314,6 +317,7 @@ def test_disk_expand_then_clone_fail(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_expand_then_clone_success(
     cirros_dv_for_online_resize,
     cirros_vm_after_expand,
@@ -343,6 +347,7 @@ def test_disk_expand_then_clone_success(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_expand_then_migrate(cpu_for_migration, cirros_vm_after_expand, orig_cksum):
     migrate_vm_and_verify(
         vm=cirros_vm_after_expand,
@@ -362,6 +367,7 @@ def test_disk_expand_then_migrate(cpu_for_migration, cirros_vm_after_expand, ori
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_expand_with_snapshots(
     skip_if_storage_for_online_resize_does_not_support_snapshots,
     cirros_dv_for_online_resize,

--- a/tests/storage/test_priority_class.py
+++ b/tests/storage/test_priority_class.py
@@ -86,6 +86,7 @@ def importer_pod(admin_client, namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_dv_template_has_the_same_priority_as_vm_when_not_specified(
     priority_class,
     vm_with_priority_class,
@@ -111,6 +112,7 @@ def test_dv_template_has_the_same_priority_as_vm_when_not_specified(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_dv_template_has_the_different_priority_as_vm_when_specify(
     priority_class, vm_with_priority_class, importer_pod
 ):

--- a/tests/storage/test_scratch_space.py
+++ b/tests/storage/test_scratch_space.py
@@ -81,6 +81,7 @@ def scratch_pvc_bound(dv):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_upload_https_scratch_space_delete_pvc(
     namespace,
     storage_class_name_scope_module,

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -179,6 +179,7 @@ def vm_from_uploaded_dv(namespace, uploaded_dv_via_virtctl_wffc, uploaded_wffc_d
 class TestWFFCUploadVirtctl:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4711")
+    @pytest.mark.s390x
     def test_wffc_fail_to_upload_dv_via_virtctl(
         self,
         namespace,
@@ -206,6 +207,7 @@ class TestWFFCUploadVirtctl:
 
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-7413")
+    @pytest.mark.s390x
     def test_wffc_create_vm_from_uploaded_dv_via_virtctl(
         self,
         downloaded_cirros_image_full_path,
@@ -230,6 +232,7 @@ class TestWFFCUploadVirtctl:
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4739")
+@pytest.mark.s390x
 def test_wffc_import_registry_dv(
     namespace,
     storage_class_matrix_wffc_matrix__module__,
@@ -250,6 +253,7 @@ def test_wffc_import_registry_dv(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4741")
+@pytest.mark.s390x
 def test_wffc_upload_dv_via_token(
     unprivileged_client,
     namespace,
@@ -286,6 +290,7 @@ def test_wffc_upload_dv_via_token(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_wffc_import_http_dv(data_volume_multi_wffc_storage_scope_module):
     with create_vm_from_dv(
         dv=data_volume_multi_wffc_storage_scope_module, vm_name=data_volume_multi_wffc_storage_scope_module.name
@@ -304,6 +309,7 @@ def test_wffc_import_http_dv(data_volume_multi_wffc_storage_scope_module):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_wffc_clone_dv(data_volume_multi_wffc_storage_scope_module):
     with create_dv(
         source="pvc",
@@ -335,6 +341,7 @@ def test_wffc_clone_dv(data_volume_multi_wffc_storage_scope_module):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_wffc_add_dv_to_vm_with_data_volume_template(
     namespace,
     data_volume_multi_wffc_storage_scope_function,
@@ -360,6 +367,7 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4743")
+@pytest.mark.s390x
 def test_wffc_vm_with_two_data_volume_templates(
     namespace,
     storage_class_matrix_wffc_matrix__module__,

--- a/tests/storage/vm_export/test_vm_export.py
+++ b/tests/storage/vm_export/test_vm_export.py
@@ -39,6 +39,7 @@ ERROR_MSG_USER_CANNOT_CREATE_VM_EXPORT = (
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_fail_to_vmexport_with_unprivileged_client_no_permissions(
     unprivileged_client,
     data_volume_scope_function,
@@ -74,6 +75,7 @@ def test_fail_to_vmexport_with_unprivileged_client_no_permissions(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vmexport_snapshot_manifests(
     namespace,
     vmexport_from_vmsnapshot,
@@ -92,6 +94,7 @@ def test_vmexport_snapshot_manifests(
 
 
 @pytest.mark.polarion("CNV-11597")
+@pytest.mark.s390x
 def test_virtctl_vmexport_unprivileged(
     vmexport_download_path, blank_dv_created_by_specific_user, virtctl_unprivileged_client
 ):

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1195,7 +1195,7 @@ def login_with_token(api_address, token):
     return login_to_account(login_command=login_command)
 
 
-def login_with_user_password(api_address, user, password=None):
+def login_with_user_password(api_address, user, password=None, insecure_skip_tls=True):
     """
     Log in to an OpenShift cluster using a username and password.
 
@@ -1210,6 +1210,8 @@ def login_with_user_password(api_address, user, password=None):
     login_command = f"oc login {api_address} -u {user}"
     if password:
         login_command += f" -p {password}"
+    if insecure_skip_tls and not user.startswith("system:"):
+        login_command += " --insecure-skip-tls-verify"
     return login_to_account(login_command=login_command)
 
 


### PR DESCRIPTION
##### Short description: 

Add s390x marker for tier2 IUO-OCS tests

##### More details:

This change adds the @pytest.mark.s390x marker to IUO tests across multiple test files. The marker is applied to annotate tests for the s390x architecture, with no modifications to test logic, parameters, or control flow in any of the affected files.

##### What this PR does / why we need it:

This PR adds s390x architecture-specific markers to identify tests that are relevant to the s390x platform. It allows better control over test execution when running IUO tests in s390x environment.

##### Which issue(s) this PR fixes:

None

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
--> 
None
