### PR TITLE
Add centos tests with common instance types

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -7,12 +7,15 @@ from utilities.constants import (
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
     HPP_CAPABILITIES,
     PREFERENCE_STR,
+    RHEL8_PREFERENCE,
+    RHEL9_PREFERENCE,
+    RHEL10_PREFERENCE,
     Images,
     StorageClassNames,
 )
 from utilities.infra import get_latest_os_dict_list
 from utilities.os_utils import (
-    generate_instance_type_rhel_os_matrix,
+    generate_linux_instance_type_os_matrix,
     generate_os_matrix_dict,
 )
 from utilities.storage import HppCsiStorageClass
@@ -54,7 +57,9 @@ rhel_os_matrix = generate_os_matrix_dict(os_name="rhel", supported_operating_sys
 latest_rhel_os_dict = get_latest_os_dict_list(os_list=[rhel_os_matrix])[0]
 
 # Modify instance_type_rhel_os_matrix for arm64
-instance_type_rhel_os_matrix = generate_instance_type_rhel_os_matrix(preferences=["rhel-8", "rhel-9", "rhel-10"])
+instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name="rhel", preferences=[RHEL8_PREFERENCE, RHEL9_PREFERENCE, RHEL10_PREFERENCE]
+)
 for os_matrix_dict in instance_type_rhel_os_matrix:
     for os_params in os_matrix_dict.values():
         os_params[PREFERENCE_STR] += f".{ARM_64}"

--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -7,7 +7,7 @@ from utilities.constants import (
     S390X,
 )
 from utilities.infra import get_latest_os_dict_list
-from utilities.os_utils import generate_instance_type_rhel_os_matrix, generate_os_matrix_dict
+from utilities.os_utils import generate_linux_instance_type_os_matrix, generate_os_matrix_dict
 
 global config
 
@@ -19,7 +19,9 @@ rhel_os_matrix = generate_os_matrix_dict(os_name="rhel", supported_operating_sys
 fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating_systems=["fedora-41"])
 centos_os_matrix = generate_os_matrix_dict(os_name="centos", supported_operating_systems=["centos-stream-9"])
 
