### PR TITLE
Refactor test_rhel_os.py

### DIFF
--- a/tests/infrastructure/instance_types/conftest.py
+++ b/tests/infrastructure/instance_types/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from ocp_resources.data_source import DataSource
 from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
@@ -7,10 +6,6 @@ from ocp_resources.virtual_machine_cluster_instancetype import (
 from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
 )
-
-from utilities.constants import DATA_SOURCE_NAME
-from utilities.storage import data_volume_template_with_source_ref_dict
-from utilities.virt import VirtualMachineForTests
 
 COMMON_INSTANCETYPE_SELECTOR = f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/vendor=redhat.com"
 
@@ -40,31 +35,4 @@ def base_vm_cluster_instancetypes():
         VirtualMachineClusterInstancetype.get(
             label_selector=COMMON_INSTANCETYPE_SELECTOR,
         )
-    )
-
-
-@pytest.fixture(scope="module")
-def golden_image_vm_with_instance_type(
-    unprivileged_client,
-    namespace,
-    golden_images_namespace,
-    modern_cpu_for_migration,
-    instance_type_rhel_os_matrix__module__,
-    storage_class_matrix__module__,
-):
-    os_name = [*instance_type_rhel_os_matrix__module__][0]
-    return VirtualMachineForTests(
-        client=unprivileged_client,
-        name=f"{os_name}-vm-with-instance-type",
-        namespace=namespace.name,
-        vm_instance_type_infer=True,
-        vm_preference_infer=True,
-        data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=DataSource(
-                name=instance_type_rhel_os_matrix__module__[os_name][DATA_SOURCE_NAME],
-                namespace=golden_images_namespace.name,
-            ),
-            storage_class=[*storage_class_matrix__module__][0],
-        ),
-        cpu_model=modern_cpu_for_migration,
     )

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -1,4 +1,9 @@
 import pytest
+from ocp_resources.data_source import DataSource
+
+from utilities.constants import DATA_SOURCE_NAME
+from utilities.storage import data_volume_template_with_source_ref_dict
+from utilities.virt import VirtualMachineForTests
 
 
 @pytest.fixture(scope="class")
@@ -6,3 +11,30 @@ def skip_if_rhel8(instance_type_rhel_os_matrix__module__):
     current_rhel_name = [*instance_type_rhel_os_matrix__module__][0]
     if current_rhel_name == "rhel-8":
         pytest.xfail("EFI is not enabled by default before RHEL9")
+
+
+@pytest.fixture(scope="module")
+def golden_image_vm_with_instance_type(
+    unprivileged_client,
+    namespace,
+    golden_images_namespace,
+    modern_cpu_for_migration,
+    instance_type_rhel_os_matrix__module__,
+    storage_class_matrix__module__,
+):
+    os_name = [*instance_type_rhel_os_matrix__module__][0]
+    return VirtualMachineForTests(
+        client=unprivileged_client,
+        name=f"{os_name}-vm-with-instance-type",
+        namespace=namespace.name,
+        vm_instance_type_infer=True,
+        vm_preference_infer=True,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=DataSource(
+                name=instance_type_rhel_os_matrix__module__[os_name][DATA_SOURCE_NAME],
+                namespace=golden_images_namespace.name,
+            ),
+            storage_class=[*storage_class_matrix__module__][0],
+        ),
+        cpu_model=modern_cpu_for_migration,
+    )


### PR DESCRIPTION
##### Short description:
Refactor test_rhel_os.py

##### More details:
The current dependency naming for tests in test_rhel_os.py is too broad, and can cause conflicts in the future when adding other test_<os_name>_os.py files.
This PR changes the dependency naming by adding the test OS name and also move specific fixtures used to a smaller scope conftest.py file

##### What this PR does / why we need it:
Improve scoping of fixtures and avoid dependency conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test dependency markers to use fully qualified names for improved clarity.
  * Added a new fixture for creating virtual machines with specific instance types and OS configurations in supported OS tests.
  * Removed a similar fixture from a different test module to streamline test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->