### PR TITLE
[CNV-67126]Update 4.20 CSV permissions

### DIFF
--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/csv-permissions.yaml
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/csv-permissions.yaml
@@ -592,6 +592,7 @@ cdi-operator:
     - get
   - apiGroups:
     - cdi.kubevirt.io
+    - forklift.cdi.kubevirt.io
     resources:
     - '*'
     verbs:
@@ -651,15 +652,6 @@ cdi-operator:
     - virtualmachines/finalizers
     verbs:
     - update
-  - apiGroups:
-    - forklift.cdi.kubevirt.io
-    resources:
-    - ovirtvolumepopulators
-    - openstackvolumepopulators
-    verbs:
-    - get
-    - list
-    - watch
   - apiGroups:
     - ''
     resources:
@@ -1189,6 +1181,18 @@ cluster-network-addons-operator:
     - get
     - create
     - update
+    - delete
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
     - delete
 hostpath-provisioner-operator:
   cluster_permission:
@@ -1722,6 +1726,7 @@ hyperconverged-cluster-operator:
     - watch
     - create
     - update
+    - delete
   - apiGroups:
     - ''
     resources:
@@ -1746,6 +1751,7 @@ hyperconverged-cluster-operator:
     resources:
     - deployments
     - replicasets
+    - daemonsets
     verbs:
     - get
     - list
@@ -1757,7 +1763,9 @@ hyperconverged-cluster-operator:
     - rbac.authorization.k8s.io
     resources:
     - roles
+    - clusterroles
     - rolebindings
+    - clusterrolebindings
     verbs:
     - get
     - list
@@ -1971,6 +1979,50 @@ hyperconverged-cluster-operator:
     - list
     - create
     - delete
+  - apiGroups:
+    - ''
+    resources:
+    - serviceaccounts
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
+  - apiGroups:
+    - k8s.cni.cncf.io
+    resources:
+    - network-attachment-definitions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
 kubevirt-operator:
   cluster_permission:
   - apiGroups:
@@ -2172,6 +2224,7 @@ kubevirt-operator:
     - persistentvolumeclaims
     verbs:
     - get
+    - list
   - apiGroups:
     - kubevirt.io
     resources:
@@ -2568,6 +2621,15 @@ kubevirt-operator:
     - get
     - delete
   - apiGroups:
+    - resource.k8s.io
+    resources:
+    - resourceslices
+    - resourceclaims
+    verbs:
+    - list
+    - watch
+    - get
+  - apiGroups:
     - kubevirt.io
     resources:
     - virtualmachineinstances
@@ -2641,6 +2703,48 @@ kubevirt-operator:
   - apiGroups:
     - kubevirt.io
     resources:
+    - virtualmachineinstances
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
+  - apiGroups:
+    - kubevirt.io
+    resources:
+    - virtualmachineinstancemigrations
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - kubevirt.io
+    resources:
+    - kubevirts
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ''
+    resources:
+    - events
+    verbs:
+    - update
+    - create
+    - patch
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - kubevirt.io
+    resources:
     - kubevirts
     verbs:
     - get
@@ -2666,6 +2770,8 @@ kubevirt-operator:
     - virtualmachineinstances/sev/fetchcertchain
     - virtualmachineinstances/sev/querylaunchmeasurement
     - virtualmachineinstances/usbredir
+    - virtualmachines/objectgraph
+    - virtualmachineinstances/objectgraph
     verbs:
     - get
   - apiGroups:
@@ -2822,6 +2928,8 @@ kubevirt-operator:
     - virtualmachineinstances/sev/fetchcertchain
     - virtualmachineinstances/sev/querylaunchmeasurement
     - virtualmachineinstances/usbredir
+    - virtualmachines/objectgraph
+    - virtualmachineinstances/objectgraph
     verbs:
     - get
   - apiGroups:
@@ -2982,6 +3090,8 @@ kubevirt-operator:
     - virtualmachineinstances/userlist
     - virtualmachineinstances/sev/fetchcertchain
     - virtualmachineinstances/sev/querylaunchmeasurement
+    - virtualmachines/objectgraph
+    - virtualmachineinstances/objectgraph
     verbs:
     - get
   - apiGroups:
@@ -3107,6 +3217,8 @@ kubevirt-operator:
     - kubevirt-virt-api-certs
     - kubevirt-controller-certs
     - kubevirt-exportproxy-certs
+    - kubevirt-synchronization-controller-certs
+    - kubevirt-synchronization-controller-server-certs
     resources:
     - secrets
     verbs:
