### PR TITLE
[4.19] Storage: fix create_vm_from_dv default args

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -32,7 +32,7 @@ from utilities.constants import (
     CDI_LABEL,
     HOTPLUG_DISK_SERIAL,
     HPP_POOL,
-    OS_FLAVOR_FEDORA,
+    OS_FLAVOR_CIRROS,
     OS_FLAVOR_WINDOWS,
     POD_CONTAINER_SPEC,
     TIMEOUT_1SEC,
@@ -994,13 +994,13 @@ def wait_for_dv_expected_restart_count(dv, expected_result):
 @contextmanager
 def create_vm_from_dv(
     dv,
-    vm_name="fedora-vm",
+    vm_name="cirros-vm",
     image=None,
     start=True,
-    os_flavor=OS_FLAVOR_FEDORA,
+    os_flavor=OS_FLAVOR_CIRROS,
     node_selector=None,
     cpu_model=None,
-    memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+    memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
     wait_for_cloud_init=False,
 ):
     with virt_util.VirtualMachineForTests(


### PR DESCRIPTION
##### Short description:
Fix automation Tier2 tests by changing fedora image to cirros into utilities.
##### More details:
This change was previously made in order to use fedora image in some storage tests, but there are other tests that uses same function to create VMs from DVs with cirros.
##### What this PR does / why we need it:
Change Fedora image to Cirros. 
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-65260
