### PR TITLE
WIP: Increase dv size test public registry data volume low capacity

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -7,7 +7,7 @@ import math
 import re
 
 import pytest
-from bitmath import GiB, MiB
+from bitmath import GiB
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.resource import Resource
@@ -538,9 +538,9 @@ def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_funct
 @pytest.mark.parametrize(
     ("size", "unit", "dv_name"),
     [
-        # pytest.param(64, "M", "cnv-1404", marks=(pytest.mark.polarion("CNV-1404"))),
+        pytest.param(64, "M", "cnv-1404", marks=(pytest.mark.polarion("CNV-1404"))),
         pytest.param(1, "G", "cnv-6532", marks=(pytest.mark.polarion("CNV-6532"))),
-        # pytest.param(13, "G", "cnv-6536", marks=(pytest.mark.polarion("CNV-6536"))),
+        pytest.param(13, "G", "cnv-6536", marks=(pytest.mark.polarion("CNV-6536"))),
     ],
 )
 def test_vmi_image_size(
@@ -554,8 +554,8 @@ def test_vmi_image_size(
     dv_name,
     default_fs_overhead,
 ):
+    m_byte = "M"
     assert size >= 1, "This test support only dv size >= 1"
-    volume_mode = storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"]
     with create_dv(
         dv_name=dv_name,
         namespace=namespace.name,
@@ -565,7 +565,9 @@ def test_vmi_image_size(
         cert_configmap=internal_http_configmap.name,
     ) as dv:
         dv.wait_for_dv_success(timeout=TIMEOUT_4MIN)
-        containers = get_containers_for_pods_with_pvc(volume_mode=volume_mode, pvc_name=dv.name)
+        containers = get_containers_for_pods_with_pvc(
+            volume_mode=storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"], pvc_name=dv.name
+        )
         with create_vm_from_dv(dv=dv, start=False):
             with PodWithPVC(
                 namespace=dv.namespace,
@@ -573,6 +575,15 @@ def test_vmi_image_size(
                 pvc_name=dv.name,
                 containers=containers,
             ) as pod:
+                # In case of file system volume mode, the FS overhead should be taken into account
+                # the default overhead is 5.5%, so in order to reserve the 5.5% for the overhead
+                # the actual size for the disk will be smaller than the requested size
+                if dv.volume_mode == DataVolume.VolumeMode.FILE:
+                    size *= 1 - default_fs_overhead
+                    # In case that size < 1, convert from Gi to Mi
+                    if size < 1:
+                        size = GiB(size).to_MiB().value
+                        unit = m_byte
                 pod.wait_for_status(status=pod.Status.RUNNING)
                 virtual_size_output_line = pod.execute(
                     command=[
@@ -581,24 +592,16 @@ def test_vmi_image_size(
                         "qemu-img info /pvc/disk.img|grep 'virtual size'",
                     ]
                 )
-                match = re.search(r"\((\d+)\s+bytes\)", virtual_size_output_line)
-                assert match, f"Failed to extract byte size from disk image info\nOutput: {virtual_size_output_line}"
-                image_bytes = int(match.group(1))
-                # Convert to bytes based on unit
-                if unit == "G":
-                    expected_bytes = GiB(size).to_Byte().value
-                elif unit == "M":
-                    expected_bytes = MiB(size).to_Byte().value
-                else:
-                    raise ValueError(f"Unsupported unit: {unit}")
-                # In case of file system volume mode, the FS overhead should be taken into account
-                # the default overhead is 5.5%, so in order to reserve the 5.5% for the overhead
-                # the actual size for the disk will be smaller than the requested size
-                if volume_mode == DataVolume.VolumeMode.FILE:
-                    expected_bytes = int(expected_bytes * (1 - default_fs_overhead))
-                assert math.isclose(image_bytes, expected_bytes, rel_tol=default_fs_overhead), (
-                    f"Expected virtual size ~{expected_bytes} bytes, but got {image_bytes} bytes"
+                match = re.search(
+                    r":\s*(\d+)\s*([MG])",
+                    virtual_size_output_line,
                 )
+                assert match, (
+                    "Incorrect virtual size found on disk image /pvc/disk.img\n"
+                    f"Virtual size reported as: {virtual_size_output_line}"
+                )
+                assert unit == match.group(2)
+                assert math.floor(size) == float(match.group(1))
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -10,7 +10,7 @@ from tests.storage.utils import (
     get_importer_pod,
     wait_for_importer_container_message,
 )
-from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_5MIN, Images
+from utilities.constants import OS_FLAVOR_FEDORA, SIX_GI_MEMORY, TIMEOUT_5MIN, Images
 from utilities.ssp import wait_for_condition_message_value
 from utilities.storage import ErrorMsg, check_disk_count_in_vm, create_dv
 from utilities.virt import running_vm
@@ -131,6 +131,7 @@ def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_
         "source": REGISTRY_STR,
         "url": QUAY_FEDORA_CONTAINER_IMAGE,
         "storage_class": storage_class_name_scope_function,
+        "size": SIX_GI_MEMORY,
     }
     # negative flow - low capacity volume
     with create_dv(
@@ -155,6 +156,7 @@ def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_
         namespace=namespace.name,
         url=dv_param["url"],
         storage_class=dv_param["storage_class"],
+        size=dv_param["size"],
     ) as dv:
         dv.wait_for_dv_success()
         with create_vm_from_dv(


### PR DESCRIPTION
##### Short description:

gcnv-flex (storage class)  >>  tried to create 5Gi (default size)  dv that import docker://quay.io/openshift-cnv/qe-cnv-tests-fedora:41 image whic is larger than > 5Gi
and the dv fail to import that with error msg  DataVolume too small to contain image

bug reported https://issues.redhat.com/browse/CNV-66517

##### More details:

dv size is small to contain the image, image size with file system sc is 5.3GiB while the request is 5Gi
reported a bug bug reported https://issues.redhat.com/browse/CNV-66517
because in different SC I saw the dv size is automaticlly resized to 6Gi 
increasing the request to 6Gi will workaround this at the moment 



##### What this PR does / why we need it:
dv size is small to contain the image, image size with file system sc is 5.3GiB while the request is 5Gi
reported a bug bug reported https://issues.redhat.com/browse/CNV-66517
because in different SC I saw the dv size is automaticlly resized to 6Gi 
increasing the request to 6Gi will workaround this at the moment 




##### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-66517

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a test to explicitly specify the data volume size in certain scenarios, improving test clarity and control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->