### PR TITLE
Remove test for none existing instance type

### DIFF
--- a/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
+++ b/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
@@ -1,5 +1,4 @@
 import pytest
-from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
@@ -104,31 +103,3 @@ def test_add_reference_to_existing_vm(
         preference_object_dict=rhel_9_vm_cluster_preference.instance.to_dict(),
     )
     assert not mismatch_list, f"Some references were not updated in the VM: {mismatch_list}"
-
-
-@pytest.mark.parametrize(
-    "error_match, spec_field, reference_class",
-    [
-        pytest.param(
-            r".*Failure to find instancetype.*",
-            "instancetype",
-            VirtualMachineClusterInstancetype,
-        ),
-        pytest.param(
-            r".*Failure to find preference.*",
-            "preference",
-            VirtualMachineClusterPreference,
-        ),
-    ],
-)
-@pytest.mark.polarion("CNV-9681")
-def test_add_non_existing_reference_to_existing_vm(error_match, spec_field, reference_class, simple_rhel_vm):
-    reference_object = reference_class(name="non-existing")
-    with pytest.raises(UnprocessibleEntityError, match=error_match):
-        spec_dict = {
-            spec_field: {
-                "kind": reference_object.kind,
-                "name": reference_object.name,
-            }
-        }
-        ResourceEditor(patches={simple_rhel_vm: {"spec": spec_dict}}).update()


### PR DESCRIPTION
##### Short description:
Remove `test_add_non_existing_reference_to_existing_vm`

##### More details:
The way the feature now works is that it is no longer rejecting on VM creation the VM but instead shows an error of it failing, so that in the future a user can create the resource - https://github.com/kubevirt/kubevirt/pull/14219

A test under [kubevirt/tests](https://github.com/kubevirt/kubevirt/blob/54ebc9c4580e67714789e590b7e6a048344d7452/tests/instancetype/instancetype.go#L112) is now covering this case

##### What this PR does / why we need it:
Remove failing tests

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-50275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a test that checked error handling when adding non-existing instancetype or preference references to a virtual machine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->