### PR TITLE
fix: update PipelineRun import and pipeline reference param name

### DIFF
--- a/tests/infrastructure/tekton/conftest.py
+++ b/tests/infrastructure/tekton/conftest.py
@@ -7,7 +7,7 @@ import yaml
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.pipeline import Pipeline
-from ocp_resources.pipelineruns import PipelineRun
+from ocp_resources.pipeline_run import PipelineRun
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
 from ocp_resources.task import Task
@@ -286,7 +286,7 @@ def pipelinerun_from_pipeline_template(
         namespace=custom_pipeline_namespace.name,
         client=admin_client,
         params=configured_windows_efi_pipelinerun_parameters,
-        pipelineref=WINDOWS_EFI_INSTALLER_STR,
+        pipeline_ref=WINDOWS_EFI_INSTALLER_STR,
     ) as pipelinerun:
         pipelinerun.wait_for_conditions()
         yield pipelinerun
@@ -374,7 +374,7 @@ def pipelinerun_for_disk_uploader(
         namespace=custom_pipeline_namespace.name,
         client=admin_client,
         params=pipeline_run_params,
-        pipelineref=pipeline_disk_uploader.name,
+        pipeline_ref=pipeline_disk_uploader.name,
     ) as pipelinerun:
         pipelinerun.wait_for_conditions()
         yield pipelinerun


### PR DESCRIPTION
##### Short description:
This change reflects recent updates introduced as part of the OpenAPI v3 adoption. Specifically, it aligns with [PR #2473](https://github.com/RedHatQE/openshift-python-wrapper/pull/2473), which updated parameter names in the PipelineRun resource to match the OpenAPI schema. The switch from pipelineref to pipeline_ref is part of that refactor.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
