### PR TITLE
Add s390x test markers for IUO-OCS tests 

### DIFF
--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -37,6 +37,7 @@ TESTS_MIGRATE_VM = f"{TESTS_CLASS_MIGRATION}::test_migrate_vm"
 class TestVMCreationAndValidation:
     @pytest.mark.dependency(name=TEST_CREATE_VM_TEST_NAME)
     @pytest.mark.polarion("CNV-11710")
+    @pytest.mark.s390x
     def test_create_vm(self, golden_image_vm_with_instance_type, instance_type_rhel_os_matrix__class__):
         golden_image_vm_with_instance_type.create(wait=True)
         os_param_dict = instance_type_rhel_os_matrix__class__[[*instance_type_rhel_os_matrix__class__][0]]
@@ -45,6 +46,7 @@ class TestVMCreationAndValidation:
 
     @pytest.mark.dependency(name=TEST_START_VM_TEST_NAME, depends=[TEST_CREATE_VM_TEST_NAME])
     @pytest.mark.polarion("CNV-11711")
+    @pytest.mark.s390x
     def test_start_vm(self, golden_image_vm_with_instance_type):
         running_vm(vm=golden_image_vm_with_instance_type)
 
@@ -119,6 +121,7 @@ class TestVMFeatures:
 class TestVMMigrationAndState:
     @pytest.mark.polarion("CNV-11714")
     @pytest.mark.dependency(name=TESTS_MIGRATE_VM, depends=[TEST_START_VM_TEST_NAME])
+    @pytest.mark.s390x
     def test_migrate_vm(self, skip_access_mode_rwo_scope_class, golden_image_vm_with_instance_type):
         migrate_vm_and_verify(vm=golden_image_vm_with_instance_type, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=golden_image_vm_with_instance_type)

--- a/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
+++ b/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
@@ -33,6 +33,7 @@ class TestCertRotation:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_certificate_renewed_in_hco(
         self,
         hco_namespace,

--- a/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
+++ b/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
@@ -58,6 +58,7 @@ class TestDisconnectedVirtctlDownload:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_download_virtcli_binary(
         self,
         downloaded_and_extracted_virtctl_binary_for_os,
@@ -84,6 +85,7 @@ class TestDisconnectedVirtctlDownloadAndExecute:
         ],
         indirect=["downloaded_and_extracted_virtctl_binary_for_os"],
     )
+    @pytest.mark.s390x
     def test_download_and_execute_virtcli_binary_linux(self, downloaded_and_extracted_virtctl_binary_for_os, platform):
         assert os.path.exists(downloaded_and_extracted_virtctl_binary_for_os)
         # this part should only be repeated if the execution is being done on a matching platform:
@@ -94,6 +96,7 @@ class TestDisconnectedVirtctlDownloadAndExecute:
 @pytest.mark.arm64
 class TestDisconnectedVirtctlAllLinksInternal:
     @pytest.mark.polarion("CNV-6915")
+    @pytest.mark.s390x
     def test_all_links_internal(self, all_virtctl_urls, non_internal_fqdns):
         assert not non_internal_fqdns, (
             "Found virtctl URLs that do not point to the cluster internally: "

--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -37,6 +37,7 @@ def crds(admin_client):
 
 
 @pytest.mark.polarion("CNV-8263")
+@pytest.mark.s390x
 def test_crds_cluster_readers_role(crds):
     LOGGER.info(f"CRds: {crds}")
     cluster_readers = "system:cluster-readers"

--- a/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
@@ -105,6 +105,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
     ],
     indirect=["resource_crypto_policy_settings"],
 )
