### PR TITLE
Add SR-IOV interface verification upon VM restart

### DIFF
--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -220,6 +220,7 @@ def restarted_sriov_vm4(request, sriov_vm4):
     LOGGER.info(f"Reboot number {request.param}")
     sriov_vm4.restart(wait=True)
     sriov_vm4.wait_for_agent_connected()
+    wait_for_vm_interfaces(vmi=sriov_vm4.vmi)
     return sriov_vm4
 
 


### PR DESCRIPTION
The need for this check was exposed due to a flaky test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of SR-IOV VM restart tests by ensuring VM interfaces are fully initialized before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->