### PR TITLE
[CNV-66017]add retry mechanism to handle oc node-logs failures in audit log tests

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1062,9 +1062,22 @@ def generate_openshift_pull_secret_file(client: DynamicClient = None) -> str:
 
 
 def get_node_audit_log_entries(log, node, log_entry):
-    return subprocess.getoutput(
-        f"{OC_ADM_LOGS_COMMAND} {node} {AUDIT_LOGS_PATH}/{log} | grep {shlex.quote(log_entry)}"
-    ).splitlines()
+    max_retries = 3
+    retry_delay = 5
+    for attempt in range(max_retries + 1):
+        result = subprocess.getoutput(
+            f"{OC_ADM_LOGS_COMMAND} {node} {AUDIT_LOGS_PATH}/{log} | grep {shlex.quote(log_entry)}"
+        )
+        lines = result.splitlines()
+        has_errors = any(line.startswith("error:") for line in lines)
+
+        if not has_errors:
+            return lines
+        if attempt < max_retries:
+            LOGGER.warning(f"oc command failed for node {node}, log {log}. Retrying in {retry_delay}s...")
+            time.sleep(retry_delay)
+        else:
+            return lines
 
 
 def get_node_audit_log_line_dict(logs, node, log_entry):


### PR DESCRIPTION
##### Short description:
Add retry mechanism to get_node_audit_log_entries() to handle temporary failures when accessing kube-apiserver audit logs. Prevents JSONDecodeError when oc command returns error messages instead of valid JSON data.

##### More details:
The test  `tests.deprecated_api.test_deprecation_audit_logs.test_deprecated_apis_in_audit_logs` sometimes fails during fixture setup with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`  when attempting to parse audit log entries. It's observed that the cluster may answer with an error to below request:
```
$ oc adm node-logs <node_name> --path=kube-apiserver/<log_file> | grep '"k8s.io/deprecated":"true"' 
error: the server could not find the requested resource
```
And therefore, the json.loads() is failing.
 
The test should handle this kind of temporary infrastructure issues gracefully and only fail for persistent problems or actual deprecated API usage.

##### What this PR does / why we need it:
The test will now try to gather the logs and if a line starting with `error:` is part of the output it will try maximum 3 times more. If the error line is still there, it will return it anyway.

##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-66017