### PR TITLE
Change test_common_templates_data_volumes.py sc to be dynamic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1375,15 +1375,6 @@ def skip_test_if_no_ocs_sc(ocs_storage_class):
 
 
 @pytest.fixture(scope="session")
-def fail_test_if_no_ocs_sc(ocs_storage_class):
-    """
-    Fail test if no OCS storage class available
-    """
-    if not ocs_storage_class:
-        pytest.fail("Failing test, OCS storage class is not deployed")
-
-
-@pytest.fixture(scope="session")
 def hyperconverged_ovs_annotations_enabled_scope_session(
     admin_client,
     hco_namespace,

--- a/tests/infrastructure/golden_images/conftest.py
+++ b/tests/infrastructure/golden_images/conftest.py
@@ -6,8 +6,6 @@ import pytest
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.storage_class import StorageClass
 
-from utilities.constants import HOSTPATH_CSI_BASIC
-
 
 @pytest.fixture()
 def updated_default_storage_class_scope_function(
@@ -42,16 +40,3 @@ def latest_fedora_release_version(downloaded_latest_libosinfo_db):
         raise FileNotFoundError("No fedora files were found in osinfo db")
     latest_fedora_os_file = list_of_fedora_os_files[-1]
     return re.findall(r"\d+", latest_fedora_os_file.name)[0]
-
-
-@pytest.fixture(scope="session")
-def fail_if_no_hostpath_csi_basic_sc(cluster_storage_classes_names):
-    """
-    Fail the test if no CSI basic storage class is available
-    """
-    if HOSTPATH_CSI_BASIC not in cluster_storage_classes_names:
-        pytest.fail(
-            f"Test failed: {HOSTPATH_CSI_BASIC} basic storage class is not deployed. "
-            f"Available storage classes: {cluster_storage_classes_names}. "
-            "Ensure the correct CSI storage class is configured before running tests."
-        )

--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -4,7 +4,7 @@ from pytest_testconfig import config as py_config
 
 from tests.infrastructure.golden_images.constants import PVC_NOT_FOUND_ERROR
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS, FEDORA_LATEST_OS
-from utilities.constants import HOSTPATH_CSI_BASIC, U1_SMALL, Images
+from utilities.constants import STORAGE_CLASS_A, STORAGE_CLASS_B, U1_SMALL, Images
 from utilities.storage import data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, running_vm
 
@@ -39,11 +39,10 @@ def vm_from_golden_image(
     request,
     unprivileged_client,
     namespace,
-    ocs_storage_class,
     golden_image_data_source_scope_function,
 ):
-    use_ocs_storage_class = request.param.get("ocs_storage_class")
-    storage_class = ocs_storage_class.name if use_ocs_storage_class else None
+    set_storage_class = request.param.get("set_storage_class")
+    storage_class = py_config[STORAGE_CLASS_B] if set_storage_class else None
     with VirtualMachineForTests(
         name="vm-from-golden-image",
         namespace=namespace.name,
@@ -108,11 +107,11 @@ def test_vm_with_existing_dv(data_volume_scope_function, vm_from_template_with_e
             {
                 "dv_name": FEDORA_LATEST_OS,
                 "image": FEDORA_LATEST.get("image_path"),
-                "storage_class": HOSTPATH_CSI_BASIC,
+                "storage_class": py_config[STORAGE_CLASS_A],
                 "dv_size": FEDORA_LATEST.get("dv_size"),
             },
             {
-                "ocs_storage_class": False,
+                "set_storage_class": False,
             },
             marks=pytest.mark.polarion("CNV-5529"),
         ),
@@ -120,8 +119,6 @@ def test_vm_with_existing_dv(data_volume_scope_function, vm_from_template_with_e
     indirect=True,
 )
 def test_vm_dv_with_different_sc(
-    fail_test_if_no_ocs_sc,
-    fail_if_no_hostpath_csi_basic_sc,
     vm_from_golden_image,
 ):
     # VM cloned PVC storage class is different from the original golden image storage class
@@ -139,7 +136,7 @@ def test_vm_dv_with_different_sc(
                 "storage_class": py_config["default_storage_class"],
             },
             {
-                "ocs_storage_class": True,
+                "set_storage_class": True,
             },
             marks=pytest.mark.polarion("CNV-7752"),
         ),

--- a/tests/storage/storage_migration/constants.py
+++ b/tests/storage/storage_migration/constants.py
@@ -1,11 +1,10 @@
+from utilities.constants import STORAGE_CLASS_A, STORAGE_CLASS_B
+
 FILE_BEFORE_STORAGE_MIGRATION = "file-before-storage-migration"
 CONTENT = "some-content"
 WINDOWS_TEST_DIRECTORY_PATH = r"C:\Users\TestFolder"
 WINDOWS_FILE_BEFORE_STORAGE_MIGRATION = f"{FILE_BEFORE_STORAGE_MIGRATION}.txt"
 WINDOWS_FILE_WITH_PATH = f"{WINDOWS_TEST_DIRECTORY_PATH}\\{WINDOWS_FILE_BEFORE_STORAGE_MIGRATION}"
-
-STORAGE_CLASS_A = "storage_class_for_storage_migration_a"
-STORAGE_CLASS_B = "storage_class_for_storage_migration_b"
 
 NO_STORAGE_CLASS_FAILURE_MESSAGE = (
     f"Test failed: {'{storage_class}'} storage class is not deployed. "

--- a/tests/storage/storage_migration/test_mtc_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_mtc_storage_class_migration.py
@@ -5,8 +5,6 @@ from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS
 from tests.storage.storage_migration.constants import (
     CONTENT,
     FILE_BEFORE_STORAGE_MIGRATION,
-    STORAGE_CLASS_A,
-    STORAGE_CLASS_B,
     WINDOWS_FILE_WITH_PATH,
 )
 from tests.storage.storage_migration.utils import (
@@ -16,6 +14,7 @@ from tests.storage.storage_migration.utils import (
     verify_vm_storage_class_updated,
     verify_vms_boot_time_after_storage_migration,
 )
+from utilities.constants import STORAGE_CLASS_A, STORAGE_CLASS_B
 from utilities.virt import migrate_vm_and_verify
 
 TESTS_CLASS_NAME_A_TO_B = "TestStorageClassMigrationAtoB"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -285,6 +285,8 @@ WORKERS_TYPE = "WORKERS_TYPE"
 FILTER_BY_OS_OPTION = f"filter-by-os=linux/{AMD_64}"
 QUARANTINED = "quarantined"
 SETUP_ERROR = "setup_error"
+STORAGE_CLASS_A = "storage_class_for_storage_migration_a"
+STORAGE_CLASS_B = "storage_class_for_storage_migration_b"
 
 # Kernel Device Driver
 # Compute: GPU Devices are bound to this Kernel Driver for GPU Passthrough.


### PR DESCRIPTION
##### Short description:
Update the storage class used in `test_common_templates_data_volumes.py` to be dynamic according to global_config

##### More details:
The current test uses constant storage classes, this changes the storage classes to be dynamic according to the used global_config file.

##### What this PR does / why we need it:
Allow the test to run on different clusters without specific storage classes
