### PR TITLE
Fix flaky behavior for test_data_import_cron_deletion_on_opt_out

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/conftest.py
+++ b/tests/infrastructure/golden_images/update_boot_source/conftest.py
@@ -5,9 +5,7 @@ from kubernetes.dynamic.exceptions import NotFoundError
 from ocp_resources.cdi import CDI
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.data_source import DataSource
-from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.ssp import SSP
-from ocp_resources.volume_snapshot import VolumeSnapshot
 from timeout_sampler import TimeoutSampler
 
 from tests.infrastructure.golden_images.update_boot_source.utils import (
@@ -18,7 +16,6 @@ from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     enable_common_boot_image_import_spec_wait_for_data_import_cron,
 )
-from utilities.storage import RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL
 
 LOGGER = logging.getLogger(__name__)
 
@@ -46,26 +43,6 @@ def enabled_common_boot_image_import_feature_gate_scope_class(
         hco_resource=hyperconverged_resource_scope_class,
         admin_client=admin_client,
         namespace=golden_images_namespace,
-    )
-
-
-@pytest.fixture()
-def golden_images_persistent_volume_claims_scope_function(golden_images_namespace):
-    return list(
-        PersistentVolumeClaim.get(
-            namespace=golden_images_namespace.name,
-            label_selector=RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
-        )
-    )
-
-
-@pytest.fixture()
-def golden_images_volume_snapshot_scope_function(golden_images_namespace):
-    return list(
-        VolumeSnapshot.get(
-            namespace=golden_images_namespace.name,
-            label_selector=RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
-        )
     )
 
 

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -16,6 +16,7 @@ from tests.infrastructure.golden_images.constants import (
     CUSTOM_DATA_SOURCE_NAME,
     DEFAULT_FEDORA_REGISTRY_URL,
 )
+from tests.infrastructure.golden_images.update_boot_source.utils import get_all_dic_volume_names
 from utilities.constants import (
     BIND_IMMEDIATE_ANNOTATION,
     TIMEOUT_1MIN,
@@ -32,10 +33,7 @@ from utilities.ssp import (
     wait_for_condition_message_value,
     wait_for_deleted_data_import_crons,
 )
-from utilities.storage import (
-    DATA_IMPORT_CRON_SUFFIX,
-    data_volume_template_with_source_ref_dict,
-)
+from utilities.storage import DATA_IMPORT_CRON_SUFFIX, data_volume_template_with_source_ref_dict
 from utilities.virt import DV_DISK, VirtualMachineForTests, running_vm
 
 LOGGER = logging.getLogger(__name__)
@@ -105,14 +103,6 @@ def create_vm_with_infer_from_volume(
         data_volume_template=data_volume_template_with_source_ref_dict(data_source=data_source_for_test),
     ) as vm:
         return vm
-
-
-def verify_expected_volumes_exist(existing_volume_names, expected_volume_names):
-    LOGGER.info("Verify volumes are not deleted after opt-out.")
-    assert all([
-        any([expected_name in existing_name for existing_name in existing_volume_names])
-        for expected_name in expected_volume_names
-    ]), f"Not all Volumes exist!\nExisting: {existing_volume_names}\nExpected: {expected_volume_names}"
 
 
 @pytest.fixture()
@@ -249,18 +239,9 @@ def created_data_import_cron(
         yield data_import_cron
 
 
-@pytest.fixture()
-def existing_golden_images_volumes_scope_function(
-    golden_images_persistent_volume_claims_scope_function,
-    golden_images_volume_snapshot_scope_function,
-    golden_images_data_import_crons_scope_function,
-):
-    if golden_images_data_import_crons_scope_function[0].instance.status.sourceFormat == "pvc":
-        cluster_volumes = golden_images_persistent_volume_claims_scope_function
-    else:
-        cluster_volumes = golden_images_volume_snapshot_scope_function
-
-    return [volume.name for volume in cluster_volumes if volume.exists]
+@pytest.fixture
+def existing_dic_volumes_before_disable(admin_client, golden_images_namespace):
+    return get_all_dic_volume_names(client=admin_client, namespace=golden_images_namespace.name)
 
 
 @pytest.mark.polarion("CNV-7531")
@@ -346,19 +327,23 @@ class TestDataImportCronDefaultStorageClass:
         )
 
 
-@pytest.mark.jira("CNV-62615", run=False)
 @pytest.mark.polarion("CNV-7532")
 def test_data_import_cron_deletion_on_opt_out(
+    admin_client,
+    golden_images_namespace,
+    existing_dic_volumes_before_disable,
     golden_images_data_import_crons_scope_function,
-    existing_golden_images_volumes_scope_function,
     disabled_common_boot_image_import_hco_spec_scope_function,
 ):
     LOGGER.info("Verify DataImportCrons are deleted after opt-out.")
     wait_for_deleted_data_import_crons(data_import_crons=golden_images_data_import_crons_scope_function)
-    expected_volume_names = [list(datasource)[0] for datasource in py_config["auto_update_data_source_matrix"]]
-    verify_expected_volumes_exist(
-        existing_volume_names=existing_golden_images_volumes_scope_function,
-        expected_volume_names=expected_volume_names,
+    volumes_after = get_all_dic_volume_names(client=admin_client, namespace=golden_images_namespace.name)
+    assert set(existing_dic_volumes_before_disable) == set(volumes_after), (
+        "DataImportCron deletion should not affect existing volumes.\n"
+        f"Volumes before: {sorted(existing_dic_volumes_before_disable)}\n"
+        f"Volumes after: {sorted(volumes_after)}\n"
+        f"Added: {sorted(set(volumes_after) - set(existing_dic_volumes_before_disable))}\n"
+        f"Removed: {sorted(set(existing_dic_volumes_before_disable) - set(volumes_after))}"
     )
 
 

--- a/tests/infrastructure/golden_images/update_boot_source/utils.py
+++ b/tests/infrastructure/golden_images/update_boot_source/utils.py
@@ -1,11 +1,14 @@
 import logging
 
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.template import Template
+from ocp_resources.volume_snapshot import VolumeSnapshot
 
 from tests.infrastructure.golden_images.constants import (
     DEFAULT_FEDORA_REGISTRY_URL,
 )
 from utilities.constants import WILDCARD_CRON_EXPRESSION
+from utilities.storage import RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,3 +48,18 @@ def template_labels(os):
         workload=Template.Workload.SERVER,
         flavor=Template.Flavor.SMALL,
     )
+
+
+def get_all_dic_volume_names(client, namespace):
+    def _fetch_volume_names(resource_cls):
+        return [
+            volume.name
+            for volume in resource_cls.get(
+                client=client,
+                namespace=namespace,
+                label_selector=RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
+            )
+            if volume.exists
+        ]
+
+    return _fetch_volume_names(PersistentVolumeClaim) + _fetch_volume_names(VolumeSnapshot)


### PR DESCRIPTION
##### Short description:

- Removed unused PVC and VolumeSnapshot fixtures that had static data.
- Added get_all_dic_volume_names()  to dynamically fetch existing volumes (PVCs and VolumeSnapshots).
- Updated test_data_import_cron_deletion_on_opt_out to compare volume state before and after DIC deletion.
- Simplified existing_data_source_volume fixture to avoid fixture chaining and rely on real-time volume fetch.
- Improved assertion logging for added/removed volumes when volume mismatch is detected.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-62615


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified test fixtures and helper functions for verifying volume existence.
  * Updated tests to use a new utility for retrieving managed volume names.
  * Improved test reliability by streamlining how volume names are checked before and after resource changes.

* **New Features**
  * Added a utility to fetch all managed volume names within a specified namespace for test validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->