### PR TITLE
[CNV-64462]Add enableMultiArchCommonBootImageImport FG

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -42,6 +42,7 @@ HCO_DEFAULT_FEATUREGATES = {
     PERSISTENT_RESERVATION: FG_DISABLED,
     "alignCPUs": FG_DISABLED,
     "downwardMetrics": FG_DISABLED,
+    "enableMultiArchCommonBootImageImport": FG_DISABLED,
 }
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"


### PR DESCRIPTION
##### Short description:

This FG is added at 4.20.0 and this change is aligning the automation.

##### More details:
Tested locally:
```
$ uv run pytest --tc-format=python -o log_cli=true -s --skip-deprecated-api-test --cluster-sanity-skip-check --tc-file=tests/global_config.py --jira -ra tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
[...]
======================================================================= 3 passed, 1 deselected, 13 warnings in 34.09s ========================================================================
```

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new feature flag for enabling multi-architecture common boot image import, currently set to disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->