### PR TITLE
[4.19][VIRT] update for descheduler test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -762,6 +762,8 @@ def get_inspect_command_namespace_string(node: Node, test_name: str) -> str:
                 namespaces_to_collect.append(NamespacesNames.NVIDIA_GPU_OPERATOR)
             if "swap" in all_markers:
                 namespaces_to_collect.append(NamespacesNames.WASP)
+            if "descheduler" in all_markers:
+                namespaces_to_collect.append(NamespacesNames.OPENSHIFT_KUBE_DESCHEDULER_OPERATOR)
         namespace_str = " ".join([f"namespace/{namespace}" for namespace in namespaces_to_collect])
     return namespace_str
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -45,6 +45,7 @@ markers =
     service_mesh: Tests that require the service mesh operator to be installed
     jumbo_frame: Tests that require network configurations supporting jumbo frames
     rwx_default_storage: Tests that require RWX storage
+    descheduler: Tests that require kube-descheduler on nodes
 
     ## Resources requirements
     high_resource_vm: Tests that create VM using a lot of resources (like Windows OS VMs, hight performance VMs, etc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,7 +156,6 @@ from utilities.infra import (
     name_prefix,
     run_virtctl_command,
     scale_deployment_replicas,
-    verify_image_info,
     wait_for_pods_deletion,
 )
 from utilities.network import (
@@ -2267,19 +2266,6 @@ def common_vm_preference_param_dict(request):
     if request.param.get("cpu_spread_option"):
         common_preference_dict.setdefault("cpu", {}).update({"spreadOption": request.param.get("cpu_spread_option")})
     return common_preference_dict
-
-
-@pytest.fixture(scope="session")
-def ocp_qe_art_image_url(ocp_current_version, nodes_cpu_architecture, generated_pulled_secret):
-    ocp_qe_image = (
-        f"quay.io/openshift-qe-optional-operators/aosqe-index:v{ocp_current_version.major}.{ocp_current_version.minor}"
-    )
-    verify_image_info(
-        image_url=ocp_qe_image,
-        generated_pulled_secret=generated_pulled_secret,
-        nodes_cpu_architecture=nodes_cpu_architecture,
-    )
-    return ocp_qe_image
 
 
 @pytest.fixture(scope="module")

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -1,8 +1,10 @@
 import logging
 
+import bitmath
 import pytest
 from bitmath import parse_string_unsafe
 from ocp_resources.datavolume import DataVolume
+from ocp_resources.deployment import Deployment
 from ocp_resources.performance_profile import PerformanceProfile
 from ocp_resources.storage_profile import StorageProfile
 from pytest_testconfig import py_config
@@ -16,9 +18,10 @@ from tests.virt.node.gpu.utils import (
     wait_for_manager_pods_deployed,
 )
 from tests.virt.utils import (
+    get_allocatable_memory_per_node,
     patch_hco_cr_with_mdev_permitted_hostdevices,
 )
-from utilities.constants import AMD, INTEL, TIMEOUT_1MIN, TIMEOUT_5SEC
+from utilities.constants import AMD, INTEL, TIMEOUT_1MIN, TIMEOUT_5SEC, NamespacesNames
 from utilities.exceptions import UnsupportedGPUDeviceError
 from utilities.infra import ExecCommandOnPod, exit_pytest_execution, label_nodes
 from utilities.virt import get_nodes_gpu_info
@@ -29,6 +32,7 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture(scope="session", autouse=True)
 def virt_special_infra_sanity(
     request,
+    admin_client,
     junitxml_plugin,
     is_psi_cluster,
     schedulable_nodes,
@@ -37,6 +41,8 @@ def virt_special_infra_sanity(
     sriov_workers,
     workers,
     nodes_cpu_virt_extension,
+    workers_utility_pods,
+    allocatable_memory_per_node_scope_session,
 ):
     """Performs verification that cluster has all required capabilities based on collected tests."""
 
@@ -100,6 +106,24 @@ def virt_special_infra_sanity(
         if not access_modes or access_modes[0] != DataVolume.AccessMode.RWX:
             failed_verifications_list.append(f"Default storage class {storage_class} doesn't support RWX mode")
 
+    def _verify_descheduler_operator_installed():
+        descheduler_deployment = Deployment(
+            name="descheduler-operator",
+            namespace=NamespacesNames.OPENSHIFT_KUBE_DESCHEDULER_OPERATOR,
+            client=admin_client,
+        )
+        if not descheduler_deployment.exists or descheduler_deployment.instance.status.readyReplicas == 0:
+            failed_verifications_list.append("kube-descheduler operator is not working on the cluster")
+
+    def _verify_if_1tb_memory_or_more_node(_memory_per_node):
+        """
+        Descheduler tests should run on nodes with less than 1Tb of memory.
+        """
+        upper_memory_limit = bitmath.TiB(value=1)
+        for node, memory in _memory_per_node.items():
+            if memory >= upper_memory_limit:
+                failed_verifications_list.append(f"Cluster has node with more than 1Tb of memory: {node.name}")
+
     skip_virt_sanity_check = "--skip-virt-sanity-check"
     failed_verifications_list = []
 
@@ -121,6 +145,9 @@ def virt_special_infra_sanity(
             _verify_hugepages_1gi(_workers=workers)
         if any(item.get_closest_marker("rwx_default_storage") for item in request.session.items):
             _verify_rwx_default_storage()
+        if any(item.get_closest_marker("descheduler") for item in request.session.items):
+            _verify_descheduler_operator_installed()
+            _verify_if_1tb_memory_or_more_node(_memory_per_node=allocatable_memory_per_node_scope_session)
     else:
         LOGGER.warning(f"Skipping virt special infra sanity because {skip_virt_sanity_check} was passed")
 
@@ -231,3 +258,8 @@ def non_existent_mdev_bus_nodes(workers_utility_pods, vgpu_ready_nodes):
                 "Ensure that in 'nvidia-gpu-operator' namespace nvidia-vgpu-manager-daemonset Pod is Running."
             )
         )
+
+
+@pytest.fixture(scope="session")
+def allocatable_memory_per_node_scope_session(schedulable_nodes):
+    return get_allocatable_memory_per_node(schedulable_nodes=schedulable_nodes)

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -15,10 +15,10 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.tier3,
+    pytest.mark.descheduler,
     pytest.mark.post_upgrade,
     pytest.mark.usefixtures(
-        "skip_if_1tb_memory_or_more_node",
-        "installed_descheduler",
+        "descheduler_long_lifecycle_profile",
     ),
 ]
 
@@ -26,7 +26,7 @@ NO_MIGRATION_STORM_ASSERT_MESSAGE = "Verify no migration storm after triggered m
 
 
 @pytest.mark.parametrize(
-    "calculated_vm_deployment_for_node_drain_test",
+    "calculated_vm_deployment_for_descheduler_test",
     [pytest.param(0.50)],
     indirect=True,
 )
@@ -38,12 +38,12 @@ class TestDeschedulerEvictsVMAfterDrainUncordon:
     def test_descheduler_evicts_vm_after_drain_uncordon(
         self,
         schedulable_nodes,
-        deployed_vms_for_node_drain,
+        deployed_vms_for_descheduler_test,
         vms_started_process_for_node_drain,
         drain_uncordon_node,
     ):
         assert_vms_distribution_after_failover(
-            vms=deployed_vms_for_node_drain,
+            vms=deployed_vms_for_descheduler_test,
             nodes=schedulable_nodes,
         )
 
@@ -54,21 +54,21 @@ class TestDeschedulerEvictsVMAfterDrainUncordon:
     @pytest.mark.polarion("CNV-7316")
     def test_no_migrations_storm(
         self,
-        deployed_vms_for_node_drain,
+        deployed_vms_for_descheduler_test,
         completed_migrations,
     ):
         LOGGER.info(NO_MIGRATION_STORM_ASSERT_MESSAGE)
-        assert_vms_consistent_virt_launcher_pods(running_vms=deployed_vms_for_node_drain)
+        assert_vms_consistent_virt_launcher_pods(running_vms=deployed_vms_for_descheduler_test)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::test_no_migrations_storm"])
     @pytest.mark.polarion("CNV-8288")
     def test_running_process_after_migrations_complete(
         self,
-        deployed_vms_for_node_drain,
+        deployed_vms_for_descheduler_test,
         vms_started_process_for_node_drain,
     ):
         assert_running_process_after_failover(
-            vms_list=deployed_vms_for_node_drain,
+            vms_list=deployed_vms_for_descheduler_test,
             process_dict=vms_started_process_for_node_drain,
         )
 

--- a/tests/virt/node/descheduler/utils.py
+++ b/tests/virt/node/descheduler/utils.py
@@ -74,24 +74,6 @@ class VirtualMachineForDeschedulerTest(VirtualMachineForTests):
             metadata["annotations"]["descheduler.alpha.kubernetes.io/evict"] = "true"
 
 
-def get_allocatable_memory_per_node(schedulable_nodes):
-    """
-    Node capacity & allocatable statuses determine how much of a resource we can "request".
-    A node may or may not have any allocatable values set by the admin, in which case, we fall back to the capacity.
-    """
-    nodes_memory = {}
-    for node in schedulable_nodes:
-        # memory format does not include the Bytes suffix(e.g: 23514144Ki)
-        memory = getattr(
-            node.instance.status.allocatable,
-            "memory",
-            node.instance.status.capacity.memory,
-        )
-        nodes_memory[node] = bitmath.parse_string_unsafe(s=memory).to_KiB()
-        LOGGER.info(f"Node {node.name} has {nodes_memory[node].to_GiB()} of allocatable memory")
-    return nodes_memory
-
-
 def calculate_vm_deployment(
     available_memory_per_node,
     deployment_size,

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -637,6 +637,7 @@ class NamespacesNames:
     MACHINE_API_NAMESPACE = "machine-api-namespace"
     OPENSHIFT_VIRTUALIZATION_OS_IMAGES = "openshift-virtualization-os-images"
     WASP = "wasp"
+    OPENSHIFT_KUBE_DESCHEDULER_OPERATOR = "openshift-kube-descheduler-operator"
 
 
 # CNV supplemental-templates

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1545,16 +1545,6 @@ def get_nodes_cpu_architecture(nodes: list[Node]) -> str:
     return next(iter(nodes_cpu_arch))
 
 
-def verify_image_info(image_url, generated_pulled_secret, nodes_cpu_architecture):
-    LOGGER.info(f"Checking image {image_url} information.")
-    run_command(
-        command=shlex.split(
-            f"oc image info {image_url} "
-            f"--registry-config={generated_pulled_secret} --filter-by-os={nodes_cpu_architecture}"
-        ),
-    )
-
-
 @cache
 def cache_admin_client():
     return get_client()

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -14,7 +14,6 @@ from ocp_resources.cluster_operator import ClusterOperator
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.image_content_source_policy import ImageContentSourcePolicy
 from ocp_resources.image_digest_mirror_set import ImageDigestMirrorSet
-from ocp_resources.installplan import InstallPlan
 from ocp_resources.machine_config_pool import MachineConfigPool
 from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
@@ -469,20 +468,6 @@ def get_install_plan_from_subscription(subscription):
             f"Subscription: {subscription.name}, did not get updated with install plan: {pformat(subscription)}"
         )
         raise
-
-
-def wait_for_operator_install(admin_client, install_plan_name, namespace_name, subscription_name):
-    install_plan = InstallPlan(
-        client=admin_client,
-        name=install_plan_name,
-        namespace=namespace_name,
-    )
-    install_plan.wait_for_status(status=install_plan.Status.COMPLETE, timeout=TIMEOUT_5MIN)
-    wait_for_csv_successful_state(
-        admin_client=admin_client,
-        namespace_name=namespace_name,
-        subscription_name=subscription_name,
-    )
 
 
 def wait_for_csv_successful_state(admin_client, namespace_name, subscription_name):


### PR DESCRIPTION
Remove descheduler installation part
Update virt sanity: check kube-descheduler operator installed 
Add descheduler operator namespace to data collector 
Remove programmatic skip

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
