### PR TITLE
Updated github workflow to build fedora ARM images

### DIFF
--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -48,15 +48,70 @@ jobs:
           local_repository: "localhost/fedora"
           remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          arch_code_tag: "${{ env.FEDORA_VERSION }}-x86_64"
         run: |
           mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image.tar"
+          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_code_tag}"
+          podman save -o artifacts/fedora-image-x86_64.tar "${remote_repository}":"${arch_code_tag}"
+          echo "Saved image to artifacts/fedora-image-x86_64.tar"
       - name: Upload container image artifact
         uses: actions/upload-artifact@v4
         with:
           name: fedora-container-image
-          path: artifacts/fedora-image.tar
+          path: artifacts/fedora-image-x86_64.tar
+          retention-days: 5
+          compression-level: 0
+  guest-fedora-arm64:
+    runs-on: ubuntu-latest
+    env:
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.aarch64.qcow2
+      FEDORA_VERSION: 41
+      CPU_ARCH: arm64
+      FULL_EMULATION: "true"
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install dependencies for VM build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            qemu-system-x86 \
+            qemu-system-aarch64 \
+            libvirt-daemon-system \
+            virtinst cloud-image-utils \
+            libguestfs-tools
+      - name: Tweak hosted runner to enable 'virt-sysprep'
+        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
+        run: sudo chmod 0644 /boot/vmlinuz*
+      - name: Fetch base Fedora image
+        working-directory: ./containers/fedora
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/aarch64/images/${{ env.FEDORA_IMAGE }}"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.11"
+      - name: Create VM
+        working-directory: ./containers/fedora
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          NO_SECRETS: "true"
+        run: ./build.sh
+      - name: Save container image as tarball
+        env:
+          local_repository: "localhost/fedora"
+          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          arch_code_tag: "${{ env.FEDORA_VERSION }}-aarch64"
+        run: |
+          mkdir -p artifacts
+          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_code_tag}"
+          podman save -o artifacts/fedora-image-aarch64.tar "${remote_repository}":"${arch_code_tag}"
+          echo "Saved image to artifacts/fedora-image-aarch64.tar"
+      - name: Upload container image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fedora-container-image
+          path: artifacts/fedora-image-aarch64.tar
           retention-days: 5
           compression-level: 0


### PR DESCRIPTION
The existing workflow included job only to build x86_64 fedora container image. This PR extends the same logic to include the job to build fedora ARM64 container image

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
"NONE"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and saving Fedora guest images for ARM64 architecture alongside AMD64.
  
* **Chores**
  * Improved artifact naming to include architecture details.
  * Set artifact retention to 5 days and disabled compression for saved images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->