### PR TITLE
[CNV-66035]increase must-gather timeout values to prevent collection failures

### DIFF
--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -21,7 +21,7 @@ from tests.install_upgrade_operators.must_gather.utils import (
     get_must_gather_dir,
 )
 from tests.utils import create_vms
-from utilities.constants import LINUX_BRIDGE
+from utilities.constants import LINUX_BRIDGE, TIMEOUT_40MIN
 from utilities.exceptions import MissingResourceException
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
@@ -667,6 +667,7 @@ def collected_must_gather_all_images(
     output = run_must_gather(
         target_base_dir=must_gather_tmpdir_all_images,
         flag_names="all-images",
+        command_timeout=TIMEOUT_40MIN,
     )
     with open(os.path.join(must_gather_tmpdir_all_images, "output.log"), "w") as _file:
         _file.write(output)

--- a/utilities/must_gather.py
+++ b/utilities/must_gather.py
@@ -16,6 +16,7 @@ def run_must_gather(
     node_name: str = "",
     flag_names: str = "",
     timeout: str = f"{TIMEOUT_15MIN}s",
+    command_timeout: int = TIMEOUT_20MIN,
     since: str | None = None,
 ) -> str:
     """
@@ -47,7 +48,7 @@ def run_must_gather(
         base_command += f" --node-name={node_name}"
     if since:
         base_command += f" --since={since}"
-    if timeout:
+    if timeout:  # Only applies to gathering and not copying stage - https://issues.redhat.com/browse/OCPBUGS-59774
         base_command += f" --timeout={timeout}"
     if script_name:
         base_command += f" -- {script_name}"
@@ -58,7 +59,7 @@ def run_must_gather(
     did_succeed, output, error = run_command(
         command=shlex.split(base_command),
         check=False,
-        timeout=TIMEOUT_20MIN,
+        timeout=command_timeout,
         log_errors=False,
     )
     if not did_succeed and error:
@@ -86,6 +87,7 @@ def collect_must_gather(
     flag_names="",
     timeout="",
     node_name="",
+    command_timeout=TIMEOUT_20MIN,
 ):
     """
     Run must gather command and puts the content in directory.
@@ -108,6 +110,7 @@ def collect_must_gather(
         node_name=node_name,
         flag_names=flag_names,
         timeout=timeout,
+        command_timeout=command_timeout,
     )
 
     with open(os.path.join(must_gather_tmpdir, "output.log"), "w") as _file:


### PR DESCRIPTION
##### Short description:
The all-images must-gather operations were timing out before completion, causing test failures and CI job to get stuck. This PR increases the timeouts.

The new timeout values are based on manual generation of the must-gather, which took around 35 minutes:

```
      Started:      Fri, 18 Jul 2025 10:29:05 -0400
      Finished:     Fri, 18 Jul 2025 11:04:30 -0400
```

##### More details:
Changes:
- Add a new parameter in utilities/must_gather.py to be able to set the
  command timeout from the tests. Default value remains set to 20
minutes.
- Set the new parameter in the test to increase the command timeout
  value to 40 minutes while generating  the "all-images" must-gather.

##### What this PR does / why we need it:
This fixes intermittent test failures related to must-gather timeouts that was in some cases provoking the overall test job to get stuck.

##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-66035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the timeout duration for certain operations to improve reliability during long-running tasks.
  * Added configurable timeout settings to enhance control over must-gather command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->