### PR TITLE
Add s390x test markers for IUO-OCS tests

### DIFF
--- a/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
+++ b/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
@@ -12,7 +12,7 @@ from tests.install_upgrade_operators.constants import (
 )
 from utilities.constants import QUARANTINED
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,6 @@ LOGGER = logging.getLogger(__name__)
 )
 class TestCertRotation:
     @pytest.mark.polarion("CNV-6203")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "hyperconverged_resource_certconfig_change",
         [

--- a/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
+++ b/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
@@ -23,6 +23,7 @@ LOGGER = logging.getLogger(__name__)
 )
 class TestCertRotation:
     @pytest.mark.polarion("CNV-6203")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "hyperconverged_resource_certconfig_change",
         [

--- a/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
+++ b/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
@@ -30,6 +30,7 @@ def validate_virtctl_versions(virtctl_bin):
         f"Compare error: virtctl client and server versions are not identical: versions={client_and_server_versions}"
     )
 
+
 @pytest.mark.s390x
 class TestDisconnectedVirtctlDownload:
     @pytest.mark.parametrize(
@@ -63,6 +64,7 @@ class TestDisconnectedVirtctlDownload:
         downloaded_and_extracted_virtctl_binary_for_os,
     ):
         assert os.path.exists(downloaded_and_extracted_virtctl_binary_for_os)
+
 
 @pytest.mark.s390x
 class TestDisconnectedVirtctlDownloadAndExecute:

--- a/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
+++ b/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
@@ -7,7 +7,7 @@ from pyhelper_utils.shell import run_command
 from utilities.constants import AMD_64
 from utilities.infra import get_machine_platform
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.s390x]
 
 ARM_64 = "arm64"
 
@@ -31,7 +31,6 @@ def validate_virtctl_versions(virtctl_bin):
     )
 
 
