### PR TITLE
[Network][Service Mesh]: Add authentication policy verification post-migration

### DIFF
--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -5,6 +5,7 @@ from tests.network.service_mesh.utils import (
     inbound_request,
 )
 from tests.network.utils import assert_authentication_request
+from utilities.virt import migrate_vm_and_verify
 
 pytestmark = pytest.mark.service_mesh
 
@@ -46,12 +47,33 @@ class TestSMPeerAuthentication:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-5784")
     @pytest.mark.single_nic
+    @pytest.mark.dependency(
+        name="test_authentication_policy_from_mesh",
+    )
     def test_authentication_policy_from_mesh(
         self,
         peer_authentication_service_mesh_deployment,
         vm_fedora_with_service_mesh_annotation,
         httpbin_service_service_mesh,
     ):
+        assert_authentication_request(
+            vm=vm_fedora_with_service_mesh_annotation,
+            service_app_name=httpbin_service_service_mesh.app_name,
+        )
+
+    @pytest.mark.ipv4
+    @pytest.mark.polarion("CNV-12181")
+    @pytest.mark.single_nic
+    @pytest.mark.dependency(
+        name="test_authentication_policy_from_mesh_post_migration",
+        depends=["test_authentication_policy_from_mesh"],
+    )
+    def test_authentication_policy_from_mesh_over_migration(
+        self,
+        vm_fedora_with_service_mesh_annotation,
+        httpbin_service_service_mesh,
+    ):
+        migrate_vm_and_verify(vm=vm_fedora_with_service_mesh_annotation)
         assert_authentication_request(
             vm=vm_fedora_with_service_mesh_annotation,
             service_app_name=httpbin_service_service_mesh.app_name,


### PR DESCRIPTION
Introduce test_authentication_policy_from_mesh_post_migration (CNV-12181). This scenario extends Service Mesh (SM) coverage by validating that peer-authentication continues to work before and after a VM live migration, guarding against regressions in post-migration traffic handling and security policy enforcement.

The new test performs the following steps:
- Ensures initial service mesh policy enforcement is active and verified (prerequisite via dependency on `test_authentication_policy_from_mesh` - CNV-5784).
- Migrates a service-mesh-enabled Fedora VM using `migrate_vm_and_verify`.
- Re-checks peer-authentication to confirm policy enforcement survives the live migration to verify complete enforcement of rules - before and after the VM migration.

**Why Use a Dependency (`pytest.mark.dependency`)?**
This new scenario depends on test_authentication_policy_from_mesh (CNV-5784) to ensure the initial SM setup, verified by CNV-5784, runs and passes before this scenario executes. If that foundational mesh setup is already broken, running the costly migration test would be a waste of time and resources for both execution and TFA.

**Verification Steps:**
To verify the automation, I performed the following manual steps within the `test_authentication_policy_from_mesh_post_migration` (CNV-12181):

1. **Pre-migration (sidecar injected):**
   - Sent a request from the VM to a pod, confirming successful communication: ```bash [fedora@service-mesh-vm-1752755644-8091047 ~]$ curl http://httpbin:8080/ip
     { "origin": "127.0.0.6" } ```
   - At this stage, the running `virt-launcher` had 4 containers, including the `istio-proxy` container.

2. **Post-migration (sidecar removed):**
   - Stopped the VM and edited it to have the `sidecar.istio.io/inject` annotation set to `"false"`.
   - Started the VM. Only 3 containers were running in the `virt-launcher` (the `istio-proxy` container was absent).
   - Ran the `curl` request again and confirmed that the connection was reset, indicating successful policy enforcement (i.e., traffic was blocked due to the missing sidecar):
     ```bash [fedora@service-mesh-vm-1752755644-8091047 ~]$ curl http://httpbin:8080/ip
     curl: (56) Recv failure: Connection reset by peer ```

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify service mesh authentication policy after VM migration.
  * Updated existing test to serve as a prerequisite for the new post-migration test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->