### PR TITLE
[4.19] Virt: Drop the cpu and memory hotplug cases with post-copy migration

### DIFF
--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -5,14 +5,8 @@ import pytest
 from ocp_resources.migration_policy import MigrationPolicy
 from pytest_testconfig import config as py_config
 
-from tests.utils import (
-    assert_guest_os_cpu_count,
-    assert_guest_os_memory_amount,
-)
 from utilities.constants import (
     REGEDIT_PROC_NAME,
-    SIX_CPU_SOCKETS,
-    SIX_GI_MEMORY,
     TIMEOUT_15MIN,
     TIMEOUT_30MIN,
     Images,
@@ -130,24 +124,4 @@ class TestPostCopyMigration:
     @pytest.mark.polarion("CNV-11422")
     def test_node_drain(self, admin_client, hotplugged_vm, vm_background_process_id, drained_node_with_hotplugged_vm):
         assert_migration_post_copy_mode(vm=hotplugged_vm)
-        assert_same_pid_after_migration(orig_pid=vm_background_process_id, vm=hotplugged_vm)
-
-    @pytest.mark.parametrize(
-        "hotplugged_sockets_memory_guest", [pytest.param({"sockets": SIX_CPU_SOCKETS})], indirect=True
-    )
-    @pytest.mark.jira("CNV-48348", run=False)
-    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::hotplug_cpu", depends=[f"{TESTS_CLASS_NAME}::node_drain"])
-    @pytest.mark.polarion("CNV-11423")
-    def test_hotplug_cpu(self, hotplugged_sockets_memory_guest, hotplugged_vm, vm_background_process_id):
-        assert_guest_os_cpu_count(vm=hotplugged_vm, spec_cpu_amount=SIX_CPU_SOCKETS)
-        assert_same_pid_after_migration(orig_pid=vm_background_process_id, vm=hotplugged_vm)
-
-    @pytest.mark.parametrize(
-        "hotplugged_sockets_memory_guest", [pytest.param({"memory_guest": SIX_GI_MEMORY})], indirect=True
-    )
-    @pytest.mark.jira("CNV-48348", run=False)
-    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu"])
-    @pytest.mark.polarion("CNV-11424")
-    def test_hotplug_memory(self, hotplugged_sockets_memory_guest, hotplugged_vm, vm_background_process_id):
-        assert_guest_os_memory_amount(vm=hotplugged_vm, spec_memory_amount=SIX_GI_MEMORY)
         assert_same_pid_after_migration(orig_pid=vm_background_process_id, vm=hotplugged_vm)


### PR DESCRIPTION
##### Short description:
The bug of cpu and memory hotplug with post-copy migration fixed on 4.20 but not plan to backport to previous version (the fix is very large), we plan to remove it directly, if it fixed on previous version, we can add it back.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
