### PR TITLE
test: update markers after merging s390x fedora image

### DIFF
--- a/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
+++ b/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
@@ -62,7 +62,7 @@ def hotplugged_vm_with_cpu_auto_limits(vm_auto_resource_limits, unprivileged_cli
                 "name": "vm-for-cpu-limit",
             },
             {"cpu": True, "memory": False},
-            marks=pytest.mark.polarion("CNV-11216"),
+            marks=[pytest.mark.polarion("CNV-11216"), pytest.mark.s390x],
             id="set_only_cpu",
         ),
         pytest.param(

--- a/tests/virt/cluster/service_account/test_service_account.py
+++ b/tests/virt/cluster/service_account/test_service_account.py
@@ -56,6 +56,7 @@ def test_vm_with_specified_service_account(service_account_vm):
     assert output[1] == vm_namespace, f"Wrong ServiceAccount attachment, VM: {vm_namespace}, OS: {output[1]}"
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-1001")
 def test_vm_with_2_service_accounts(namespace):
     """

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -181,6 +181,7 @@ def test_machine_type_kubevirt_config_update(updated_kubevirt_config_machine_typ
     validate_machine_type(vm=vm, expected_machine_type=MachineTypesNames.pc_q35_rhel8_1)
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-3688")
 def test_unsupported_machine_type(namespace, unprivileged_client):
     vm_name = "vm-invalid-machine-type"

--- a/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_features.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_features.py
@@ -72,6 +72,7 @@ def test_vm_with_cpu_feature_positive(cpu_features_vm_positive):
         ),
     ],
 )
+@pytest.mark.s390x
 def test_invalid_cpu_feature_policy_negative(unprivileged_client, namespace, features):
     """VM should not be created successfully"""
     vm_name = "invalid-cpu-feature-policy-vm"

--- a/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_flag.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_flag.py
@@ -38,6 +38,7 @@ def cpu_flag_vm_positive(cluster_common_node_cpu, namespace, unprivileged_client
     ],
     ids=["CPU-flag: Bad-Skylake-Server", "CPU-flag: commodore64"],
 )
+@pytest.mark.s390x
 def cpu_flag_vm_negative(request, unprivileged_client, namespace):
     name = f"vm-cpu-flags-negative-{request.param[1]}"
     with VirtualMachineForTests(


### PR DESCRIPTION
The merge of the qe-cnv-tests Fedora image enables additional tests to run. This commit updates the markers accordingly.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added platform-specific markers to several tests and fixtures to indicate compatibility with the s390x architecture.
  * Updated test annotations to improve test selection and relevance for s390x environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->