### PR TITLE
Remove preferred storage test 10328

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,6 @@ from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.daemonset import DaemonSet
-from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.deployment import Deployment
 from ocp_resources.hostpath_provisioner import HostPathProvisioner
@@ -99,7 +98,6 @@ from utilities.constants import (
     NODE_ROLE_KUBERNETES_IO,
     NODE_TYPE_WORKER_LABEL,
     OC_ADM_LOGS_COMMAND,
-    OS_FLAVOR_FEDORA,
     OS_FLAVOR_RHEL,
     OVS_BRIDGE,
     POD_SECURITY_NAMESPACE_LABELS,
@@ -2929,13 +2927,3 @@ def ping_process_in_rhel_os():
 def smbios_from_kubevirt_config(kubevirt_config_scope_module):
     """Extract SMBIOS default from kubevirt CR."""
     return kubevirt_config_scope_module["smbios"]
-
-
-@pytest.fixture(scope="module")
-def golden_images_fedora_data_source(golden_images_namespace):
-    return DataSource(
-        namespace=golden_images_namespace.name,
-        name=OS_FLAVOR_FEDORA,
-        client=golden_images_namespace.client,
-        ensure_exists=True,
-    )

--- a/tests/infrastructure/instance_types/test_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_vm_preference.py
@@ -1,62 +1,6 @@
 import pytest
-from ocp_resources.storage_profile import StorageProfile
-from ocp_resources.virtual_machine_cluster_preference import (
-    VirtualMachineClusterPreference,
-)
-from pytest_testconfig import py_config
 
 from tests.infrastructure.instance_types.constants import ALL_OPTIONS_VM_PREFERENCE_SPEC
-from utilities.constants import Images
-from utilities.storage import data_volume_template_with_source_ref_dict
-from utilities.virt import VirtualMachineForTests
-
-PREFERENCE_STORAGE_CLASS = py_config["default_storage_class"]
-
-
-# in PVC api accessModes are needed and the resources request should be in the pvc field
-def pvc_api_adjustments(dv_template):
-    storage_profile_info = StorageProfile(name=PREFERENCE_STORAGE_CLASS).instance.status["claimPropertySets"][0]
-    dv_template["spec"]["pvc"] = {
-        "volumeMode": storage_profile_info["volumeMode"],
-        "accessModes": storage_profile_info["accessModes"],
-        "resources": {"requests": {"storage": dv_template["spec"]["storage"]["resources"]["requests"]["storage"]}},
-    }
-    del dv_template["spec"]["storage"]
-    return dv_template
-
-
-@pytest.fixture(scope="class")
-def vm_storage_class_preference():
-    with VirtualMachineClusterPreference(
-        name="storage-class-vm-preference",
-        volumes={"preferredStorageClassName": PREFERENCE_STORAGE_CLASS},
-    ) as vm_cluster_preference:
-        yield vm_cluster_preference
-
-
-@pytest.fixture()
-def rhel_vm_with_storage_preference(
-    namespace,
-    unprivileged_client,
-    vm_storage_class_preference,
-    fedora_data_volume_template,
-):
-    with VirtualMachineForTests(
-        client=unprivileged_client,
-        name="rhel-vm-with-storage-pref",
-        namespace=namespace.name,
-        memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
-        vm_preference=vm_storage_class_preference,
-        data_volume_template=fedora_data_volume_template,
-    ) as vm:
-        yield vm
-
-
-@pytest.fixture()
-def fedora_data_volume_template(golden_images_fedora_data_source):
-    # When using data volume template with storage API adjustment to the fields are needed
-    fedora_dv_template = data_volume_template_with_source_ref_dict(data_source=golden_images_fedora_data_source)
-    return pvc_api_adjustments(dv_template=fedora_dv_template)
 
 
 @pytest.mark.gating
@@ -107,11 +51,3 @@ class TestVmClusterPreference:
     def test_create_cluster_preference(self, vm_cluster_preference_for_test):
         with vm_cluster_preference_for_test as vm_cluster_preference:
             assert vm_cluster_preference.exists
-
-
-@pytest.mark.polarion("CNV-10328")
-def test_vm_pref_storage_class_pvc_api(
-    rhel_vm_with_storage_preference,
-):
-    vm_sc = rhel_vm_with_storage_preference.instance.spec.dataVolumeTemplates[0].spec["pvc"]["storageClassName"]
-    assert vm_sc == PREFERENCE_STORAGE_CLASS, f"VM storage class is: {vm_sc}, expected: {PREFERENCE_STORAGE_CLASS}"

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -139,10 +139,16 @@ def target_storage_class(request, cluster_storage_classes_names):
 def vm_for_storage_class_migration_with_instance_type(
     unprivileged_client,
     namespace,
-    golden_images_fedora_data_source,
+    golden_images_namespace,
     source_storage_class,
     cpu_for_migration,
 ):
+    golden_images_fedora_data_source = DataSource(
+        namespace=golden_images_namespace.name,
+        name=OS_FLAVOR_FEDORA,
+        client=golden_images_namespace.client,
+        ensure_exists=True,
+    )
     with VirtualMachineForTests(
         name="vm-with-instance-type",
         namespace=namespace.name,


### PR DESCRIPTION
##### Short description:
The preferred storage test is now being tested as a unit test at - https://github.com/kubevirt/kubevirt/blob/411a69b1572308c119c2ae5f445fa35d55445181/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go#L418

Removing this test since it's duplicate coverage

##### Special notes for reviewer:
The test merge PR - https://github.com/kubevirt/kubevirt/pull/15053

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-62618


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed tests and fixtures related to storage class preferences for virtual machines.
  * Updated fixture setup for Fedora OS flavor data source to enhance storage migration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->