### PR TITLE
Add 4.19 versions to allolist in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps:
 commands =
     pip install pip --upgrade
     pip install tox --upgrade
-    pyutils-jira --config-file-path jira.cfg --target-versions "4.19.1,4.19.z" --verbose
+    pyutils-jira --config-file-path jira.cfg --target-versions "4.19.1,4.19.2, 4.19.3, 4.19.4, 4.19.z" --verbose
 
 #Unused code
 [testenv:unused-code]


### PR DESCRIPTION
##### Short description:
Tox for 4.19 fails because versions are missing.
Added the versions to the allowlist.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-66579
