### PR TITLE
Storage: fix test - add standalone DV cleanup after storage migration

### DIFF
--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -209,6 +209,7 @@ def vm_for_storage_class_migration_from_template_with_existing_dv(
     unprivileged_client,
     namespace,
     data_volume_scope_class,
+    cleaned_up_standalone_data_volume_after_storage_migration,
 ):
     with vm_instance_from_template(
         request=request,
@@ -364,3 +365,11 @@ def written_file_to_the_mounted_hotplugged_disk(vm_with_mounted_hotplugged_disk)
         ),
     )
     yield vm_with_mounted_hotplugged_disk
+
+
+@pytest.fixture(scope="class")
+def cleaned_up_standalone_data_volume_after_storage_migration(unprivileged_client, namespace, data_volume_scope_class):
+    yield
+    for dv in DataVolume.get(dyn_client=unprivileged_client, namespace=namespace.name):
+        if dv.name.startswith(f"{data_volume_scope_class.name}-mig"):
+            assert dv.clean_up(wait=True)


### PR DESCRIPTION
##### Short description:
Fix T2 test: `test_vm_storage_class_migration_with_hotplugged_volume`

##### More details:
A standalone DV is not owned by any resource, the same as a standalone DV after storage migration.
This was causing the leftover in the test namespace, so the next test (volume hotplug + storage migration) was failing because it failed to migrate the leftover DV that was left from a previous test. 

```
storage-migration-test-mtc-storage-class-migration   blank-dv-for-hotplug            Succeeded   100.0%                10m
storage-migration-test-mtc-storage-class-migration   blank-dv-for-hotplug-mig-4rj5   Succeeded   100.0%                5m46s
storage-migration-test-mtc-storage-class-migration   standalone-dv-fedora-mig-ff6b   Succeeded   100.0%                13m
```

We need to clean up the `standalone-dv-fedora-mig-...` DV after the VM cleanup (because if the VM is Running, it will prevent the PVC from being deleted)