+@pytest.mark.s390x
 def test_default_crypto_policy(resource_crypto_policy_settings, resource_type):
     expected_result = CRYPTO_POLICY_EXPECTED_DICT[TLS_INTERMEDIATE_POLICY].get(resource_type)
     assert resource_crypto_policy_settings == expected_result, (
@@ -114,6 +115,7 @@ def test_default_crypto_policy(resource_crypto_policy_settings, resource_type):
 
 
 @pytest.mark.polarion("CNV-9266")
+@pytest.mark.s390x
 def test_default_crypto_policy_check_connectivity(
     workers, workers_utility_pods, services_to_check_connectivity, fips_enabled_cluster
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
@@ -41,6 +41,7 @@ def updated_hco_crypto_policy(
 
 
 @pytest.mark.polarion("CNV-9331")
+@pytest.mark.s390x
 def test_set_hco_crypto_policy(
     cnv_crypto_policy_matrix__function__,
     updated_hco_crypto_policy,

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.polarion("CNV-9367")
+@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):
@@ -41,6 +42,7 @@ def test_set_hco_crypto_failed_without_required_cipher(
 
 
 @pytest.mark.polarion("CNV-10551")
+@pytest.mark.s390x
 def test_set_ciphers_for_tlsv13(hyperconverged_resource_scope_function):
     error_string = r"custom ciphers cannot be selected when minTLSVersion is VersionTLS13"
     tls_custom_profile = copy.deepcopy(TLS_CUSTOM_PROFILE)

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.polarion("CNV-9367")
+@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -140,6 +140,7 @@ def updated_cr_with_custom_crypto_policy(
     ],
     indirect=["updated_cr_with_custom_crypto_policy"],
 )
+@pytest.mark.s390x
 def test_update_specific_component_crypto_policy(
     resources_dict,
     updated_cr_with_custom_crypto_policy,

--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -66,6 +66,7 @@ def csv_permissions_from_yaml(pytestconfig):
 
 
 @pytest.mark.polarion("CNV-9805")
+@pytest.mark.s390x
 def test_new_operator_in_csv(operators_from_csv):
     assert sorted(list(operators_from_csv)) == sorted(CNV_OPERATORS), (
         f"Expected cnv operators:{CNV_OPERATORS} does not match operators {operators_from_csv} "
@@ -73,6 +74,7 @@ def test_new_operator_in_csv(operators_from_csv):
 
 
 @pytest.mark.polarion("CNV-9547")
+@pytest.mark.s390x
 def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissions_from_yaml, csv_permissions):
     from_yaml = csv_permissions_from_yaml.get(cnv_operators_matrix__function__, {})
     from_csv = csv_permissions.get(cnv_operators_matrix__function__, {})
@@ -86,6 +88,7 @@ def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissio
 
 
 @pytest.mark.polarion("CNV-9548")
+@pytest.mark.s390x
 def test_global_csv_permissions(cnv_operators_matrix__function__, global_permission_from_csv):
     error_message = f"Found global permission for {cnv_operators_matrix__function__}"
     errors = {}

--- a/tests/install_upgrade_operators/csv/test_csv.py
+++ b/tests/install_upgrade_operators/csv/test_csv.py
@@ -27,6 +27,7 @@ EXPECTED_LINK_MAP = {
 @pytest.mark.polarion("CNV-4456")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_keywords(csv_scope_session):
     """
     Assert keywords. Check that each one of the expected keywords are actually there
@@ -37,6 +38,7 @@ def test_csv_keywords(csv_scope_session):
 @pytest.mark.polarion("CNV-4457")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_links(csv_scope_session):
     """
     Check links list.
@@ -53,6 +55,7 @@ def test_csv_links(csv_scope_session):
 @pytest.mark.polarion("CNV-4458")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_icon(csv_scope_session):
     """
     Assert Icon/Logo.
@@ -69,6 +72,7 @@ def test_csv_icon(csv_scope_session):
 @pytest.mark.polarion("CNV-4376")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_properties(csv_scope_session):
     """
     Asserting remaining csv properties.
@@ -96,6 +100,7 @@ def test_csv_properties(csv_scope_session):
         ),
     ],
 )
+@pytest.mark.s390x
 def test_csv_annotations(csv_scope_session, csv_annotation, expected_value):
     """
     Validates badges have been added to csv's operators.openshift.io/infrastructure-features annotation

--- a/tests/install_upgrade_operators/csv/test_csv_infrastructure_features_disconnected.py
+++ b/tests/install_upgrade_operators/csv/test_csv_infrastructure_features_disconnected.py
@@ -6,6 +6,7 @@ pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-5840")
+@pytest.mark.s390x
 def test_csv_infrastructure_features_disconnected(csv_annotation):
     """
     In the Cluster Service Version annotations for Infrastructure Feature disconnected looks like:

--- a/tests/install_upgrade_operators/csv/test_hco_api_version.py
+++ b/tests/install_upgrade_operators/csv/test_hco_api_version.py
@@ -5,6 +5,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-5832")
+@pytest.mark.s390x
 def test_hyperconverged_cr_api_version(hyperconverged_resource_scope_function):
     """
     This test will check the Hyperconverged CR's api_version for v1beta1

--- a/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
+++ b/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
@@ -7,6 +7,7 @@ pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-5884")
+@pytest.mark.s390x
 def test_hco_cr_explainable(hyperconverged_resource_scope_function):
     """
     This test case ensure that after executing 'oc explain hyperconvergeds'
@@ -51,6 +52,7 @@ def test_hco_cr_explainable(hyperconverged_resource_scope_function):
         ),
     ],
 )
+@pytest.mark.s390x
 def test_hco_cr_fields_explainable(fields, description):
     """
     This test case ensure that after executing 'oc explain hyperconvergeds.{fields}'

--- a/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
+++ b/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-4751")
+@pytest.mark.s390x
 def test_immutable_image_using_sha(kubevirt_package_manifest_current_channel):
     """
     check all images of the current channel on the kubevirt-hyperconverged Package Manifest.

--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-7169")
+@pytest.mark.s390x
 def test_channels_in_manifest(kubevirt_package_manifest_channels):
     expected_channels = {"stable", "dev-preview"}
     missing_channels = expected_channels - {channel.name for channel in kubevirt_package_manifest_channels}
@@ -11,5 +12,6 @@ def test_channels_in_manifest(kubevirt_package_manifest_channels):
 
 
 @pytest.mark.polarion("CNV-11944")
+@pytest.mark.s390x
 def test_cnv_subscription_channel(cnv_subscription_scope_session, kubevirt_package_manifest_current_channel):
     assert cnv_subscription_scope_session.instance.spec.channel == kubevirt_package_manifest_current_channel.name

--- a/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
+++ b/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
@@ -13,6 +13,7 @@ def cnv_daemonset_names(admin_client, hco_namespace):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8509")
+@pytest.mark.s390x
 def test_no_new_cnv_daemonset_added(sno_cluster, cnv_daemonset_names):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -32,6 +32,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_liveness_probe(deployment_by_name):
     """Validates various livenessProbe fields values for different deployment objects"""
     validate_liveness_probe_fields(deployment=deployment_by_name)
@@ -56,6 +57,7 @@ def test_liveness_probe(deployment_by_name):
     ],
     indirect=["deployment_by_name"],
 )
+@pytest.mark.s390x
 def test_request_param(deployment_by_name, cpu_min_value):
     """Validates resources.requests fields keys and default cpu values for different deployment objects"""
     validate_request_fields(deployment=deployment_by_name, cpu_min_value=cpu_min_value)
