### PR TITLE
Give grace for connectivity process to appear

### DIFF
--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -107,7 +107,6 @@ def _is_process_running(vm: BaseVirtualMachine, cmd: str) -> bool:
     except TimeoutExpiredError as e:
         LOGGER.warning(f"Process is not running on VM {vm.name}. Error: {str(e.last_exp)}")
         return False
-    return False
 
 
 def is_tcp_connection(server: Server, client: Client) -> bool:

--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -93,7 +93,9 @@ def _stop_process(vm: BaseVirtualMachine, cmd: str) -> None:
         LOGGER.warning(str(e))
 
 
-def _is_process_running(vm: BaseVirtualMachine, cmd: str) -> bool:
+def _is_process_running(  # type: ignore[return]
+    vm: BaseVirtualMachine, cmd: str
+) -> bool:
     try:
         for sample in TimeoutSampler(
             wait_timeout=60,

--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -107,6 +107,7 @@ def _is_process_running(vm: BaseVirtualMachine, cmd: str) -> bool:
     except TimeoutExpiredError as e:
         LOGGER.warning(f"Process is not running on VM {vm.name}. Error: {str(e.last_exp)}")
         return False
+    return False
 
 
 def is_tcp_connection(server: Server, client: Client) -> bool:

--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -99,13 +99,13 @@ def _is_process_running(vm: BaseVirtualMachine, cmd: str) -> bool:
             wait_timeout=60,
             sleep=5,
             func=vm.console,
-            commands=[f"pgrep -fAx {cmd}"],
+            commands=[f"pgrep -fx '{cmd}'"],
             timeout=_DEFAULT_CMD_TIMEOUT_SEC,
         ):
             if sample:
                 return True
     except TimeoutExpiredError as e:
-        LOGGER.info(f"Process is not running on VM {vm.name}. Error: {str(e.last_exp)}")
+        LOGGER.warning(f"Process is not running on VM {vm.name}. Error: {str(e.last_exp)}")
         return False
 
 


### PR DESCRIPTION
Tests that use this function for verifying that iperf3 is running on the VM occasionally fail, in case the process is not found yet without a real retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of process detection by introducing a timeout-based retry mechanism, ensuring more robust handling of process status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->