### PR TITLE
Add s390x test marker to observability tests

### DIFF
--- a/tests/observability/metrics/test_cdi_metrics.py
+++ b/tests/observability/metrics/test_cdi_metrics.py
@@ -22,6 +22,7 @@ def test_kubevirt_cdi_clone_pods_high_restart(
 
 
 @pytest.mark.polarion("CNV-10717")
+@pytest.mark.s390x
 def test_kubevirt_cdi_upload_pods_high_restart(
     prometheus,
     zero_upload_dv_restart_count,
@@ -35,6 +36,7 @@ def test_kubevirt_cdi_upload_pods_high_restart(
 
 
 @pytest.mark.polarion("CNV-11744")
+@pytest.mark.s390x
 def test_metric_kubevirt_cdi_storageprofile_info(prometheus, storage_class_labels_for_testing):
     expected_metric_labels_and_values(
         values_from_prometheus=get_metric_labels_non_empty_value(
@@ -57,6 +59,7 @@ def test_metric_kubevirt_cdi_storageprofile_info(prometheus, storage_class_label
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_kubevirt_cdi_operator_up(
     prometheus,
     disabled_virt_operator,

--- a/tests/observability/metrics/test_cnao_metrics.py
+++ b/tests/observability/metrics/test_cnao_metrics.py
@@ -24,6 +24,7 @@ class TestSSPMetrics:
         ],
         indirect=["cluster_network_addons_operator_scaled_down_and_up"],
     )
+    @pytest.mark.s390x
     def test_kubevirt_cnao_cr_ready(
         self,
         prometheus,

--- a/tests/observability/metrics/test_cpu_usage_metrics.py
+++ b/tests/observability/metrics/test_cpu_usage_metrics.py
@@ -37,6 +37,7 @@ class TestCpuUsageMetrics:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_vmi_non_empty_cpu_metrics(self, prometheus, query, running_metric_vm):
         wait_for_non_empty_metrics_value(
             prometheus=prometheus, metric_name=query.format(vm_name=running_metric_vm.name)

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -67,6 +67,7 @@ class TestVmiNodeCpuAffinityLinux:
         indirect=True,
     )
     @pytest.mark.polarion("CNV-7295")
+    @pytest.mark.s390x
     def test_kubevirt_vmi_node_cpu_affinity(self, prometheus, vm_from_template_scope_class):
         validate_vmi_node_cpu_affinity_with_prometheus(
             vm=vm_from_template_scope_class,
@@ -86,6 +87,7 @@ class TestVmiNodeCpuAffinityWindows:
 
 class TestVmNameInLabel:
     @pytest.mark.polarion("CNV-8582")
+    @pytest.mark.s390x
     def test_vm_name_in_virt_launcher_label(self, fedora_vm_without_name_in_label):
         """
         when VM created from vm.yaml,for the kind=VirtualMachine, doesn't have
@@ -104,6 +106,7 @@ class TestVmNameInLabel:
 class TestVirtHCOSingleStackIpv6:
     @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11740")
+    @pytest.mark.s390x
     def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus, ipv6_single_stack_cluster):
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/observability/metrics/test_instance_type_metrics.py
+++ b/tests/observability/metrics/test_instance_type_metrics.py
@@ -42,6 +42,7 @@ def running_rhel_vm_with_instance_type_and_preference(
 
 class TestInstanceType:
     @pytest.mark.polarion("CNV-10181")
+    @pytest.mark.s390x
     def test_verify_instancetype_labels(
         self,
         prometheus,
@@ -58,6 +59,7 @@ class TestInstanceType:
         )
 
     @pytest.mark.polarion("CNV-10182")
+    @pytest.mark.s390x
     def test_verify_migrated_instancetype_labels(
         self,
         prometheus,
@@ -125,6 +127,7 @@ class TestInstanceType:
 )
 class TestInstanceTypeLabling:
     @pytest.mark.polarion("CNV-10183")
+    @pytest.mark.s390x
     def test_kubevirt_vmi_phase_count_cloned_instance_types(
         self,
         prometheus,
@@ -141,6 +144,7 @@ class TestInstanceTypeLabling:
         )
 
     @pytest.mark.polarion("CNV-10797")
+    @pytest.mark.s390x
     def test_cnv_vmi_status_running_count_cloned_instance_types(
         self,
         prometheus,

--- a/tests/observability/metrics/test_key_metrics.py
+++ b/tests/observability/metrics/test_key_metrics.py
@@ -97,6 +97,7 @@ class TestKeyMetrics:
         ],
         indirect=["vm_metrics_setup", "node_setup"],
     )
+    @pytest.mark.s390x
     def test_key_metric_active(self, node_setup, vm_metrics_setup, query, prometheus):
         """
         Tests that validates various metrics are present and our ability to make prometheus cli queries for them. These

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -24,6 +24,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
 class TestMetricsLinux:
     @pytest.mark.polarion("CNV-11906")
+    @pytest.mark.s390x
     def test_cnv_vmi_monitoring_metrics_linux_vm(
         self, prometheus, single_metric_vm, cnv_vmi_monitoring_metrics_matrix__function__
     ):
@@ -57,6 +58,7 @@ class TestMetricsWindows:
 
 
 @pytest.mark.polarion("CNV-10438")
+@pytest.mark.s390x
 def test_cnv_installation_with_hco_cr_metrics(
     prometheus,
 ):
@@ -68,6 +70,7 @@ def test_cnv_installation_with_hco_cr_metrics(
 
 class TestVMIMetricsLinuxVms:
     @pytest.mark.polarion("CNV-8262")
+    @pytest.mark.s390x
     def test_vmi_domain_total_memory_bytes(
         self,
         single_metric_vm,
@@ -81,6 +84,7 @@ class TestVMIMetricsLinuxVms:
         )
 
     @pytest.mark.polarion("CNV-8931")
+    @pytest.mark.s390x
     def test_vmi_used_memory_bytes(
         self,
         prometheus,
@@ -90,6 +94,7 @@ class TestVMIMetricsLinuxVms:
         wait_vmi_dommemstat_match_with_metric_value(prometheus=prometheus, vm=single_metric_vm)
 
     @pytest.mark.polarion("CNV-11400")
+    @pytest.mark.s390x
     def test_kubevirt_vmi_info(self, prometheus, single_metric_vm, vmi_guest_os_kernel_release_info_linux):
         compare_kubevirt_vmi_info_metric_with_vm_info(
             prometheus=prometheus,
@@ -99,6 +104,7 @@ class TestVMIMetricsLinuxVms:
         )
 
     @pytest.mark.polarion("CNV-11862")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_info(self, prometheus, single_metric_vm, linux_vm_info_to_compare):
         compare_kubevirt_vmi_info_metric_with_vm_info(
             prometheus=prometheus,
@@ -187,6 +193,7 @@ class TestMemoryDeltaFromRequestedBytes:
             ),
         ],
     )
+    @pytest.mark.s390x
     def test_memory_delta_from_requested_bytes(self, prometheus, admin_client, hco_namespace, metric, rss):
         validate_memory_delta_metrics_value_within_range(
             prometheus=prometheus,
@@ -199,6 +206,7 @@ class TestMemoryDeltaFromRequestedBytes:
 
 class TestKubeDaemonsetStatusNumberReady:
     @pytest.mark.polarion("CNV-11727")
+    @pytest.mark.s390x
     def test_kube_daemonset_status_number_ready(self, prometheus, virt_handler_pods_count):
         validate_metrics_value(
             prometheus=prometheus,
@@ -209,6 +217,7 @@ class TestKubeDaemonsetStatusNumberReady:
 
 class TestKubevirtApiRequestDeprecatedTotal:
     @pytest.mark.polarion("CNV-11739")
+    @pytest.mark.s390x
     def test_metric_kubevirt_api_request_deprecated_total(self, prometheus, generated_api_deprecated_requests):
         validate_metrics_value(
             prometheus=prometheus,
@@ -219,6 +228,7 @@ class TestKubevirtApiRequestDeprecatedTotal:
 
 class TestAllocatableNodes:
     @pytest.mark.polarion("CNV-11818")
+    @pytest.mark.s390x
     def test_metirc_kubevirt_allocatable_nodes(self, prometheus, allocatable_nodes):
         validate_metrics_value(
             prometheus=prometheus, metric_name="kubevirt_allocatable_nodes", expected_value=f"{len(allocatable_nodes)}"

--- a/tests/observability/metrics/test_metrics_cpu.py
+++ b/tests/observability/metrics/test_metrics_cpu.py
@@ -12,16 +12,19 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 @pytest.mark.usefixtures("initial_metric_cpu_value_zero")
 class TestMetricsCpu:
     @pytest.mark.polarion("CNV-9649")
+    @pytest.mark.s390x
     def test_verify_metrics_vmi_request_cpu_sum(self, prometheus, running_metric_vm):
         wait_for_metric_vmi_request_cpu_cores_output(prometheus=prometheus, expected_cpu=ONE_CPU_CORES)
 
     @pytest.mark.polarion("CNV-9653")
     @pytest.mark.order(after="test_verify_metrics_vmi_request_cpu_sum")
+    @pytest.mark.s390x
     def test_verify_metrics_stopped_vm(self, prometheus, stopped_metrics_vm):
         wait_for_metric_vmi_request_cpu_cores_output(prometheus=prometheus, expected_cpu=ZERO_CPU_CORES)
 
     @pytest.mark.polarion("CNV-9652")
     @pytest.mark.order(after="test_verify_metrics_stopped_vm")
+    @pytest.mark.s390x
     def test_verify_metrics_paused_vm(
         self,
         prometheus,
@@ -34,5 +37,6 @@ class TestMetricsCpu:
 @pytest.mark.usefixtures("initial_metric_cpu_value_zero")
 class TestMetricsCpuErrorState:
     @pytest.mark.polarion("CNV-9654")
+    @pytest.mark.s390x
     def test_verify_metrics_error_state_vm(self, prometheus, error_state_vm):
         wait_for_metric_vmi_request_cpu_cores_output(prometheus=prometheus, expected_cpu=ZERO_CPU_CORES)

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -24,6 +24,7 @@ LOGGER = logging.getLogger(__name__)
 
 class TestMigrationMetrics:
     @pytest.mark.polarion("CNV-8480")
+    @pytest.mark.s390x
     def test_migration_metrics_scheduling(
         self,
         admin_client,
@@ -41,6 +42,7 @@ class TestMigrationMetrics:
         )
 
     @pytest.mark.polarion("CNV-8481")
+    @pytest.mark.s390x
     def test_migration_metrics_running(
         self,
         prometheus,
@@ -81,6 +83,7 @@ class TestKubevirtVmiMigrationMetrics:
         ],
     )
     @pytest.mark.jira("CNV-57777", run=False)
+    @pytest.mark.s390x
     def test_kubevirt_vmi_migration_metrics(
         self,
         prometheus,
@@ -106,6 +109,7 @@ class TestKubevirtVmiMigrationMetrics:
 
 class TestKubevirtVmiMigrationStartAndEnd:
     @pytest.mark.polarion("CNV-11809")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vmi_migration_start_time_seconds(
         self,
         prometheus,
@@ -123,6 +127,7 @@ class TestKubevirtVmiMigrationStartAndEnd:
         )
 
     @pytest.mark.polarion("CNV-11810")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vmi_migration_end_time_seconds(
         self,
         prometheus,

--- a/tests/observability/metrics/test_network_metrics.py
+++ b/tests/observability/metrics/test_network_metrics.py
@@ -38,6 +38,7 @@ class TestVmiNetworkMetricsLinux:
         ],
         indirect=False,
     )
+    @pytest.mark.s390x
     def test_kubevirt_vmi_network_receive_and_transmit_packets_total(
         self, prometheus, metric_dict, vm_for_test, linux_vm_for_test_interface_name, generated_network_traffic
     ):
@@ -49,6 +50,7 @@ class TestVmiNetworkMetricsLinux:
         )
 
     @pytest.mark.polarion("CNV-11177")
+    @pytest.mark.s390x
     def test_kubevirt_vmi_network_traffic_bytes_total(
         self, prometheus, vm_for_test, linux_vm_for_test_interface_name, generated_network_traffic
     ):

--- a/tests/observability/metrics/test_prometheus_service_monitor.py
+++ b/tests/observability/metrics/test_prometheus_service_monitor.py
@@ -21,10 +21,12 @@ def kubevirt_service_monitor_namespace(kubevirt_hyperconverged_spec_scope_functi
 
 class TestPrometheusServiceMonitor:
     @pytest.mark.polarion("CNV-9287")
+    @pytest.mark.s390x
     def test_kubevirt_service_monitor_namespace(self, kubevirt_service_monitor_namespace, hco_namespace):
         assert kubevirt_service_monitor_namespace == hco_namespace.name
 
     @pytest.mark.polarion("CNV-9264")
+    @pytest.mark.s390x
     def test_prometheus_service_monitor_in_our_namespace(
         self,
         kubevirt_prometheus_service_monitor_list,

--- a/tests/observability/metrics/test_recording_rules.py
+++ b/tests/observability/metrics/test_recording_rules.py
@@ -50,6 +50,7 @@ KUBEVIRT_VIRT_CONTROLLER_UP = "kubevirt_virt_controller_up"
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_virt_recording_rules(
     prometheus,
     admin_client,
@@ -97,6 +98,7 @@ def test_virt_recording_rules(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_virt_up_recording_rules(
     prometheus,
     admin_client,

--- a/tests/observability/metrics/test_ssp_metrics.py
+++ b/tests/observability/metrics/test_ssp_metrics.py
@@ -61,6 +61,7 @@ def created_multiple_failed_vms(
 
 class TestSSPTemplate:
     @pytest.mark.polarion("CNV-11356")
+    @pytest.mark.s390x
     def test_metric_kubevirt_ssp_common_templates_restored_increase(self, prometheus, template_modified):
         validate_metric_value_within_range(
             prometheus=prometheus,
@@ -84,6 +85,7 @@ class TestSSPTemplate:
         ],
         indirect=["scaled_deployment"],
     )
+    @pytest.mark.s390x
     def test_metrics_kubevirt_ssp_operator_validator_up(
         self, prometheus, paused_ssp_operator, scaled_deployment, metric_name
     ):
@@ -94,6 +96,7 @@ class TestSSPTemplate:
         )
 
     @pytest.mark.polarion("CNV-11357")
+    @pytest.mark.s390x
     def test_metric_kubevirt_ssp_operator_reconcile_succeeded_aggregated(
         self, prometheus, paused_ssp_operator, template_validator_finalizer, deleted_ssp_operator_pod
     ):
@@ -121,6 +124,7 @@ class TestSSPTemplate:
 @pytest.mark.usefixtures("initiate_metric_value", "instance_type_for_test_scope_class", "created_multiple_failed_vms")
 class TestSSPTemplateValidatorRejected:
     @pytest.mark.polarion("CNV-11310")
+    @pytest.mark.s390x
     def test_metric_kubevirt_ssp_template_validator_rejected_increase(self, prometheus, initiate_metric_value):
         validate_metric_value_with_round_down(
             prometheus=prometheus,

--- a/tests/observability/metrics/test_total_created_vms.py
+++ b/tests/observability/metrics/test_total_created_vms.py
@@ -7,6 +7,7 @@ from utilities.constants import RHEL_WITH_INSTANCETYPE_AND_PREFERENCE
 
 class TestTotalCreatedInstanceType:
     @pytest.mark.polarion("CNV-10771")
+    @pytest.mark.s390x
     def test_kubevirt_vm_created_total_instance_type(
         self, prometheus, namespace, initial_total_created_vms, rhel_vm_with_instancetype_and_preference_for_cloning
     ):
@@ -26,6 +27,7 @@ class TestTotalCreatedInstanceType:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_kubevirt_vm_created_total_cloned_instancetype(
         self,
         prometheus,

--- a/tests/observability/metrics/test_version_metrics.py
+++ b/tests/observability/metrics/test_version_metrics.py
@@ -23,6 +23,7 @@ def virtctl_go_kube_server_version():
 
 
 @pytest.mark.polarion("CNV-11017")
+@pytest.mark.s390x
 def test_kubevirt_info_version(prometheus, virtctl_go_kube_server_version):
     metric_result_output = prometheus.query_sampler(query="kubevirt_info")
     assert_virtctl_version_equal_metric_output(

--- a/tests/observability/metrics/test_virt_resource_mutation_metrics.py
+++ b/tests/observability/metrics/test_virt_resource_mutation_metrics.py
@@ -216,6 +216,7 @@ COMPONENT_CONFIG = {
     ],
 )
 @pytest.mark.dependency(name="test_metric_invalid_change")
+@pytest.mark.s390x
 def test_metric_invalid_change(
     prometheus,
     mutation_count_before_change,
@@ -336,6 +337,7 @@ def test_metric_invalid_change(
     ],
 )
 @pytest.mark.dependency(name="test_metric_multiple_invalid_change")
+@pytest.mark.s390x
 def test_metric_multiple_invalid_change(
     prometheus,
     mutation_count_before_change,

--- a/tests/observability/metrics/test_vm_template_metrics.py
+++ b/tests/observability/metrics/test_vm_template_metrics.py
@@ -36,6 +36,7 @@ SUM_QUERY = f"sum({METRIC_QUERY})"
 class TestVmTemplateMetrics:
     @pytest.mark.polarion("CNV-6504")
     @pytest.mark.dependency(name="test_vmi_phase_count_metric")
+    @pytest.mark.s390x
     def test_vmi_phase_count_metric(
         self,
         prometheus,
@@ -53,6 +54,7 @@ class TestVmTemplateMetrics:
     @pytest.mark.dependency(
         depends=["test_vmi_phase_count_metric"],
     )
+    @pytest.mark.s390x
     def test_vmi_phase_count_metric_after_stopped_vm(
         self,
         prometheus,

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -187,6 +187,7 @@ def check_vmi_count_metric(expected_vmi_count, prometheus):
 
 class TestVMICountMetric:
     @pytest.mark.polarion("CNV-3048")
+    @pytest.mark.s390x
     def test_vmi_count_metric_increase(
         self,
         prometheus,
@@ -197,6 +198,7 @@ class TestVMICountMetric:
         assert check_vmi_count_metric(number_of_running_vmis + 2, prometheus)
 
     @pytest.mark.polarion("CNV-3589")
+    @pytest.mark.s390x
     def test_vmi_count_metric_decrease(
         self,
         prometheus,
@@ -210,6 +212,7 @@ class TestVMICountMetric:
 
 class TestVMStatusLastTransitionMetrics:
     @pytest.mark.polarion("CNV-9661")
+    @pytest.mark.s390x
     def test_vm_running_status_metrics(self, prometheus, vm_metric_1):
         check_vm_last_transition_metric_value(
             prometheus=prometheus,
@@ -218,6 +221,7 @@ class TestVMStatusLastTransitionMetrics:
         )
 
     @pytest.mark.polarion("CNV-9662")
+    @pytest.mark.s390x
     def test_vm_error_status_metrics(self, prometheus, vm_in_error_state):
         check_vm_last_transition_metric_value(
             prometheus=prometheus,
@@ -226,6 +230,7 @@ class TestVMStatusLastTransitionMetrics:
         )
 
     @pytest.mark.polarion("CNV-9665")
+    @pytest.mark.s390x
     def test_vm_migrating_status_metrics(
         self, skip_if_no_common_cpu, prometheus, vm_metric_1, migration_policy_with_bandwidth, vm_metric_1_vmim
     ):
@@ -236,6 +241,7 @@ class TestVMStatusLastTransitionMetrics:
         )
 
     @pytest.mark.polarion("CNV-9664")
+    @pytest.mark.s390x
     def test_vm_non_running_status_metrics(self, prometheus, vm_metric_1, stopped_vm_metric_1):
         check_vm_last_transition_metric_value(
             prometheus=prometheus,
@@ -244,6 +250,7 @@ class TestVMStatusLastTransitionMetrics:
         )
 
     @pytest.mark.polarion("CNV-9751")
+    @pytest.mark.s390x
     def test_vm_starting_status_metrics(self, prometheus, vm_in_starting_state):
         check_vm_last_transition_metric_value(
             prometheus=prometheus,
@@ -260,6 +267,7 @@ class TestVMStatusLastTransitionMetrics:
 @pytest.mark.usefixtures("vm_for_test")
 class TestVmConsolesAndVmCreateDateTimestampMetrics:
     @pytest.mark.polarion("CNV-11024")
+    @pytest.mark.s390x
     def test_kubevirt_console_active_connections(self, prometheus, vm_for_test, connected_vm_console_successfully):
         validate_metrics_value(
             prometheus=prometheus,
@@ -268,6 +276,7 @@ class TestVmConsolesAndVmCreateDateTimestampMetrics:
         )
 
     @pytest.mark.polarion("CNV-10842")
+    @pytest.mark.s390x
     def test_kubevirt_vnc_active_connections(self, prometheus, vm_for_test, connected_vnc_console):
         validate_metrics_value(
             prometheus=prometheus,
@@ -276,6 +285,7 @@ class TestVmConsolesAndVmCreateDateTimestampMetrics:
         )
 
     @pytest.mark.polarion("CNV-11805")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_create_date_timestamp_seconds(self, prometheus, vm_for_test):
         validate_metrics_value(
             prometheus=prometheus,
@@ -290,6 +300,7 @@ class TestVmiMemoryCachedBytes:
         [pytest.param("test-vm-memory-cached", marks=pytest.mark.polarion("CNV-11031"))],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_kubevirt_vmi_memory_cached_bytes(
         self,
         prometheus,
@@ -323,6 +334,7 @@ class TestVmiFileSystemMetricsLinux:
         ],
         indirect=["file_system_metric_mountpoints_existence"],
     )
+    @pytest.mark.s390x
     def test_metric_kubevirt_vmi_filesystem_capacity_used_bytes_linux(
         self,
         prometheus,
@@ -377,6 +389,7 @@ class TestVmiMemoryAvailableBytes:
         [pytest.param("available-mem-test", marks=pytest.mark.polarion("CNV-11497"))],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_kubevirt_vmi_memory_available_bytes(self, prometheus, vm_for_test, vmi_memory_available_memory):
         validate_metric_value_within_range(
             prometheus=prometheus,
@@ -388,6 +401,7 @@ class TestVmiMemoryAvailableBytes:
 @pytest.mark.usefixtures("vm_with_cpu_spec")
 class TestVmResourceRequests:
     @pytest.mark.polarion("CNV-11521")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_resource_requests(
         self,
         prometheus,
@@ -407,6 +421,7 @@ class TestVmiStatusAddresses:
     @pytest.mark.parametrize(
         "vm_for_test", [pytest.param("vmi-status-addresses", marks=pytest.mark.polarion("CNV-11534"))], indirect=True
     )
+    @pytest.mark.s390x
     def test_metric_kubevirt_vmi_status_addresses(
         self,
         prometheus,
@@ -427,6 +442,7 @@ class TestVmSnapshotSucceededTimeStamp:
     @pytest.mark.parametrize(
         "vm_for_test", [pytest.param("vm-snapshot-test", marks=pytest.mark.polarion("CNV-11536"))], indirect=True
     )
+    @pytest.mark.s390x
     def test_metric_kubevirt_vmsnapshot_succeeded_timestamp_seconds(
         self, prometheus, vm_for_test, vm_for_test_snapshot
     ):
@@ -439,6 +455,7 @@ class TestVmSnapshotSucceededTimeStamp:
 
 class TestVmResourceLimits:
     @pytest.mark.polarion("CNV-11601")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_resource_limits(
         self, prometheus, cnv_vm_resources_limits_matrix__function__, vm_for_test_with_resource_limits
     ):
@@ -458,6 +475,7 @@ class TestVmResourceLimits:
 @pytest.mark.parametrize("vm_for_test", [pytest.param("memory-working-set-vm")], indirect=True)
 class TestVmFreeMemoryBytes:
     @pytest.mark.polarion("CNV-11692")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_container_free_memory_bytes_based_on_working_set_bytes(self, prometheus, vm_for_test):
         validate_metric_vm_container_free_memory_bytes_based_on_working_set_rss_bytes(
             prometheus=prometheus,
@@ -468,6 +486,7 @@ class TestVmFreeMemoryBytes:
         )
 
     @pytest.mark.polarion("CNV-11693")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_container_free_memory_bytes_based_on_rss(
         self,
         prometheus,
@@ -505,6 +524,7 @@ class TestKubevirtVmiNonEvictable:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_kubevirt_vmi_non_evictable(
         self,
         prometheus,
@@ -520,6 +540,7 @@ class TestKubevirtVmiNonEvictable:
 
 class TestVmSnapshotPersistentVolumeClaimLabels:
     @pytest.mark.polarion("CNV-11762")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vmsnapshot_persistentvolumeclaim_labels(
         self,
         prometheus,
@@ -540,6 +561,7 @@ class TestVmSnapshotPersistentVolumeClaimLabels:
 
 class TestVmDiskAllocatedSizeLinux:
     @pytest.mark.polarion("CNV-11817")
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_disk_allocated_size_bytes(
         self,
         prometheus,
@@ -580,6 +602,7 @@ class TestVmVnicInfo:
         ],
         indirect=["vnic_info_from_vm_or_vmi"],
     )
+    @pytest.mark.s390x
     def test_metric_kubevirt_vm_vnic_info(self, prometheus, running_metric_vm, vnic_info_from_vm_or_vmi, query):
         validate_vnic_info(
             prometheus=prometheus,

--- a/tests/observability/network/test_cnao_observability.py
+++ b/tests/observability/network/test_cnao_observability.py
@@ -11,6 +11,7 @@ from utilities.constants import CLUSTER_NETWORK_ADDONS_OPERATOR, TIMEOUT_5MIN
 
 class TestCnaoDown:
     @pytest.mark.polarion("CNV-11302")
+    @pytest.mark.s390x
     def test_metric_kubevirt_cnao_operator_up(
         self, prometheus, disabled_virt_operator, wait_csv_image_updated_with_bad_image
     ):
@@ -27,6 +28,7 @@ class TestCnaoDown:
 )
 class TestDuplicateMacs:
     @pytest.mark.polarion("CNV-11304")
+    @pytest.mark.s390x
     def test_metric_kubevirt_cnao_kubemacpool_duplicate_macs(self, prometheus):
         validate_metrics_value(
             prometheus=prometheus,
@@ -38,6 +40,7 @@ class TestDuplicateMacs:
 @pytest.mark.usefixtures("updated_cnao_kubemacpool_with_bad_image_csv")
 class TestKubeMacPool:
     @pytest.mark.polarion("CNV-11305")
+    @pytest.mark.s390x
     def test_metric_kubevirt_cnao_kubemacpool_manager_up(self, prometheus):
         validate_metrics_value(
             prometheus=prometheus,
@@ -55,6 +58,7 @@ class TestKubeMacPool:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_metric_kubevirt_cnao_cr_kubemacpool_aggregated(self, prometheus, scaled_deployment):
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/observability/runbook_url/test_runbook_url.py
+++ b/tests/observability/runbook_url/test_runbook_url.py
@@ -23,6 +23,7 @@ def cnv_prometheus_rules_names(hco_namespace):
 
 
 @pytest.mark.polarion("CNV-10081")
+@pytest.mark.s390x
 def test_no_new_prometheus_rules(cnv_prometheus_rules_names):
     """
     Since validations for runbook url of all cnv alerts are done via polarion parameterization of prometheusrules,
@@ -48,6 +49,7 @@ def cnv_prometheus_rules_unique_alert_names_runbook(cnv_alerts_from_prometheus_r
 
 
 @pytest.mark.polarion("CNV-10083")
+@pytest.mark.s390x
 def test_runbook_upstream_urls(cnv_prometheus_rules_unique_alert_names_runbook):
     url_not_reachable = {}
     for alert_name in cnv_prometheus_rules_unique_alert_names_runbook.keys():
@@ -64,6 +66,7 @@ def test_runbook_upstream_urls(cnv_prometheus_rules_unique_alert_names_runbook):
 
 
 @pytest.mark.polarion("CNV-10084")
+@pytest.mark.s390x
 def test_runbook_downstream_urls(cnv_prometheus_rules_unique_alert_names_runbook):
     error_messages = []
     alerts_without_runbook = {}

--- a/tests/observability/storage/test_hpp_observability.py
+++ b/tests/observability/storage/test_hpp_observability.py
@@ -21,6 +21,7 @@ class TestHPPSharingPoolPathWithOS:
 
     @pytest.mark.dependency(name=TEST_HPP_POOL_NAME)
     @pytest.mark.polarion("CNV-11221")
+    @pytest.mark.s390x
     def test_kubevirt_hpp_pool_path_shared_path_metric(self, prometheus):
         validate_metrics_value(
             prometheus=prometheus,
@@ -46,6 +47,7 @@ class TestHPPSharingPoolPathWithOS:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_hpp_sharing_pool_path_alert(self, prometheus, alert_tested):
         validate_alerts(
             prometheus=prometheus,
@@ -62,6 +64,7 @@ class TestHPPSharingPoolPathWithOS:
 @pytest.mark.usefixtures("disabled_virt_operator", "scaled_deployment_scope_class")
 class TestHPPOperatorUpMetric:
     @pytest.mark.polarion("CNV-10435")
+    @pytest.mark.s390x
     def test_kubevirt_hpp_operator_up_metric(
         self,
         prometheus,
@@ -75,6 +78,7 @@ class TestHPPOperatorUpMetric:
 
 class TestHPPCrReady:
     @pytest.mark.polarion("CNV-11022")
+    @pytest.mark.s390x
     def test_kubevirt_hpp_cr_ready_metric(self, prometheus, modified_hpp_non_exist_node_selector):
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/observability/test_healthy_cluster_no_alerts.py
+++ b/tests/observability/test_healthy_cluster_no_alerts.py
@@ -5,6 +5,7 @@ from tests.observability.utils import verify_no_listed_alerts_on_cluster
 
 
 @pytest.mark.polarion("CNV-7610")
+@pytest.mark.s390x
 @pytest.mark.order(0)
 def test_no_virt_alerts_on_healthy_cluster(
     prometheus,
@@ -13,6 +14,7 @@ def test_no_virt_alerts_on_healthy_cluster(
 
 
 @pytest.mark.polarion("CNV-7612")
+@pytest.mark.s390x
 @pytest.mark.order(1)
 def test_no_ssp_alerts_on_healthy_cluster(
     prometheus,

--- a/tests/observability/virt/test_virt_controller_ready.py
+++ b/tests/observability/virt/test_virt_controller_ready.py
@@ -16,5 +16,6 @@ class TestVirtControllerReady:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_metric_kubevirt_virt_controller_ready(self, prometheus, scaled_deployment):
         validate_metrics_value(prometheus=prometheus, metric_name="kubevirt_virt_controller_ready", expected_value="0")

--- a/tests/observability/virt/test_virt_metrics_alerts.py
+++ b/tests/observability/virt/test_virt_metrics_alerts.py
@@ -53,6 +53,7 @@ class TestLowReadyVirtOperatorCount:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_alert_low_virt_operator_count(
         self,
         prometheus,
@@ -86,6 +87,7 @@ class TestVirtPodsDownMetrics:
         ],
         indirect=["scaled_deployment"],
     )
+    @pytest.mark.s390x
     def test_metrics_virt_pods_down(
         self,
         prometheus,
@@ -116,6 +118,7 @@ class TestVirtHandlerDaemonSet:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_alert_virt_handler(
         self,
         prometheus,
@@ -134,6 +137,7 @@ class TestVirtHandlerDaemonSet:
 class TestLowKvmCounts:
     @pytest.mark.dependency(name="test_metric_kubevirt_nodes_with_kvm")
     @pytest.mark.polarion("CNV-11708")
+    @pytest.mark.s390x
     def test_metric_kubevirt_nodes_with_kvm(self, prometheus):
         validate_metrics_value(
             prometheus=prometheus,
@@ -158,6 +162,7 @@ class TestLowKvmCounts:
             )
         ],
     )
+    @pytest.mark.s390x
     def test_low_kvm_nodes_count(
         self,
         prometheus,


### PR DESCRIPTION
##### Short description:
This change adds the @pytest.mark.s390x marker to observability test functions and methods across multiple test files. This marker enables execution on the s390x architecture without modifying test logic, parameters, or flow.

##### More details:
The marker helps identify tests relevant for the s390x environment. This is useful for running architecture-specific test suites as needed.

##### What this PR does / why we need it:
This PR adds s390x architecture-specific markers to identify tests that are relevant to the s390x platform. It allows better control over test execution when running observability tests in s390x environments.

##### Which issue(s) this PR fixes:
NONE
##### Special notes for reviewer:

##### jira-ticket:
NONE
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
