### PR TITLE
Use nodeAffinity instead of  nodeSelector in test VM specification.

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,6 @@ from ocp_resources.virtual_machine_instance_migration import VirtualMachineInsta
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.virt.utils import get_match_expressions_dict
 from utilities.constants import (
     DISK_SERIAL,
     HCO_DEFAULT_CPU_MODEL_KEY,
@@ -609,4 +608,3 @@ def create_cirros_vm(
         if wait_running:
             running_vm(vm=vm, wait_for_interfaces=False)
         yield vm
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,6 +22,7 @@ from ocp_resources.virtual_machine_instance_migration import VirtualMachineInsta
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.virt.utils import get_match_expressions_dict
 from utilities.constants import (
     DISK_SERIAL,
     HCO_DEFAULT_CPU_MODEL_KEY,
@@ -608,3 +609,4 @@ def create_cirros_vm(
         if wait_running:
             running_vm(vm=vm, wait_for_interfaces=False)
         yield vm
+

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -24,7 +24,7 @@ from tests.virt.node.descheduler.utils import (
     vms_per_nodes,
     wait_vmi_failover,
 )
-from tests.virt.utils import get_allocatable_memory_per_node, get_match_expressions_dict, start_stress_on_vm
+from tests.virt.utils import build_node_affinity_dict, get_allocatable_memory_per_node, start_stress_on_vm
 from utilities.constants import TIMEOUT_5SEC
 from utilities.infra import wait_for_pods_deletion
 from utilities.virt import (
@@ -215,16 +215,7 @@ def node_labeled_for_test(node_with_least_available_memory):
 
 @pytest.fixture(scope="class")
 def node_affinity_for_node_with_least_available_memory(node_with_least_available_memory):
-    return {
-        "nodeAffinity": {
-            "preferredDuringSchedulingIgnoredDuringExecution": [
-                {
-                    "preference": get_match_expressions_dict(nodes_list=[node_with_least_available_memory.hostname]),
-                    "weight": 1,
-                }
-            ]
-        }
-    }
+    return build_node_affinity_dict(preferred_nodes=[node_with_least_available_memory.hostname])
 
 
 @pytest.fixture(scope="class")

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -21,14 +21,13 @@ def unscheduled_node_vm(
     namespace,
     data_volume_scope_function,
 ):
-    vm_affinity = build_node_affinity(required_nodes=[worker_node1.hostname])
 
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_scope_function,
-        vm_affinity=vm_affinity,
+        vm_affinity=build_node_affinity(required_nodes=[worker_node1.hostname]),
     ) as vm:
         yield vm
 

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -2,14 +2,27 @@ import pytest
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
+from tests.virt.utils import get_match_expressions_dict
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
 from utilities.constants import TIMEOUT_20SEC
-from utilities.infra import get_node_selector_dict, get_node_selector_name
 from utilities.virt import (
     node_mgmt_console,
     vm_instance_from_template,
     wait_for_node_schedulable_status,
 )
+
+
+@pytest.fixture
+def required_affinity_for_worker_node(worker_node1):
+    return {
+        "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    get_match_expressions_dict([worker_node1.hostname])
+                ]
+            }
+        }
+    }
 
 
 @pytest.fixture()
@@ -20,16 +33,16 @@ def unscheduled_node_vm(
     unprivileged_client,
     namespace,
     data_volume_scope_function,
+    required_affinity_for_worker_node,
 ):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_scope_function,
-        node_selector=get_node_selector_dict(node_selector=worker_node1.name),
+        vm_affinity=required_affinity_for_worker_node,
     ) as vm:
         yield vm
-
 
 @pytest.mark.gating
 @pytest.mark.s390x
@@ -53,21 +66,22 @@ def unscheduled_node_vm(
     ],
     indirect=True,
 )
+
 @pytest.mark.polarion("CNV-4157")
