### PR TITLE
 [service mesh] fix: correct service mesh traffic blocking test

### DIFF
--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -95,7 +95,6 @@ class TestSMPeerAuthentication:
         httpbin_service_service_mesh,
         outside_mesh_console_ready_vm,
     ):
-        expected_failure_output = "curl: (56) Recv failure"
         # We must specify the full service DNS name since the VM is outside the mesh in a different namespace
         # Format: http://<service_name>.<service_namespace>.svc.cluster.local
         assert_authentication_request(
@@ -103,7 +102,7 @@ class TestSMPeerAuthentication:
             service_app_name=(
                 f"{httpbin_service_service_mesh.app_name}.{httpbin_service_service_mesh.namespace}.svc.cluster.local"
             ),
-            expected_output=expected_failure_output,
+            expected_output="curl: (56) Recv failure",
         )
 
     @pytest.mark.polarion("CNV-7128")

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -2,7 +2,6 @@ import pytest
 
 from tests.network.service_mesh.constants import AUTH_COMMAND, EXPECTED_MESH_SUCCESS_OUTPUT
 from tests.network.service_mesh.utils import (
-    assert_authentication_request,
     assert_traffic_management_request,
     inbound_request,
     run_console_command,
@@ -97,13 +96,16 @@ class TestSMPeerAuthentication:
     ):
         # We must specify the full service DNS name since the VM is outside the mesh in a different namespace
         # Format: http://<service_name>.<service_namespace>.svc.cluster.local
-        assert_authentication_request(
+        result = run_console_command(
             vm=outside_mesh_vm_fedora_with_service_mesh_annotation,
-            service_app_name=(
-                f"{httpbin_service_service_mesh.app_name}.{httpbin_service_service_mesh.namespace}.svc.cluster.local"
+            command=AUTH_COMMAND.format(
+                service=(
+                    f"{httpbin_service_service_mesh.app_name}.{httpbin_service_service_mesh.namespace}."
+                    "svc.cluster.local"
+                )
             ),
-            expected_output="curl: (56) Recv failure",
         )
+        assert "curl: (56) Recv failure" in result
 
     @pytest.mark.polarion("CNV-7128")
     @pytest.mark.single_nic

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -95,11 +95,16 @@ class TestSMPeerAuthentication:
         httpbin_service_service_mesh,
         outside_mesh_console_ready_vm,
     ):
-        with pytest.raises(AssertionError):
-            assert_authentication_request(
-                vm=outside_mesh_vm_fedora_with_service_mesh_annotation,
-                service_app_name=httpbin_service_service_mesh.app_name,
-            )
+        expected_failure_output = "curl: (56) Recv failure"
+        # We must specify the full service DNS name since the VM is outside the mesh in a different namespace
+        # Format: http://<service_name>.<service_namespace>.svc.cluster.local
+        assert_authentication_request(
+            vm=outside_mesh_vm_fedora_with_service_mesh_annotation,
+            service_app_name=(
+                f"{httpbin_service_service_mesh.app_name}.{httpbin_service_service_mesh.namespace}.svc.cluster.local"
+            ),
+            expected_output=expected_failure_output,
+        )
 
     @pytest.mark.polarion("CNV-7128")
     @pytest.mark.single_nic

--- a/tests/network/service_mesh/utils.py
+++ b/tests/network/service_mesh/utils.py
@@ -3,7 +3,6 @@ import logging
 import pexpect
 import pytest
 
-from tests.network.service_mesh.constants import AUTH_COMMAND
 from utilities import console
 from utilities.constants import TIMEOUT_1MIN, TIMEOUT_3MIN
 from utilities.virt import VirtualMachineForTests
@@ -52,16 +51,6 @@ def assert_service_mesh_request(expected_output, request_response):
     assert expected_output in request_response, (
         f"Server response error.Expected output - {expected_output}received - {request_response}"
     )
-
-
-def assert_authentication_request(vm, service_app_name):
-    # Envoy proxy IP
-    expected_output = "127.0.0.6"
-    request_response = run_console_command(
-        vm=vm,
-        command=AUTH_COMMAND.format(service=service_app_name),
-    )
-    assert_service_mesh_request(expected_output=expected_output, request_response=request_response)
 
 
 def run_console_command(vm: VirtualMachineForTests, command: str, timeout: int = TIMEOUT_1MIN) -> str:


### PR DESCRIPTION
The test was previously failing due to DNS resolution failure (curl: (6) Could not resolve host) rather than service mesh (SM) policy blocking. This meant the test passed but wasn't actually validating SM functionality.

Changes:
- Use full service FQDN for cross-namespace access to ensure DNS resolution succeeds.
- Check for specific service mesh blocking error (curl: (56) Recv failure) instead of generic assertion.
- Add expected_output parameter to assert_authentication_request for flexible error checking.

Now the test properly validates that service mesh peer authentication blocks outside mesh traffic rather than passing due to unrelated DNS failures.

##### Short description:

##### More details:
Fixes this automation bug: https://issues.redhat.com/browse/CNV-65999

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined service-mesh tests for traffic originating outside the mesh to use the full service DNS name and validate an expected network failure response.
  * Removed an internal test helper and updated assertions to reduce flakiness and improve accuracy of out-of-mesh authentication/connection checks, increasing test reliability without affecting runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->