### PR TITLE
[MIAN] [STORAGE] Xfail mtc migcluster not found

### DIFF
--- a/tests/storage/fs_overhead/test_fs_overhead.py
+++ b/tests/storage/fs_overhead/test_fs_overhead.py
@@ -21,16 +21,9 @@ def get_pvc_size_gib(pvc):
 
 
 def assert_fs_overhead_added(actual_size, requested_size):
-    allowed_tolerance = bitmath.KiB(1).to_Byte().value  # 1 KiB tolerance
-    expected_bytes = requested_size.to_Byte().value * (1 + FS_OVERHEAD_20)
-    actual_bytes = actual_size.to_Byte().value
-    diff = abs(actual_bytes - expected_bytes)
-    assert diff <= allowed_tolerance, (
-        f"❌ PVC size mismatch:\n"
-        f"  Requested: {requested_size}\n"
-        f"  Expected (+20% overhead): {bitmath.Byte(expected_bytes).best_prefix()}\n"
-        f"  Actual: {actual_size}\n"
-        f"  Diff: {bitmath.Byte(diff)} (allowed: {bitmath.Byte(allowed_tolerance)})"
+    expected_size = actual_size * (1 - FS_OVERHEAD_20)
+    assert expected_size == requested_size, (
+        f"actual size: {actual_size}, expected size: {expected_size}, requested size: {requested_size}"
     )
 
 

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -61,7 +61,10 @@ def golden_images_rhel9_data_source(golden_images_namespace):
 
 @pytest.fixture(scope="module")
 def mig_cluster(admin_client):
-    return MigCluster(name="host", namespace=OPENSHIFT_MIGRATION_NAMESPACE, client=admin_client, ensure_exists=True)
+    try:
+        return MigCluster(name="host", namespace=OPENSHIFT_MIGRATION_NAMESPACE, client=admin_client, ensure_exists=True)
+    except Exception as exp:
+        pytest.xfail(reason=f"Failed to locate MigCluster in namespace '{OPENSHIFT_MIGRATION_NAMESPACE}': {exp}")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### Short description:

Xfail migcluster test that fails due to missing namespace "openshift-migration"

for instance: if MTC  operatoris not installed the namespace will not be found, so relevant tests need to be skipped 


##### More details:

following tests are failing witherror msg: Couldn't find MigCluster in migration.openshift.io api group


test_vm_storage_class_migration_a_to_b_running_vms
test_vm_storage_class_migration_b_to_a_with_running_and_stopped_vms
test_vm_storage_class_migration_with_hotplugged_volume

due to failure in mig_cluster fixture to return 



##### What this PR does / why we need it:

this will xfail these test and cause more stable run

##### Which issue(s) this PR fixes:

NotImplementedError: Couldn't find MigCluster in migration.openshift.io api group


##### Special notes for reviewer:
None

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64380
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding exception handling to skip tests gracefully if the required cluster cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->