@@ -3218,6 +3330,28 @@ kubevirt-operator:
     - get
     - list
     - watch
+  - apiGroups:
+    - ''
+    resourceNames:
+    - kubevirt-ca
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - list
+    - watch
+    - delete
+    - update
+    - create
+    - patch
 ssp-operator:
   cluster_permission:
   - apiGroups:
@@ -3369,6 +3503,17 @@ ssp-operator:
     - servicemonitors
     verbs:
     - create
+    - delete
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - create
+    - delete
     - list
     - update
     - watch


### PR DESCRIPTION
##### Short description:
Update CSV permissions to reflect new values in 4.20

Summary generated by ClaudeAI: 

 **1. cdi-operator (Containerized Data Importer)**

  ✅ Added

  - API Group: forklift.cdi.kubevirt.io added to resources with * permissions
   - Impact: CDI can now manage Forklift-related resources (VM migration)

  ❌ Removed

  Specific rule removed:
  - apiGroups: [forklift.cdi.kubevirt.io]
    resources: [ovirtvolumepopulators, openstackvolumepopulators]
    verbs: [get, list, watch]
  - Impact: Specific permissions for oVirt and OpenStack populators were consolidated into the general * rule

  **2. cluster-network-addons-operator**

  ✅ Added

  - apiGroups: [networking.k8s.io]
    resources: [networkpolicies]
    verbs: [get, list, watch, create, update, patch, delete]
  - Impact: Can now manage Kubernetes NetworkPolicies (network security)

  **3. hyperconverged-cluster-operator (Significant expansion)**

  ✅ Enhanced existing permissions

  - Secrets: Added delete verb for comprehensive secret management
  - Apps resources: Added daemonsets to the deployments/replicasets rule
  - RBAC: Extended to include clusterroles and clusterrolebindings

  ✅ New permission rules added

  Service Accounts management
  - apiGroups: ['']
    resources: [serviceaccounts]
    verbs: [get, list, watch, create, update, delete]

  Network Attachment Definitions (CNI)
  - apiGroups: [k8s.cni.cncf.io]
    resources: [network-attachment-definitions]
    verbs: [get, list, watch, create, update, delete]

  Security Context Constraints (OpenShift)
  - apiGroups: [security.openshift.io]
    resources: [securitycontextconstraints]
    verbs: [get, list, watch, create, update, delete]

  Network Policies
  - apiGroups: [networking.k8s.io]
    resources: [networkpolicies]
    verbs: [get, list, watch, create, update, delete]

  **4. kubevirt-operator (Extensive changes)**

  ✅ Cluster permissions enhanced

  Persistent Volume Claims:
  - verbs: [get, list]  # Added 'list'

  Dynamic Resource Allocation (K8s 1.26+):
  - apiGroups: [resource.k8s.io]
    resources: [resourceslices, resourceclaims]
    verbs: [list, watch, get]

  Enhanced VM introspection:
  resources: [
    virtualmachines/objectgraph,           # New
    virtualmachineinstances/objectgraph    # New
  ]

  Additional certificate management:
  resourceNames: [
    kubevirt-synchronization-controller-certs,        # New
    kubevirt-synchronization-controller-server-certs  # New
  ]

  ✅ Namespace permissions enhanced

  CA certificate access:
  resourceNames: [kubevirt-ca]
  resources: [configmaps]
  verbs: [get, list, watch]

  Coordination improvements:
  - apiGroups: [coordination.k8s.io]
    resources: [leases]
    verbs: [get, list, watch, delete, update, create, patch]

  **5. ssp-operator (Enhanced monitoring capabilities)**

  ✅ Added

  Enhanced ServiceMonitor management
  verbs: [create, delete, list, update, watch]  # Added 'delete'

  New NetworkPolicy management
  - apiGroups: [networking.k8s.io]
    resources: [networkpolicies]
    verbs: [create, delete, list, update, watch]

##### More details:
uv run pytest tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py::test_compare_csv_permissions -v --update-csv -x

##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-67126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded operator permissions across multiple components: added network policy management, monitoring rules/servicemonitors, leases, resource slices/claims, objectgraph subresources, pods/exec, and broader VM-related resource access.
  * Broadened secrets/configmap access for certificate handling and synchronization components.
  * Removed a forklift-specific permission block and replaced it with a consolidated wildcard-style access entry.
  * General cleanup to align exported permissions with current operator needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->