### PR TITLE
 [Storage][main] fix expected error msg  for test_disk_expand_then_clone_fail

### DIFF
--- a/tests/storage/test_online_resize.py
+++ b/tests/storage/test_online_resize.py
@@ -275,11 +275,7 @@ def test_simultaneous_disk_expand(
 @pytest.mark.polarion("CNV-8257")
 @pytest.mark.parametrize(
     "cirros_vm_name",
-    [
-        pytest.param(
-            {"vm_name": "cnv-8257"},
-        ),
-    ],
+    [pytest.param({"vm_name": "cnv-8257"})],
     indirect=True,
 )
 def test_disk_expand_then_clone_fail(
@@ -297,9 +293,8 @@ def test_disk_expand_then_clone_fail(
             func=lambda: dv.instance.status.conditions,
         ):
             if any(
-                "The clone doesn't meet the validation requirements:"
-                " target resources requests storage size is smaller than the source" in condition["message"]
-                for condition in sample
+                "resources requests storage size is smaller than the source" in condition.get("message", "")
+                for condition in sample or []
             ):
                 return
 


### PR DESCRIPTION
**Short description:**
Fix and adjust existing test to handle DV clone failure on new storage class (gcnv-flex).

**More details:**
The test test_disk_expand_then_clone_fail was previously assuming a specific error message format. However, with the new gcnv-flex storage class, the validation error appears under a different condition type or message. This change adjusts the test logic to check for the expected error substring across all condition messages, regardless of type, making the test more resilient and accurate.

**What this PR does / why we need it:**
Ensures that the test correctly detects DV clone failure due to insufficient storage overhead or validation failure across different storage classes, including the newly used gcnv-flex.

**Which issue(s) this PR fixes:**
N/A (test stability improvement)

**Special notes for reviewer:**

This issue started occurring with the introduction of gcnv-flex.

No change to functional logic — only test robustness was improved.

**Jira ticket:**
https://issues.redhat.com/browse/CNV-66509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of disk expansion and clone-failure tests by handling empty or missing samples more safely, using safer message extraction, and relaxing error matching to target the specific storage-size mismatch substring.
  * Minor test input formatting consolidated for readability with no behavioral change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->