### PR TITLE
Cirros to fedora change 

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -89,6 +89,7 @@ LOGGER = logging.getLogger(__name__)
 K8S_TAINT = "node.kubernetes.io/unschedulable"
 NO_SCHEDULE = "NoSchedule"
 CIRROS_IMAGE = "kubevirt/cirros-container-disk-demo:latest"
+FEDORA_IMAGE = "quay.io/containerdisks/fedora:39"
 FLAVORS_EXCLUDED_FROM_CLOUD_INIT = (OS_FLAVOR_WINDOWS, OS_FLAVOR_CIRROS)
 VM_ERROR_STATUSES = [
     VirtualMachine.Status.CRASH_LOOPBACK_OFF,


### PR DESCRIPTION
##### Short description:
Cirros to fedora image change as for s390x cirros is not supported  

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to use a Fedora-based virtual machine instead of a Cirros-based virtual machine for network configuration validation.
* **Chores**
  * Added a new Fedora image reference for use in virtual machine testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->