-instance_type_rhel_os_matrix = generate_instance_type_rhel_os_matrix(preferences=["rhel-9"])
+instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name="rhel", preferences=[utilities.constants.RHEL9_PREFERENCE]
+)
 
 latest_rhel_os_dict, latest_fedora_os_dict, latest_centos_os_dict = get_latest_os_dict_list(
     os_list=[rhel_os_matrix, fedora_os_matrix, centos_os_matrix]

--- a/tests/global_config_x86_64.py
+++ b/tests/global_config_x86_64.py
@@ -1,7 +1,17 @@
 from typing import Any
 
+from utilities.constants import (
+    CENTOS_STREAM9_PREFERENCE,
+    CENTOS_STREAM10_PREFERENCE,
+    RHEL8_PREFERENCE,
+    RHEL9_PREFERENCE,
+    RHEL10_PREFERENCE,
+)
 from utilities.infra import get_latest_os_dict_list
-from utilities.os_utils import generate_instance_type_rhel_os_matrix, generate_os_matrix_dict
+from utilities.os_utils import (
+    generate_linux_instance_type_os_matrix,
+    generate_os_matrix_dict,
+)
 
 global config
 
@@ -28,7 +38,12 @@ windows_os_matrix = generate_os_matrix_dict(
 
 fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating_systems=["fedora-42"])
 centos_os_matrix = generate_os_matrix_dict(os_name="centos", supported_operating_systems=["centos-stream-9"])
-instance_type_rhel_os_matrix = generate_instance_type_rhel_os_matrix(preferences=["rhel-8", "rhel-9", "rhel-10"])
+instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name="rhel", preferences=[RHEL8_PREFERENCE, RHEL9_PREFERENCE, RHEL10_PREFERENCE]
+)
+instance_type_centos_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name="centos.stream", preferences=[CENTOS_STREAM9_PREFERENCE, CENTOS_STREAM10_PREFERENCE]
+)
 
 (
     latest_rhel_os_dict,

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -6,8 +6,7 @@ from utilities.constants import DATA_SOURCE_NAME
 
 @pytest.fixture(scope="class")
 def xfail_if_rhel8(instance_type_rhel_os_matrix__module__):
-    current_rhel_name = [*instance_type_rhel_os_matrix__module__][0]
-    if current_rhel_name == "rhel-8":
+    if [*instance_type_rhel_os_matrix__module__][0] == "rhel.8":
         pytest.xfail("EFI is not enabled by default before RHEL9")
 
 
@@ -28,4 +27,24 @@ def golden_image_rhel_vm_with_instance_type(
         modern_cpu_for_migration=modern_cpu_for_migration,
         storage_class_name=[*storage_class_matrix__module__][0],
         data_source_name=instance_type_rhel_os_matrix__module__[os_name][DATA_SOURCE_NAME],
+    )
+
+
+@pytest.fixture(scope="module")
+def golden_image_centos_vm_with_instance_type(
+    unprivileged_client,
+    namespace,
+    golden_images_namespace,
+    modern_cpu_for_migration,
+    instance_type_centos_os_matrix__module__,
+    storage_class_matrix__module__,
+):
+    os_name = next(iter(instance_type_centos_os_matrix__module__))
+    return golden_image_vm_with_instance_type(
+        client=unprivileged_client,
+        namespace_name=namespace.name,
+        golden_images_namespace_name=golden_images_namespace.name,
+        modern_cpu_for_migration=modern_cpu_for_migration,
+        storage_class_name=[*storage_class_matrix__module__][0],
+        data_source_name=instance_type_centos_os_matrix__module__[os_name][DATA_SOURCE_NAME],
     )

--- a/tests/infrastructure/instance_types/supported_os/test_centos_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_centos_os.py
@@ -1,0 +1,55 @@
+import pytest
+
+from tests.infrastructure.instance_types.supported_os.constants import TEST_CREATE_VM_TEST_NAME, TEST_START_VM_TEST_NAME
+from utilities.constants import PREFERENCE_STR, U1_MEDIUM_STR
+from utilities.virt import (
+    check_qemu_guest_agent_installed,
+    running_vm,
+    wait_for_console,
+)
+
+pytestmark = pytest.mark.post_upgrade
+
+TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeCentos"
+
+
+@pytest.mark.arm64
+@pytest.mark.sno
+class TestVMCreationAndValidation:
+    @pytest.mark.dependency(name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}")
+    @pytest.mark.polarion("CNV-12068")
+    def test_create_vm(self, golden_image_centos_vm_with_instance_type, instance_type_centos_os_matrix__module__):
+        golden_image_centos_vm_with_instance_type.create(wait=True)
+        os_param_dict = instance_type_centos_os_matrix__module__[[*instance_type_centos_os_matrix__module__][0]]
+        assert golden_image_centos_vm_with_instance_type.instance.spec.instancetype.name == U1_MEDIUM_STR
+        assert golden_image_centos_vm_with_instance_type.instance.spec.preference.name == os_param_dict[PREFERENCE_STR]
+
+    @pytest.mark.dependency(
+        name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}",
+        depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}"],
+    )
+    @pytest.mark.polarion("CNV-12069")
+    def test_start_vm(self, golden_image_centos_vm_with_instance_type):
+        running_vm(vm=golden_image_centos_vm_with_instance_type)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-12070")
+    def test_vm_console(self, golden_image_centos_vm_with_instance_type):
+        wait_for_console(vm=golden_image_centos_vm_with_instance_type)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-12071")
+    def test_vmi_guest_agent_exists(self, golden_image_centos_vm_with_instance_type):
+        assert check_qemu_guest_agent_installed(ssh_exec=golden_image_centos_vm_with_instance_type.ssh_exec), (
+            "qemu guest agent package is not installed"
+        )
+
+
+@pytest.mark.arm64
+@pytest.mark.sno
+@pytest.mark.order(-1)
+class TestVMDeletion:
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-12078")
+    def test_vm_deletion(self, golden_image_centos_vm_with_instance_type):
+        golden_image_centos_vm_with_instance_type.delete(wait=True)

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -1,4 +1,6 @@
+import logging
 import os