-def test_schedule_vm_on_cordoned_node(nodes, data_volume_scope_function, unscheduled_node_vm):
+def test_schedule_vm_on_cordoned_node(nodes, data_volume_scope_function, unscheduled_node_vm, worker_node1):
     """Test VM scheduling on a node under maintenance.
-    1. Cordon the Node
-    2. Once node status is 'Ready,SchedulingDisabled', start a VM (on the
-    selected node) and check that VMI phase is 'scheduling'
-    3. Uncordon the Node
-    4. Verify the VMI phase is still 'scheduling'
-    5. Wait for node status to be 'Ready'
-    6. Wait for VMI status to be 'Running'
-    7. Verify VMI is running on the selected node
+    1. Cordon the target node specified in the VM's nodeAffinity (worker_node1).
+    2. Wait until the node status becomes 'Ready,SchedulingDisabled'.
+    3. Start the VM and verify that the VMI phase is 'Scheduling'.
+    4. Uncordon the node.
+    5. Ensure the VMI remains in 'Scheduling' phase after uncordoning.
+    6. Wait for the node status to return to 'Ready'.
+    7. Wait for the VMI phase to become 'Running'.
+    8. Verify that the VMI is running on the expected node (worker_node1).
     """
-    vm_node = [
-        node for node in nodes if node.name == get_node_selector_name(node_selector=unscheduled_node_vm.node_selector)
-    ][0]
+
+    vm_node = worker_node1  # Since we know affinity targets it
+
     with node_mgmt_console(node=vm_node, node_mgmt="cordon"):
         wait_for_node_schedulable_status(node=vm_node, status=False)
         unscheduled_node_vm.start()
@@ -75,5 +89,5 @@ def test_schedule_vm_on_cordoned_node(nodes, data_volume_scope_function, unsched
     unscheduled_node_vm.vmi.wait_for_status(status=VirtualMachineInstance.Status.RUNNING)
     vmi_node_name = unscheduled_node_vm.privileged_vmi.virt_launcher_pod.node.name
     assert vmi_node_name == vm_node.name, (
-        f"VMI is running on {vmi_node_name} and not on the selected node {unscheduled_node_vm.node_selector}"
+        f"VMI is running on {vmi_node_name} and not on the expected node {vm_node.name}"
     )

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -2,8 +2,8 @@ import pytest
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
-from tests.virt.utils import get_match_expressions_dict
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
+from tests.virt.utils import get_match_expressions_dict
 from utilities.constants import TIMEOUT_20SEC
 from utilities.virt import (
     node_mgmt_console,
@@ -17,9 +17,7 @@ def required_affinity_for_worker_node(worker_node1):
     return {
         "nodeAffinity": {
             "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                    get_match_expressions_dict([worker_node1.hostname])
-                ]
+                "nodeSelectorTerms": [get_match_expressions_dict([worker_node1.hostname])]
             }
         }
     }
@@ -44,6 +42,7 @@ def unscheduled_node_vm(
     ) as vm:
         yield vm
 
+
 @pytest.mark.gating
 @pytest.mark.s390x
 @pytest.mark.rwx_default_storage
@@ -66,7 +65,6 @@ def unscheduled_node_vm(
     ],
     indirect=True,
 )
-
 @pytest.mark.polarion("CNV-4157")
 def test_schedule_vm_on_cordoned_node(nodes, data_volume_scope_function, unscheduled_node_vm, worker_node1):
     """Test VM scheduling on a node under maintenance.

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -21,7 +21,6 @@ def unscheduled_node_vm(
     namespace,
     data_volume_scope_function,
 ):
-
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -3,7 +3,7 @@ from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
-from tests.virt.utils import build_node_affinity
+from tests.virt.utils import build_node_affinity_dict
 from utilities.constants import TIMEOUT_20SEC
 from utilities.virt import (
     node_mgmt_console,
@@ -26,7 +26,7 @@ def unscheduled_node_vm(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_scope_function,
-        vm_affinity=build_node_affinity(required_nodes=[worker_node1.hostname]),
+        vm_affinity=build_node_affinity_dict(required_nodes=[worker_node1.hostname]),
     ) as vm:
         yield vm
 

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -3,7 +3,7 @@ from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
-from tests.virt.utils import get_match_expressions_dict
+from tests.virt.utils import build_node_affinity
 from utilities.constants import TIMEOUT_20SEC
 from utilities.virt import (
     node_mgmt_console,
@@ -21,14 +21,7 @@ def unscheduled_node_vm(
     namespace,
     data_volume_scope_function,
 ):
-
-    vm_affinity = {
-        "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [get_match_expressions_dict([worker_node1.hostname])]
-            }
-        }
-    }
+    vm_affinity = build_node_affinity(required_nodes=[worker_node1.hostname])
 
     with vm_instance_from_template(
         request=request,
@@ -63,16 +56,15 @@ def unscheduled_node_vm(
     indirect=True,
 )
 @pytest.mark.polarion("CNV-4157")
-def test_schedule_vm_on_cordoned_node(nodes, data_volume_scope_function, unscheduled_node_vm, worker_node1):
+def test_schedule_vm_on_cordoned_node(worker_node1, data_volume_scope_function, unscheduled_node_vm):
     """Test VM scheduling on a node under maintenance.
     1. Cordon the target node specified in the VM's nodeAffinity (worker_node1).
     2. Wait until the node status becomes 'Ready,SchedulingDisabled'.
     3. Start the VM and verify that the VMI phase is 'Scheduling'.
     4. Uncordon the node.
