### PR TITLE
[CNV-65997]Skip redundant observability test test_metric_invalid_change

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -168,31 +168,6 @@ def wait_for_component_value_to_be_expected(prometheus, component_name, expected
 
 
 @pytest.fixture()
-def updated_resource_with_invalid_label(request, admin_client, hco_namespace, hco_status_related_objects):
-    resource_name = request.param["name"]
-    resource = get_resource_object(
-        related_objects=hco_status_related_objects,
-        admin_client=admin_client,
-        resource_kind=request.param["resource"],
-        resource_name=request.param["name"],
-    )
-    labels = resource.instance.metadata.labels
-    LOGGER.info(f"Updating metadata.label.{VERSION_LABEL_KEY} for {resource_name} ")
-    with ResourceEditor(
-        patches={
-            resource: {
-                "metadata": {
-                    "labels": {VERSION_LABEL_KEY: None},
-                    "namespace": hco_namespace.name,
-                },
-            }
-        }
-    ):
-        wait_for_cr_labels_change(component=resource, expected_value=labels)
-        yield
-
-
-@pytest.fixture()
 def updated_resource_multiple_times_with_invalid_label(
     request, prometheus, admin_client, hco_namespace, hco_status_related_objects
 ):

--- a/tests/observability/metrics/test_virt_resource_mutation_metrics.py
+++ b/tests/observability/metrics/test_virt_resource_mutation_metrics.py
@@ -16,7 +16,6 @@ from ocp_resources.ssp import SSP
 from tests.observability.metrics.utils import (
     COUNT_THREE,
     COUNT_TWO,
-    get_changed_mutation_component_value,
     wait_for_summary_count_to_be_expected,
 )
 from utilities.constants import (
@@ -127,115 +126,6 @@ COMPONENT_CONFIG = {
         },
     },
 }