+import re
 from typing import Any
 
 from ocp_resources.template import Template
@@ -21,6 +23,9 @@ from utilities.constants import (
     WORKLOAD_STR,
     Images,
 )
+
+LOGGER = logging.getLogger(__name__)
+
 
 RHEL_OS_MAPPING: dict[str, dict[str, Any]] = {
     WORKLOAD_STR: Template.Workload.SERVER,
@@ -218,30 +223,41 @@ def generate_os_matrix_dict(os_name: str, supported_operating_systems: list[str]
     return os_formatted_list
 
 
-def generate_instance_type_rhel_os_matrix(preferences: list[str]) -> list[dict[str, dict[str, Any]]]:
+def generate_linux_instance_type_os_matrix(os_name: str, preferences: list[str]) -> list[dict[str, dict[str, Any]]]:
     """
-    Generate a list of dictionaries representing the instance type matrix for RHEL OS.
-
+    Generate a list of dictionaries representing the instance type matrix for a Linux OS type.
     Each dictionary represents a specific instance type and its configuration.
 
     Args:
-        preferences (list[str]): A list of preferences for the instance types. Preference format is "rhel-<version>".
+        os_name (str): The name of the OS.
+        preferences (list[str]): A list of preferences for the instance types. Preference format is "<os>.<version>".
 
     Returns:
         list[dict[str, dict[str, Any]]]: A list of dictionaries representing the instance type matrix.
-    """
-    latest_rhel = f"rhel-{max([preference.split('-')[1] for preference in preferences], key=int)}"
 
+    """
+
+    def _extract_version(pref: str) -> Any:
+        match = re.search(r"\d+", pref)
+        return int(match.group()) if match else None
+
+    def _format_data_source_name(preference_name: str) -> str:
+        version = _extract_version(pref=preference_name)
+        if version is None:
+            return preference_name
+        return f"{os_name.replace('.', '-')}{version}"
+
+    latest_os = max(preferences, key=_extract_version)
     instance_types: list[dict[str, dict[str, Any]]] = []
 
     for preference in preferences:
         preference_config: dict[str, Any] = {
-            PREFERENCE_STR: preference.replace("-", "."),
-            DATA_SOURCE_NAME: preference.replace("-", ""),
+            PREFERENCE_STR: preference,
+            DATA_SOURCE_NAME: _format_data_source_name(preference_name=preference),
         }
-        if preference == latest_rhel:
+
+        if preference == latest_os:
             preference_config[LATEST_RELEASE_STR] = True
 
         instance_types.append({preference: preference_config})
-
     return instance_types


### PR DESCRIPTION
##### Short description:
Add centos tests with common instance types

##### More details:
 - Add `instance_type_centos_os_matrix` to global_config
 - Added `test_centos_os.py`
 - Update `generate_instance_type_rhel_os_matrix` to `generate_instance_type_os_matrix` to work for all OS names


##### What this PR does / why we need it:
Add tests supporting CentOs operating systems


##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-54690


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new tests for CentOS VM instance types, including creation, validation, and deletion scenarios.
  * Introduced support for generating CentOS instance type OS matrices, similar to existing RHEL support.

* **Tests**
  * Implemented comprehensive test coverage for CentOS-based VM lifecycle and guest agent validation.

* **Chores**
  * Enhanced configuration to include CentOS instance type OS matrices for improved test parameterization.
  * Generalized instance type OS matrix generation to support multiple OS types with updated version notation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->