### PR TITLE
Fix setting username and password for VMs from template

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1171,7 +1171,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         Returns:
             obj `VirtualMachine`: VM resource
         """
-        # Must be set here to get username and password for running VMs
+        # Must be set here to set VM flavor (used to set username and password)
         self.template_labels = labels
         self.os_flavor = self._extract_os_from_template()
 


### PR DESCRIPTION
##### Short description:
VM from template did not get the correct username and password as `flavor` was set too late in the flow.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the initialization process for virtual machine templates, ensuring attributes are set in a more logical order.
  * Enhanced consistency in how operating system information is handled during virtual machine creation and conversion to dictionary format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->