### PR TITLE
disable wffc gcp gcnv sc config

### DIFF
--- a/tests/global_config_gcp.py
+++ b/tests/global_config_gcp.py
@@ -15,7 +15,7 @@ storage_class_matrix = [
             "access_mode": DataVolume.AccessMode.RWX,
             "snapshot": True,
             "online_resize": True,
-            "wffc": True,
+            "wffc": False,
         }
     },
     {
@@ -24,7 +24,7 @@ storage_class_matrix = [
             "access_mode": DataVolume.AccessMode.RWX,
             "snapshot": True,
             "online_resize": True,
-            "wffc": True,
+            "wffc": False,
             "default": True,
         }
     },


### PR DESCRIPTION
##### Short description:
gcp & gcnv are both volumeBindingMode: Immediate
 so configuration need to be match 

##### More details:
since this storage class's are volumeBindingMode: Immediate 
then no wffc related test need to be run for those storageclass



##### What this PR does / why we need it:

we need this because we want to skip testing/runing WFFC test in T2 for those SC


##### Which issue(s) this PR fixes:
this fix's few T2 fails in test_wffc.py file 
we need to skip those in T2

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to set the `wffc` flag to `False` for specific storage classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->