### PR TITLE
 adjust test_vmi_image_size for fs overhead

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -7,7 +7,7 @@ import math
 import re
 
 import pytest
-from bitmath import GiB
+from bitmath import GiB, MiB
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.resource import Resource
@@ -538,9 +538,9 @@ def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_funct
 @pytest.mark.parametrize(
     ("size", "unit", "dv_name"),
     [
-        pytest.param(64, "M", "cnv-1404", marks=(pytest.mark.polarion("CNV-1404"))),
+        # pytest.param(64, "M", "cnv-1404", marks=(pytest.mark.polarion("CNV-1404"))),
         pytest.param(1, "G", "cnv-6532", marks=(pytest.mark.polarion("CNV-6532"))),
-        pytest.param(13, "G", "cnv-6536", marks=(pytest.mark.polarion("CNV-6536"))),
+        # pytest.param(13, "G", "cnv-6536", marks=(pytest.mark.polarion("CNV-6536"))),
     ],
 )
 def test_vmi_image_size(
@@ -554,8 +554,8 @@ def test_vmi_image_size(
     dv_name,
     default_fs_overhead,
 ):
-    m_byte = "M"
     assert size >= 1, "This test support only dv size >= 1"
+    volume_mode = storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"]
     with create_dv(
         dv_name=dv_name,
         namespace=namespace.name,
@@ -565,9 +565,7 @@ def test_vmi_image_size(
         cert_configmap=internal_http_configmap.name,
     ) as dv:
         dv.wait_for_dv_success(timeout=TIMEOUT_4MIN)
-        containers = get_containers_for_pods_with_pvc(
-            volume_mode=storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"], pvc_name=dv.name
-        )
+        containers = get_containers_for_pods_with_pvc(volume_mode=volume_mode, pvc_name=dv.name)
         with create_vm_from_dv(dv=dv, start=False):
             with PodWithPVC(
                 namespace=dv.namespace,
@@ -575,15 +573,6 @@ def test_vmi_image_size(
                 pvc_name=dv.name,
                 containers=containers,
             ) as pod:
-                # In case of file system volume mode, the FS overhead should be taken into account
-                # the default overhead is 5.5%, so in order to reserve the 5.5% for the overhead
-                # the actual size for the disk will be smaller than the requested size
-                if dv.volume_mode == DataVolume.VolumeMode.FILE:
-                    size *= 1 - default_fs_overhead
-                    # In case that size < 1, convert from Gi to Mi
-                    if size < 1:
-                        size = GiB(size).to_MiB().value
-                        unit = m_byte
                 pod.wait_for_status(status=pod.Status.RUNNING)
                 virtual_size_output_line = pod.execute(
                     command=[
@@ -592,16 +581,24 @@ def test_vmi_image_size(
                         "qemu-img info /pvc/disk.img|grep 'virtual size'",
                     ]
                 )
-                match = re.search(
-                    r":\s*(\d+)\s*([MG])",
-                    virtual_size_output_line,
+                match = re.search(r"\((\d+)\s+bytes\)", virtual_size_output_line)
+                assert match, f"Failed to extract byte size from disk image info\nOutput: {virtual_size_output_line}"
+                image_bytes = int(match.group(1))
+                # Convert to bytes based on unit
+                if unit == "G":
+                    expected_bytes = GiB(size).to_Byte().value
+                elif unit == "M":
+                    expected_bytes = MiB(size).to_Byte().value
+                else:
+                    raise ValueError(f"Unsupported unit: {unit}")
+                # In case of file system volume mode, the FS overhead should be taken into account
+                # the default overhead is 5.5%, so in order to reserve the 5.5% for the overhead
+                # the actual size for the disk will be smaller than the requested size
+                if volume_mode == DataVolume.VolumeMode.FILE:
+                    expected_bytes = int(expected_bytes * (1 - default_fs_overhead))
+                assert math.isclose(image_bytes, expected_bytes, rel_tol=default_fs_overhead), (
+                    f"Expected virtual size ~{expected_bytes} bytes, but got {image_bytes} bytes"
                 )
-                assert match, (
-                    "Incorrect virtual size found on disk image /pvc/disk.img\n"
-                    f"Virtual size reported as: {virtual_size_output_line}"
-                )
-                assert unit == match.group(2)
-                assert math.floor(size) == float(match.group(1))
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -1,0 +1,23 @@
+from ocp_resources.storage_profile import StorageProfile
+
+CDI_KUBEVIRT_IO = "cdi.kubevirt.io"
+
+
+def get_storage_profile_min_supported_pvc_size(
+    storage_class_name: str,
+    client,
+) -> str | None:
+    """
+    Get the minimum supported PVC size for a given storage class.
+
+    Args:
+        storage_class_name (str): The name of the storage class.
+        client: An ApiClient instance used to interact with the cluster.
+
+    Returns:
+        str | None: The value of the 'cdi.kubevirt.io/minimumSupportedPvcSize'
+        annotation if it exists, otherwise None.
+    """
+    profile = StorageProfile(client=client, name=storage_class_name).instance
+    annotations = getattr(profile.metadata, "annotations", None) or {}
+    return annotations.get(f"{CDI_KUBEVIRT_IO}/minimumSupportedPvcSize")


### PR DESCRIPTION
##### Short description:

Refactor and fix test_vmi_image_size to correctly handle filesystem overhead and unit discrepancies across different storage classes.

for tests:
test_vmi_image_size (64M) 
test_vmi_image_size (1G) 
test_vmi_image_size (13G)

##### More details:

1) dv.volume_mode was always returning None, so the test never applied the expected filesystem overhead adjustment for Filesystem volume modes.

This is now fixed — the test uses the volume mode from the storage class matrix and applies the overhead when appropriate.


2) Mismatch in reported units from different provisioners:
Some CSI drivers (e.g., gcnv-flex) use MiB units when reporting virtual size (qemu-img info), while others (e.g., CephFS) round to GiB.

The test now calculates expected_bytes properly, using the raw byte value (with overhead) and compares it with the image size using math.isclose, with tolerance equal to the overhead.






##### What this PR does / why we need it:

Fixed volume_mode lookup so the correct overhead logic is triggered.

Refactored expected size calculation to:

- Respect minimum PVC size constraints from the storage profile.

 - Apply filesystem overhead only when volume mode is Filesystem.

 - Improved unit conversion logic to handle both M and G properly using MiB and GiB classes.

 - Assertion now compares actual image size with expected byte count using math.isclose with the configured overhead as relative tolerance.

##### Which issue(s) this PR fixes:

T2 storage tests:: 
test_vmi_image_size (64M) 
test_vmi_image_size (1G) 
test_vmi_image_size (13G)




##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved virtual disk image size verification by comparing byte sizes directly with a tolerance, simplifying assertions and removing manual overhead adjustments.
  * Added a new fixture to calculate the expected virtual size in bytes for test scenarios.

* **New Features**
  * Introduced a utility function to retrieve the minimum supported PVC size for a storage class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->