### PR TITLE
Remove FLAVOR_STR from EXPECTED_NAMESPACE_INSTANCE_TYPE_LABELS

### DIFF
--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -3,9 +3,7 @@ import shlex
 from ocp_resources.resource import Resource
 
 from utilities.constants import (
-    FLAVOR_STR,
     INSTANCE_TYPE_STR,
-    NONE_STR,
     OS_STR,
     PREFERENCE_STR,
 )
@@ -35,7 +33,6 @@ INSTANCE_TYPE_LABELS = [INSTANCE_TYPE_STR, PREFERENCE_STR, OS_STR]
 EXPECTED_NAMESPACE_INSTANCE_TYPE_LABELS = {
     INSTANCE_TYPE_STR: OTHER_STR,
     PREFERENCE_STR: OTHER_STR,
-    FLAVOR_STR: NONE_STR,
     OS_STR: None,
 }
 KUBEVIRT_VMI_PHASE_COUNT_STR = "kubevirt_vmi_phase_count"


### PR DESCRIPTION
##### Short description:
`FLAVOR_STR` is not used, as such we can remove it from the constant `EXPECTED_NAMESPACE_INSTANCE_TYPE_LABELS`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up unused constants and dictionary entries in metrics tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->