-    5. Ensure the VMI remains in 'Scheduling' phase after uncordoning.
-    6. Wait for the node status to return to 'Ready'.
-    7. Wait for the VMI phase to become 'Running'.
-    8. Verify that the VMI is running on the expected node (worker_node1).
+    5. Wait for the node status to return to 'Ready'.
+    6. Wait for the VMI phase to become 'Running'.
+    7. Verify that the VMI is running on the expected node (worker_node1).
     """
 
     with node_mgmt_console(node=worker_node1, node_mgmt="cordon"):

--- a/tests/virt/node/workload_density/test_swap.py
+++ b/tests/virt/node/workload_density/test_swap.py
@@ -7,7 +7,7 @@ from ocp_resources.daemonset import DaemonSet
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.virt.constants import REMOVE_NEWLINE
-from tests.virt.utils import get_match_expressions_dict, start_stress_on_vm
+from tests.virt.utils import build_node_affinity_dict, start_stress_on_vm
 from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC, TIMEOUT_20MIN, Images
 from utilities.infra import ExecCommandOnPod
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
@@ -47,21 +47,10 @@ def wait_virt_launcher_pod_using_swap(vm):
 
 @pytest.fixture(scope="class")
 def node_affinity_rule_for_two_nodes(worker_node1, worker_node2, node_with_less_available_memory):
-    return {
-        "nodeAffinity": {
-            "preferredDuringSchedulingIgnoredDuringExecution": [
-                {
-                    "preference": get_match_expressions_dict(nodes_list=[next(iter(node_with_less_available_memory))]),
-                    "weight": 1,
-                }
-            ],
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                    get_match_expressions_dict(nodes_list=[worker_node1.hostname, worker_node2.hostname])
-                ]
-            },
-        }
-    }
+    return build_node_affinity_dict(
+        required_nodes=[worker_node1.hostname, worker_node2.hostname],
+        preferred_nodes=[next(iter(node_with_less_available_memory))]
+    )
 
 
 @pytest.fixture(scope="package")

--- a/tests/virt/node/workload_density/test_swap.py
+++ b/tests/virt/node/workload_density/test_swap.py
@@ -49,7 +49,7 @@ def wait_virt_launcher_pod_using_swap(vm):
 def node_affinity_rule_for_two_nodes(worker_node1, worker_node2, node_with_less_available_memory):
     return build_node_affinity_dict(
         required_nodes=[worker_node1.hostname, worker_node2.hostname],
-        preferred_nodes=[next(iter(node_with_less_available_memory))]
+        preferred_nodes=[next(iter(node_with_less_available_memory))],
     )
 
 

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -503,17 +503,12 @@ def build_node_affinity(required_nodes=None, preferred_nodes=None):
 
     if required_nodes:
         affinity["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"] = {
-            "nodeSelectorTerms": [
-                get_match_expressions_dict(nodes_list=required_nodes)
-            ]
+            "nodeSelectorTerms": [get_match_expressions_dict(nodes_list=required_nodes)]
         }
 
     if preferred_nodes:
         affinity["nodeAffinity"]["preferredDuringSchedulingIgnoredDuringExecution"] = [
-            {
-                "weight": 1,
-                "preference": get_match_expressions_dict(nodes_list=preferred_nodes)
-            }
+            {"weight": 1, "preference": get_match_expressions_dict(nodes_list=preferred_nodes)}
         ]
 
     return affinity

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -498,7 +498,7 @@ def assert_migration_post_copy_mode(vm):
     assert migration_state.mode == "PostCopy", f"Migration mode is not PostCopy! VMI MigrationState {migration_state}"
 
 
-def build_node_affinity(required_nodes=None, preferred_nodes=None):
+def build_node_affinity_dict(required_nodes=None, preferred_nodes=None):
     affinity = {"nodeAffinity": {}}
 
     if required_nodes:

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -496,3 +496,24 @@ def get_allocatable_memory_per_node(schedulable_nodes):
 def assert_migration_post_copy_mode(vm):
     migration_state = vm.vmi.instance.status.migrationState
     assert migration_state.mode == "PostCopy", f"Migration mode is not PostCopy! VMI MigrationState {migration_state}"
+
+
+def build_node_affinity(required_nodes=None, preferred_nodes=None):
+    affinity = {"nodeAffinity": {}}
+
+    if required_nodes:
+        affinity["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"] = {
+            "nodeSelectorTerms": [
+                get_match_expressions_dict(nodes_list=required_nodes)
+            ]
+        }
+
+    if preferred_nodes:
+        affinity["nodeAffinity"]["preferredDuringSchedulingIgnoredDuringExecution"] = [
+            {
+                "weight": 1,
+                "preference": get_match_expressions_dict(nodes_list=preferred_nodes)
+            }
+        ]
+
+    return affinity

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1169,6 +1169,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
             template_object (Template, optional): Template object to create the VM from
             non_existing_pvc(bool, default=False): If True, referenced PVC in DataSource is missing
             data_volume_template_from_vm_spec (bool, default=False): Use (and don't manipulate) VM's DataVolumeTemplates
+            vm_affinity (dict, optional): Affinity rules for scheduling the VM on specific nodes
         Returns:
             obj `VirtualMachine`: VM resource
         """

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1148,6 +1148,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         sno_cluster=False,
         tpm_params=None,
         additional_labels=None,
