### PR TITLE
 [main][storage] Fix race condition in resize wait logic

### DIFF
--- a/tests/storage/test_online_resize.py
+++ b/tests/storage/test_online_resize.py
@@ -134,7 +134,7 @@ def wait_for_resize(vm, count=1):
             LOGGER.info(
                 f"Current resize count is {current_resize_count}. Waiting until resize count is {desired_count}"
             )
-            if current_resize_count == desired_count:
+            if current_resize_count in (desired_count, desired_count + 1):
                 break
     except TimeoutExpiredError:
         dmesg = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("dmesg"))[0]


### PR DESCRIPTION
**Short description:**
Fix condition in resize wait logic to handle fast resize updates.

**More details:**
The check current_resize_count == desired_count was too strict, causing test failures when the resize count jumped past the expected value due to rapid updates. This PR changes the condition to current_resize_count == desired_count  or =desired_count+1  to make the check more robust.

**What this PR does / why we need it:**
Updates the resize wait logic to avoid false negatives in tests caused by fast or skipped increments in the resize count. This makes the test more reliable and tolerant to legitimate fast changes in VM state.

**Which issue(s) this PR fixes:**

**Special notes for reviewer:**
Observed that the resize count sometimes jumps quickly (e.g., from 1 to 4), skipping intermediate values. The new condition ensures the test proceeds once the desired threshold is reached or exceeded.

**jira-ticket:**
https://issues.redhat.com/browse/CNV-66509


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of storage resize tests by allowing the wait to finish when the resize count reaches the desired value or is one higher, reducing flaky failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->