### PR TITLE
Revert "Update Fedora OS to fedora42 for x86_64 (#1566)"

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -73,7 +73,6 @@ class Windows:
 @dataclass
 class Fedora:
     FEDORA41_IMG: str | None = None
-    FEDORA42_IMG: str | None = None
     FEDORA_CONTAINER_IMAGE: str | None = None
     DISK_DEMO: str | None = None
     DIR: str = f"{BASE_IMAGES_DIR}/fedora-images"

--- a/tests/global_config_x86_64.py
+++ b/tests/global_config_x86_64.py
@@ -26,7 +26,7 @@ windows_os_matrix = generate_os_matrix_dict(
     ],
 )
 
-fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating_systems=["fedora-42"])
+fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating_systems=["fedora-41"])
 centos_os_matrix = generate_os_matrix_dict(os_name="centos", supported_operating_systems=["centos-stream-9"])
 instance_type_rhel_os_matrix = generate_instance_type_rhel_os_matrix(preferences=["rhel-8", "rhel-9", "rhel-10"])
 

--- a/tests/infrastructure/golden_images/conftest.py
+++ b/tests/infrastructure/golden_images/conftest.py
@@ -34,7 +34,7 @@ def updated_default_storage_class_scope_function(
 def latest_fedora_release_version(downloaded_latest_libosinfo_db):
     """
     Extract the version from file name, if no files found raise KeyError
-    file example: /tmp/pytest-6axFnW3vzouCkjWokhvbDi/osinfodb0/osinfo-db-20221121/os/fedoraproject.org/fedora-42.xml
+    file example: /tmp/pytest-6axFnW3vzouCkjWokhvbDi/osinfodb0/osinfo-db-20221121/os/fedoraproject.org/fedora-41.xml
     """
     osinfo_file_folder_path = os.path.join(downloaded_latest_libosinfo_db, "os/fedoraproject.org/")
     list_of_fedora_os_files = list(sorted(Path(osinfo_file_folder_path).glob("*fedora-[0-9][0-9]*.xml")))

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -89,11 +89,11 @@ class ArchImages:
         Windows.LATEST_RELEASE_STR = Windows.WIN2k19_IMG
 
         Fedora = Fedora(
-            FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",
-            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:42",
+            FEDORA41_IMG="Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2",
+            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41",
             DISK_DEMO="fedora-cloud-registry-disk-demo",
         )
-        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG
+        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA41_IMG
 
         Centos = Centos(CENTOS_STREAM_9_IMG="CentOS-Stream-GenericCloud-9-20220107.0.x86_64.qcow2")
         Centos.LATEST_RELEASE_STR = Centos.CENTOS_STREAM_9_IMG

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -98,11 +98,6 @@ FEDORA_OS_MAPPING: dict[str, dict[str, str | Any]] = {
         OS_VERSION_STR: "41",
         OS_STR: "fedora41",
     },
-    "fedora-42": {
-        IMAGE_NAME_STR: "FEDORA42_IMG",
-        OS_VERSION_STR: "42",
-        OS_STR: "fedora42",
-    },
 }
 
 CENTOS_OS_MAPPING: dict[str, dict[str, str | Any]] = {


### PR DESCRIPTION
Fedora42 introduced a bug in logging in to a VM console, hence reverting back to 41.

This reverts commit 7287c85d351d6db3b1fa4ffd4c781eb0377e95cc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Fedora support to version 41, replacing Fedora 42 across the application.
* **Bug Fixes**
  * Corrected documentation and configuration references to reflect Fedora 41.
* **Chores**
  * Removed all references to Fedora 42 images and container tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->