@@ -63,6 +65,7 @@ def test_request_param(deployment_by_name, cpu_min_value):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-7675")
+@pytest.mark.s390x
 def test_cnv_deployment_priority_class_name(
     cnv_deployment_by_name_no_hpp,
 ):
@@ -75,6 +78,7 @@ def test_cnv_deployment_priority_class_name(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8289")
+@pytest.mark.s390x
 def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added
@@ -90,6 +94,7 @@ def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8264")
+@pytest.mark.s390x
 def test_cnv_deployment_container_image(cnv_deployment_by_name):
     assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)
     assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -79,6 +79,7 @@ def resource_object_value_by_key(request):
     ],
     indirect=["resource_object_value_by_key"],
 )
+@pytest.mark.s390x
 def test_default_featuregates_by_resource(
     expected,
     resource_object_value_by_key,

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -52,6 +52,7 @@ class TestHardcodedFeatureGates:
         ],
         indirect=["updated_resource"],
     )
+    @pytest.mark.s390x
     def test_managed_cr_featuregate_reconcile(
         self,
         updated_resource,

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -42,6 +42,7 @@ def updated_fg_hco(
     ],
     indirect=["updated_fg_hco"],
 )
+@pytest.mark.s390x
 def test_enable_fg_hco(
     updated_fg_hco,
     hco_spec,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -178,6 +178,7 @@ class TestDefaultCommonTemplates:
             pytest.param("ssp_spec_templates_scope_function", marks=pytest.mark.polarion("CNV-11677")),
         ],
     )
+    @pytest.mark.s390x
     def test_custom_namespace_added_to_templates_metadata(
         self,
         request,
@@ -197,6 +198,7 @@ class TestDefaultCommonTemplates:
             pytest.param(DataSource, DataSource.Condition.READY, marks=pytest.mark.polarion("CNV-11476")),
         ],
     )
+    @pytest.mark.s390x
     def test_resources_in_custom_ns(
         self,
         admin_client,
@@ -221,6 +223,7 @@ class TestDefaultCommonTemplates:
             )
 
     @pytest.mark.polarion("CNV-11477")
