### PR TITLE
tests, net: Move service-mesh helpers from net/utils to net/mesh/utils

### DIFF
--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -27,12 +27,11 @@ from tests.network.service_mesh.constants import (
     VERSION_2_DEPLOYMENT,
     VIRTUAL_SERVICE_TYPE,
 )
-from tests.network.service_mesh.utils import traffic_management_request
+from tests.network.service_mesh.utils import authentication_request, traffic_management_request
 from tests.network.utils import (
     FedoraVirtualMachineForServiceMesh,
     ServiceMeshDeployments,
     ServiceMeshDeploymentService,
-    authentication_request,
 )
 from utilities.constants import PORT_80, TIMEOUT_4MIN, TIMEOUT_10SEC
 from utilities.infra import add_scc_to_service_account, create_ns, label_project, unique_name

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -1,10 +1,10 @@
 import pytest
 
 from tests.network.service_mesh.utils import (
+    assert_authentication_request,
     assert_traffic_management_request,
     inbound_request,
 )
-from tests.network.utils import assert_authentication_request
 from utilities.virt import migrate_vm_and_verify
 
 pytestmark = pytest.mark.service_mesh

--- a/tests/network/service_mesh/utils.py
+++ b/tests/network/service_mesh/utils.py
@@ -1,12 +1,11 @@
 import logging
 
+import pexpect
 import pytest
 
-from tests.network.utils import (
-    assert_service_mesh_request,
-    run_console_command,
-)
-from utilities.constants import TIMEOUT_3MIN
+from tests.network.constants import SERVICE_MESH_PORT
+from utilities import console
+from utilities.constants import TIMEOUT_1MIN, TIMEOUT_3MIN
 
 LOGGER = logging.getLogger(__name__)
 
@@ -46,3 +45,54 @@ def inbound_request(vm, destination_address, destination_port):
     )
     with pytest.raises(AssertionError):
         assert_service_mesh_request(expected_output=expected_output, request_response=request_response)
+
+
+def authentication_request(vm, **kwargs):
+    """
+    Return server response to a request sent from VM console. This request allows testing client authentication.
+
+    Args:
+        vm (VirtualMachine): VM that will be used for console connection
+
+    Kwargs: ( Used to allow passing args from wait_service_mesh_components_convergence in service_mesh/conftest)
+        service (str): target svc dns name
+
+    Returns:
+        str: Server response
+    """
+    return run_console_command(
+        vm=vm,
+        command=f"curl http://{kwargs['service']}:{SERVICE_MESH_PORT}/ip",
+    )
+
+
+def assert_service_mesh_request(expected_output, request_response):
+    assert expected_output in request_response, (
+        f"Server response error.Expected output - {expected_output}received - {request_response}"
+    )
+
+
+def assert_authentication_request(vm, service_app_name):
+    # Envoy proxy IP
+    expected_output = "127.0.0.6"
+    request_response = authentication_request(vm=vm, service=service_app_name)
+    assert_service_mesh_request(expected_output=expected_output, request_response=request_response)
+
+
+def run_console_command(vm, command, timeout=TIMEOUT_1MIN):
+    """
+    Run a single command through a VM console.
+    """
+    prompt = r"\$ "
+    with console.Console(vm=vm, prompt=prompt) as vmc:
+        LOGGER.info(f"Execute {command} on {vm.name}")
+        try:
+            vmc.sendline(command)
+            vmc.expect(prompt, timeout=timeout)
+            return vmc.before
+        except pexpect.exceptions.TIMEOUT:
+            LOGGER.info(f"Timeout: {vmc.before}")
+            return vmc.before
+        except pexpect.exceptions.EOF:
+            LOGGER.info(f"EOF: {vmc.before}")
+            return vmc.before

--- a/tests/network/utils.py
+++ b/tests/network/utils.py
@@ -2,7 +2,6 @@ import logging
 import shlex
 from collections import OrderedDict
 
-import pexpect
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.deployment import Deployment
 from ocp_resources.node_network_state import NodeNetworkState
@@ -10,8 +9,7 @@ from ocp_resources.service import Service
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.network.constants import BRCNV, SERVICE_MESH_PORT
-from utilities import console
+from tests.network.constants import BRCNV
 from utilities.constants import (
     IPV4_STR,
     OS_FLAVOR_FEDORA,
@@ -272,57 +270,6 @@ def assert_nncp_successfully_configured(nncp):
     except TimeoutExpiredError:
         LOGGER.error(f"{nncp.name} is not {successfully_configured}, but rather {nncp.status}.")
         raise
-
-
-def authentication_request(vm, **kwargs):
-    """
-    Return server response to a request sent from VM console. This request allows testing client authentication.
-
-    Args:
-        vm (VirtualMachine): VM that will be used for console connection
-
-    Kwargs: ( Used to allow passing args from wait_service_mesh_components_convergence in service_mesh/conftest)
-        service (str): target svc dns name
-
-    Returns:
-        str: Server response
-    """
-    return run_console_command(
-        vm=vm,
-        command=f"curl http://{kwargs['service']}:{SERVICE_MESH_PORT}/ip",
-    )
-
-
-def assert_service_mesh_request(expected_output, request_response):
-    assert expected_output in request_response, (
-        f"Server response error.Expected output - {expected_output}received - {request_response}"
-    )
-
-
-def assert_authentication_request(vm, service_app_name):
-    # Envoy proxy IP
-    expected_output = "127.0.0.6"
-    request_response = authentication_request(vm=vm, service=service_app_name)
-    assert_service_mesh_request(expected_output=expected_output, request_response=request_response)
-
-
-def run_console_command(vm, command, timeout=TIMEOUT_1MIN):
-    """
-    Run a single command through a VM console.
-    """
-    prompt = r"\$ "
-    with console.Console(vm=vm, prompt=prompt) as vmc:
-        LOGGER.info(f"Execute {command} on {vm.name}")
-        try:
-            vmc.sendline(command)
-            vmc.expect(prompt, timeout=timeout)
-            return vmc.before
-        except pexpect.exceptions.TIMEOUT:
-            LOGGER.info(f"Timeout: {vmc.before}")
-            return vmc.before
-        except pexpect.exceptions.EOF:
-            LOGGER.info(f"EOF: {vmc.before}")
-            return vmc.before
 
 
 def vm_for_brcnv_tests(


### PR DESCRIPTION
##### What this PR does / why we need it:

Move service-mesh helpers from net/utils to the more specific net/mesh/utils.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities for service mesh authentication testing and console command execution with timeout handling.

* **Refactor**
  * Consolidated service mesh authentication and console command test utilities into a dedicated module for better organization.

* **Tests**
  * Updated test imports to reflect the new utility locations, improving consistency across service mesh tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->