### PR TITLE
[VIRT] Use latest windows image in postcopy tests

### DIFF
--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -101,7 +101,7 @@ def drained_node_with_hotplugged_vm(admin_client, hotplugged_vm):
         pytest.param(
             {
                 "dv_name": "dv-windows-latest-vm",
-                "image": f"{Images.Windows.DIR}/{Images.Windows.WIN11_IMG}",
+                "image": py_config.get("latest_windows_os_dict", {}).get("image_path"),
                 "storage_class": py_config["default_storage_class"],
                 "dv_size": Images.Windows.DEFAULT_DV_SIZE,
             },


### PR DESCRIPTION
Use latest windows image in postcopy tests

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test to use a dynamically retrieved Windows VM image path from the configuration, replacing the previous hardcoded path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->