+    @pytest.mark.s390x
     def test_boot_sources_not_reconciled_in_default_namespace(self, admin_client, golden_images_namespace):
         verify_resources_not_reconciled(
             resources_to_verify=[DataVolume, VolumeSnapshot],
@@ -230,6 +233,7 @@ class TestDefaultCommonTemplates:
 
 
 @pytest.mark.polarion("CNV-11631")
+@pytest.mark.s390x
 def test_non_existent_namespace(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
@@ -9,6 +9,7 @@ pytestmark = [pytest.mark.gating, pytest.mark.arm64]
 
 @pytest.mark.usefixtures("hyperconverged_spec_scope_session", "hyperconverged_status_scope_session")
 @pytest.mark.polarion("CNV-7504")
+@pytest.mark.s390x
 def test_data_import_schedule_default_in_hco_cr(
     data_import_schedule,
 ):
@@ -18,6 +19,7 @@ def test_data_import_schedule_default_in_hco_cr(
 
 
 @pytest.mark.polarion("CNV-8168")
+@pytest.mark.s390x
 def test_default_hco_cr_image_streams(
     admin_client,
     golden_images_namespace,
@@ -36,6 +38,7 @@ def test_default_hco_cr_image_streams(
 
 
 @pytest.mark.polarion("CNV-8935")
+@pytest.mark.s390x
 def test_no_data_import_template_in_hco_spec(
     hyperconverged_spec_scope_session,
 ):
@@ -45,6 +48,7 @@ def test_no_data_import_template_in_hco_spec(
 
 
 @pytest.mark.polarion("CNV-8703")
+@pytest.mark.s390x
 def test_data_import_template_defaults_hco_status(
     hyperconverged_status_scope_session,
     hyperconverged_spec_scope_session,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.mark.jira("CNV-63031", run=False)
 @pytest.mark.polarion("CNV-7603")
+@pytest.mark.s390x
 def test_same_random_minute_after_delete_hco_pod(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 class TestEnableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7626")
+    @pytest.mark.s390x
     def test_set_enable_common_boot_image_import_true_ssp_cr(
         self,
         ssp_cr_spec,
@@ -26,6 +27,7 @@ class TestEnableCommonBootImageImport:
 
 
 @pytest.mark.polarion("CNV-7778")
+@pytest.mark.s390x
 def test_enable_and_delete_spec_enable_common_boot_image_import_hco_cr(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -128,6 +128,7 @@ class TestModifyCommonTemplateSpec:
         ],
         indirect=["updated_common_template"],
     )
+    @pytest.mark.s390x
     def test_modified_common_template(self, updated_common_template, hyperconverged_status_templates_scope_function):
         template_name = updated_common_template[0]["metadata"]["name"]
         hco_template = get_template_dict_by_name(
@@ -164,6 +165,7 @@ class TestModifyCommonTemplateSpec:
         ],
         indirect=["updated_common_template"],
     )
+    @pytest.mark.s390x
     def test_common_template_modify_spec(
         self,
         updated_common_template,
@@ -249,6 +251,7 @@ class TestCommonTemplatesEnableDisable:
         ],
         indirect=["updated_common_template"],
     )
+    @pytest.mark.s390x
     def test_common_template_config_disable(
         self,
         updated_common_template,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
@@ -71,6 +71,7 @@ def updated_hco_cr_custom_template_disable(
 
 
 @pytest.mark.polarion("CNV-8731")
+@pytest.mark.s390x
 def test_custom_template_no_disable(
     updated_hco_cr_custom_template_disable,
     hyperconverged_status_templates_scope_function,
@@ -89,6 +90,7 @@ def test_custom_template_no_disable(
 
 
 @pytest.mark.polarion("CNV-8709")
+@pytest.mark.s390x
 def test_disable_template_annotation_value(admin_client, hco_namespace, editor_hyperconverged_custom_template):
     try:
         with pytest.raises(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
@@ -11,6 +11,7 @@ pytestmark = [pytest.mark.gating, pytest.mark.arm64]
 @pytest.mark.usefixtures("disabled_common_boot_image_import_hco_spec_scope_class")
 class TestDisableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7473")
+    @pytest.mark.s390x
     def test_disable_spec_verify_hco_cr_and_ssp_cr(
         self,
         ssp_cr_spec,
@@ -20,6 +21,7 @@ class TestDisableCommonBootImageImport:
         )
 
     @pytest.mark.polarion("CNV-8183")
+    @pytest.mark.s390x
     def test_image_streams_disable_feature_gate(
         self,
         golden_images_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -62,6 +62,7 @@ def updated_hco_cr_custom_template_scope_class(
 class TestCustomTemplates:
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-8707")
+    @pytest.mark.s390x
     def test_custom_template_status(self, hyperconverged_status_templates_scope_function):
         custom_template_name = CUSTOM_CRON_TEMPLATE["metadata"]["name"]
         custom_templates_name = [
@@ -77,6 +78,7 @@ class TestCustomTemplates:
 
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7884")
+    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template(
         self,
         hyperconverged_status_templates_scope_function,
@@ -89,6 +91,7 @@ class TestCustomTemplates:
 
     @pytest.mark.dependency(name="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7914")
+    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template_disable_spec(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
@@ -46,6 +46,7 @@ def json_patched_cdi(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8717")
+    @pytest.mark.s390x
     def test_cdi_json_patch(
         self,
         admin_client,
@@ -66,6 +67,7 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9707")
+    @pytest.mark.s390x
     def test_cdi_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -80,5 +82,6 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9706")
+    @pytest.mark.s390x
     def test_cdi_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT_CDI)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
@@ -51,6 +51,7 @@ def json_patched_cnao(
 )
 class TestCNAOJsonPatch:
     @pytest.mark.polarion("CNV-8715")
+    @pytest.mark.s390x
     def test_cnao_json_patch(
         self,
         admin_client,
@@ -68,6 +69,7 @@ class TestCNAOJsonPatch:
         assert not cnao_spec.get(PATH), f"Unable to replace {PATH} from CNAO via json patch. Current value: {cnao_spec}"
 
     @pytest.mark.polarion("CNV-9713")
+    @pytest.mark.s390x
     def test_cnao_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -82,5 +84,6 @@ class TestCNAOJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9712")
+    @pytest.mark.s390x
     def test_cnao_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
@@ -44,6 +44,7 @@ def json_patched_kubevirt(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8689")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch(
         self,
         admin_client,
@@ -60,6 +61,7 @@ class TestKubevirtJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-9697")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -74,6 +76,7 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9698")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch_alert(self, prometheus):
         wait_for_alert(
             prometheus=prometheus,

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
@@ -79,6 +79,7 @@ def multiple_json_patched(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestMultipleJsonPatch:
     @pytest.mark.polarion("CNV-8718")
+    @pytest.mark.s390x
     def test_multiple_json_patch(
         self,
         admin_client,
@@ -101,6 +102,7 @@ class TestMultipleJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-8720")
+    @pytest.mark.s390x
     def test_multiple_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         component_metrics_dict = {
             component: filter_metric_by_component(
@@ -120,6 +122,7 @@ class TestMultipleJsonPatch:
             )
 
     @pytest.mark.polarion("CNV-8813")
+    @pytest.mark.s390x
     def test_multiple_json_patch_alert(self, prometheus):
         for component in COMPONENT_DICT.keys():
             LOGGER.info(f"Waiting for alert: {ALERT_NAME} for component: {component}")

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -47,6 +47,7 @@ def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestSSPJsonPatch:
     @pytest.mark.polarion("CNV-8690")
+    @pytest.mark.s390x
     def test_ssp_json_patch(
         self,
         admin_client,
@@ -67,6 +68,7 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8691")
+    @pytest.mark.s390x
     def test_ssp_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -81,5 +83,6 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8714")
+    @pytest.mark.s390x
     def test_ssp_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
@@ -41,6 +41,7 @@ LOGGER = logging.getLogger(__name__)
         ),
     ],
 )
+@pytest.mark.s390x
 def test_default_workload_update_strategy(admin_client, hco_namespace, resource_name, expected):
     """Validates by default, hyperconverged's and kubevirt's spec.workloadUpdateStrategy is set to correct values"""
     LOGGER.info("Ensure HCO is is in stable condition before checking for spec.workloadUpdateStrategy")

--- a/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
@@ -65,6 +65,7 @@ class TestLauncherUpdateNegative:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_hyperconverged_reset_custom_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,

--- a/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
@@ -51,6 +51,7 @@ class TestLauncherUpdateResetFields:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_reset_custom_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,

--- a/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
@@ -60,6 +60,7 @@ class TestLauncherUpdateModifyDefault:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_modify_custom_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,
@@ -112,6 +113,7 @@ class TestLauncherUpdateModifyDefault:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_modify_all_workload_update_strategy(
         self,
         updated_workload_strategy_custom_values,

--- a/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
@@ -42,6 +42,7 @@ class TestLauncherUpdateAll:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_modify_custom_workload_update_strategy_all(
         self,
         admin_client,
@@ -162,6 +163,7 @@ class TestCustomWorkLoadStrategy:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_hyperconverged_modify_custom_workload_update_strategy(
         self, admin_client, hco_namespace, updated_hco_cr, expected
     ):

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -78,6 +78,7 @@ class TestMustGatherCluster:
         ],
         indirect=["resource_type"],
     )
+    @pytest.mark.s390x
     def test_resource_type(
         self,
         admin_client,
@@ -95,6 +96,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2982")
+    @pytest.mark.s390x
     def test_namespace(self, hco_namespace, must_gather_for_test):
         namespace_name = hco_namespace.name
         check_resource(
@@ -106,6 +108,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-5885")
+    @pytest.mark.s390x
     def test_no_upstream_only_namespaces(self, must_gather_for_test, sriov_namespace):
         """
         After running must-gather command on the cluster, there are some upstream-only namespaces
@@ -179,6 +182,7 @@ class TestMustGatherCluster:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_pods(
         self,
         admin_client,
@@ -197,6 +201,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2727")
+    @pytest.mark.s390x
     def test_template_in_openshift_ns_data(self, admin_client, must_gather_for_test):
         template_resources = list(
             Template.get(dyn_client=admin_client, singular_name="template", namespace="openshift")
@@ -214,6 +219,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2809")
+    @pytest.mark.s390x
     def test_node_nftables(self, collected_nft_files_must_gather, nftables_from_utility_pods):
         table_not_found_errors = []
         for node_name in collected_nft_files_must_gather:
@@ -255,6 +261,7 @@ class TestMustGatherCluster:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_node_resource(
         self,
         must_gather_for_test,
@@ -273,6 +280,7 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-2801")
+    @pytest.mark.s390x
     def test_nmstate_config_data(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -287,6 +295,7 @@ class TestMustGatherCluster:
         "label_selector",
         [pytest.param({"app": "cni-plugins"}, marks=(pytest.mark.polarion("CNV-2715")))],
     )
+    @pytest.mark.s390x
     def test_logs_gathering(self, must_gather_for_test, running_hco_containers, label_selector):
         check_logs(
             cnv_must_gather=must_gather_for_test,
@@ -307,6 +316,7 @@ class TestMustGatherCluster:
         ],
         indirect=["config_map_by_name"],
     )
+    @pytest.mark.s390x
     def test_gathered_config_maps(
         self,
         must_gather_for_test,
@@ -326,6 +336,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2723")
+    @pytest.mark.s390x
     def test_apiservice_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -337,6 +348,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2726")
+    @pytest.mark.s390x
     def test_webhookconfig_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -365,11 +377,13 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-8508")
+    @pytest.mark.s390x
     def test_no_new_cnv_crds(self, kubevirt_crd_names):
         new_crds = [crd for crd in kubevirt_crd_names if crd not in ALL_CNV_CRDS]
         assert not new_crds, f"Following crds are new: {new_crds}."
 
     @pytest.mark.polarion("CNV-2724")
+    @pytest.mark.s390x
     def test_crd_resources(self, admin_client, must_gather_for_test, kubevirt_crd_by_type):
         crd_name = kubevirt_crd_by_type.name
         for version in kubevirt_crd_by_type.instance.spec.versions:
@@ -420,6 +434,7 @@ class TestMustGatherCluster:
                 )
 
     @pytest.mark.polarion("CNV-2939")
+    @pytest.mark.s390x
     def test_image_stream_tag_resources(self, admin_client, must_gather_for_test):
         resource_path = (
             f"namespaces/{NamespacesNames.OPENSHIFT}/{ImageStreamTag.ApiGroup.IMAGE_OPENSHIFT_IO}/imagestreamtags"
@@ -462,6 +477,7 @@ class TestSriovMustGather:
 
 class TestCNVCollectsLogs:
     @pytest.mark.polarion("CNV-9906")
+    @pytest.mark.s390x
     def test_kubevirt_logs_collected(self, gathered_kubevirt_logs, running_hco_containers, hco_namespace):
         LOGGER.info(f"Pod containers: {running_hco_containers}")
         check_logs(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -33,6 +33,7 @@ class TestImageGathering:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_image_gather(self, admin_client, gathered_images, resource, resource_path):
         check_list_of_resources(
             dyn_client=admin_client,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
@@ -22,6 +22,7 @@ class TestInstanceTypesAndPreferencesCollected:
         indirect=True,
     )
     @pytest.mark.polarion("CNV-9648")
+    @pytest.mark.s390x
     def test_instancestypes_collected(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -83,6 +83,7 @@ class TestMustGatherClusterWithVMs:
         ],
         indirect=["resource_type"],
     )
+    @pytest.mark.s390x
     def test_resource_type(
         self,
         admin_client,
@@ -262,6 +263,7 @@ class TestMustGatherVmDetails:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_blockjob_file_collected_from_virt_launcher(
         self,
         data_volume_scope_class,
@@ -276,6 +278,7 @@ class TestMustGatherVmDetails:
         )
 
     @pytest.mark.polarion("CNV-10243")
+    @pytest.mark.s390x
     def test_must_gather_and_vm_same_node(
         self,
         must_gather_vm,
@@ -291,6 +294,7 @@ class TestMustGatherVmDetails:
 class TestGuestConsoleLog:
     @pytest.mark.usefixtures("updated_disable_serial_console_log_false", "must_gather_vm_scope_class")
     @pytest.mark.polarion("CNV-10630")
+    @pytest.mark.s390x
     def test_guest_console_logs(
         self,
         must_gather_vm_scope_class,
@@ -305,6 +309,7 @@ class TestGuestConsoleLog:
 @pytest.mark.sno
 class TestMustGatherVmLongNameDetails:
     @pytest.mark.polarion("CNV-9233")
+    @pytest.mark.s390x
     def test_data_collected_from_virt_launcher_long(
         self,
         must_gather_long_name_vm,
@@ -330,6 +335,7 @@ class TestNoMultipleFilesCollected:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_no_multiple_empty_files_collected_from_must_gather_migrated_vm(
         self,
         skip_if_no_common_cpu,
@@ -353,6 +359,7 @@ class TestNoMultipleFilesCollected:
 @pytest.mark.sno
 class TestControllerRevisionCollected:
     @pytest.mark.polarion("CNV-10978")
+    @pytest.mark.s390x
     def test_controller_revision_collected(
         self,
         rhel_vm_with_cluster_instance_type_and_preference,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
@@ -49,6 +49,7 @@ class TestMustGatherVmDetailsWithParams:
         ],
         indirect=["collected_vm_details_must_gather_with_params"],
     )
+    @pytest.mark.s390x
     def test_must_gather_params(
         self,
         must_gather_vm,
@@ -66,6 +67,7 @@ class TestMustGatherVmDetailsWithParams:
         )
 
     @pytest.mark.polarion("CNV-9039")
+    @pytest.mark.s390x
     def test_must_gather_stopped_vm(
         self,
         must_gather_vms_from_alternate_namespace,

--- a/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
+++ b/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
@@ -45,6 +45,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_change_subscription_on_selected_node_before_workload(
         self,
         admin_client,
@@ -78,6 +79,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         indirect=True,
     )
     @pytest.mark.dependency(name="test_change_infrastructure_components_on_selected_node_before_workload")
+    @pytest.mark.s390x
     def test_change_infrastructure_components_on_selected_node_before_workload(
         self,
         admin_client,
@@ -114,6 +116,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_change_workload_components_on_selected_node_before_workload",
         depends=["test_change_infrastructure_components_on_selected_node_before_workload"],
     )
+    @pytest.mark.s390x
     def test_change_workload_components_on_selected_node_before_workload(
         self,
         admin_client,
@@ -143,6 +146,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_deploying_workloads_on_selected_nodes",
         depends=["test_change_workload_components_on_selected_node_before_workload"],
     )
+    @pytest.mark.s390x
     def test_deploying_workloads_on_selected_nodes(
         self,
         vm_placement_vm_work3,
@@ -154,6 +158,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_deploying_workloads_on_selected_nodes"],
     )
+    @pytest.mark.s390x
     def test_workload_components_selection_change_denied_with_workloads(
         self,
         nodes_labeled,
@@ -182,6 +187,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_infrastructure_components_selection_change_allowed_with_workloads",
         depends=["test_deploying_workloads_on_selected_nodes"],
     )
+    @pytest.mark.s390x
     def test_infrastructure_components_selection_change_allowed_with_workloads(
         self,
         admin_client,
@@ -221,6 +227,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_infrastructure_components_selection_change_allowed_with_workloads"],
     )
+    @pytest.mark.s390x
     def test_operator_components_selection_change_allowed_with_workloads(
         self,
         admin_client,
@@ -258,6 +265,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         name="test_infrastructure_components_selection_change_allowed_after_workloads",
         depends=["test_infrastructure_components_selection_change_allowed_with_workloads"],
     )
+    @pytest.mark.s390x
     def test_infrastructure_components_selection_change_allowed_after_workloads(
         self,
         admin_client,
@@ -297,6 +305,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_infrastructure_components_selection_change_allowed_after_workloads"],
     )
+    @pytest.mark.s390x
     def test_operator_components_selection_change_allowed_after_workloads(
         self,
         admin_client,
@@ -332,6 +341,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.dependency(
         depends=["test_infrastructure_components_selection_change_allowed_after_workloads"],
     )
+    @pytest.mark.s390x
     def test_workload_components_selection_change_allowed_after_workloads(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/node_component/test_hco_vm.py
+++ b/tests/install_upgrade_operators/node_component/test_hco_vm.py
@@ -49,6 +49,7 @@ def hco_vm(unprivileged_client, namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_remove_workload_label_from_node_while_vm_running(
     node_placement_labels, hyperconverged_with_node_placement, hco_vm
 ):

--- a/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
+++ b/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
@@ -27,6 +27,7 @@ LOGGER = logging.getLogger(__name__)
 class TestCreateHCOWithNodePlacement:
     @pytest.mark.polarion("CNV-5368")
     @pytest.mark.dependency(name="test_hco_cr_with_node_placement")
+    @pytest.mark.s390x
     def test_hco_cr_with_node_placement(
         self,
         admin_client,
@@ -63,6 +64,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5369")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_ssp_cr(
         self,
         ssp_cr_spec,
@@ -81,6 +83,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5382")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_network_addons_cr(
         self,
         network_addon_config_spec_placement,
@@ -123,6 +126,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5383")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_kubevirt_cr(
         self,
         kubevirt_hyperconverged_spec_scope_function,
@@ -158,6 +162,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5384")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_cdi_cr(
         self,
         cdi_spec,

--- a/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
+++ b/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
@@ -57,6 +57,7 @@ def pod_security_violations_apis_calls(audit_logs, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-9115")
+@pytest.mark.s390x
 def test_cnv_pod_security_violation_audit_logs(pod_security_violations_apis_calls):
     LOGGER.info("Test pod security violations API calls:")
     if pod_security_violations_apis_calls:

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -40,6 +40,7 @@ def cnv_pods_by_type_no_hpp_csi_hpp_pool(cnv_pod_priority_class_matrix__function
 
 
 @pytest.mark.polarion("CNV-7261")
+@pytest.mark.s390x
 def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
     all_pods = ALL_CNV_PODS.copy()
     all_pods.append(HPP_POOL)
@@ -53,12 +54,14 @@ def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
 
 
 @pytest.mark.polarion("CNV-7262")
+@pytest.mark.s390x
 def test_pods_priority_class_value(cnv_pods_by_type_no_hpp_csi_hpp_pool):
     validate_cnv_pods_priority_class_name_exists(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
     validate_priority_class_value(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
 
 
 @pytest.mark.polarion("CNV-7306")
+@pytest.mark.s390x
 def test_pods_resource_request(
     cnv_pods_by_type,
     pod_resource_validation_matrix__function__,
@@ -70,6 +73,7 @@ def test_pods_resource_request(
 
 
 @pytest.mark.polarion("CNV-8267")
+@pytest.mark.s390x
 def test_cnv_pod_container_image(cnv_pods_by_type):
     assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)
     assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)

--- a/tests/install_upgrade_operators/product_install/test_crds_schema.py
+++ b/tests/install_upgrade_operators/product_install/test_crds_schema.py
@@ -36,6 +36,7 @@ def crd_operator_resources(request, admin_client):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_check_crd_non_structural_schema(crd_operator_resources):
     failed_crds = [
         crd_resource.name

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
@@ -35,6 +35,7 @@ def remove_kubevirt_vm(unprivileged_client, namespace):
 
 
 @pytest.mark.polarion("CNV-3738")
+@pytest.mark.s390x
 def test_validate_default_uninstall_strategy(kubevirt_resource):
     strategy = kubevirt_resource.instance.spec.uninstallStrategy
     assert strategy == "BlockUninstallIfWorkloadsExist", (

--- a/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
@@ -88,6 +88,7 @@ def cnv_resources(hco_namespace):
 
 
 @pytest.mark.polarion("CNV-10307")
+@pytest.mark.s390x
 def test_relationship_labels_all_cnv_resources(
     ocp_resources_submodule_list, admin_client, cnv_resources, hco_namespace
 ):

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -42,6 +42,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_mismatch_relationship_labels_deployments(self, expected_label_dictionary, cnv_deployment_by_name):
         verify_component_labels_by_resource(
             component=cnv_deployment_by_name,
@@ -58,6 +59,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_mismatch_relationship_labels_daemonsets(self, expected_label_dictionary, cnv_daemonset_by_name):
         verify_component_labels_by_resource(
             component=cnv_daemonset_by_name,
@@ -74,6 +76,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_mismatch_relationship_labels_pods(self, expected_label_dictionary, cnv_pod_by_name):
         verify_component_labels_by_resource(
             component=cnv_pod_by_name,
@@ -90,6 +93,7 @@ class TestRelationshipLabels:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_verify_relationship_labels_hco_components(
         self,
         expected_label_dictionary,

--- a/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
+++ b/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
@@ -23,6 +23,7 @@ LOGGER = logging.getLogger(__name__)
         ),
     ],
 )
+@pytest.mark.s390x
 def test_hco_status_conditions(admin_client, hco_namespace, expected_condition_fields):
     """Validates hco status conditions contains expected field"""
     LOGGER.info("Check for hco to be in stable condition:")

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -35,6 +35,7 @@ def required_scc_deployment_check(admin_client, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-11964")
+@pytest.mark.s390x
 def test_deployments_missing_required_scc_annotation(required_scc_deployment_check):
     assert not required_scc_deployment_check["missing_required_scc_annotation"], (
         f"Deployments missing {REQUIRED_SCC_ANNOTATION} annotation: "
@@ -43,6 +44,7 @@ def test_deployments_missing_required_scc_annotation(required_scc_deployment_che
 
 
 @pytest.mark.polarion("CNV-11965")
+@pytest.mark.s390x
 def test_deployments_with_incorrect_required_scc(required_scc_deployment_check):
     assert not required_scc_deployment_check["incorrect_required_scc_annotation_value"], (
         f"Deployments incorrect {REQUIRED_SCC_ANNOTATION} annotation : "

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -44,6 +44,7 @@ def verify_cnv_pods_with_scc(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4438")
+@pytest.mark.s390x
 def test_openshift_io_scc_exists(cnv_pods):
     """
     Validate that Pods in openshift-cnv have 'openshift.io/scc' annotation
@@ -64,6 +65,7 @@ def pods_not_allowlisted_or_anyuid(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4211")
+@pytest.mark.s390x
 def test_pods_scc_in_allowlist(pods_not_allowlisted_or_anyuid):
     """
     Validate that Pods in openshift-cnv have SCC from a predefined allowlist

--- a/tests/install_upgrade_operators/security/scc/test_default_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_default_scc.py
@@ -16,6 +16,7 @@ def privileged_scc():
 
 
 @pytest.mark.polarion("CNV-4439")
+@pytest.mark.s390x
 def test_users_in_privileged_scc(privileged_scc):
     """
     Validate that Users in privileged SCC is not updated after installing CNV

--- a/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
+++ b/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
@@ -36,6 +36,7 @@ def vm_virt_launcher_pod(developer_vm, namespace, unprivileged_client):
 
 
 @pytest.mark.polarion("CNV-4897")
+@pytest.mark.s390x
 def test_unprivileged_client_virt_launcher(unprivileged_client, developer_vm, vm_virt_launcher_pod):
     with pytest.raises(
         ApiException,

--- a/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
+++ b/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-4296")
+@pytest.mark.s390x
 def test_selinuxlaunchertype_in_kubevirt_config(kubevirt_config):
     selinux_launcher_type = "selinuxLauncherType"
     assert selinux_launcher_type not in kubevirt_config, f"{selinux_launcher_type} is found in {kubevirt_config}"

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
@@ -237,6 +237,7 @@ class TestCRDefaultsOnStanzaDeletion:
         ],
         indirect=["deleted_stanza_on_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_certconfig_defaults_on_stanza_delete(
         self,
         deleted_stanza_on_hco_cr,
@@ -270,6 +271,7 @@ class TestCRDefaultsOnStanzaDeletion:
         ],
         indirect=["deleted_stanza_on_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_featuregates_defaults_on_stanza_delete(
         self,
         admin_client,
@@ -428,6 +430,7 @@ class TestCRDefaultsOnStanzaDeletion:
         ],
         indirect=["deleted_stanza_on_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_livemigrationconfig_defaults_on_stanza_delete(
         self,
         deleted_stanza_on_hco_cr,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
@@ -317,6 +317,7 @@ class TestOperatorsModify:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_modify_hco_cr(
         self,
         hco_cr_custom_values,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
@@ -156,6 +156,7 @@ class TestHCONonDefaultFields:
         ],
         indirect=["deleted_stanza_on_hco_cr", "reconciled_cr_post_hco_update"],
     )
+    @pytest.mark.s390x
     def test_non_default_fields_cdi(
         self,
         hco_status_related_objects_scope_function,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -92,6 +92,7 @@ def hco_with_default_cpu_model_set(
 
 
 @pytest.mark.polarion("CNV-9024")
+@pytest.mark.s390x
 def test_default_value_for_cpu_model(
     hco_spec_scope_module,
     kubevirt_hyperconverged_spec_scope_module,
@@ -119,6 +120,7 @@ def test_default_value_for_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9025")
+@pytest.mark.s390x
 def test_set_hco_default_cpu_model(
     hyperconverged_resource_scope_function,
     hco_with_default_cpu_model_set,
@@ -145,6 +147,7 @@ def test_set_hco_default_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9026")
+@pytest.mark.s390x
 def test_set_hco_default_cpu_model_with_existing_vm(
     hyperconverged_resource_scope_function,
     fedora_vm_scope_module,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
@@ -53,6 +53,7 @@ class TestNegativeFeatureGates:
         ],
         indirect=["hco_with_non_default_feature_gates"],
     )
+    @pytest.mark.s390x
     def test_invalid_featuregates_in_hco_cr(
         self,
         admin_client,
@@ -91,6 +92,7 @@ class TestNegativeFeatureGates:
         ],
         indirect=["updated_kv_with_feature_gates"],
     )
+    @pytest.mark.s390x
     def test_optional_featuregates_removed_from_kubevirt_cr(
         self,
         admin_client,
@@ -118,6 +120,7 @@ class TestHCOOptionalFeatureGatesSuite:
         [["fakeGate"]],
         indirect=["updated_cdi_with_feature_gates"],
     )
+    @pytest.mark.s390x
     def test_optional_featuregates_fake_removed_from_cdi_cr(
         self,
         updated_cdi_with_feature_gates,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -12,6 +12,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
+    @pytest.mark.s390x
     def test_no_new_hco_related_objects(self, hco_status_related_objects):
         actual_related_objects = {
             related_object["name"]: related_object["kind"]
@@ -28,6 +29,7 @@ class TestRelatedObjects:
         assert not new_related_objects, f"There are new HCO related objects:\n {new_related_objects.to_json(indent=2)}"
 
     @pytest.mark.polarion("CNV-7267")
+    @pytest.mark.s390x
     def test_hco_related_objects(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
@@ -37,6 +37,7 @@ class TestLiveMigrationConfigUpdate:
         ],
         indirect=["updated_hco_cr"],
     )
+    @pytest.mark.s390x
     def test_modify_hco_cr(
         self,
         updated_hco_cr,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
@@ -118,6 +118,7 @@ class TestOperatorsDefaults:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_verify_expected_config_in_crs(
         self,
         expected,
@@ -160,6 +161,7 @@ class TestOperatorsDefaults:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_no_defaults_in_cr_for_permittedhostdevices_and_obsoletecpu(
         self,
         expected_to_be_absent,
@@ -169,6 +171,7 @@ class TestOperatorsDefaults:
         assert expected_to_be_absent not in str(cr_func_map[resource_kind_str]).lower()
 
     @pytest.mark.polarion("CNV-7312")
+    @pytest.mark.s390x
     def test_bandwidthpermigration_does_not_exist_in_hco_cr(
         self,
         hco_spec,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
@@ -109,6 +109,7 @@ class TestOperatorsModify:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_modify_cdi_cr(
         self,
         admin_client,
@@ -282,6 +283,7 @@ class TestOperatorsModify:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_modify_kubevirt_cr(
         self,
         admin_client,
@@ -370,6 +372,7 @@ class TestOperatorsModify:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_modify_cnao_cr(
         self,
         admin_client,


### PR DESCRIPTION
##### Short description:

This change adds the @pytest.mark.s390x marker to iuo-ocs tests across multiple test files. The marker is applied to annotate tests for the s390x architecture, with no modifications to test logic, parameters, or control flow in any of the affected files.

##### More details:

The marker helps identify tests relevant for the s390x environment. This is useful for running architecture-specific test suites as needed.

##### What this PR does / why we need it:

This PR adds s390x architecture-specific markers to identify tests that are relevant to the s390x platform. It allows better control over test execution when running iuo-ocs tests in s390x environment.

##### Which issue(s) this PR fixes:

None

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->

None