-
-
-@pytest.mark.parametrize(
-    "mutation_count_before_change, updated_resource_with_invalid_label, component_name",
-    [
-        pytest.param(
-            COMPONENT_CONFIG["ssp"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["ssp"]["resource_info"],
-            COMPONENT_CONFIG["ssp"]["resource_info"]["comp_name"],
-            id="ssp",
-            marks=(pytest.mark.polarion("CNV-6129")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["console_cli_download"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["console_cli_download"]["resource_info"],
-            COMPONENT_CONFIG["console_cli_download"]["resource_info"]["comp_name"],
-            id="console_cli_download",
-            marks=(pytest.mark.polarion("CNV-6130")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["priority_class"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["priority_class"]["resource_info"],
-            COMPONENT_CONFIG["priority_class"]["resource_info"]["comp_name"],
-            id="priority_class",
-            marks=pytest.mark.polarion("CNV-6131"),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["kubevirt"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["kubevirt"]["resource_info"],
-            COMPONENT_CONFIG["kubevirt"]["resource_info"]["comp_name"],
-            id="kubevirt",
-            marks=(pytest.mark.polarion("CNV-6132")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["cdi"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["cdi"]["resource_info"],
-            COMPONENT_CONFIG["cdi"]["resource_info"]["comp_name"],
-            id="cdi",
-            marks=(pytest.mark.polarion("CNV-6133")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["cluster"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["cluster"]["resource_info"],
-            COMPONENT_CONFIG["cluster"]["resource_info"]["comp_name"],
-            id="networkaddonsconfig",
-            marks=(pytest.mark.polarion("CNV-6135")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["service"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["service"]["resource_info"],
-            COMPONENT_CONFIG["service"]["resource_info"]["comp_name"],
-            id="service",
-            marks=(pytest.mark.polarion("CNV-6137")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["service_monitor"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["service_monitor"]["resource_info"],
-            COMPONENT_CONFIG["service_monitor"]["resource_info"]["comp_name"],
-            id="service_monitor",
-            marks=(pytest.mark.polarion("CNV-6138")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["prometheus_rule"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["prometheus_rule"]["resource_info"],
-            COMPONENT_CONFIG["prometheus_rule"]["resource_info"]["comp_name"],
-            id="prometheus_rule",
-            marks=(pytest.mark.polarion("CNV-6139")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["console_quick_start_creating_virtual_machine"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["console_quick_start_creating_virtual_machine"]["resource_info"],
-            COMPONENT_CONFIG["console_quick_start_creating_virtual_machine"]["resource_info"]["comp_name"],
-            id="console_quick_start_creating_virtual_machine",
-            marks=(pytest.mark.polarion("CNV-8975")),
-        ),
-        pytest.param(
-            COMPONENT_CONFIG["console_quick_start_upload_boot_source"]["resource_info"]["comp_name"],
-            COMPONENT_CONFIG["console_quick_start_upload_boot_source"]["resource_info"],
-            COMPONENT_CONFIG["console_quick_start_upload_boot_source"]["resource_info"]["comp_name"],
-            id="console_quick_start_upload_boot_source",
-            marks=(pytest.mark.polarion("CNV-8974")),
-        ),
-    ],
-    indirect=[
-        "updated_resource_with_invalid_label",
-        "mutation_count_before_change",
-    ],
-)
-@pytest.mark.dependency(name="test_metric_invalid_change")
-def test_metric_invalid_change(
-    prometheus,
-    mutation_count_before_change,
-    updated_resource_with_invalid_label,
-    component_name,
-):
-    """
-    Any single change to Kubevirt spec will trigger the kubevirt_hco_out_of_band_modifications_total' metrics with
-    component name with it's value.
-    """
-    mutation_count_after_change = get_changed_mutation_component_value(
-        prometheus=prometheus,
-        component_name=component_name,
-        previous_value=mutation_count_before_change,
-    )
-    assert mutation_count_after_change - mutation_count_before_change == 1, (
-        f"'{component_name}' Count before '{mutation_count_before_change}',and after '{mutation_count_after_change}'"
-    )
-
-    # Check an alert state is firing after metric is generated.
 
 
 @pytest.mark.parametrize(

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -94,26 +94,6 @@ def get_mutation_component_value_from_prometheus(prometheus: Prometheus, compone
     return int(metric_results[0]["value"][1]) if metric_results else 0
 
 
-def get_changed_mutation_component_value(
-    prometheus: Prometheus, component_name: str, previous_value: int
-) -> Optional[int]:
-    samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_10MIN,
-        sleep=10,
-        func=get_mutation_component_value_from_prometheus,
-        prometheus=prometheus,
-        component_name=component_name,
-    )
-    try:
-        for sample in samples:
-            if sample != previous_value:
-                return sample
-    except TimeoutExpiredError:
-        LOGGER.error(f"component value did not change for component_name '{component_name}'.")
-        raise
-    return None
-
-
 def wait_for_metric_vmi_request_cpu_cores_output(prometheus: Prometheus, expected_cpu: int) -> None:
     """
     This function will wait for the expected metrics core cpu to show up in Prometheus query output


### PR DESCRIPTION
##### Short description:
Skip tests.observability.metrics.test_virt_resource_mutation_metrics.test_metric_invalid_change in favor of test_metric_multiple_invalid_change which provides same HCO mutation metric coverage plus alert verification.

##### More details:
Once merged, the corresponding removed Polarion IDs should be marked as obsolete.

##### What this PR does / why we need it:
The multiple change test inherently validates single change work (if 5 mutations increment the metric by 5, then 1 mutation must work), while also testing alert generation which the simple test doesn't cover.

##### Which issue(s) this PR fixes:
It's observed on CI that there are flakiness related to these tests. 

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-65997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed a test that verified metric increments for single-component changes to KubeVirt-related resources.
  * Removed a fixture that applied a one-off invalid-label update to resources.
  * Removed a helper used to poll/prometheus metrics for value changes during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->