### PR TITLE
Give the console password prompt grace time to appear

### DIFF
--- a/utilities/console.py
+++ b/utilities/console.py
@@ -5,6 +5,7 @@ import pexpect
 from timeout_sampler import TimeoutSampler
 
 from utilities.constants import (
+    TIMEOUT_1MIN,
     TIMEOUT_5MIN,
     VIRTCTL,
 )
@@ -55,7 +56,7 @@ class Console(object):
             LOGGER.info(f"{self.vm.name}: Using username {self.username}")
             self.child.sendline(self.username)
             if self.password:
-                self.child.expect("Password:")
+                self.child.expect("Password:", timeout=TIMEOUT_1MIN)
                 LOGGER.info(f"{self.vm.name}: Using password {self.password}")
                 self.child.sendline(self.password)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the console connection process to use a defined timeout when waiting for the password prompt, improving reliability during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->