### PR TITLE
Quarantine test class TestVmFreeMemoryBytes

### DIFF
--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -458,6 +458,13 @@ class TestVmResourceLimits:
 
 @pytest.mark.parametrize("vm_for_test", [pytest.param("memory-working-set-vm")], indirect=True)
 class TestVmFreeMemoryBytes:
+    @pytest.mark.xfail(
+        reason=(
+            f"{QUARANTINED}: The memory rss value from BMs reported in metric is less than 5% from expected. "
+            f"tracked in CNV-64128"
+        ),
+        run=False,
+    )
     @pytest.mark.polarion("CNV-11692")
     def test_metric_kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes(self, prometheus, vm_for_test):
         validate_metric_vm_container_free_memory_bytes_based_on_working_set_rss_bytes(


### PR DESCRIPTION
##### Short description:
The test class TestVmFreeMemoryBytes is flaky,
In BM's I doesn't get the expected value from the metric.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Quarantined a test related to VM container free memory metrics, marking it as expected to fail and preventing it from running due to a known issue with memory reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->