-@pytest.mark.s390x
 class TestDisconnectedVirtctlDownload:
     @pytest.mark.parametrize(
         "downloaded_and_extracted_virtctl_binary_for_os",
@@ -66,7 +65,6 @@ class TestDisconnectedVirtctlDownload:
         assert os.path.exists(downloaded_and_extracted_virtctl_binary_for_os)
 
 
-@pytest.mark.s390x
 class TestDisconnectedVirtctlDownloadAndExecute:
     @pytest.mark.parametrize(
         ("downloaded_and_extracted_virtctl_binary_for_os", "platform"),
@@ -94,7 +92,6 @@ class TestDisconnectedVirtctlDownloadAndExecute:
 
 
 @pytest.mark.arm64
-@pytest.mark.s390x
 class TestDisconnectedVirtctlAllLinksInternal:
     @pytest.mark.polarion("CNV-6915")
     def test_all_links_internal(self, all_virtctl_urls, non_internal_fqdns):

--- a/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
+++ b/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
@@ -30,7 +30,7 @@ def validate_virtctl_versions(virtctl_bin):
         f"Compare error: virtctl client and server versions are not identical: versions={client_and_server_versions}"
     )
 
-
+@pytest.mark.s390x
 class TestDisconnectedVirtctlDownload:
     @pytest.mark.parametrize(
         "downloaded_and_extracted_virtctl_binary_for_os",
@@ -64,7 +64,7 @@ class TestDisconnectedVirtctlDownload:
     ):
         assert os.path.exists(downloaded_and_extracted_virtctl_binary_for_os)
 
-
+@pytest.mark.s390x
 class TestDisconnectedVirtctlDownloadAndExecute:
     @pytest.mark.parametrize(
         ("downloaded_and_extracted_virtctl_binary_for_os", "platform"),
@@ -92,6 +92,7 @@ class TestDisconnectedVirtctlDownloadAndExecute:
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 class TestDisconnectedVirtctlAllLinksInternal:
     @pytest.mark.polarion("CNV-6915")
     def test_all_links_internal(self, all_virtctl_urls, non_internal_fqdns):

--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -37,6 +37,7 @@ def crds(admin_client):
 
 
 @pytest.mark.polarion("CNV-8263")
+@pytest.mark.s390x
 def test_crds_cluster_readers_role(crds):
     LOGGER.info(f"CRds: {crds}")
     cluster_readers = "system:cluster-readers"

--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -15,7 +15,7 @@ MTV_VOLUME_POPULATOR_CRDS = [
 ]
 
 
-pytestmark = [pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.fixture()
@@ -37,7 +37,6 @@ def crds(admin_client):
 
 
 @pytest.mark.polarion("CNV-8263")
-@pytest.mark.s390x
 def test_crds_cluster_readers_role(crds):
     LOGGER.info(f"CRds: {crds}")
     cluster_readers = "system:cluster-readers"

--- a/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
@@ -35,7 +35,7 @@ from utilities.constants import (
 LOGGER = logging.getLogger(__name__)
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("resource_crypto_policy_settings", "resource_type"),
     [
@@ -114,6 +114,7 @@ def test_default_crypto_policy(resource_crypto_policy_settings, resource_type):
 
 
 @pytest.mark.polarion("CNV-9266")
+@pytest.mark.s390x
 def test_default_crypto_policy_check_connectivity(
     workers, workers_utility_pods, services_to_check_connectivity, fips_enabled_cluster
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
@@ -35,6 +35,7 @@ from utilities.constants import (
 LOGGER = logging.getLogger(__name__)
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     ("resource_crypto_policy_settings", "resource_type"),

--- a/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
@@ -33,10 +33,9 @@ from utilities.constants import (
 )
 
 LOGGER = logging.getLogger(__name__)
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("resource_crypto_policy_settings", "resource_type"),
     [
@@ -115,7 +114,6 @@ def test_default_crypto_policy(resource_crypto_policy_settings, resource_type):
 
 
 @pytest.mark.polarion("CNV-9266")
-@pytest.mark.s390x
 def test_default_crypto_policy_check_connectivity(
     workers, workers_utility_pods, services_to_check_connectivity, fips_enabled_cluster
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
@@ -41,6 +41,7 @@ def updated_hco_crypto_policy(
 
 
 @pytest.mark.polarion("CNV-9331")
+@pytest.mark.s390x
 def test_set_hco_crypto_policy(
     cnv_crypto_policy_matrix__function__,
     updated_hco_crypto_policy,

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
@@ -15,7 +15,7 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
 from utilities.constants import TLS_SECURITY_PROFILE
 
 LOGGER = logging.getLogger(__name__)
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]
 
 
 @pytest.fixture()
@@ -41,7 +41,6 @@ def updated_hco_crypto_policy(
 
 
 @pytest.mark.polarion("CNV-9331")
-@pytest.mark.s390x
 def test_set_hco_crypto_policy(
     cnv_crypto_policy_matrix__function__,
     updated_hco_crypto_policy,

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.polarion("CNV-9367")
+@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):
@@ -41,6 +42,7 @@ def test_set_hco_crypto_failed_without_required_cipher(
 
 
 @pytest.mark.polarion("CNV-10551")
+@pytest.mark.s390x
 def test_set_ciphers_for_tlsv13(hyperconverged_resource_scope_function):
     error_string = r"custom ciphers cannot be selected when minTLSVersion is VersionTLS13"
     tls_custom_profile = copy.deepcopy(TLS_CUSTOM_PROFILE)

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -12,10 +12,9 @@ from utilities.constants import TLS_CUSTOM_POLICY, TLS_SECURITY_PROFILE
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 LOGGER = logging.getLogger(__name__)
-
+pytestmark = pytest.mark.s390x
 
 @pytest.mark.polarion("CNV-9367")
-@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):
@@ -42,7 +41,6 @@ def test_set_hco_crypto_failed_without_required_cipher(
 
 
 @pytest.mark.polarion("CNV-10551")
-@pytest.mark.s390x
 def test_set_ciphers_for_tlsv13(hyperconverged_resource_scope_function):
     error_string = r"custom ciphers cannot be selected when minTLSVersion is VersionTLS13"
     tls_custom_profile = copy.deepcopy(TLS_CUSTOM_PROFILE)

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -14,6 +14,7 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 LOGGER = logging.getLogger(__name__)
 pytestmark = pytest.mark.s390x
 
+
 @pytest.mark.polarion("CNV-9367")
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.polarion("CNV-9367")
+@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
@@ -12,10 +12,9 @@ from utilities.constants import TLS_CUSTOM_POLICY, TLS_SECURITY_PROFILE
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 LOGGER = logging.getLogger(__name__)
-
+pytestmark = pytest.mark.s390x
 
 @pytest.mark.polarion("CNV-9367")
-@pytest.mark.s390x
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,
 ):

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_without_required_cipher.py
@@ -14,6 +14,7 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 LOGGER = logging.getLogger(__name__)
 pytestmark = pytest.mark.s390x
 
+
 @pytest.mark.polarion("CNV-9367")
 def test_set_hco_crypto_failed_without_required_cipher(
     hyperconverged_resource_scope_function,

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -93,6 +93,7 @@ def updated_cr_with_custom_crypto_policy(
         yield {"resource": resource, "tls_policy": value}
     assert not is_hco_tainted(admin_client=admin_client, hco_namespace=hco_namespace.name)
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "updated_cr_with_custom_crypto_policy",

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -93,7 +93,7 @@ def updated_cr_with_custom_crypto_policy(
         yield {"resource": resource, "tls_policy": value}
     assert not is_hco_tainted(admin_client=admin_client, hco_namespace=hco_namespace.name)
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "updated_cr_with_custom_crypto_policy",
     [

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -33,7 +33,7 @@ from utilities.hco import (
     wait_for_hco_conditions,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 TLS_POLICIES_WITHOUT_CUSTOM_POLICY = {
@@ -94,7 +94,6 @@ def updated_cr_with_custom_crypto_policy(
     assert not is_hco_tainted(admin_client=admin_client, hco_namespace=hco_namespace.name)
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "updated_cr_with_custom_crypto_policy",
     [

--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -66,6 +66,7 @@ def csv_permissions_from_yaml(pytestconfig):
 
 
 @pytest.mark.polarion("CNV-9805")
+@pytest.mark.s390x
 def test_new_operator_in_csv(operators_from_csv):
     assert sorted(list(operators_from_csv)) == sorted(CNV_OPERATORS), (
         f"Expected cnv operators:{CNV_OPERATORS} does not match operators {operators_from_csv} "
@@ -73,6 +74,7 @@ def test_new_operator_in_csv(operators_from_csv):
 
 
 @pytest.mark.polarion("CNV-9547")
+@pytest.mark.s390x
 def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissions_from_yaml, csv_permissions):
     from_yaml = csv_permissions_from_yaml.get(cnv_operators_matrix__function__, {})
     from_csv = csv_permissions.get(cnv_operators_matrix__function__, {})
@@ -86,6 +88,7 @@ def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissio
 
 
 @pytest.mark.polarion("CNV-9548")
+@pytest.mark.s390x
 def test_global_csv_permissions(cnv_operators_matrix__function__, global_permission_from_csv):
     error_message = f"Found global permission for {cnv_operators_matrix__function__}"
     errors = {}

--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -19,6 +19,8 @@ from utilities.infra import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.s390x
+
 JIRA_LINKS = {
     "kubevirt-operator": "CNV-23061",
 }
@@ -66,7 +68,6 @@ def csv_permissions_from_yaml(pytestconfig):
 
 
 @pytest.mark.polarion("CNV-9805")
-@pytest.mark.s390x
 def test_new_operator_in_csv(operators_from_csv):
     assert sorted(list(operators_from_csv)) == sorted(CNV_OPERATORS), (
         f"Expected cnv operators:{CNV_OPERATORS} does not match operators {operators_from_csv} "
@@ -74,7 +75,6 @@ def test_new_operator_in_csv(operators_from_csv):
 
 
 @pytest.mark.polarion("CNV-9547")
-@pytest.mark.s390x
 def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissions_from_yaml, csv_permissions):
     from_yaml = csv_permissions_from_yaml.get(cnv_operators_matrix__function__, {})
     from_csv = csv_permissions.get(cnv_operators_matrix__function__, {})
@@ -88,7 +88,6 @@ def test_compare_csv_permissions(cnv_operators_matrix__function__, csv_permissio
 
 
 @pytest.mark.polarion("CNV-9548")
-@pytest.mark.s390x
 def test_global_csv_permissions(cnv_operators_matrix__function__, global_permission_from_csv):
     error_message = f"Found global permission for {cnv_operators_matrix__function__}"
     errors = {}

--- a/tests/install_upgrade_operators/csv/test_csv.py
+++ b/tests/install_upgrade_operators/csv/test_csv.py
@@ -93,6 +93,7 @@ def test_csv_properties(csv_scope_session):
     assert annotations.get("capabilities") == "Deep Insights"
     assert annotations.get("support") == "Red Hat"
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "expected_feature",

--- a/tests/install_upgrade_operators/csv/test_csv.py
+++ b/tests/install_upgrade_operators/csv/test_csv.py
@@ -3,7 +3,7 @@ from base64 import b64decode
 import pytest
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 # Check CSV properties like keywords, title, provided by, links etc.
 
@@ -36,7 +36,6 @@ def csv_infrastructure_features_annotation_value(csv_scope_session):
 @pytest.mark.polarion("CNV-4456")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
-@pytest.mark.s390x
 def test_csv_keywords(csv_scope_session):
     """
     Assert keywords. Check that each one of the expected keywords are actually there
@@ -47,7 +46,6 @@ def test_csv_keywords(csv_scope_session):
 @pytest.mark.polarion("CNV-4457")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
-@pytest.mark.s390x
 def test_csv_links(csv_scope_session):
     """
     Check links list.
@@ -64,7 +62,6 @@ def test_csv_links(csv_scope_session):
 @pytest.mark.polarion("CNV-4458")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
-@pytest.mark.s390x
 def test_csv_icon(csv_scope_session):
     """
     Assert Icon/Logo.
@@ -81,7 +78,6 @@ def test_csv_icon(csv_scope_session):
 @pytest.mark.polarion("CNV-4376")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
-@pytest.mark.s390x
 def test_csv_properties(csv_scope_session):
     """
     Asserting remaining csv properties.
@@ -94,7 +90,6 @@ def test_csv_properties(csv_scope_session):
     assert annotations.get("support") == "Red Hat"
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "expected_feature",
     [

--- a/tests/install_upgrade_operators/csv/test_csv.py
+++ b/tests/install_upgrade_operators/csv/test_csv.py
@@ -36,6 +36,7 @@ def csv_infrastructure_features_annotation_value(csv_scope_session):
 @pytest.mark.polarion("CNV-4456")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_keywords(csv_scope_session):
     """
     Assert keywords. Check that each one of the expected keywords are actually there
@@ -46,6 +47,7 @@ def test_csv_keywords(csv_scope_session):
 @pytest.mark.polarion("CNV-4457")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_links(csv_scope_session):
     """
     Check links list.
@@ -62,6 +64,7 @@ def test_csv_links(csv_scope_session):
 @pytest.mark.polarion("CNV-4458")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_icon(csv_scope_session):
     """
     Assert Icon/Logo.
@@ -78,6 +81,7 @@ def test_csv_icon(csv_scope_session):
 @pytest.mark.polarion("CNV-4376")
 @pytest.mark.smoke
 @pytest.mark.ocp_interop
+@pytest.mark.s390x
 def test_csv_properties(csv_scope_session):
     """
     Asserting remaining csv properties.
@@ -89,7 +93,7 @@ def test_csv_properties(csv_scope_session):
     assert annotations.get("capabilities") == "Deep Insights"
     assert annotations.get("support") == "Red Hat"
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "expected_feature",
     [

--- a/tests/install_upgrade_operators/csv/test_hco_api_version.py
+++ b/tests/install_upgrade_operators/csv/test_hco_api_version.py
@@ -5,6 +5,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-5832")
+@pytest.mark.s390x
 def test_hyperconverged_cr_api_version(hyperconverged_resource_scope_function):
     """
     This test will check the Hyperconverged CR's api_version for v1beta1

--- a/tests/install_upgrade_operators/csv/test_hco_api_version.py
+++ b/tests/install_upgrade_operators/csv/test_hco_api_version.py
@@ -1,11 +1,10 @@
 import pytest
 from ocp_resources.resource import Resource
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.s390x]
 
 
 @pytest.mark.polarion("CNV-5832")
-@pytest.mark.s390x
 def test_hyperconverged_cr_api_version(hyperconverged_resource_scope_function):
     """
     This test will check the Hyperconverged CR's api_version for v1beta1

--- a/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
+++ b/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
@@ -16,6 +16,7 @@ def test_hco_cr_explainable(hyperconverged_resource_scope_function):
     command_output = run_command(command=shlex.split("oc explain hyperconvergeds"), check=False)[1]
     assert "HyperConverged is the Schema for the hyperconvergeds API" in command_output
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "fields, description",

--- a/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
+++ b/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
@@ -3,11 +3,10 @@ import shlex
 import pytest
 from pyhelper_utils.shell import run_command
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.mark.polarion("CNV-5884")
-@pytest.mark.s390x
 def test_hco_cr_explainable(hyperconverged_resource_scope_function):
     """
     This test case ensure that after executing 'oc explain hyperconvergeds'
@@ -17,7 +16,6 @@ def test_hco_cr_explainable(hyperconverged_resource_scope_function):
     assert "HyperConverged is the Schema for the hyperconvergeds API" in command_output
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "fields, description",
     [

--- a/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
+++ b/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
@@ -7,6 +7,7 @@ pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-5884")
+@pytest.mark.s390x
 def test_hco_cr_explainable(hyperconverged_resource_scope_function):
     """
     This test case ensure that after executing 'oc explain hyperconvergeds'
@@ -15,7 +16,7 @@ def test_hco_cr_explainable(hyperconverged_resource_scope_function):
     command_output = run_command(command=shlex.split("oc explain hyperconvergeds"), check=False)[1]
     assert "HyperConverged is the Schema for the hyperconvergeds API" in command_output
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "fields, description",
     [

--- a/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
+++ b/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-4751")
+@pytest.mark.s390x
 def test_immutable_image_using_sha(kubevirt_package_manifest_current_channel):
     """
     check all images of the current channel on the kubevirt-hyperconverged Package Manifest.

--- a/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
+++ b/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
@@ -2,6 +2,7 @@ import pytest
 
 pytestmark = [pytest.mark.sno, pytest.mark.s390x]
 
+
 @pytest.mark.polarion("CNV-4751")
 def test_immutable_image_using_sha(kubevirt_package_manifest_current_channel):
     """

--- a/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
+++ b/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
@@ -1,10 +1,8 @@
 import pytest
 
-pytestmark = pytest.mark.sno
-
+pytestmark = [pytest.mark.sno, pytest.mark.s390x]
 
 @pytest.mark.polarion("CNV-4751")
-@pytest.mark.s390x
 def test_immutable_image_using_sha(kubevirt_package_manifest_current_channel):
     """
     check all images of the current channel on the kubevirt-hyperconverged Package Manifest.

--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -1,10 +1,9 @@
 import pytest
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.s390x]
 
 
 @pytest.mark.polarion("CNV-7169")
-@pytest.mark.s390x
 def test_channels_in_manifest(kubevirt_package_manifest_channels):
     expected_channels = {"stable", "dev-preview"}
     missing_channels = expected_channels - {channel.name for channel in kubevirt_package_manifest_channels}
@@ -12,7 +11,6 @@ def test_channels_in_manifest(kubevirt_package_manifest_channels):
 
 
 @pytest.mark.polarion("CNV-11944")
-@pytest.mark.s390x
 def test_cnv_subscription_channel(
     cnv_subscription_scope_session, kubevirt_package_manifest_channels, cnv_current_version
 ):

--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -4,6 +4,7 @@ pytestmark = pytest.mark.sno
 
 
 @pytest.mark.polarion("CNV-7169")
+@pytest.mark.s390x
 def test_channels_in_manifest(kubevirt_package_manifest_channels):
     expected_channels = {"stable", "dev-preview"}
     missing_channels = expected_channels - {channel.name for channel in kubevirt_package_manifest_channels}
@@ -11,6 +12,7 @@ def test_channels_in_manifest(kubevirt_package_manifest_channels):
 
 
 @pytest.mark.polarion("CNV-11944")
+@pytest.mark.s390x
 def test_cnv_subscription_channel(
     cnv_subscription_scope_session, kubevirt_package_manifest_channels, cnv_current_version
 ):

--- a/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
+++ b/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
@@ -13,6 +13,7 @@ def cnv_daemonset_names(admin_client, hco_namespace):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8509")
+@pytest.mark.s390x
 def test_no_new_cnv_daemonset_added(sno_cluster, cnv_daemonset_names):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added

--- a/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
+++ b/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
@@ -3,7 +3,7 @@ import pytest
 from utilities.constants import ALL_CNV_DAEMONSETS, ALL_CNV_DAEMONSETS_NO_HPP_CSI
 from utilities.infra import get_daemonsets
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.fixture(scope="module")
@@ -13,7 +13,6 @@ def cnv_daemonset_names(admin_client, hco_namespace):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8509")
-@pytest.mark.s390x
 def test_no_new_cnv_daemonset_added(sno_cluster, cnv_daemonset_names):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -12,11 +12,10 @@ from utilities.constants import (
     HCO_WEBHOOK,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.mark.gating
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "deployment_by_name",
     [
@@ -39,7 +38,6 @@ def test_liveness_probe(deployment_by_name):
 
 
 @pytest.mark.gating
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "deployment_by_name, cpu_min_value",
     [
@@ -65,7 +63,6 @@ def test_request_param(deployment_by_name, cpu_min_value):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-7675")
-@pytest.mark.s390x
 def test_cnv_deployment_priority_class_name(
     cnv_deployment_by_name_no_hpp,
 ):
@@ -78,7 +75,6 @@ def test_cnv_deployment_priority_class_name(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8289")
-@pytest.mark.s390x
 def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added
@@ -94,7 +90,6 @@ def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8264")
-@pytest.mark.s390x
 def test_cnv_deployment_container_image(cnv_deployment_by_name):
     assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)
     assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -16,6 +16,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 
 @pytest.mark.gating
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "deployment_by_name",
     [
@@ -38,6 +39,7 @@ def test_liveness_probe(deployment_by_name):
 
 
 @pytest.mark.gating
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "deployment_by_name, cpu_min_value",
     [
@@ -63,6 +65,7 @@ def test_request_param(deployment_by_name, cpu_min_value):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-7675")
+@pytest.mark.s390x
 def test_cnv_deployment_priority_class_name(
     cnv_deployment_by_name_no_hpp,
 ):
@@ -75,6 +78,7 @@ def test_cnv_deployment_priority_class_name(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8289")
+@pytest.mark.s390x
 def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
     """
     Since cnv deployments image validations are done via polarion parameterization, this test has been added
@@ -90,6 +94,7 @@ def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8264")
+@pytest.mark.s390x
 def test_cnv_deployment_container_image(cnv_deployment_by_name):
     assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)
     assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -25,7 +25,7 @@ from tests.install_upgrade_operators.utils import (
 from utilities.constants import CDI_KUBEVIRT_HYPERCONVERGED, KUBEVIRT_HCO_NAME
 from utilities.infra import is_jira_open
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,6 @@ def resource_object_value_by_key(request):
     return get_resource_key_value(resource=resource_obj, key_name=request.param.get(KEY_NAME_STR))
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("expected", "resource_object_value_by_key"),
     [

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -39,6 +39,7 @@ def resource_object_value_by_key(request):
     )
     return get_resource_key_value(resource=resource_obj, key_name=request.param.get(KEY_NAME_STR))
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     ("expected", "resource_object_value_by_key"),

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -39,7 +39,7 @@ def resource_object_value_by_key(request):
     )
     return get_resource_key_value(resource=resource_obj, key_name=request.param.get(KEY_NAME_STR))
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("expected", "resource_object_value_by_key"),
     [

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -19,11 +19,10 @@ from utilities.constants import (
     KUBEVIRT_KUBEVIRT_HYPERCONVERGED,
 )
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.s390x]
 
 
 class TestHardcodedFeatureGates:
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         ("updated_resource", "expected_value", "key_name"),
         [

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.sno
 
 
 class TestHardcodedFeatureGates:
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         ("updated_resource", "expected_value", "key_name"),
         [

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -14,6 +14,7 @@ FEATUREGATE_NAME_KEY_STR = "featuregate_name"
 
 pytestmark = pytest.mark.s390x
 
+
 @pytest.fixture()
 def updated_fg_hco(
     request,

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -25,6 +25,7 @@ def updated_fg_hco(
     ):
         yield
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     ("updated_fg_hco", "kubevirt_featuregate_name", "hco_featuregate"),

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -25,7 +25,7 @@ def updated_fg_hco(
     ):
         yield
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("updated_fg_hco", "kubevirt_featuregate_name", "hco_featuregate"),
     [

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -12,6 +12,7 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 
 FEATUREGATE_NAME_KEY_STR = "featuregate_name"
 
+pytestmark = pytest.mark.s390x
 
 @pytest.fixture()
 def updated_fg_hco(
@@ -26,7 +27,6 @@ def updated_fg_hco(
         yield
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     ("updated_fg_hco", "kubevirt_featuregate_name", "hco_featuregate"),
     [

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -31,7 +31,7 @@ from utilities.storage import get_data_sources_managed_by_data_import_cron
 LOGGER = logging.getLogger(__name__)
 COMMON_BOOT_IMAGE_NAMESPACE_STR = "commonBootImageNamespace"
 
-pytestmark = [pytest.mark.arm64]
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 
 def get_templates_resources_names_dict(templates):
@@ -162,7 +162,6 @@ def updated_common_templates_non_existent_ns(
 
 
 @pytest.mark.gating
-@pytest.mark.s390x
 @pytest.mark.usefixtures("updated_common_template_custom_ns")
 class TestDefaultCommonTemplates:
     @pytest.mark.parametrize(
@@ -224,7 +223,6 @@ class TestDefaultCommonTemplates:
 
 
 @pytest.mark.polarion("CNV-11631")
-@pytest.mark.s390x
 def test_non_existent_namespace(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -162,6 +162,7 @@ def updated_common_templates_non_existent_ns(
 
 
 @pytest.mark.gating
+@pytest.mark.s390x
 @pytest.mark.usefixtures("updated_common_template_custom_ns")
 class TestDefaultCommonTemplates:
     @pytest.mark.parametrize(
@@ -223,6 +224,7 @@ class TestDefaultCommonTemplates:
 
 
 @pytest.mark.polarion("CNV-11631")
+@pytest.mark.s390x
 def test_non_existent_namespace(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
@@ -9,6 +9,7 @@ pytestmark = [pytest.mark.gating, pytest.mark.arm64]
 
 @pytest.mark.usefixtures("hyperconverged_spec_scope_session", "hyperconverged_status_scope_session")
 @pytest.mark.polarion("CNV-7504")
+@pytest.mark.s390x
 def test_data_import_schedule_default_in_hco_cr(
     data_import_schedule,
 ):
@@ -18,6 +19,7 @@ def test_data_import_schedule_default_in_hco_cr(
 
 
 @pytest.mark.polarion("CNV-8168")
+@pytest.mark.s390x
 def test_default_hco_cr_image_streams(
     admin_client,
     golden_images_namespace,
@@ -36,6 +38,7 @@ def test_default_hco_cr_image_streams(
 
 
 @pytest.mark.polarion("CNV-8935")
+@pytest.mark.s390x
 def test_no_data_import_template_in_hco_spec(
     hyperconverged_spec_scope_session,
 ):
@@ -45,6 +48,7 @@ def test_no_data_import_template_in_hco_spec(
 
 
 @pytest.mark.polarion("CNV-8703")
+@pytest.mark.s390x
 def test_data_import_template_defaults_hco_status(
     hyperconverged_status_scope_session,
     hyperconverged_spec_scope_session,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
@@ -4,12 +4,11 @@ import pytest
 
 from utilities.constants import SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME
 
-pytestmark = [pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.mark.usefixtures("hyperconverged_spec_scope_session", "hyperconverged_status_scope_session")
 @pytest.mark.polarion("CNV-7504")
-@pytest.mark.s390x
 def test_data_import_schedule_default_in_hco_cr(
     data_import_schedule,
 ):
@@ -19,7 +18,6 @@ def test_data_import_schedule_default_in_hco_cr(
 
 
 @pytest.mark.polarion("CNV-8168")
-@pytest.mark.s390x
 def test_default_hco_cr_image_streams(
     admin_client,
     golden_images_namespace,
@@ -38,7 +36,6 @@ def test_default_hco_cr_image_streams(
 
 
 @pytest.mark.polarion("CNV-8935")
-@pytest.mark.s390x
 def test_no_data_import_template_in_hco_spec(
     hyperconverged_spec_scope_session,
 ):
@@ -48,7 +45,6 @@ def test_no_data_import_template_in_hco_spec(
 
 
 @pytest.mark.polarion("CNV-8703")
-@pytest.mark.s390x
 def test_data_import_template_defaults_hco_status(
     hyperconverged_status_scope_session,
     hyperconverged_spec_scope_session,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_delete_hco_pod.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.mark.jira("CNV-64433", run=False)
 @pytest.mark.polarion("CNV-7603")
+@pytest.mark.s390x
 def test_same_random_minute_after_delete_hco_pod(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 class TestEnableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7626")
+    @pytest.mark.s390x
     def test_set_enable_common_boot_image_import_true_ssp_cr(
         self,
         ssp_cr_spec,
@@ -26,6 +27,7 @@ class TestEnableCommonBootImageImport:
 
 
 @pytest.mark.polarion("CNV-7778")
+@pytest.mark.s390x
 def test_enable_and_delete_spec_enable_common_boot_image_import_hco_cr(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
@@ -9,14 +9,13 @@ from utilities.constants import (
 )
 from utilities.hco import wait_for_auto_boot_config_stabilization
 
-pytestmark = [pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
 
 class TestEnableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7626")
-    @pytest.mark.s390x
     def test_set_enable_common_boot_image_import_true_ssp_cr(
         self,
         ssp_cr_spec,
@@ -27,7 +26,6 @@ class TestEnableCommonBootImageImport:
 
 
 @pytest.mark.polarion("CNV-7778")
-@pytest.mark.s390x
 def test_enable_and_delete_spec_enable_common_boot_image_import_hco_cr(
     admin_client,
     hco_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -21,7 +21,7 @@ from utilities.constants import (
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
-pytestmark = [pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 COMMON_TEMPLATE_DISABLE = {DATA_IMPORT_CRON_ENABLE: "false"}
 COMMON_TEMPLATE_ENABLE = {DATA_IMPORT_CRON_ENABLE: "true"}
@@ -114,7 +114,6 @@ def updated_common_template(
     assert not modified_common_templates, f"Following templates were not reverted back: {modified_common_templates}"
 
 
-@pytest.mark.s390x
 class TestModifyCommonTemplateSpec:
     @pytest.mark.parametrize(
         "updated_common_template",
@@ -217,7 +216,6 @@ class TestModifyCommonTemplateSpec:
         assert not errors, "".join(errors)
 
 
-@pytest.mark.s390x
 @pytest.mark.usefixtures("common_templates_scope_session")
 class TestCommonTemplatesEnableDisable:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -113,6 +113,7 @@ def updated_common_template(
     modified_common_templates = get_modifed_common_template_names(hyperconverged=hyperconverged_resource_scope_function)
     assert not modified_common_templates, f"Following templates were not reverted back: {modified_common_templates}"
 
+
 @pytest.mark.s390x
 class TestModifyCommonTemplateSpec:
     @pytest.mark.parametrize(
@@ -214,6 +215,7 @@ class TestModifyCommonTemplateSpec:
                     f"Mismatch for template: {template_name} in dataimportcron.spec: {''.join(data_import_cron_error)}."
                 )
         assert not errors, "".join(errors)
+
 
 @pytest.mark.s390x
 @pytest.mark.usefixtures("common_templates_scope_session")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -113,7 +113,7 @@ def updated_common_template(
     modified_common_templates = get_modifed_common_template_names(hyperconverged=hyperconverged_resource_scope_function)
     assert not modified_common_templates, f"Following templates were not reverted back: {modified_common_templates}"
 
-
+@pytest.mark.s390x
 class TestModifyCommonTemplateSpec:
     @pytest.mark.parametrize(
         "updated_common_template",
@@ -215,7 +215,7 @@ class TestModifyCommonTemplateSpec:
                 )
         assert not errors, "".join(errors)
 
-
+@pytest.mark.s390x
 @pytest.mark.usefixtures("common_templates_scope_session")
 class TestCommonTemplatesEnableDisable:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
@@ -71,6 +71,7 @@ def updated_hco_cr_custom_template_disable(
 
 
 @pytest.mark.polarion("CNV-8731")
+@pytest.mark.s390x
 def test_custom_template_no_disable(
     updated_hco_cr_custom_template_disable,
     hyperconverged_status_templates_scope_function,
@@ -89,6 +90,7 @@ def test_custom_template_no_disable(
 
 
 @pytest.mark.polarion("CNV-8709")
+@pytest.mark.s390x
 def test_disable_template_annotation_value(admin_client, hco_namespace, editor_hyperconverged_custom_template):
     try:
         with pytest.raises(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
@@ -21,7 +21,7 @@ from utilities.constants import (
 )
 from utilities.hco import update_hco_templates_spec, wait_for_hco_conditions
 
-pytestmark = [pytest.mark.arm64]
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 INVALID_ANNOTATION = (
     r"admission webhook.* denied the request: the dataimportcrontemplate.kubevirt.io/enable "
@@ -71,7 +71,6 @@ def updated_hco_cr_custom_template_disable(
 
 
 @pytest.mark.polarion("CNV-8731")
-@pytest.mark.s390x
 def test_custom_template_no_disable(
     updated_hco_cr_custom_template_disable,
     hyperconverged_status_templates_scope_function,
@@ -90,7 +89,6 @@ def test_custom_template_no_disable(
 
 
 @pytest.mark.polarion("CNV-8709")
-@pytest.mark.s390x
 def test_disable_template_annotation_value(admin_client, hco_namespace, editor_hyperconverged_custom_template):
     try:
         with pytest.raises(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
@@ -11,6 +11,7 @@ pytestmark = [pytest.mark.gating, pytest.mark.arm64]
 @pytest.mark.usefixtures("disabled_common_boot_image_import_hco_spec_scope_class")
 class TestDisableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7473")
+    @pytest.mark.s390x
     def test_disable_spec_verify_hco_cr_and_ssp_cr(
         self,
         ssp_cr_spec,
@@ -20,6 +21,7 @@ class TestDisableCommonBootImageImport:
         )
 
     @pytest.mark.polarion("CNV-8183")
+    @pytest.mark.s390x
     def test_image_streams_disable_feature_gate(
         self,
         golden_images_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
@@ -5,13 +5,12 @@ from utilities.constants import (
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
 )
 
-pytestmark = [pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.mark.usefixtures("disabled_common_boot_image_import_hco_spec_scope_class")
 class TestDisableCommonBootImageImport:
     @pytest.mark.polarion("CNV-7473")
-    @pytest.mark.s390x
     def test_disable_spec_verify_hco_cr_and_ssp_cr(
         self,
         ssp_cr_spec,
@@ -21,7 +20,6 @@ class TestDisableCommonBootImageImport:
         )
 
     @pytest.mark.polarion("CNV-8183")
-    @pytest.mark.s390x
     def test_image_streams_disable_feature_gate(
         self,
         golden_images_namespace,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -62,6 +62,7 @@ def updated_hco_cr_custom_template_scope_class(
 class TestCustomTemplates:
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-8707")
+    @pytest.mark.s390x
     def test_custom_template_status(self, hyperconverged_status_templates_scope_function):
         custom_template_name = CUSTOM_CRON_TEMPLATE["metadata"]["name"]
         custom_templates_name = [
@@ -77,6 +78,7 @@ class TestCustomTemplates:
 
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7884")
+    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template(
         self,
         hyperconverged_status_templates_scope_function,
@@ -89,6 +91,7 @@ class TestCustomTemplates:
 
     @pytest.mark.dependency(name="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7914")
+    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template_disable_spec(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -15,7 +15,7 @@ from utilities.hco import (
     wait_for_auto_boot_config_stabilization,
 )
 
-pytestmark = [pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 
 def validate_custom_template_added(hyperconverged_status_templates_scope_function, ssp_spec_templates_scope_function):
@@ -62,7 +62,6 @@ def updated_hco_cr_custom_template_scope_class(
 class TestCustomTemplates:
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-8707")
-    @pytest.mark.s390x
     def test_custom_template_status(self, hyperconverged_status_templates_scope_function):
         custom_template_name = CUSTOM_CRON_TEMPLATE["metadata"]["name"]
         custom_templates_name = [
@@ -78,7 +77,6 @@ class TestCustomTemplates:
 
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7884")
-    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template(
         self,
         hyperconverged_status_templates_scope_function,
@@ -91,7 +89,6 @@ class TestCustomTemplates:
 
     @pytest.mark.dependency(name="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7914")
-    @pytest.mark.s390x
     def test_add_custom_data_import_cron_template_disable_spec(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
@@ -46,6 +46,7 @@ def json_patched_cdi(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8717")
+    @pytest.mark.s390x
     def test_cdi_json_patch(
         self,
         admin_client,
@@ -66,6 +67,7 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9707")
+    @pytest.mark.s390x
     def test_cdi_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -80,5 +82,6 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9706")
+    @pytest.mark.s390x
     def test_cdi_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT_CDI)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
@@ -21,7 +21,7 @@ from utilities.hco import (
     wait_for_hco_conditions,
 )
 
-pytestmark = [pytest.mark.arm64]
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.fixture(scope="class")
@@ -46,7 +46,6 @@ def json_patched_cdi(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8717")
-    @pytest.mark.s390x
     def test_cdi_json_patch(
         self,
         admin_client,
@@ -67,7 +66,6 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9707")
-    @pytest.mark.s390x
     def test_cdi_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -82,6 +80,5 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9706")
-    @pytest.mark.s390x
     def test_cdi_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT_CDI)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
@@ -51,6 +51,7 @@ def json_patched_cnao(
 )
 class TestCNAOJsonPatch:
     @pytest.mark.polarion("CNV-8715")
+    @pytest.mark.s390x
     def test_cnao_json_patch(
         self,
         admin_client,
@@ -68,6 +69,7 @@ class TestCNAOJsonPatch:
         assert not cnao_spec.get(PATH), f"Unable to replace {PATH} from CNAO via json patch. Current value: {cnao_spec}"
 
     @pytest.mark.polarion("CNV-9713")
+    @pytest.mark.s390x
     def test_cnao_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -82,5 +84,6 @@ class TestCNAOJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9712")
+    @pytest.mark.s390x
     def test_cnao_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
@@ -18,7 +18,7 @@ from utilities.hco import (
     wait_for_hco_conditions,
 )
 
-pytestmark = [pytest.mark.arm64]
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 PATH = "selfSignConfiguration"
 COMPONENT = "cnao"
@@ -51,7 +51,6 @@ def json_patched_cnao(
 )
 class TestCNAOJsonPatch:
     @pytest.mark.polarion("CNV-8715")
-    @pytest.mark.s390x
     def test_cnao_json_patch(
         self,
         admin_client,
@@ -69,7 +68,6 @@ class TestCNAOJsonPatch:
         assert not cnao_spec.get(PATH), f"Unable to replace {PATH} from CNAO via json patch. Current value: {cnao_spec}"
 
     @pytest.mark.polarion("CNV-9713")
-    @pytest.mark.s390x
     def test_cnao_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -84,6 +82,5 @@ class TestCNAOJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9712")
-    @pytest.mark.s390x
     def test_cnao_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
@@ -44,6 +44,7 @@ def json_patched_kubevirt(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8689")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch(
         self,
         admin_client,
@@ -60,6 +61,7 @@ class TestKubevirtJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-9697")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -74,6 +76,7 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9698")
+    @pytest.mark.s390x
     def test_kubevirt_json_patch_alert(self, prometheus):
         wait_for_alert(
             prometheus=prometheus,

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
@@ -21,7 +21,7 @@ from utilities.hco import (
     wait_for_hco_conditions,
 )
 
-pytestmark = [pytest.mark.arm64]
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.fixture(scope="class")
@@ -44,7 +44,6 @@ def json_patched_kubevirt(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestKubevirtJsonPatch:
     @pytest.mark.polarion("CNV-8689")
-    @pytest.mark.s390x
     def test_kubevirt_json_patch(
         self,
         admin_client,
@@ -61,7 +60,6 @@ class TestKubevirtJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-9697")
-    @pytest.mark.s390x
     def test_kubevirt_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -76,7 +74,6 @@ class TestKubevirtJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-9698")
-    @pytest.mark.s390x
     def test_kubevirt_json_patch_alert(self, prometheus):
         wait_for_alert(
             prometheus=prometheus,

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
@@ -79,6 +79,7 @@ def multiple_json_patched(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestMultipleJsonPatch:
     @pytest.mark.polarion("CNV-8718")
+    @pytest.mark.s390x
     def test_multiple_json_patch(
         self,
         admin_client,
@@ -101,6 +102,7 @@ class TestMultipleJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-8720")
+    @pytest.mark.s390x
     def test_multiple_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         component_metrics_dict = {
             component: filter_metric_by_component(
@@ -120,6 +122,7 @@ class TestMultipleJsonPatch:
             )
 
     @pytest.mark.polarion("CNV-8813")
+    @pytest.mark.s390x
     def test_multiple_json_patch_alert(self, prometheus):
         for component in COMPONENT_DICT.keys():
             LOGGER.info(f"Waiting for alert: {ALERT_NAME} for component: {component}")

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
@@ -29,7 +29,7 @@ from utilities.hco import (
     wait_for_hco_conditions,
 )
 
-pytestmark = [pytest.mark.arm64]
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 COMPONENT_DICT = {
     COMPONENT_CDI: {"op": "remove", "value": None, "path": PATH_CDI},
@@ -79,7 +79,6 @@ def multiple_json_patched(admin_client, hco_namespace, prometheus, hyperconverge
 )
 class TestMultipleJsonPatch:
     @pytest.mark.polarion("CNV-8718")
-    @pytest.mark.s390x
     def test_multiple_json_patch(
         self,
         admin_client,
@@ -102,7 +101,6 @@ class TestMultipleJsonPatch:
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)
 
     @pytest.mark.polarion("CNV-8720")
-    @pytest.mark.s390x
     def test_multiple_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         component_metrics_dict = {
             component: filter_metric_by_component(
@@ -122,7 +120,6 @@ class TestMultipleJsonPatch:
             )
 
     @pytest.mark.polarion("CNV-8813")
-    @pytest.mark.s390x
     def test_multiple_json_patch_alert(self, prometheus):
         for component in COMPONENT_DICT.keys():
             LOGGER.info(f"Waiting for alert: {ALERT_NAME} for component: {component}")

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -47,6 +47,7 @@ def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestSSPJsonPatch:
     @pytest.mark.polarion("CNV-8690")
+    @pytest.mark.s390x
     def test_ssp_json_patch(
         self,
         admin_client,
@@ -67,6 +68,7 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8691")
+    @pytest.mark.s390x
     def test_ssp_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -81,5 +83,6 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8714")
+    @pytest.mark.s390x
     def test_ssp_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -22,8 +22,7 @@ from utilities.hco import (
 COMPONENT = "ssp"
 REPLICAS = 5
 
-pytestmark = [pytest.mark.arm64]
-
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 @pytest.fixture(scope="class")
 def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_resource_scope_class):
@@ -47,7 +46,6 @@ def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_res
 )
 class TestSSPJsonPatch:
     @pytest.mark.polarion("CNV-8690")
-    @pytest.mark.s390x
     def test_ssp_json_patch(
         self,
         admin_client,
@@ -68,7 +66,6 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8691")
-    @pytest.mark.s390x
     def test_ssp_json_patch_metrics(self, prometheus, kubevirt_all_unsafe_modification_metrics_before_test):
         before_value = filter_metric_by_component(
             metrics=kubevirt_all_unsafe_modification_metrics_before_test,
@@ -83,6 +80,5 @@ class TestSSPJsonPatch:
         )
 
     @pytest.mark.polarion("CNV-8714")
-    @pytest.mark.s390x
     def test_ssp_json_patch_alert(self, prometheus):
         wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=COMPONENT)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -24,6 +24,7 @@ REPLICAS = 5
 
 pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
+
 @pytest.fixture(scope="class")
 def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_resource_scope_class):
     with update_hco_annotations(

--- a/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
@@ -15,7 +15,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 LOGGER = logging.getLogger(__name__)
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "resource_name, expected",
     [

--- a/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
@@ -15,6 +15,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 LOGGER = logging.getLogger(__name__)
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "resource_name, expected",

--- a/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
@@ -12,11 +12,10 @@ from tests.install_upgrade_operators.utils import wait_for_spec_change
 from utilities.hco import get_hco_spec, wait_for_hco_conditions
 from utilities.virt import get_hyperconverged_kubevirt
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "resource_name, expected",
     [

--- a/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
@@ -15,7 +15,7 @@ KUBEVIRT_NEGATIVE_STRATEGY = {
     WORKLOADUPDATEMETHODS: ["Evict"],
 }
 
-
+@pytest.mark.s390x
 class TestLauncherUpdateNegative:
     @pytest.mark.parametrize(
         "updated_kubevirt_cr,",

--- a/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
@@ -15,6 +15,7 @@ KUBEVIRT_NEGATIVE_STRATEGY = {
     WORKLOADUPDATEMETHODS: ["Evict"],
 }
 
+
 @pytest.mark.s390x
 class TestLauncherUpdateNegative:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
@@ -8,7 +8,7 @@ from tests.install_upgrade_operators.utils import wait_for_spec_change
 from utilities.hco import get_hco_spec
 from utilities.virt import get_hyperconverged_kubevirt
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 KUBEVIRT_NEGATIVE_STRATEGY = {
     "batchEvictionInterval": "2m",
     "batchEvictionSize": 30,
@@ -16,7 +16,6 @@ KUBEVIRT_NEGATIVE_STRATEGY = {
 }
 
 
-@pytest.mark.s390x
 class TestLauncherUpdateNegative:
     @pytest.mark.parametrize(
         "updated_kubevirt_cr,",

--- a/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
@@ -13,7 +13,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
-
+@pytest.mark.s390x
 class TestLauncherUpdateResetFields:
     @pytest.mark.parametrize(
         "updated_hco_cr, expected",

--- a/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
@@ -11,10 +11,9 @@ from tests.install_upgrade_operators.utils import wait_for_spec_change
 from utilities.hco import get_hco_spec
 from utilities.virt import get_hyperconverged_kubevirt
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
-@pytest.mark.s390x
 class TestLauncherUpdateResetFields:
     @pytest.mark.parametrize(
         "updated_hco_cr, expected",

--- a/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
@@ -13,6 +13,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
+
 @pytest.mark.s390x
 class TestLauncherUpdateResetFields:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
@@ -16,6 +16,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
+
 @pytest.mark.s390x
 class TestLauncherUpdateModifyDefault:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
@@ -16,7 +16,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
-
+@pytest.mark.s390x
 class TestLauncherUpdateModifyDefault:
     @pytest.mark.parametrize(
         "updated_hco_cr, expected",

--- a/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
@@ -14,10 +14,9 @@ from tests.install_upgrade_operators.utils import wait_for_spec_change
 from utilities.hco import get_hco_spec
 from utilities.virt import get_hyperconverged_kubevirt
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
-@pytest.mark.s390x
 class TestLauncherUpdateModifyDefault:
     @pytest.mark.parametrize(
         "updated_hco_cr, expected",

--- a/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
@@ -21,10 +21,9 @@ from tests.install_upgrade_operators.utils import wait_for_spec_change
 from utilities.hco import get_hco_spec
 from utilities.virt import get_hyperconverged_kubevirt
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
-@pytest.mark.s390x
 class TestLauncherUpdateAll:
     @pytest.mark.parametrize(
         "resource_name, expected",
@@ -72,7 +71,6 @@ class TestLauncherUpdateAll:
             raise AssertionError(f"Unexpected resource name: {resource_name}")
 
 
-@pytest.mark.s390x
 class TestCustomWorkLoadStrategy:
     @pytest.mark.parametrize(
         "updated_hco_cr, expected",

--- a/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
@@ -23,7 +23,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
-
+@pytest.mark.s390x
 class TestLauncherUpdateAll:
     @pytest.mark.parametrize(
         "resource_name, expected",
@@ -70,7 +70,7 @@ class TestLauncherUpdateAll:
         else:
             raise AssertionError(f"Unexpected resource name: {resource_name}")
 
-
+@pytest.mark.s390x
 class TestCustomWorkLoadStrategy:
     @pytest.mark.parametrize(
         "updated_hco_cr, expected",

--- a/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
+++ b/tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py
@@ -23,6 +23,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64]
 
+
 @pytest.mark.s390x
 class TestLauncherUpdateAll:
     @pytest.mark.parametrize(
@@ -69,6 +70,7 @@ class TestLauncherUpdateAll:
             )
         else:
             raise AssertionError(f"Unexpected resource name: {resource_name}")
+
 
 @pytest.mark.s390x
 class TestCustomWorkLoadStrategy:

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -41,7 +41,13 @@ from utilities.constants import (
 )
 from utilities.must_gather import get_must_gather_output_file
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
+pytestmark = [
+    pytest.mark.sno,
+    pytest.mark.post_upgrade,
+    pytest.mark.skip_must_gather_collection,
+    pytest.mark.arm64,
+    pytest.mark.s390x,
+]
 LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -49,6 +49,7 @@ LOGGER = logging.getLogger(__name__)
     "collected_cluster_must_gather", "collected_must_gather_all_images", "cnv_image_path_must_gather_all_images"
 )
 class TestMustGatherCluster:
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         ("resource_type", "resource_path", "checks"),
         [
@@ -95,6 +96,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2982")
+    @pytest.mark.s390x
     def test_namespace(self, hco_namespace, must_gather_for_test):
         namespace_name = hco_namespace.name
         check_resource(
@@ -106,6 +108,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-5885")
+    @pytest.mark.s390x
     def test_no_upstream_only_namespaces(self, must_gather_for_test, sriov_namespace):
         """
         After running must-gather command on the cluster, there are some upstream-only namespaces
@@ -131,7 +134,8 @@ class TestMustGatherCluster:
         assert not matching_upstream_namespaces, (
             f"Found namespace errors in must-gather for the following namespaces {matching_upstream_namespaces}"
         )
-
+        
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "label_selector, resource_namespace",
         [
@@ -197,6 +201,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2727")
+    @pytest.mark.s390x
     def test_template_in_openshift_ns_data(self, admin_client, must_gather_for_test):
         template_resources = list(
             Template.get(dyn_client=admin_client, singular_name="template", namespace="openshift")
@@ -214,6 +219,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2809")
+    @pytest.mark.s390x
     def test_node_nftables(self, collected_nft_files_must_gather, nftables_from_utility_pods):
         table_not_found_errors = []
         for node_name in collected_nft_files_must_gather:
@@ -229,6 +235,7 @@ class TestMustGatherCluster:
 
         assert not table_not_found_errors, f"Following nftables were not collected: {table_not_found_errors}"
 
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "cmd, results_file, compare_method",
         [
@@ -273,6 +280,7 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-2801")
+    @pytest.mark.s390x
     def test_nmstate_config_data(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -283,6 +291,7 @@ class TestMustGatherCluster:
             checks=(("metadata", "name"), ("metadata", "uid")),
         )
 
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "label_selector",
         [pytest.param({"app": "cni-plugins"}, marks=(pytest.mark.polarion("CNV-2715")))],
@@ -295,6 +304,7 @@ class TestMustGatherCluster:
             namespace=py_config["hco_namespace"],
         )
 
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "config_map_by_name, has_owner",
         [
@@ -326,6 +336,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2723")
+    @pytest.mark.s390x
     def test_apiservice_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -337,6 +348,7 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2726")
+    @pytest.mark.s390x
     def test_webhookconfig_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -365,11 +377,13 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-8508")
+    @pytest.mark.s390x
     def test_no_new_cnv_crds(self, kubevirt_crd_names):
         new_crds = [crd for crd in kubevirt_crd_names if crd not in ALL_CNV_CRDS]
         assert not new_crds, f"Following crds are new: {new_crds}."
 
     @pytest.mark.polarion("CNV-2724")
+    @pytest.mark.s390x
     def test_crd_resources(self, admin_client, must_gather_for_test, kubevirt_crd_by_type):
         crd_name = kubevirt_crd_by_type.name
         for version in kubevirt_crd_by_type.instance.spec.versions:
@@ -420,6 +434,7 @@ class TestMustGatherCluster:
                 )
 
     @pytest.mark.polarion("CNV-2939")
+    @pytest.mark.s390x
     def test_image_stream_tag_resources(self, admin_client, must_gather_for_test):
         resource_path = (
             f"namespaces/{NamespacesNames.OPENSHIFT}/{ImageStreamTag.ApiGroup.IMAGE_OPENSHIFT_IO}/imagestreamtags"
@@ -446,6 +461,7 @@ class TestMustGatherCluster:
 @pytest.mark.special_infra
 class TestSriovMustGather:
     @pytest.mark.polarion("CNV-3045")
+    @pytest.mark.s390x
     def test_node_sriov_resource(
         self,
         must_gather_for_test,
@@ -463,6 +479,7 @@ class TestSriovMustGather:
 
 class TestCNVCollectsLogs:
     @pytest.mark.polarion("CNV-9906")
+    @pytest.mark.s390x
     def test_kubevirt_logs_collected(self, gathered_kubevirt_logs, running_hco_containers, hco_namespace):
         LOGGER.info(f"Pod containers: {running_hco_containers}")
         check_logs(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -41,7 +41,7 @@ from utilities.constants import (
 )
 from utilities.must_gather import get_must_gather_output_file
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
 LOGGER = logging.getLogger(__name__)
 
 
@@ -49,7 +49,6 @@ LOGGER = logging.getLogger(__name__)
     "collected_cluster_must_gather", "collected_must_gather_all_images", "cnv_image_path_must_gather_all_images"
 )
 class TestMustGatherCluster:
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         ("resource_type", "resource_path", "checks"),
         [
@@ -96,7 +95,6 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2982")
-    @pytest.mark.s390x
     def test_namespace(self, hco_namespace, must_gather_for_test):
         namespace_name = hco_namespace.name
         check_resource(
@@ -108,7 +106,6 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-5885")
-    @pytest.mark.s390x
     def test_no_upstream_only_namespaces(self, must_gather_for_test, sriov_namespace):
         """
         After running must-gather command on the cluster, there are some upstream-only namespaces
@@ -135,7 +132,6 @@ class TestMustGatherCluster:
             f"Found namespace errors in must-gather for the following namespaces {matching_upstream_namespaces}"
         )
 
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "label_selector, resource_namespace",
         [
@@ -201,7 +197,6 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2727")
-    @pytest.mark.s390x
     def test_template_in_openshift_ns_data(self, admin_client, must_gather_for_test):
         template_resources = list(
             Template.get(dyn_client=admin_client, singular_name="template", namespace="openshift")
@@ -219,7 +214,6 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2809")
-    @pytest.mark.s390x
     def test_node_nftables(self, collected_nft_files_must_gather, nftables_from_utility_pods):
         table_not_found_errors = []
         for node_name in collected_nft_files_must_gather:
@@ -235,7 +229,6 @@ class TestMustGatherCluster:
 
         assert not table_not_found_errors, f"Following nftables were not collected: {table_not_found_errors}"
 
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "cmd, results_file, compare_method",
         [
@@ -280,7 +273,6 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-2801")
-    @pytest.mark.s390x
     def test_nmstate_config_data(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -291,7 +283,6 @@ class TestMustGatherCluster:
             checks=(("metadata", "name"), ("metadata", "uid")),
         )
 
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "label_selector",
         [pytest.param({"app": "cni-plugins"}, marks=(pytest.mark.polarion("CNV-2715")))],
@@ -304,7 +295,6 @@ class TestMustGatherCluster:
             namespace=py_config["hco_namespace"],
         )
 
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "config_map_by_name, has_owner",
         [
@@ -336,7 +326,6 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2723")
-    @pytest.mark.s390x
     def test_apiservice_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -348,7 +337,6 @@ class TestMustGatherCluster:
         )
 
     @pytest.mark.polarion("CNV-2726")
-    @pytest.mark.s390x
     def test_webhookconfig_resources(self, admin_client, must_gather_for_test):
         check_list_of_resources(
             dyn_client=admin_client,
@@ -377,13 +365,11 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-8508")
-    @pytest.mark.s390x
     def test_no_new_cnv_crds(self, kubevirt_crd_names):
         new_crds = [crd for crd in kubevirt_crd_names if crd not in ALL_CNV_CRDS]
         assert not new_crds, f"Following crds are new: {new_crds}."
 
     @pytest.mark.polarion("CNV-2724")
-    @pytest.mark.s390x
     def test_crd_resources(self, admin_client, must_gather_for_test, kubevirt_crd_by_type):
         crd_name = kubevirt_crd_by_type.name
         for version in kubevirt_crd_by_type.instance.spec.versions:
@@ -434,7 +420,6 @@ class TestMustGatherCluster:
                 )
 
     @pytest.mark.polarion("CNV-2939")
-    @pytest.mark.s390x
     def test_image_stream_tag_resources(self, admin_client, must_gather_for_test):
         resource_path = (
             f"namespaces/{NamespacesNames.OPENSHIFT}/{ImageStreamTag.ApiGroup.IMAGE_OPENSHIFT_IO}/imagestreamtags"
@@ -461,7 +446,6 @@ class TestMustGatherCluster:
 @pytest.mark.special_infra
 class TestSriovMustGather:
     @pytest.mark.polarion("CNV-3045")
-    @pytest.mark.s390x
     def test_node_sriov_resource(
         self,
         must_gather_for_test,
@@ -479,7 +463,6 @@ class TestSriovMustGather:
 
 class TestCNVCollectsLogs:
     @pytest.mark.polarion("CNV-9906")
-    @pytest.mark.s390x
     def test_kubevirt_logs_collected(self, gathered_kubevirt_logs, running_hco_containers, hco_namespace):
         LOGGER.info(f"Pod containers: {running_hco_containers}")
         check_logs(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -134,7 +134,7 @@ class TestMustGatherCluster:
         assert not matching_upstream_namespaces, (
             f"Found namespace errors in must-gather for the following namespaces {matching_upstream_namespaces}"
         )
-        
+
     @pytest.mark.s390x
     @pytest.mark.parametrize(
         "label_selector, resource_namespace",

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -9,7 +9,13 @@ from tests.install_upgrade_operators.must_gather.utils import (
 )
 from utilities.constants import NamespacesNames
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
+pytestmark = [
+    pytest.mark.sno,
+    pytest.mark.post_upgrade,
+    pytest.mark.skip_must_gather_collection,
+    pytest.mark.arm64,
+    pytest.mark.s390x,
+]
 
 
 class TestImageGathering:

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -11,6 +11,7 @@ from utilities.constants import NamespacesNames
 
 pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
 
+
 @pytest.mark.s390x
 class TestImageGathering:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -9,10 +9,9 @@ from tests.install_upgrade_operators.must_gather.utils import (
 )
 from utilities.constants import NamespacesNames
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
 
 
-@pytest.mark.s390x
 class TestImageGathering:
     @pytest.mark.parametrize(
         "resource_path, resource",

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -11,7 +11,7 @@ from utilities.constants import NamespacesNames
 
 pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
 
-
+@pytest.mark.s390x
 class TestImageGathering:
     @pytest.mark.parametrize(
         "resource_path, resource",

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
@@ -22,6 +22,7 @@ class TestInstanceTypesAndPreferencesCollected:
         indirect=True,
     )
     @pytest.mark.polarion("CNV-9648")
+    @pytest.mark.s390x
     def test_instancestypes_collected(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
@@ -2,7 +2,13 @@ import pytest
 
 from tests.install_upgrade_operators.must_gather.utils import check_list_of_resources
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
+pytestmark = [
+    pytest.mark.sno,
+    pytest.mark.post_upgrade,
+    pytest.mark.skip_must_gather_collection,
+    pytest.mark.arm64,
+    pytest.mark.s390x,
+]
 
 
 class TestInstanceTypesAndPreferencesCollected:

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vm_preferences.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.install_upgrade_operators.must_gather.utils import check_list_of_resources
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
 
 
 class TestInstanceTypesAndPreferencesCollected:
@@ -22,7 +22,6 @@ class TestInstanceTypesAndPreferencesCollected:
         indirect=True,
     )
     @pytest.mark.polarion("CNV-9648")
-    @pytest.mark.s390x
     def test_instancestypes_collected(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -33,12 +33,7 @@ from tests.install_upgrade_operators.must_gather.utils import (
 from tests.os_params import FEDORA_LATEST
 from utilities.constants import ARM_64, COUNT_FIVE
 
-pytestmark = [
-    pytest.mark.post_upgrade,
-    pytest.mark.skip_must_gather_collection,
-    pytest.mark.arm64,
-    pytest.mark.s390x,
-]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -33,7 +33,12 @@ from tests.install_upgrade_operators.must_gather.utils import (
 from tests.os_params import FEDORA_LATEST
 from utilities.constants import ARM_64, COUNT_FIVE
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade, 
+    pytest.mark.skip_must_gather_collection, 
+    pytest.mark.arm64, 
+    pytest.mark.s390x,
+]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +63,6 @@ def kubevirt_architecture_configuration_scope_session(
 @pytest.mark.usefixtures("collected_cluster_must_gather_with_vms")
 @pytest.mark.sno
 class TestMustGatherClusterWithVMs:
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         ("resource_type", "resource_path", "checks"),
         [
@@ -100,7 +104,6 @@ class TestMustGatherClusterWithVMs:
 
 @pytest.mark.sno
 class TestMustGatherVmDetails:
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "extracted_data_from_must_gather_file, format_regex",
         [
@@ -245,7 +248,6 @@ class TestMustGatherVmDetails:
                     f"Gathered data:\n{extracted_data_from_must_gather_file}"
                 )
 
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "data_volume_scope_class",
         [
@@ -276,7 +278,6 @@ class TestMustGatherVmDetails:
         )
 
     @pytest.mark.polarion("CNV-10243")
-    @pytest.mark.s390x
     def test_must_gather_and_vm_same_node(
         self,
         must_gather_vm,
@@ -292,7 +293,6 @@ class TestMustGatherVmDetails:
 class TestGuestConsoleLog:
     @pytest.mark.usefixtures("updated_disable_serial_console_log_false", "must_gather_vm_scope_class")
     @pytest.mark.polarion("CNV-10630")
-    @pytest.mark.s390x
     def test_guest_console_logs(
         self,
         must_gather_vm_scope_class,
@@ -307,7 +307,6 @@ class TestGuestConsoleLog:
 @pytest.mark.sno
 class TestMustGatherVmLongNameDetails:
     @pytest.mark.polarion("CNV-9233")
-    @pytest.mark.s390x
     def test_data_collected_from_virt_launcher_long(
         self,
         must_gather_long_name_vm,
@@ -320,7 +319,6 @@ class TestMustGatherVmLongNameDetails:
             nftables_ruleset_from_utility_pods=nftables_ruleset_from_utility_pods,
         )
 
-@pytest.mark.s390x
 class TestNoMultipleFilesCollected:
     @pytest.mark.parametrize(
         "vm_for_migration_test, migrated_vm_multiple_times",
@@ -354,7 +352,6 @@ class TestNoMultipleFilesCollected:
 
 
 @pytest.mark.sno
-@pytest.mark.s390x
 class TestControllerRevisionCollected:
     @pytest.mark.polarion("CNV-10978")
     def test_controller_revision_collected(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -58,6 +58,7 @@ def kubevirt_architecture_configuration_scope_session(
 @pytest.mark.usefixtures("collected_cluster_must_gather_with_vms")
 @pytest.mark.sno
 class TestMustGatherClusterWithVMs:
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         ("resource_type", "resource_path", "checks"),
         [
@@ -99,6 +100,7 @@ class TestMustGatherClusterWithVMs:
 
 @pytest.mark.sno
 class TestMustGatherVmDetails:
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "extracted_data_from_must_gather_file, format_regex",
         [
@@ -243,6 +245,7 @@ class TestMustGatherVmDetails:
                     f"Gathered data:\n{extracted_data_from_must_gather_file}"
                 )
 
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "data_volume_scope_class",
         [
@@ -273,6 +276,7 @@ class TestMustGatherVmDetails:
         )
 
     @pytest.mark.polarion("CNV-10243")
+    @pytest.mark.s390x
     def test_must_gather_and_vm_same_node(
         self,
         must_gather_vm,
@@ -288,6 +292,7 @@ class TestMustGatherVmDetails:
 class TestGuestConsoleLog:
     @pytest.mark.usefixtures("updated_disable_serial_console_log_false", "must_gather_vm_scope_class")
     @pytest.mark.polarion("CNV-10630")
+    @pytest.mark.s390x
     def test_guest_console_logs(
         self,
         must_gather_vm_scope_class,
@@ -302,6 +307,7 @@ class TestGuestConsoleLog:
 @pytest.mark.sno
 class TestMustGatherVmLongNameDetails:
     @pytest.mark.polarion("CNV-9233")
+    @pytest.mark.s390x
     def test_data_collected_from_virt_launcher_long(
         self,
         must_gather_long_name_vm,
@@ -314,7 +320,7 @@ class TestMustGatherVmLongNameDetails:
             nftables_ruleset_from_utility_pods=nftables_ruleset_from_utility_pods,
         )
 
-
+@pytest.mark.s390x
 class TestNoMultipleFilesCollected:
     @pytest.mark.parametrize(
         "vm_for_migration_test, migrated_vm_multiple_times",
@@ -348,6 +354,7 @@ class TestNoMultipleFilesCollected:
 
 
 @pytest.mark.sno
+@pytest.mark.s390x
 class TestControllerRevisionCollected:
     @pytest.mark.polarion("CNV-10978")
     def test_controller_revision_collected(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -34,9 +34,9 @@ from tests.os_params import FEDORA_LATEST
 from utilities.constants import ARM_64, COUNT_FIVE
 
 pytestmark = [
-    pytest.mark.post_upgrade, 
-    pytest.mark.skip_must_gather_collection, 
-    pytest.mark.arm64, 
+    pytest.mark.post_upgrade,
+    pytest.mark.skip_must_gather_collection,
+    pytest.mark.arm64,
     pytest.mark.s390x,
 ]
 
@@ -318,6 +318,7 @@ class TestMustGatherVmLongNameDetails:
             vm_list=[must_gather_long_name_vm],
             nftables_ruleset_from_utility_pods=nftables_ruleset_from_utility_pods,
         )
+
 
 class TestNoMultipleFilesCollected:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
@@ -10,7 +10,7 @@ from tests.install_upgrade_operators.must_gather.utils import (
 
 pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
 
-
+@pytest.mark.s390x
 @pytest.mark.usefixtures("must_gather_vms_from_alternate_namespace", "nftables_ruleset_from_utility_pods")
 class TestMustGatherVmDetailsWithParams:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
@@ -10,6 +10,7 @@ from tests.install_upgrade_operators.must_gather.utils import (
 
 pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
 
+
 @pytest.mark.s390x
 @pytest.mark.usefixtures("must_gather_vms_from_alternate_namespace", "nftables_ruleset_from_utility_pods")
 class TestMustGatherVmDetailsWithParams:

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
@@ -8,7 +8,13 @@ from tests.install_upgrade_operators.must_gather.utils import (
     validate_must_gather_vm_file_collection,
 )
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
+pytestmark = [
+    pytest.mark.sno,
+    pytest.mark.post_upgrade,
+    pytest.mark.skip_must_gather_collection,
+    pytest.mark.arm64,
+    pytest.mark.s390x,
+]
 
 
 @pytest.mark.usefixtures("must_gather_vms_from_alternate_namespace", "nftables_ruleset_from_utility_pods")

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms_params.py
@@ -8,10 +8,9 @@ from tests.install_upgrade_operators.must_gather.utils import (
     validate_must_gather_vm_file_collection,
 )
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
 
 
-@pytest.mark.s390x
 @pytest.mark.usefixtures("must_gather_vms_from_alternate_namespace", "nftables_ruleset_from_utility_pods")
 class TestMustGatherVmDetailsWithParams:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
+++ b/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
@@ -35,6 +35,7 @@ LOGGER = logging.getLogger(__name__)
 )
 class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.polarion("CNV-5226")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_cnv_subscription_configuration",
         [
@@ -70,6 +71,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5228")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -103,6 +105,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5229")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -139,6 +142,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5230")
+    @pytest.mark.s390x
     @pytest.mark.dependency(
         name="test_deploying_workloads_on_selected_nodes",
         depends=["test_change_workload_components_on_selected_node_before_workload"],
@@ -151,6 +155,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         assert vm_placement_vm_work3.vmi.node.name == nodes_labeled["work3"][0]
 
     @pytest.mark.polarion("CNV-5231")
+    @pytest.mark.s390x
     @pytest.mark.dependency(
         depends=["test_deploying_workloads_on_selected_nodes"],
     )
@@ -171,6 +176,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
             raise
 
     @pytest.mark.polarion("CNV-5232")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -208,6 +214,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5233")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_cnv_subscription_configuration",
         [
@@ -247,6 +254,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5236")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -284,6 +292,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5237")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_cnv_subscription_configuration",
         [
@@ -322,6 +331,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5235")
+    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [

--- a/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
+++ b/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
@@ -22,7 +22,7 @@ from tests.install_upgrade_operators.node_component.utils import (
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -35,7 +35,6 @@ LOGGER = logging.getLogger(__name__)
 )
 class TestDeployCNVOnSubsetOfClusterNodes:
     @pytest.mark.polarion("CNV-5226")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_cnv_subscription_configuration",
         [
@@ -71,7 +70,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5228")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -105,7 +103,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5229")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -142,7 +139,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5230")
-    @pytest.mark.s390x
     @pytest.mark.dependency(
         name="test_deploying_workloads_on_selected_nodes",
         depends=["test_change_workload_components_on_selected_node_before_workload"],
@@ -155,7 +151,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         assert vm_placement_vm_work3.vmi.node.name == nodes_labeled["work3"][0]
 
     @pytest.mark.polarion("CNV-5231")
-    @pytest.mark.s390x
     @pytest.mark.dependency(
         depends=["test_deploying_workloads_on_selected_nodes"],
     )
@@ -176,7 +171,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
             raise
 
     @pytest.mark.polarion("CNV-5232")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -214,7 +208,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5233")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_cnv_subscription_configuration",
         [
@@ -254,7 +247,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5236")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [
@@ -292,7 +284,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5237")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_cnv_subscription_configuration",
         [
@@ -331,7 +322,6 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         )
 
     @pytest.mark.polarion("CNV-5235")
-    @pytest.mark.s390x
     @pytest.mark.parametrize(
         "alter_np_configuration",
         [

--- a/tests/install_upgrade_operators/node_component/test_hco_vm.py
+++ b/tests/install_upgrade_operators/node_component/test_hco_vm.py
@@ -16,7 +16,7 @@ from utilities.virt import (
     wait_for_vm_interfaces,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64, pytest.mark.s390x]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -39,7 +39,6 @@ def hco_vm(unprivileged_client, namespace):
         vm.stop(wait=True)
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "hyperconverged_with_node_placement",
     [

--- a/tests/install_upgrade_operators/node_component/test_hco_vm.py
+++ b/tests/install_upgrade_operators/node_component/test_hco_vm.py
@@ -38,7 +38,7 @@ def hco_vm(unprivileged_client, namespace):
         yield vm
         vm.stop(wait=True)
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "hyperconverged_with_node_placement",
     [

--- a/tests/install_upgrade_operators/node_component/test_hco_vm.py
+++ b/tests/install_upgrade_operators/node_component/test_hco_vm.py
@@ -38,6 +38,7 @@ def hco_vm(unprivileged_client, namespace):
         yield vm
         vm.stop(wait=True)
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "hyperconverged_with_node_placement",

--- a/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
+++ b/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
@@ -27,6 +27,7 @@ LOGGER = logging.getLogger(__name__)
 class TestCreateHCOWithNodePlacement:
     @pytest.mark.polarion("CNV-5368")
     @pytest.mark.dependency(name="test_hco_cr_with_node_placement")
+    @pytest.mark.s390x
     def test_hco_cr_with_node_placement(
         self,
         admin_client,
@@ -63,6 +64,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5369")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_ssp_cr(
         self,
         ssp_cr_spec,
@@ -81,6 +83,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5382")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_network_addons_cr(
         self,
         network_addon_config_spec_placement,
@@ -123,6 +126,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5383")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_kubevirt_cr(
         self,
         kubevirt_hyperconverged_spec_scope_function,
@@ -158,6 +162,7 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5384")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
+    @pytest.mark.s390x
     def test_node_placement_propagated_to_cdi_cr(
         self,
         cdi_spec,

--- a/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
+++ b/tests/install_upgrade_operators/node_component/test_node_placement_cr.py
@@ -11,7 +11,7 @@ from tests.install_upgrade_operators.node_component.utils import (
     verify_components_exist_only_on_selected_node,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,6 @@ LOGGER = logging.getLogger(__name__)
 class TestCreateHCOWithNodePlacement:
     @pytest.mark.polarion("CNV-5368")
     @pytest.mark.dependency(name="test_hco_cr_with_node_placement")
-    @pytest.mark.s390x
     def test_hco_cr_with_node_placement(
         self,
         admin_client,
@@ -64,7 +63,6 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5369")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
-    @pytest.mark.s390x
     def test_node_placement_propagated_to_ssp_cr(
         self,
         ssp_cr_spec,
@@ -83,7 +81,6 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5382")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
-    @pytest.mark.s390x
     def test_node_placement_propagated_to_network_addons_cr(
         self,
         network_addon_config_spec_placement,
@@ -126,7 +123,6 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5383")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
-    @pytest.mark.s390x
     def test_node_placement_propagated_to_kubevirt_cr(
         self,
         kubevirt_hyperconverged_spec_scope_function,
@@ -162,7 +158,6 @@ class TestCreateHCOWithNodePlacement:
 
     @pytest.mark.polarion("CNV-5384")
     @pytest.mark.dependency(depends=["test_hco_cr_with_node_placement"])
-    @pytest.mark.s390x
     def test_node_placement_propagated_to_cdi_cr(
         self,
         cdi_spec,

--- a/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
+++ b/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
@@ -57,6 +57,7 @@ def pod_security_violations_apis_calls(audit_logs, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-9115")
+@pytest.mark.s390x
 def test_cnv_pod_security_violation_audit_logs(pod_security_violations_apis_calls):
     LOGGER.info("Test pod security violations API calls:")
     if pod_security_violations_apis_calls:

--- a/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
+++ b/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
@@ -12,7 +12,7 @@ POD_SECURITY_AUDIT_VIOLATIONS = "pod-security.kubernetes.io/audit-violations"
 POD_SECURITY_REASON = "authorization.k8s.io/reason"
 HCO_NAMESPACE = "openshift-cnv"
 
-pytestmark = [pytest.mark.arm64]
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 
 class PodSecurityViolationError(Exception):
@@ -57,7 +57,6 @@ def pod_security_violations_apis_calls(audit_logs, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-9115")
-@pytest.mark.s390x
 def test_cnv_pod_security_violation_audit_logs(pod_security_violations_apis_calls):
     LOGGER.info("Test pod security violations API calls:")
     if pod_security_violations_apis_calls:

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -40,6 +40,7 @@ def cnv_pods_by_type_no_hpp_csi_hpp_pool(cnv_pod_priority_class_matrix__function
 
 
 @pytest.mark.polarion("CNV-7261")
+@pytest.mark.s390x
 def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
     all_pods = ALL_CNV_PODS.copy()
     all_pods.append(HPP_POOL)
@@ -53,12 +54,14 @@ def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
 
 
 @pytest.mark.polarion("CNV-7262")
+@pytest.mark.s390x
 def test_pods_priority_class_value(cnv_pods_by_type_no_hpp_csi_hpp_pool):
     validate_cnv_pods_priority_class_name_exists(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
     validate_priority_class_value(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
 
 
 @pytest.mark.polarion("CNV-7306")
+@pytest.mark.s390x
 def test_pods_resource_request(
     cnv_pods_by_type,
     pod_resource_validation_matrix__function__,
@@ -70,6 +73,7 @@ def test_pods_resource_request(
 
 
 @pytest.mark.polarion("CNV-8267")
+@pytest.mark.s390x
 def test_cnv_pod_container_image(cnv_pods_by_type):
     assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)
     assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -15,7 +15,7 @@ from utilities.constants import (
     HPP_POOL,
 )
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,6 @@ def cnv_pods_by_type_no_hpp_csi_hpp_pool(cnv_pod_priority_class_matrix__function
 
 
 @pytest.mark.polarion("CNV-7261")
-@pytest.mark.s390x
 def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
     all_pods = ALL_CNV_PODS.copy()
     all_pods.append(HPP_POOL)
@@ -54,14 +53,12 @@ def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
 
 
 @pytest.mark.polarion("CNV-7262")
-@pytest.mark.s390x
 def test_pods_priority_class_value(cnv_pods_by_type_no_hpp_csi_hpp_pool):
     validate_cnv_pods_priority_class_name_exists(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
     validate_priority_class_value(pod_list=cnv_pods_by_type_no_hpp_csi_hpp_pool)
 
 
 @pytest.mark.polarion("CNV-7306")
-@pytest.mark.s390x
 def test_pods_resource_request(
     cnv_pods_by_type,
     pod_resource_validation_matrix__function__,
@@ -73,7 +70,6 @@ def test_pods_resource_request(
 
 
 @pytest.mark.polarion("CNV-8267")
-@pytest.mark.s390x
 def test_cnv_pod_container_image(cnv_pods_by_type):
     assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)
     assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)

--- a/tests/install_upgrade_operators/product_install/test_crds_schema.py
+++ b/tests/install_upgrade_operators/product_install/test_crds_schema.py
@@ -4,6 +4,7 @@ from ocp_resources.custom_resource_definition import CustomResourceDefinition
 
 pytestmark = pytest.mark.s390x
 
+
 @pytest.fixture(scope="module")
 def crd_operator_resources(request, admin_client):
     """

--- a/tests/install_upgrade_operators/product_install/test_crds_schema.py
+++ b/tests/install_upgrade_operators/product_install/test_crds_schema.py
@@ -17,7 +17,7 @@ def crd_operator_resources(request, admin_client):
     """
     return list(CustomResourceDefinition.get(dyn_client=admin_client, group=request.param))
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "crd_operator_resources",
     [

--- a/tests/install_upgrade_operators/product_install/test_crds_schema.py
+++ b/tests/install_upgrade_operators/product_install/test_crds_schema.py
@@ -17,6 +17,7 @@ def crd_operator_resources(request, admin_client):
     """
     return list(CustomResourceDefinition.get(dyn_client=admin_client, group=request.param))
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "crd_operator_resources",

--- a/tests/install_upgrade_operators/product_install/test_crds_schema.py
+++ b/tests/install_upgrade_operators/product_install/test_crds_schema.py
@@ -2,6 +2,7 @@
 import pytest
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
 
+pytestmark = pytest.mark.s390x
 
 @pytest.fixture(scope="module")
 def crd_operator_resources(request, admin_client):
@@ -18,7 +19,6 @@ def crd_operator_resources(request, admin_client):
     return list(CustomResourceDefinition.get(dyn_client=admin_client, group=request.param))
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "crd_operator_resources",
     [

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
@@ -35,6 +35,7 @@ def remove_kubevirt_vm(unprivileged_client, namespace):
 
 
 @pytest.mark.polarion("CNV-3738")
+@pytest.mark.s390x
 def test_validate_default_uninstall_strategy(kubevirt_resource):
     strategy = kubevirt_resource.instance.spec.uninstallStrategy
     assert strategy == "BlockUninstallIfWorkloadsExist", (

--- a/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
@@ -88,6 +88,7 @@ def cnv_resources(hco_namespace):
 
 
 @pytest.mark.polarion("CNV-10307")
+@pytest.mark.s390x
 def test_relationship_labels_all_cnv_resources(
     ocp_resources_submodule_list, admin_client, cnv_resources, hco_namespace
 ):

--- a/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
@@ -11,7 +11,7 @@ from tests.install_upgrade_operators.utils import (
 from utilities.exceptions import ResourceValueError
 from utilities.infra import is_jira_open
 
-pytestmark = pytest.mark.arm64
+pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 ALLOWLIST_STRING_LIST = [
     "dockercfg",
@@ -88,7 +88,6 @@ def cnv_resources(hco_namespace):
 
 
 @pytest.mark.polarion("CNV-10307")
-@pytest.mark.s390x
 def test_relationship_labels_all_cnv_resources(
     ocp_resources_submodule_list, admin_client, cnv_resources, hco_namespace
 ):

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -14,7 +14,7 @@ from tests.install_upgrade_operators.relationship_labels.utils import (
 )
 from utilities.constants import VERSION_LABEL_KEY
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 LOGGER = logging.getLogger(__name__)
 
 
@@ -31,7 +31,6 @@ def expected_label_dictionary(hco_version_scope_class, request):
     return updated_expected_labels_dict
 
 
-@pytest.mark.s390x
 class TestRelationshipLabels:
     @pytest.mark.parametrize(
         "expected_label_dictionary",

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -30,6 +30,7 @@ def expected_label_dictionary(hco_version_scope_class, request):
         deployment_labels[VERSION_LABEL_KEY] = hco_version_scope_class
     return updated_expected_labels_dict
 
+
 @pytest.mark.s390x
 class TestRelationshipLabels:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -30,7 +30,7 @@ def expected_label_dictionary(hco_version_scope_class, request):
         deployment_labels[VERSION_LABEL_KEY] = hco_version_scope_class
     return updated_expected_labels_dict
 
-
+@pytest.mark.s390x
 class TestRelationshipLabels:
     @pytest.mark.parametrize(
         "expected_label_dictionary",

--- a/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
+++ b/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
@@ -12,7 +12,7 @@ from utilities.infra import get_hyperconverged_resource
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
 LOGGER = logging.getLogger(__name__)
 
-
+@pytest.mark.s390x
 @pytest.mark.parametrize(
     "expected_condition_fields",
     [

--- a/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
+++ b/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
@@ -9,11 +9,10 @@ from tests.install_upgrade_operators.resource_params.utils import (
 from utilities.hco import wait_for_hco_conditions
 from utilities.infra import get_hyperconverged_resource
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.s390x
 @pytest.mark.parametrize(
     "expected_condition_fields",
     [

--- a/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
+++ b/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
@@ -12,6 +12,7 @@ from utilities.infra import get_hyperconverged_resource
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
 LOGGER = logging.getLogger(__name__)
 
+
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "expected_condition_fields",

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -35,6 +35,7 @@ def required_scc_deployment_check(admin_client, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-11964")
+@pytest.mark.s390x
 def test_deployments_missing_required_scc_annotation(required_scc_deployment_check):
     assert not required_scc_deployment_check["missing_required_scc_annotation"], (
         f"Deployments missing {REQUIRED_SCC_ANNOTATION} annotation: "
@@ -43,6 +44,7 @@ def test_deployments_missing_required_scc_annotation(required_scc_deployment_che
 
 
 @pytest.mark.polarion("CNV-11965")
+@pytest.mark.s390x
 def test_deployments_with_incorrect_required_scc(required_scc_deployment_check):
     assert not required_scc_deployment_check["incorrect_required_scc_annotation_value"], (
         f"Deployments incorrect {REQUIRED_SCC_ANNOTATION} annotation : "

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -13,6 +13,7 @@ REQUIRED_SCC_VALUE = "restricted-v2"
 
 pytestmark = pytest.mark.s390x
 
+
 @pytest.fixture(scope="module")
 def required_scc_deployment_check(admin_client, hco_namespace):
     missing_required_scc_annotation = []

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -11,6 +11,7 @@ from utilities.constants import ALL_CNV_DEPLOYMENTS_NO_HPP_POOL
 REQUIRED_SCC_ANNOTATION = "openshift.io/required-scc"
 REQUIRED_SCC_VALUE = "restricted-v2"
 
+pytestmark = pytest.mark.s390x
 
 @pytest.fixture(scope="module")
 def required_scc_deployment_check(admin_client, hco_namespace):
@@ -35,7 +36,6 @@ def required_scc_deployment_check(admin_client, hco_namespace):
 
 
 @pytest.mark.polarion("CNV-11964")
-@pytest.mark.s390x
 def test_deployments_missing_required_scc_annotation(required_scc_deployment_check):
     assert not required_scc_deployment_check["missing_required_scc_annotation"], (
         f"Deployments missing {REQUIRED_SCC_ANNOTATION} annotation: "
@@ -44,7 +44,6 @@ def test_deployments_missing_required_scc_annotation(required_scc_deployment_che
 
 
 @pytest.mark.polarion("CNV-11965")
-@pytest.mark.s390x
 def test_deployments_with_incorrect_required_scc(required_scc_deployment_check):
     assert not required_scc_deployment_check["incorrect_required_scc_annotation_value"], (
         f"Deployments incorrect {REQUIRED_SCC_ANNOTATION} annotation : "

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -44,6 +44,7 @@ def verify_cnv_pods_with_scc(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4438")
+@pytest.mark.s390x
 def test_openshift_io_scc_exists(cnv_pods):
     """
     Validate that Pods in openshift-cnv have 'openshift.io/scc' annotation
@@ -64,6 +65,7 @@ def pods_not_allowlisted_or_anyuid(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4211")
+@pytest.mark.s390x
 def test_pods_scc_in_allowlist(pods_not_allowlisted_or_anyuid):
     """
     Validate that Pods in openshift-cnv have SCC from a predefined allowlist

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -16,7 +16,7 @@ from utilities.constants import (
     LINUX_BRIDGE,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 
 LOGGER = logging.getLogger(__name__)
@@ -44,7 +44,6 @@ def verify_cnv_pods_with_scc(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4438")
-@pytest.mark.s390x
 def test_openshift_io_scc_exists(cnv_pods):
     """
     Validate that Pods in openshift-cnv have 'openshift.io/scc' annotation
@@ -65,7 +64,6 @@ def pods_not_allowlisted_or_anyuid(cnv_pods):
 
 
 @pytest.mark.polarion("CNV-4211")
-@pytest.mark.s390x
 def test_pods_scc_in_allowlist(pods_not_allowlisted_or_anyuid):
     """
     Validate that Pods in openshift-cnv have SCC from a predefined allowlist

--- a/tests/install_upgrade_operators/security/scc/test_default_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_default_scc.py
@@ -16,6 +16,7 @@ def privileged_scc():
 
 
 @pytest.mark.polarion("CNV-4439")
+@pytest.mark.s390x
 def test_users_in_privileged_scc(privileged_scc):
     """
     Validate that Users in privileged SCC is not updated after installing CNV

--- a/tests/install_upgrade_operators/security/scc/test_default_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_default_scc.py
@@ -7,7 +7,7 @@ Tests to check, the default Security Context Constraint
 import pytest
 from ocp_resources.security_context_constraints import SecurityContextConstraints
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.fixture(scope="module")
@@ -16,7 +16,6 @@ def privileged_scc():
 
 
 @pytest.mark.polarion("CNV-4439")
-@pytest.mark.s390x
 def test_users_in_privileged_scc(privileged_scc):
     """
     Validate that Users in privileged SCC is not updated after installing CNV

--- a/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
+++ b/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
@@ -36,6 +36,7 @@ def vm_virt_launcher_pod(developer_vm, namespace, unprivileged_client):
 
 
 @pytest.mark.polarion("CNV-4897")
+@pytest.mark.s390x
 def test_unprivileged_client_virt_launcher(unprivileged_client, developer_vm, vm_virt_launcher_pod):
     with pytest.raises(
         ApiException,

--- a/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
+++ b/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
@@ -4,7 +4,7 @@ from ocp_resources.pod import Pod
 
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.fixture()
@@ -36,7 +36,6 @@ def vm_virt_launcher_pod(developer_vm, namespace, unprivileged_client):
 
 
 @pytest.mark.polarion("CNV-4897")
-@pytest.mark.s390x
 def test_unprivileged_client_virt_launcher(unprivileged_client, developer_vm, vm_virt_launcher_pod):
     with pytest.raises(
         ApiException,

--- a/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
+++ b/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
 @pytest.mark.polarion("CNV-4296")
+@pytest.mark.s390x
 def test_selinuxlaunchertype_in_kubevirt_config(kubevirt_config):
     selinux_launcher_type = "selinuxLauncherType"
     assert selinux_launcher_type not in kubevirt_config, f"{selinux_launcher_type} is found in {kubevirt_config}"

--- a/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
+++ b/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
@@ -6,11 +6,10 @@ Test to check, SELinuxLauncher Type in kubevirt config map
 
 import pytest
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64, pytest.mark.s390x]
 
 
 @pytest.mark.polarion("CNV-4296")
-@pytest.mark.s390x
 def test_selinuxlaunchertype_in_kubevirt_config(kubevirt_config):
     selinux_launcher_type = "selinuxLauncherType"
     assert selinux_launcher_type not in kubevirt_config, f"{selinux_launcher_type} is found in {kubevirt_config}"

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
@@ -43,6 +43,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 LOGGER = logging.getLogger(__name__)
 
+
 @pytest.mark.s390x
 class TestCRDefaultsOnStanzaDeletion:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
@@ -39,12 +39,11 @@ from tests.install_upgrade_operators.strict_reconciliation.constants import (
 )
 from utilities.hco import wait_for_hco_conditions
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.s390x
 class TestCRDefaultsOnStanzaDeletion:
     @pytest.mark.parametrize(
         "deleted_stanza_on_hco_cr, expected",

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_defaults_on_stanza_deletion.py
@@ -43,7 +43,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 LOGGER = logging.getLogger(__name__)
 
-
+@pytest.mark.s390x
 class TestCRDefaultsOnStanzaDeletion:
     @pytest.mark.parametrize(
         "deleted_stanza_on_hco_cr, expected",

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
@@ -58,6 +58,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.arm64]
 LOGGER = logging.getLogger(__name__)
 
+
 @pytest.mark.s390x
 class TestOperatorsModify:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
@@ -58,7 +58,7 @@ from utilities.virt import get_hyperconverged_kubevirt
 pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.arm64]
 LOGGER = logging.getLogger(__name__)
 
-
+@pytest.mark.s390x
 class TestOperatorsModify:
     @pytest.mark.parametrize(
         ("updated_hco_cr", "expected"),

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_modify_defaults.py
@@ -55,11 +55,10 @@ from utilities.hco import get_hco_spec
 from utilities.storage import get_hyperconverged_cdi
 from utilities.virt import get_hyperconverged_kubevirt
 
-pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.post_upgrade, pytest.mark.arm64, pytest.mark.s390x]
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.s390x
 class TestOperatorsModify:
     @pytest.mark.parametrize(
         ("updated_hco_cr", "expected"),

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
@@ -53,7 +53,7 @@ def get_resource_current_value(resource_spec, field_to_validate):
         pytest.fail("Bad test configuration. This should never be reached.")
     return current_value
 
-
+@pytest.mark.s390x
 class TestHCONonDefaultFields:
     @pytest.mark.parametrize(
         (

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
@@ -30,7 +30,7 @@ from utilities.constants import (
     RESOURCE_REQUIREMENTS_KEY_HCO_CR,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +54,6 @@ def get_resource_current_value(resource_spec, field_to_validate):
     return current_value
 
 
-@pytest.mark.s390x
 class TestHCONonDefaultFields:
     @pytest.mark.parametrize(
         (

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
@@ -53,6 +53,7 @@ def get_resource_current_value(resource_spec, field_to_validate):
         pytest.fail("Bad test configuration. This should never be reached.")
     return current_value
 
+
 @pytest.mark.s390x
 class TestHCONonDefaultFields:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -92,6 +92,7 @@ def hco_with_default_cpu_model_set(
 
 
 @pytest.mark.polarion("CNV-9024")
+@pytest.mark.s390x
 def test_default_value_for_cpu_model(
     hco_spec_scope_module,
     kubevirt_hyperconverged_spec_scope_module,
@@ -119,6 +120,7 @@ def test_default_value_for_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9025")
+@pytest.mark.s390x
 def test_set_hco_default_cpu_model(
     hyperconverged_resource_scope_function,
     hco_with_default_cpu_model_set,
@@ -145,6 +147,7 @@ def test_set_hco_default_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9026")
+@pytest.mark.s390x
 def test_set_hco_default_cpu_model_with_existing_vm(
     hyperconverged_resource_scope_function,
     fedora_vm_scope_module,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -10,7 +10,7 @@ KUBEVIRT_CPU_MODEL_KEY = "cpuModel"
 HOST_PASSTHROUGH = "host-passthrough"
 
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
 def assert_updated_hco_default_cpu_model(hco_resource, expected_cpu_model):
@@ -92,7 +92,6 @@ def hco_with_default_cpu_model_set(
 
 
 @pytest.mark.polarion("CNV-9024")
-@pytest.mark.s390x
 def test_default_value_for_cpu_model(
     hco_spec_scope_module,
     kubevirt_hyperconverged_spec_scope_module,
@@ -120,7 +119,6 @@ def test_default_value_for_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9025")
-@pytest.mark.s390x
 def test_set_hco_default_cpu_model(
     hyperconverged_resource_scope_function,
     hco_with_default_cpu_model_set,
@@ -147,7 +145,6 @@ def test_set_hco_default_cpu_model(
 
 
 @pytest.mark.polarion("CNV-9026")
-@pytest.mark.s390x
 def test_set_hco_default_cpu_model_with_existing_vm(
     hyperconverged_resource_scope_function,
     fedora_vm_scope_module,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
@@ -17,6 +17,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 LOGGER = logging.getLogger(__name__)
 
+
 @pytest.mark.s390x
 class TestNegativeFeatureGates:
     @pytest.mark.parametrize(
@@ -109,6 +110,7 @@ class TestNegativeFeatureGates:
                 "configuration"
             ]["developerConfiguration"][FEATURE_GATES]
         )
+
 
 @pytest.mark.s390x
 class TestHCOOptionalFeatureGatesSuite:

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
@@ -17,7 +17,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 LOGGER = logging.getLogger(__name__)
 
-
+@pytest.mark.s390x
 class TestNegativeFeatureGates:
     @pytest.mark.parametrize(
         ("hco_with_non_default_feature_gates",),
@@ -110,7 +110,7 @@ class TestNegativeFeatureGates:
             ]["developerConfiguration"][FEATURE_GATES]
         )
 
-
+@pytest.mark.s390x
 class TestHCOOptionalFeatureGatesSuite:
     @pytest.mark.polarion("CNV-6277")
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
@@ -13,12 +13,11 @@ from utilities.virt import (
     wait_for_kubevirt_conditions,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.s390x
 class TestNegativeFeatureGates:
     @pytest.mark.parametrize(
         ("hco_with_non_default_feature_gates",),
@@ -112,7 +111,6 @@ class TestNegativeFeatureGates:
         )
 
 
-@pytest.mark.s390x
 class TestHCOOptionalFeatureGatesSuite:
     @pytest.mark.polarion("CNV-6277")
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -6,12 +6,11 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
 )
 from utilities.constants import ALL_HCO_RELATED_OBJECTS
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
-    @pytest.mark.s390x
     def test_no_new_hco_related_objects(self, hco_status_related_objects):
         actual_related_objects = {
             related_object["name"]: related_object["kind"] for related_object in hco_status_related_objects
@@ -26,7 +25,6 @@ class TestRelatedObjects:
         assert not new_related_objects, f"There are new HCO related objects:\n {new_related_objects.to_json(indent=2)}"
 
     @pytest.mark.polarion("CNV-7267")
-    @pytest.mark.s390x
     def test_hco_related_objects(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -11,6 +11,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-9843")
+    @pytest.mark.s390x
     def test_no_new_hco_related_objects(self, hco_status_related_objects):
         actual_related_objects = {
             related_object["name"]: related_object["kind"] for related_object in hco_status_related_objects
@@ -25,6 +26,7 @@ class TestRelatedObjects:
         assert not new_related_objects, f"There are new HCO related objects:\n {new_related_objects.to_json(indent=2)}"
 
     @pytest.mark.polarion("CNV-7267")
+    @pytest.mark.s390x
     def test_hco_related_objects(
         self,
         admin_client,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
@@ -13,7 +13,7 @@ EXPECTED_VALUE = True
 SPEC_STR = "spec"
 PATCH_STR = "patch"
 
-
+@pytest.mark.s390x
 class TestLiveMigrationConfigUpdate:
     @pytest.mark.parametrize(
         ("updated_hco_cr", "expected"),

--- a/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
@@ -8,13 +8,12 @@ from tests.install_upgrade_operators.strict_reconciliation.constants import (
     LIVE_MIGRATION_CONFIG_KEY,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 EXPECTED_VALUE = True
 SPEC_STR = "spec"
 PATCH_STR = "patch"
 
 
-@pytest.mark.s390x
 class TestLiveMigrationConfigUpdate:
     @pytest.mark.parametrize(
         ("updated_hco_cr", "expected"),

--- a/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_livemigration_config_update.py
@@ -13,6 +13,7 @@ EXPECTED_VALUE = True
 SPEC_STR = "spec"
 PATCH_STR = "patch"
 
+
 @pytest.mark.s390x
 class TestLiveMigrationConfigUpdate:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
@@ -26,6 +26,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pyt
 
 LOGGER = logging.getLogger(__name__)
 
+
 @pytest.mark.s390x
 class TestOperatorsDefaults:
     @pytest.mark.parametrize(

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
@@ -22,12 +22,11 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
     expected_certconfig_stanza,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.s390x
 class TestOperatorsDefaults:
     @pytest.mark.parametrize(
         ("expected", "resource_kind_str", "subkeys_list"),

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_defaults.py
@@ -26,7 +26,7 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pyt
 
 LOGGER = logging.getLogger(__name__)
 
-
+@pytest.mark.s390x
 class TestOperatorsDefaults:
     @pytest.mark.parametrize(
         ("expected", "resource_kind_str", "subkeys_list"),

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
@@ -26,7 +26,7 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import verify_s
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
-
+@pytest.mark.s390x
 class TestOperatorsModify:
     @pytest.mark.parametrize(
         "updated_cdi_cr",

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
@@ -24,10 +24,9 @@ from tests.install_upgrade_operators.strict_reconciliation.constants import (
 )
 from tests.install_upgrade_operators.strict_reconciliation.utils import verify_specs
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 
-@pytest.mark.s390x
 class TestOperatorsModify:
     @pytest.mark.parametrize(
         "updated_cdi_cr",

--- a/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_operator_modify.py
@@ -26,6 +26,7 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import verify_s
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
 
+
 @pytest.mark.s390x
 class TestOperatorsModify:
     @pytest.mark.parametrize(


### PR DESCRIPTION
##### Short description:

This change adds the @pytest.mark.s390x marker to iuo-ocs tests across multiple test files. The marker is applied to annotate tests for the s390x architecture, with no modifications to test logic, parameters, or control flow in any of the affected files.

##### More details:

The marker helps identify tests relevant for the s390x environment. This is useful for running architecture-specific test suites as needed.

##### What this PR does / why we need it:

This PR adds s390x architecture-specific markers to identify tests that are relevant to the s390x platform. 

##### Which issue(s) this PR fixes:

None

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added platform-specific markers to numerous test modules and functions to explicitly include support for the s390x architecture, enabling targeted test runs on s390x systems without altering test logic or outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->