### PR TITLE
gh cherrypick: use pat for workflow

### DIFF
--- a/.github/workflows/cherrypick-to-4.99.yml
+++ b/.github/workflows/cherrypick-to-4.99.yml
@@ -101,7 +101,7 @@ jobs:
         if: steps.prepare_branch.outputs.status == 'success'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
           commit-message: "Cherry-pick: ${{ steps.get_latest_commit.outputs.commit_message }} (from ${{ steps.get_latest_commit.outputs.commit_sha }})" # Updated reference
           title: "Auto Cherry-pick: ${{ steps.get_latest_commit.outputs.commit_message }}" # Updated reference
           body: |
@@ -124,7 +124,7 @@ jobs:
         if: steps.prepare_branch.outputs.status == 'conflicted'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
           commit-message: "Cherry-pick Conflicts: ${{ steps.get_latest_commit.outputs.commit_message }} (from ${{ steps.get_latest_commit.outputs.commit_sha }})" # Updated reference
           title: "Cherry-pick Conflicts: ${{ steps.get_latest_commit.outputs.commit_message }}" # Updated reference
           body: |


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow authentication settings for creating pull requests during cherry-pick operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->