### PR TITLE
[CNV-64462]update enableMultiArchBootImageImport FG

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -42,7 +42,7 @@ HCO_DEFAULT_FEATUREGATES = {
     PERSISTENT_RESERVATION: FG_DISABLED,
     "alignCPUs": FG_DISABLED,
     "downwardMetrics": FG_DISABLED,
-    "enableMultiArchCommonBootImageImport": FG_DISABLED,
+    "enableMultiArchBootImageImport": FG_DISABLED,
 }
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"


### PR DESCRIPTION
##### Short description:
FG has been updated from `enableMultiArchCommonBootImageImport` to  `enableMultiArchBootImageImport` on  https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3620

##### More details:
N/A
##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a feature flag key name to improve consistency. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->