### PR TITLE
cherry-pick: add `action` as permissions

### DIFF
--- a/.github/workflows/cherrypick-to-4.99.yml
+++ b/.github/workflows/cherrypick-to-4.99.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   cherry-pick-to-4-99:
     permissions:
+      actions: write
       contents: write
       pull-requests: write # Required for creating PRs
 
@@ -24,8 +25,8 @@ jobs:
         # Configure Git user for commits made directly in the workflow
         # The create-pull-request action handles its own commit authorship.
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ secrets.GH_BOT_USERNAME }}"
+          git config user.email "${{ secrets.GH_BOT_EMAIL }}"
 
       - name: Get latest commit from main # Renamed step for clarity
         id: get_latest_commit # Updated ID


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to enhance security.
  * Improved Git commit author configuration in workflows by using dynamic user identity from secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->