+        vm_affinity=None,
     ):
         """
         VM creation using common templates.
@@ -1218,6 +1219,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
             tpm_params=tpm_params,
             eviction_strategy=eviction_strategy,
             additional_labels=additional_labels,
+            vm_affinity=vm_affinity,
             os_flavor=self.os_flavor,
         )
         self.data_source = data_source
@@ -1237,6 +1239,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         self.data_volume_template_from_vm_spec = data_volume_template_from_vm_spec
         self.eviction_strategy = eviction_strategy
         self.sno_cluster = sno_cluster
+        self.vm_affinity = vm_affinity
 
     def to_dict(self):
         self.set_login_params()
@@ -1945,6 +1948,7 @@ def vm_instance_from_template(
     vm_cpu_flags=None,
     host_device_name=None,
     gpu_name=None,
+    vm_affinity=None,
 ):
     """Create a VM from template and start it (start step could be skipped by setting
     request.param['start_vm'] to False.
@@ -1994,6 +1998,7 @@ def vm_instance_from_template(
         vhostmd=params.get("vhostmd"),
         machine_type=params.get("machine_type"),
         eviction_strategy=params.get("eviction_strategy"),
+        vm_affinity=vm_affinity,
     ) as vm:
         if params.get("start_vm", True):
             running_vm(


### PR DESCRIPTION
##### Short description:
This PR replaces usage of nodeSelector with a requiredDuringSchedulingIgnoredDuringExecution nodeAffinity rule for scheduling VirtualMachines to specific nodes. This aligns with Kubernetes best practices and provides more flexibility for node selection logic.

##### More details:

##### What this PR does / why we need it:
###### virt.py:
The VirtualMachineForTests class needed to support setting affinity in the VM spec. Previously, it only handled nodeSelector. To make the test reusable and generic for affinity rules, I extended the VM creation logic in virt.py to accept a vm_affinity parameter and apply it to the VM manifest.

###### test_vm_unscheduled_node.py:
The original test injected nodeSelector into the VM, but this is now  insufficient for advanced scheduling logic. I updated the test to use nodeAffinity instead and passed it via the new vm_affinity mechanism to the VM fixture.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-5679



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the ability to specify node affinity for virtual machine scheduling in tests.
  * Added a utility function for building node affinity configurations.

* **Tests**
  * Updated VM scheduling tests to use node affinity instead of node selectors, improving clarity and flexibility.
  * Simplified node affinity fixtures by using the new utility function for affinity dictionary construction.
  * Enhanced test documentation and assertions for better readability and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->