### PR TITLE
Add test for metric kubevirt_vmi_phase_transition_time_from_deletion_…

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -25,7 +25,6 @@ from tests.observability.metrics.constants import (
     BINDING_TYPE,
     CNV_VMI_STATUS_RUNNING_COUNT,
     KUBEVIRT_API_REQUEST_DEPRECATED_TOTAL_WITH_VERSION_VERB_AND_RESOURCE,
-    KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART,
     KUBEVIRT_CONSOLE_ACTIVE_CONNECTIONS_BY_VMI,
     KUBEVIRT_VM_CREATED_TOTAL_STR,
     KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE,
@@ -1166,5 +1165,11 @@ def created_fake_data_volume_resource(namespace, admin_client):
 
 
 @pytest.fixture()
-def metric_cdi_import_pods_high_restart_initial_value(prometheus):
-    return int(get_metrics_value(prometheus=prometheus, metrics_name=KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART))
+def initial_metric_value(request, prometheus):
+    return int(get_metrics_value(prometheus=prometheus, metrics_name=request.param))
+
+
+@pytest.fixture()
+def deleted_vmi(running_metric_vm):
+    running_metric_vm.delete(wait=True)
+    yield

--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -78,6 +78,9 @@ KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE = "kubevirt_vmi_migrations_in_schedu
 KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE = "kubevirt_vmi_migrations_in_running_phase"
 KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES = "kubevirt_vmi_migration_data_total_bytes{{name='{vm_name}'}}"
 KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART = "kubevirt_cdi_import_pods_high_restart"
+KUBEVIRT_VMI_PHASE_TRANSITION_TIME_FROM_DELETION_SECONDS_SUM = (
+    "kubevirt_vmi_phase_transition_time_from_deletion_seconds_sum"
+)
 BINDING_NAME = "binding_name"
 BINDING_TYPE = "binding_type"
 RSS_MEMORY_COMMAND = shlex.split("bash -c \"cat /sys/fs/cgroup/memory.stat | grep '^anon ' | awk '{print $2}'\"")

--- a/tests/observability/metrics/test_cdi_metrics.py
+++ b/tests/observability/metrics/test_cdi_metrics.py
@@ -69,12 +69,14 @@ def test_kubevirt_cdi_operator_up(
     )
 
 
-@pytest.mark.polarion("CNV-10019")
-def test_kubevirt_cdi_import_pods_high_restart(
-    prometheus, metric_cdi_import_pods_high_restart_initial_value, created_fake_data_volume_resource
-):
+@pytest.mark.parametrize(
+    "initial_metric_value",
+    [pytest.param(KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART, marks=pytest.mark.polarion("CNV-10019"))],
+    indirect=True,
+)
+def test_kubevirt_cdi_import_pods_high_restart(prometheus, initial_metric_value, created_fake_data_volume_resource):
     validate_metrics_value(
         prometheus=prometheus,
         metric_name=KUBEVIRT_CDI_IMPORT_PODS_HIGH_RESTART,
-        expected_value=str(metric_cdi_import_pods_high_restart_initial_value + 1),
+        expected_value=str(initial_metric_value + 1),
     )

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -17,6 +17,7 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_CONSOLE_ACTIVE_CONNECTIONS_BY_VMI,
     KUBEVIRT_VM_DISK_ALLOCATED_SIZE_BYTES,
     KUBEVIRT_VMI_MEMORY_AVAILABLE_BYTES,
+    KUBEVIRT_VMI_PHASE_TRANSITION_TIME_FROM_DELETION_SECONDS_SUM,
     KUBEVIRT_VMSNAPSHOT_PERSISTENTVOLUMECLAIM_LABELS,
     KUBEVIRT_VNC_ACTIVE_CONNECTIONS_BY_VMI,
 )
@@ -26,6 +27,7 @@ from tests.observability.metrics.utils import (
     get_metric_labels_non_empty_value,
     get_pvc_size_bytes,
     timestamp_to_seconds,
+    validate_metric_value_greater_than_initial_value,
     validate_metric_value_within_range,
     validate_metric_vm_container_free_memory_bytes_based_on_working_set_rss_bytes,
     validate_vnic_info,
@@ -600,4 +602,25 @@ class TestVmVnicInfo:
             prometheus=prometheus,
             vnic_info_to_compare=vnic_info_from_vm_or_vmi,
             metric_name=query.format(vm_name=running_metric_vm.name),
+        )
+
+
+class TestVmiPhaseTransitionFromDeletion:
+    @pytest.mark.parametrize(
+        "initial_metric_value",
+        [
+            pytest.param(
+                KUBEVIRT_VMI_PHASE_TRANSITION_TIME_FROM_DELETION_SECONDS_SUM,
+                marks=pytest.mark.polarion("CNV-12067"),
+            )
+        ],
+        indirect=True,
+    )
+    def test_kubevirt_vmi_phase_transition_from_deletion_seconds_sum(
+        self, prometheus, initial_metric_value, running_metric_vm, deleted_vmi
+    ):
+        validate_metric_value_greater_than_initial_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_VMI_PHASE_TRANSITION_TIME_FROM_DELETION_SECONDS_SUM,
+            initial_value=initial_metric_value,
         )

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -1603,3 +1603,23 @@ def validate_metric_vm_container_free_memory_bytes_based_on_working_set_rss_byte
     except TimeoutExpiredError:
         LOGGER.error(f"{sample} should be within 5% of {expected_value}")
         raise
+
+
+def validate_metric_value_greater_than_initial_value(
+    prometheus: Prometheus, metric_name: str, initial_value: int, timeout: int = TIMEOUT_4MIN
+) -> None:
+    samples = TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=TIMEOUT_15SEC,
+        func=get_metrics_value,
+        prometheus=prometheus,
+        metrics_name=metric_name,
+    )
+    try:
+        for sample in samples:
+            if sample:
+                if int(sample) > initial_value:
+                    return
+    except TimeoutExpiredError:
+        LOGGER.error(f"{sample} should be greater than {initial_value}")
+        raise


### PR DESCRIPTION

##### Short description:
Test for metric kubevirt_vmi_phase_transition_time_from_deletion_seconds_sum

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-38121
