### PR TITLE
Storage: use cirros back in smoke and gating clone tests

### DIFF
--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -1,37 +1,33 @@
 import pytest
 from ocp_resources.datavolume import DataVolume
 
-from tests.storage.utils import create_fedora_dv
+from tests.storage.utils import create_cirros_dv
 from utilities.storage import data_volume
 
 
 @pytest.fixture(scope="module")
-def fedora_dv_with_filesystem_volume_mode(
+def cirros_dv_with_filesystem_volume_mode(
     namespace,
     storage_class_with_filesystem_volume_mode,
-    fedora_latest_os_params,
 ):
-    yield from create_fedora_dv(
+    yield from create_cirros_dv(
         namespace=namespace.name,
-        name="fedora-fs",
+        name="cirros-fs",
         storage_class=storage_class_with_filesystem_volume_mode,
         volume_mode=DataVolume.VolumeMode.FILE,
-        fedora_latest_os_params=fedora_latest_os_params,
     )
 
 
 @pytest.fixture(scope="module")
-def fedora_dv_with_block_volume_mode(
+def cirros_dv_with_block_volume_mode(
     namespace,
     storage_class_with_block_volume_mode,
-    fedora_latest_os_params,
 ):
-    yield from create_fedora_dv(
+    yield from create_cirros_dv(
         namespace=namespace.name,
-        name="fedora-block",
+        name="cirros-block",
         storage_class=storage_class_with_block_volume_mode,
         volume_mode=DataVolume.VolumeMode.BLOCK,
-        fedora_latest_os_params=fedora_latest_os_params,
     )
 
 

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -16,6 +16,7 @@ from tests.storage.utils import (
     create_windows_vm_validate_guest_agent_info,
 )
 from utilities.constants import (
+    OS_FLAVOR_CIRROS,
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
     TIMEOUT_1MIN,
@@ -51,9 +52,9 @@ def create_vm_from_clone_dv_template(
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace_name,
-        os_flavor=OS_FLAVOR_FEDORA,
+        os_flavor=OS_FLAVOR_CIRROS,
         client=client,
-        memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
         data_volume_template=data_volume_template_dict(
             target_dv_name=dv_name,
             target_dv_namespace=namespace_name,
@@ -312,7 +313,7 @@ def test_clone_from_block_to_fs_using_dv_template(
     skip_test_if_no_block_sc,
     unprivileged_client,
     namespace,
-    fedora_dv_with_block_volume_mode,
+    cirros_dv_with_block_volume_mode,
     storage_class_with_filesystem_volume_mode,
     default_fs_overhead,
 ):
@@ -320,12 +321,12 @@ def test_clone_from_block_to_fs_using_dv_template(
         vm_name="vm-5608",
         dv_name="dv-5608",
         namespace_name=namespace.name,
-        source_dv=fedora_dv_with_block_volume_mode,
+        source_dv=cirros_dv_with_block_volume_mode,
         client=unprivileged_client,
         volume_mode=DataVolume.VolumeMode.FILE,
         # add fs overhead and round up the result
         size=overhead_size_for_dv(
-            image_size=int(fedora_dv_with_block_volume_mode.size[:-2]),
+            image_size=int(cirros_dv_with_block_volume_mode.size[:-2]),
             overhead_value=default_fs_overhead,
         ),
         storage_class=storage_class_with_filesystem_volume_mode,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -292,14 +292,14 @@ def test_clone_from_fs_to_block_using_dv_template(
     skip_test_if_no_block_sc,
     unprivileged_client,
     namespace,
-    fedora_dv_with_filesystem_volume_mode,
+    cirros_dv_with_filesystem_volume_mode,
     storage_class_with_block_volume_mode,
 ):
     create_vm_from_clone_dv_template(
         vm_name="vm-5607",
         dv_name="dv-5607",
         namespace_name=namespace.name,
-        source_dv=fedora_dv_with_filesystem_volume_mode,
+        source_dv=cirros_dv_with_filesystem_volume_mode,
         client=unprivileged_client,
         volume_mode=DataVolume.VolumeMode.BLOCK,
         storage_class=storage_class_with_block_volume_mode,

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -61,7 +61,6 @@ from utilities.storage import (
     create_cirros_dv_for_snapshot_dict,
     data_volume,
     get_downloaded_artifact,
-    get_test_artifact_server_url,
     sc_volume_binding_mode_is_wffc,
     write_file,
 )
@@ -592,18 +591,3 @@ def storage_class_name_scope_module(storage_class_matrix__module__):
 @pytest.fixture(scope="session")
 def cluster_csi_drivers_names():
     yield [csi_driver.name for csi_driver in list(CSIDriver.get())]
-
-
-@pytest.fixture(scope="session")
-def fedora_latest_os_params():
-    """This fixture is needed as during collection pytest_testconfig is empty.
-    os_params or any globals using py_config in conftest cannot be used.
-    """
-    if latest_fedora_dict := py_config.get("latest_fedora_os_dict"):
-        return {
-            "fedora_image_path": f"{get_test_artifact_server_url()}{latest_fedora_dict['image_path']}",
-            "fedora_dv_size": latest_fedora_dict["dv_size"],
-            "fedora_template_labels": latest_fedora_dict["template_labels"],
-        }
-
-    raise ValueError("Failed to get latest Fedora OS parameters")

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -416,30 +416,6 @@ def create_cirros_dv(
         yield dv
 
 
-def create_fedora_dv(
-    namespace,
-    name,
-    storage_class,
-    fedora_latest_os_params,
-    access_modes=None,
-    volume_mode=None,
-    client=None,
-    dv_size=Images.Fedora.DEFAULT_DV_SIZE,
-):
-    with create_dv(
-        dv_name=f"dv-{name}",
-        namespace=namespace,
-        url=fedora_latest_os_params["fedora_image_path"],
-        size=dv_size,
-        storage_class=storage_class,
-        access_modes=access_modes,
-        volume_mode=volume_mode,
-        client=client,
-    ) as dv:
-        dv.wait_for_dv_success()
-        yield dv
-
-
 def check_snapshot_indication(snapshot, is_online):
     snapshot_indications = snapshot.instance.status.indications
     online = "Online"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and test cases to use Cirros-based DataVolumes and images instead of Fedora-based ones for storage cloning scenarios.  
  * Removed Fedora OS-related test fixtures and utilities to streamline testing resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->