### PR TITLE
Add s390x marker for the initial tier2 storage tests.

### DIFF
--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -31,6 +31,7 @@ TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeRhel"
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.smoke
 @pytest.mark.gating
 @pytest.mark.sno
@@ -120,6 +121,7 @@ class TestVMFeatures:
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 class TestVMMigrationAndState:
     @pytest.mark.polarion("CNV-11714")
     @pytest.mark.dependency(

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -212,6 +212,7 @@ def test_successful_vm_from_cloned_dv_windows(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_image_after_clone(
     skip_block_volumemode_scope_function,
     unprivileged_client,
@@ -291,6 +292,7 @@ def test_successful_snapshot_clone(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-5607")
+@pytest.mark.s390x
 def test_clone_from_fs_to_block_using_dv_template(
     skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,
@@ -312,6 +314,7 @@ def test_clone_from_fs_to_block_using_dv_template(
 
 @pytest.mark.polarion("CNV-5608")
 @pytest.mark.smoke()
+@pytest.mark.s390x
 def test_clone_from_block_to_fs_using_dv_template(
     skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -158,6 +158,7 @@ def test_delete_pvc_after_successful_import(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-876")
+@pytest.mark.s390x
 def test_invalid_url(dv_non_exist_url):
     dv_non_exist_url.wait_for_status(
         status=DataVolume.Status.IMPORT_IN_PROGRESS,
@@ -173,6 +174,7 @@ def test_invalid_url(dv_non_exist_url):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-674")
+@pytest.mark.s390x
 def test_empty_url(namespace, storage_class_name_scope_module):
     with pytest.raises(UnprocessibleEntityError):
         with create_dv(
@@ -200,6 +202,7 @@ def test_empty_url(namespace, storage_class_name_scope_module):
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2145")
+@pytest.mark.s390x
 def test_successful_import_archive(
     skip_block_volumemode_scope_module,
     running_pod_with_dv_pvc,
@@ -264,6 +267,7 @@ def test_successful_import_image(
     indirect=True,
 )
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_successful_import_secure_archive(
     skip_block_volumemode_scope_module, internal_http_configmap, running_pod_with_dv_pvc
 ):
@@ -307,6 +311,7 @@ def test_successful_import_secure_image(internal_http_configmap, running_pod_wit
     ],
     ids=["import_basic_auth_archive", "import_basic_auth_kubevirt"],
 )
+@pytest.mark.s390x
 def test_successful_import_basic_auth(
     namespace,
     storage_class_matrix__module__,
@@ -399,6 +404,7 @@ def test_wrong_content_type(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unpack_compressed(
     admin_client,
     dv_from_http_import,
@@ -454,6 +460,7 @@ def test_certconfigmap(internal_http_configmap, running_pod_with_dv_pvc):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_certconfigmap_incorrect_cert(
     admin_client,
     https_config_map,
@@ -484,6 +491,7 @@ def test_certconfigmap_incorrect_cert(
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2815")
+@pytest.mark.s390x
 def test_certconfigmap_missing_or_wrong_cm(data_volume_multi_storage_scope_function):
     with pytest.raises(TimeoutExpiredError):
         samples = TimeoutSampler(
@@ -514,6 +522,7 @@ def test_certconfigmap_missing_or_wrong_cm(data_volume_multi_storage_scope_funct
         ),
     ],
 )
+@pytest.mark.s390x
 def test_successful_concurrent_blank_disk_import(
     dv_list_created_by_multiprocess,
     vm_list_created_by_multiprocess,
@@ -530,6 +539,7 @@ def test_successful_concurrent_blank_disk_import(
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2004")
+@pytest.mark.s390x
 def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_function):
     data_volume_multi_storage_scope_function.wait_for_dv_success(timeout=TIMEOUT_5MIN)
 
@@ -714,12 +724,14 @@ def test_successful_vm_from_imported_dv_windows(
 
 @pytest.mark.polarion("CNV-4032")
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_disk_image_after_import(skip_block_volumemode_scope_module, cirros_dv_unprivileged):
     create_vm_and_verify_image_permission(dv=cirros_dv_unprivileged)
 
 
 @pytest.mark.polarion("CNV-4724")
 @pytest.mark.sno
+@pytest.mark.s390x
 def test_dv_api_version_after_import(cirros_dv_unprivileged):
     assert (
         cirros_dv_unprivileged.api_version
@@ -728,6 +740,7 @@ def test_dv_api_version_after_import(cirros_dv_unprivileged):
 
 
 @pytest.mark.polarion("CNV-5509")
+@pytest.mark.s390x
 def test_importer_pod_annotation(dv_with_annotation, linux_nad):
     # verify "k8s.v1.cni.cncf.io/networks" can pass to the importer pod
     assert dv_with_annotation.get(f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks") == linux_nad.name

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -61,6 +61,7 @@ def test_disk_image_not_conform_to_registy_disk(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2028")
+@pytest.mark.s390x
 def test_public_registry_multiple_data_volume(
     namespace, storage_class_name_scope_function, dvs_and_vms_from_public_registry
 ):
@@ -125,6 +126,7 @@ def test_public_registry_data_volume(
 # we can overcome by updating to the right requested volume size and import successfully
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2024")
+@pytest.mark.s390x
 def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_scope_function):
     dv_param = {
         "dv_name": "import-public-registry-low-capacity-dv",
@@ -169,6 +171,7 @@ def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2150")
+@pytest.mark.s390x
 def test_public_registry_data_volume_archive(namespace, storage_class_name_scope_function):
     with pytest.raises(ApiException, match=r".*ContentType must be kubevirt when Source is Registry.*"):
         with create_dv(

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -54,6 +54,7 @@ def wait_for_upload_response_code(token, data, response_code, asynchronous=False
 
 
 @pytest.mark.polarion("CNV-2318")
+@pytest.mark.s390x
 def test_cdi_uploadproxy_route_owner_references(hco_namespace):
     route = Route(name=CDI_UPLOADPROXY, namespace=hco_namespace.name)
     assert route.instance
@@ -198,6 +199,7 @@ def test_successful_upload_with_supported_formats(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-2018")
+@pytest.mark.s390x
 def test_successful_upload_token_validity(
     namespace,
     data_volume_multi_storage_scope_function,
@@ -248,6 +250,7 @@ def test_successful_upload_token_validity(
 )
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2011")
+@pytest.mark.s390x
 def test_successful_upload_token_expiry(namespace, data_volume_multi_storage_scope_function):
     dv = data_volume_multi_storage_scope_function
     dv.wait_for_status(status=DataVolume.Status.UPLOAD_READY, timeout=TIMEOUT_3MIN)
@@ -288,6 +291,7 @@ def _upload_image(dv_name, namespace, storage_class, local_name, size=None):
 
 
 @pytest.mark.sno
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-2015")
 def test_successful_concurrent_uploads(
     upload_file_path,
@@ -369,6 +373,7 @@ def test_successful_upload_missing_file_in_transit(namespace, storage_class_matr
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_print_response_body_on_error_upload(
     namespace,
     download_specified_image,

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -131,6 +131,7 @@ def test_image_upload_with_overridden_url(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3031")
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_ca(
     enabled_ca,
     skip_no_reencrypt_route,
@@ -195,6 +196,7 @@ def test_virtctl_image_upload_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_dv_image(
     data_volume_multi_storage_scope_function,
     storage_class_name_scope_function,
@@ -231,6 +233,7 @@ def test_virtctl_image_upload_with_exist_dv_image(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-3728")
+@pytest.mark.s390x
 def test_virtctl_image_upload_pvc(download_image, namespace, storage_class_name_scope_module):
     """
     Check that virtctl can create a new PVC and upload an image to it
@@ -342,6 +345,7 @@ def test_virtctl_image_upload_with_exist_pvc(
 
 
 @pytest.mark.polarion("CNV-3729")
+@pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_pvc_image(
     download_image,
     namespace,
@@ -384,6 +388,7 @@ def test_virtctl_image_upload_with_exist_pvc_image(
 
 
 @pytest.mark.polarion("CNV-3730")
+@pytest.mark.s390x
 def test_virtctl_image_upload_dv_with_exist_pvc(
     empty_pvc,
     download_image,
@@ -447,6 +452,7 @@ def test_successful_vm_from_uploaded_dv_windows(
 
 
 @pytest.mark.polarion("CNV-4033")
+@pytest.mark.s390x
 def test_disk_image_after_upload_virtctl(
     skip_block_volumemode_scope_module,
     unprivileged_client,
@@ -487,6 +493,7 @@ def test_disk_image_after_upload_virtctl(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_print_response_body_on_error_upload_virtctl(
     namespace, download_specified_image, storage_class_name_scope_module
 ):

--- a/tests/storage/checkups/test_checkups.py
+++ b/tests/storage/checkups/test_checkups.py
@@ -24,6 +24,7 @@ LOGGER = logging.getLogger(__name__)
     indirect=True,
 )
 class TestCheckupPositive:
+    @pytest.mark.s390x
     @pytest.mark.polarion("CNV-10707")
     def test_overriden_storage_profile_claim_propertyset(
         self,

--- a/tests/storage/checkups/test_checkups_negative.py
+++ b/tests/storage/checkups/test_checkups_negative.py
@@ -39,6 +39,7 @@ class TestCheckupNegative:
         )
 
     @pytest.mark.polarion("CNV-10705")
+    @pytest.mark.s390x
     def test_additional_default_storage_class(
         self,
         updated_two_default_storage_classes,
@@ -57,6 +58,7 @@ class TestCheckupNegative:
         )
 
     @pytest.mark.polarion("CNV-10706")
+    @pytest.mark.s390x
     def test_unknown_provisioner(
         self,
         storage_class_with_unknown_provisioner,
@@ -74,6 +76,7 @@ class TestCheckupNegative:
         )
 
     @pytest.mark.polarion("CNV-10711")
+    @pytest.mark.s390x
     def test_golden_image_data_source_not_ready(
         self,
         broken_data_import_cron,

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -221,6 +221,7 @@ def rhel9_golden_image_vm(
 
 
 @pytest.mark.polarion("CNV-10721")
+@pytest.mark.s390x
 def test_automatic_update_for_system_cached_snapshot(
     rhel9_cached_snapshot,
     disabled_common_boot_image_import_hco_spec_rhel9_scope_function,
@@ -234,6 +235,7 @@ def test_automatic_update_for_system_cached_snapshot(
 
 
 @pytest.mark.polarion("CNV-10722")
+@pytest.mark.s390x
 def test_disable_automatic_update_using_annotation(
     disabled_data_import_cron_annotation_rhel9,
     rhel9_data_import_cron,
@@ -260,5 +262,6 @@ def test_disable_automatic_update_using_annotation(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unprivileged_user_vm_snapshot_datasource(rhel9_golden_image_vm):
     running_vm(vm=rhel9_golden_image_vm)

--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -48,6 +48,7 @@ def dv_created_by_unprivileged_user_with_rolebinding(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4755")
+@pytest.mark.s390x
 def test_regular_user_cant_create_dv_in_ns(
     golden_images_namespace,
     unprivileged_client,
@@ -76,6 +77,7 @@ def test_regular_user_cant_create_dv_in_ns(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_cant_delete_dv_from_cloned_dv(
     golden_images_namespace,
     unprivileged_client,
@@ -114,6 +116,7 @@ def test_regular_user_cant_delete_dv_from_cloned_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_can_create_vm_from_cloned_dv(
     golden_image_data_volume_multi_storage_scope_function,
     golden_image_vm_instance_from_template_multi_storage_scope_function,
@@ -129,6 +132,7 @@ def test_regular_user_can_create_vm_from_cloned_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_can_list_all_pvc_in_ns(
     golden_images_namespace,
     unprivileged_client,
@@ -152,6 +156,7 @@ def test_regular_user_can_list_all_pvc_in_ns(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_cant_clone_dv_in_ns(
     unprivileged_client,
     golden_image_data_volume_scope_module,
@@ -190,6 +195,7 @@ def test_regular_user_cant_clone_dv_in_ns(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_regular_user_can_create_dv_in_ns_given_proper_rolebinding(
     dv_created_by_unprivileged_user_with_rolebinding,
 ):

--- a/tests/storage/hpp/test_hostpath.py
+++ b/tests/storage/hpp/test_hostpath.py
@@ -305,6 +305,7 @@ def get_pod_and_scratch_pvc_nodes(dyn_client, namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_hostpath_pod_reference_pvc(
     namespace,
     dv_kwargs,
@@ -322,6 +323,7 @@ def test_hostpath_pod_reference_pvc(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3354")
+@pytest.mark.s390x
 def test_hpp_not_specify_node_immediate(
     skip_when_hpp_no_immediate,
     namespace,
@@ -350,6 +352,7 @@ def test_hpp_not_specify_node_immediate(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3228")
+@pytest.mark.s390x
 def test_hpp_specify_node_immediate(
     skip_when_hpp_no_immediate,
     namespace,
@@ -390,6 +393,7 @@ def test_hpp_specify_node_immediate(
         ),
     ],
 )
+@pytest.mark.s390x
 def test_hostpath_http_import_dv(
     skip_when_hpp_no_immediate,
     namespace,
@@ -416,6 +420,7 @@ def test_hostpath_http_import_dv(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3227")
+@pytest.mark.s390x
 def test_hpp_pvc_without_specify_node_waitforfirstconsumer(
     skip_when_hpp_no_waitforfirstconsumer,
     namespace,
@@ -451,6 +456,7 @@ def test_hpp_pvc_without_specify_node_waitforfirstconsumer(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3280")
+@pytest.mark.s390x
 def test_hpp_pvc_specify_node_immediate(
     skip_when_hpp_no_immediate,
     namespace,
@@ -482,6 +488,7 @@ def test_hpp_pvc_specify_node_immediate(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2771")
+@pytest.mark.s390x
 def test_hpp_upload_virtctl(
     skip_when_hpp_no_waitforfirstconsumer,
     skip_when_cdiconfig_scratch_no_hpp,
@@ -527,6 +534,7 @@ def test_hpp_upload_virtctl(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2769")
+@pytest.mark.s390x
 def test_hostpath_upload_dv_with_token(
     skip_when_cdiconfig_scratch_no_hpp,
     skip_when_hpp_no_waitforfirstconsumer,
@@ -556,6 +564,7 @@ def test_hostpath_upload_dv_with_token(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3326")
+@pytest.mark.s390x
 def test_hostpath_registry_import_dv(
     admin_client,
     skip_when_hpp_no_waitforfirstconsumer,
@@ -604,6 +613,7 @@ def test_hostpath_registry_import_dv(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_hostpath_clone_dv_without_annotation_wffc(
     skip_when_hpp_no_waitforfirstconsumer,
     admin_client,
@@ -656,6 +666,7 @@ def test_hostpath_clone_dv_without_annotation_wffc(
 
 
 @pytest.mark.polarion("CNV-2770")
+@pytest.mark.s390x
 def test_hostpath_clone_dv_with_annotation(
     skip_when_hpp_no_immediate,
     namespace,
@@ -699,6 +710,7 @@ def test_hostpath_clone_dv_with_annotation(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8928")
+@pytest.mark.s390x
 def test_hpp_cr(hostpath_provisioner_scope_module):
     assert hostpath_provisioner_scope_module.exists
     hostpath_provisioner_scope_module.wait_for_condition(
@@ -710,6 +722,7 @@ def test_hpp_cr(hostpath_provisioner_scope_module):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-7969")
+@pytest.mark.s390x
 def test_hpp_prometheus_resources(hpp_prometheus_resources):
     non_existing_resources = []
     for rsc in hpp_prometheus_resources:
@@ -720,6 +733,7 @@ def test_hpp_prometheus_resources(hpp_prometheus_resources):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3279")
+@pytest.mark.s390x
 def test_hpp_serviceaccount(
     hpp_serviceaccount,
     hpp_daemonset_scope_module,
@@ -745,6 +759,7 @@ def test_hpp_serviceaccount(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8901")
+@pytest.mark.s390x
 def test_hpp_scc(hpp_scc, hpp_cr_suffix_scope_module):
     assert hpp_scc.exists
     assert (
@@ -755,6 +770,7 @@ def test_hpp_scc(hpp_scc, hpp_cr_suffix_scope_module):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8902")
+@pytest.mark.s390x
 def test_hpp_clusterrole_and_clusterrolebinding(
     hpp_clusterrole,
     hpp_clusterrolebinding,
@@ -776,6 +792,7 @@ def test_hpp_clusterrole_and_clusterrolebinding(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8903")
+@pytest.mark.s390x
 def test_hpp_daemonset(hpp_daemonset_scope_module):
     assert (
         hpp_daemonset_scope_module.instance.status.numberReady
@@ -785,6 +802,7 @@ def test_hpp_daemonset(hpp_daemonset_scope_module):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-8904")
+@pytest.mark.s390x
 def test_hpp_operator_pod(hpp_operator_pod):
     assert hpp_operator_pod.status == Pod.Status.RUNNING, f"HPP operator pod {hpp_operator_pod.name} is not running"
 
@@ -810,6 +828,7 @@ def test_hpp_operator_recreate_after_deletion(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-6097")
+@pytest.mark.s390x
 def test_hpp_operator_scc(hpp_scc, hpp_operator_pod):
     assert hpp_scc.exists, f"scc {hpp_scc.name} is not existed"
     user_id = hpp_operator_pod.instance.spec["containers"][0]["securityContext"]["runAsUser"]
@@ -870,6 +889,7 @@ def test_hpp_operator_scc(hpp_scc, hpp_operator_pod):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_verify_hpp_res_app_label(
     hpp_resources,
     cnv_current_version,

--- a/tests/storage/hpp/test_hpp_csi_cr.py
+++ b/tests/storage/hpp/test_hpp_csi_cr.py
@@ -185,6 +185,7 @@ def vm_from_template_with_existing_dv_on_hpp_pvc(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_install_and_delete_hpp_csi_cr_basic(
     admin_client,
     hpp_csi_custom_resource,
@@ -240,6 +241,7 @@ def test_install_and_delete_hpp_csi_cr_basic(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_install_and_delete_hpp_csi_cr_with_pvc_template(
     admin_client,
     hpp_csi_custom_resource,
@@ -285,6 +287,7 @@ def test_install_and_delete_hpp_csi_cr_with_pvc_template(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_install_and_delete_hpp_csi_cr_basic_and_with_pvc_template(
     admin_client,
     hpp_csi_custom_resource,

--- a/tests/storage/hpp/test_hpp_node_placement.py
+++ b/tests/storage/hpp/test_hpp_node_placement.py
@@ -81,6 +81,7 @@ def test_create_dv_on_right_node_with_node_placement(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_on_node_without_hpp_pod_and_after_update(
     update_node_labels,
     updated_hpp_with_node_placement,
@@ -113,6 +114,7 @@ def test_create_vm_on_node_without_hpp_pod_and_after_update(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_with_dv_on_functional_after_configuring_hpp_not_to_work_on_that_same_node(
     hostpath_provisioner_scope_module,
     update_node_labels,
@@ -140,6 +142,7 @@ def test_vm_with_dv_on_functional_after_configuring_hpp_not_to_work_on_that_same
     indirect=True,
 )
 @pytest.mark.post_upgrade
+@pytest.mark.s390x
 def test_pv_stay_released_after_deleted_when_no_hpp_pod(
     hostpath_provisioner_scope_module,
     update_node_labels,

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -47,6 +47,7 @@ pytestmark = pytest.mark.usefixtures("fail_when_no_unprivileged_client_available
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unprivileged_user_clone_dv_same_namespace_positive(
     permissions_pvc_source,
     dv_cloned_by_unprivileged_user_in_the_same_namespace,
@@ -125,6 +126,7 @@ def test_user_permissions_positive(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_user_permissions_negative(
     storage_class_name_scope_module,
     namespace,
@@ -157,6 +159,7 @@ def test_user_permissions_negative(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_unprivileged_user_clone_same_namespace_negative(
     storage_class_name_scope_module,
     namespace,
@@ -187,6 +190,7 @@ def test_unprivileged_user_clone_same_namespace_negative(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_user_permissions_only_for_dst_ns_negative(
     storage_class_name_scope_module,
     data_volume_multi_storage_scope_module,

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
@@ -83,6 +83,7 @@ def create_vm_negative(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_with_cloned_data_volume_positive(
     unprivileged_client,
     restricted_role_binding_for_vms_in_destination_namespace,
@@ -116,6 +117,7 @@ def test_create_vm_with_cloned_data_volume_positive(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_with_cloned_data_volume_grant_unprivileged_client_permissions_negative(
     namespace,
     destination_namespace,
@@ -147,6 +149,7 @@ def test_create_vm_with_cloned_data_volume_grant_unprivileged_client_permissions
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_cloned_data_volume_restricted_ns_service_account_no_clone_perm_negative(
     namespace,
     destination_namespace,
@@ -176,6 +179,7 @@ def test_create_vm_cloned_data_volume_restricted_ns_service_account_no_clone_per
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_create_vm_with_cloned_data_volume_permissions_for_pods_positive(
     unprivileged_client,
     data_volume_clone_settings,

--- a/tests/storage/snapshots/test_snapshots.py
+++ b/tests/storage/snapshots/test_snapshots.py
@@ -38,6 +38,7 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.mark.polarion("CNV-5781")
+@pytest.mark.s390x
 def test_snapshot_feature_gate_present(kubevirt_feature_gates):
     """
     This test will ensure that 'Snapshot' feature gate is present in KubeVirt ConfigMap.
@@ -323,6 +324,7 @@ def test_remove_snapshots_while_vm_is_running(
     ],
     indirect=["namespace"],
 )
+@pytest.mark.s390x
 def test_unprivileged_client_fails_to_list_resources(namespace, unprivileged_client, resource, error_msg):
     with pytest.raises(
         ApiException,
@@ -343,6 +345,7 @@ def test_unprivileged_client_fails_to_list_resources(namespace, unprivileged_cli
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_fail_to_snapshot_with_unprivileged_client_no_permissions(
     cirros_vm_for_snapshot,
     unprivileged_client,
@@ -366,6 +369,7 @@ def test_fail_to_snapshot_with_unprivileged_client_no_permissions(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_fail_to_snapshot_with_unprivileged_client_dv_permissions(
     cirros_vm_for_snapshot,
     permissions_for_dv,

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -309,6 +309,7 @@ def downloaded_cirros_image(tmpdir):
     return local_path
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-5708")
 def test_cert_exposure_rotation(
     enabled_ca,

--- a/tests/storage/test_cdi_config.py
+++ b/tests/storage/test_cdi_config.py
@@ -113,6 +113,7 @@ def initial_cdi_config_from_cr(cdi):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2451")
+@pytest.mark.s390x
 def test_cdiconfig_scratchspace_fs_upload_to_block(
     available_hpp_storage_class,
     tmpdir,
@@ -139,6 +140,7 @@ def test_cdiconfig_scratchspace_fs_upload_to_block(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2478")
+@pytest.mark.s390x
 def test_cdiconfig_scratchspace_fs_import_to_block(
     available_hpp_storage_class,
     hyperconverged_resource_scope_module,
@@ -163,6 +165,7 @@ def test_cdiconfig_scratchspace_fs_import_to_block(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2214")
+@pytest.mark.s390x
 def test_cdiconfig_status_scratchspace_update_with_spec(
     available_hpp_storage_class,
     hyperconverged_resource_scope_module,
@@ -185,6 +188,7 @@ def test_cdiconfig_status_scratchspace_update_with_spec(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2440")
+@pytest.mark.s390x
 def test_cdiconfig_scratch_space_not_default(
     available_hpp_storage_class,
     hyperconverged_resource_scope_module,
@@ -210,6 +214,7 @@ def test_cdiconfig_scratch_space_not_default(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-2412")
+@pytest.mark.s390x
 def test_cdi_config_scratch_space_value_is_default(
     default_sc_as_fallback_for_scratch,
     cdi_config,
@@ -220,6 +225,7 @@ def test_cdi_config_scratch_space_value_is_default(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-2208")
+@pytest.mark.s390x
 def test_cdi_config_exists(cdi_config, upload_proxy_route):
     assert cdi_config.upload_proxy_url == upload_proxy_route.host
 
@@ -237,6 +243,7 @@ def test_different_route_for_upload_proxy(hco_namespace, cdi_config, uploadproxy
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2215")
+@pytest.mark.s390x
 def test_route_for_different_service(cdi_config, upload_proxy_route):
     with Route(namespace=upload_proxy_route.namespace, name="cdi-api", service="cdi-api") as cdi_api_route:
         assert cdi_config.upload_proxy_url != cdi_api_route.host
@@ -245,6 +252,7 @@ def test_route_for_different_service(cdi_config, upload_proxy_route):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2216")
+@pytest.mark.s390x
 def test_upload_proxy_url_overridden(cdi_config, namespace, cdi_config_upload_proxy_overridden):
     with Route(namespace=namespace.name, name="my-route", service=CDI_UPLOADPROXY) as new_route:
         assert cdi_config.upload_proxy_url != new_route.host
@@ -252,6 +260,7 @@ def test_upload_proxy_url_overridden(cdi_config, namespace, cdi_config_upload_pr
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2441")
+@pytest.mark.s390x
 def test_cdiconfig_changing_storage_class_default(
     skip_test_if_no_ocs_sc,
     available_hpp_storage_class,
@@ -286,6 +295,7 @@ def test_cdiconfig_changing_storage_class_default(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-6312")
+@pytest.mark.s390x
 def test_cdi_spec_reconciled_by_hco(initial_cdi_config_from_cr, updated_cdi_extra_non_existent_feature_gate):
     """
     Test that added feature gate on the CDI CR does not persist
@@ -320,6 +330,7 @@ def test_cdi_spec_reconciled_by_hco(initial_cdi_config_from_cr, updated_cdi_extr
         ),
     ],
 )
+@pytest.mark.s390x
 def test_cdi_tunables_in_hco_propagated_to_cr(
     hyperconverged_resource_scope_module,
     cdi,

--- a/tests/storage/test_cdi_resources.py
+++ b/tests/storage/test_cdi_resources.py
@@ -163,12 +163,14 @@ def data_volume_without_snapshot_capability_scope_function(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_verify_pod_cdi_label(cdi_resources_scope_module):
     verify_label(cdi_resources=cdi_resources_scope_module)
 
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3475")
+@pytest.mark.s390x
 def test_importer_pod_cdi_label(namespace, https_server_certificate):
     # verify "cdi.kubevirt.io" label is included in importer pod
     with import_image_to_dv(
@@ -185,6 +187,7 @@ def test_importer_pod_cdi_label(namespace, https_server_certificate):
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3474")
+@pytest.mark.s390x
 def test_uploader_pod_cdi_label(unprivileged_client, namespace, storage_class_name_scope_module):
     """
     Verify "cdi.kubevirt.io" label is included in uploader pod
@@ -216,6 +219,7 @@ def test_uploader_pod_cdi_label(unprivileged_client, namespace, storage_class_na
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_cloner_pods_cdi_label(
     namespace,
     data_volume_without_snapshot_capability_scope_function,
@@ -301,6 +305,7 @@ def test_cloner_pods_cdi_label(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_verify_cdi_res_app_label(
     cdi_resources_scope_module,
     cnv_current_version,

--- a/tests/storage/test_data_import_cron.py
+++ b/tests/storage/test_data_import_cron.py
@@ -206,6 +206,7 @@ def second_object_cleanup(
 
 
 @pytest.mark.polarion("CNV-7602")
+@pytest.mark.s390x
 def test_data_import_cron_garbage_collection(
     namespace,
     second_object_cleanup,

--- a/tests/storage/test_disk_preallocation.py
+++ b/tests/storage/test_disk_preallocation.py
@@ -93,6 +93,7 @@ def cdi_preallocation_enabled(hyperconverged_resource_scope_module, cdi_config):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_preallocation_dv(
     data_volume_multi_storage_scope_function,
 ):
@@ -180,6 +181,7 @@ def test_preallocation_globally_dv_spec_with_preallocation_false(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_preallocation_for_blank_dv(
     data_volume_multi_storage_scope_function,
 ):

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -165,6 +165,7 @@ class TestHotPlugWithSerial:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6013")
     @pytest.mark.dependency(name="test_hotplug_volume_with_serial")
+    @pytest.mark.s390x
     def test_hotplug_volume_with_serial(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -198,6 +199,7 @@ class TestHotPlugWithPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6014")
     @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
+    @pytest.mark.s390x
     def test_hotplug_volume_with_persist(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -209,6 +211,7 @@ class TestHotPlugWithPersist:
 
     @pytest.mark.polarion("CNV-11390")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
+    @pytest.mark.s390x
     def test_hotplug_volume_with_persist_migrate(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -231,6 +234,7 @@ class TestHotPlugWithSerialPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6425")
     @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
+    @pytest.mark.s390x
     def test_hotplug_volume_with_serial_and_persist(
         self,
         blank_disk_dv_multi_storage_scope_class,
@@ -243,6 +247,7 @@ class TestHotPlugWithSerialPersist:
 
     @pytest.mark.polarion("CNV-6425b")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
+    @pytest.mark.s390x
     def test_hotplug_volume_with_serial_and_persist_migrate(
         self,
         blank_disk_dv_multi_storage_scope_class,

--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -87,6 +87,7 @@ def client_for_test(request, admin_client, unprivileged_client):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_virtctl_libguestfs_with_specific_user(
     client_for_test,
     virtctl_libguestfs_by_user,

--- a/tests/storage/test_local_storage.py
+++ b/tests/storage/test_local_storage.py
@@ -56,6 +56,7 @@ def local_storage_profile_claim_property_sets(local_storage_class):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_local_storage_profile_claim_property_sets(
     skip_if_no_local_storage_class,
     local_storage_class,

--- a/tests/storage/test_online_resize.py
+++ b/tests/storage/test_online_resize.py
@@ -259,6 +259,7 @@ def test_sequential_disk_expand(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_simultaneous_disk_expand(
     cirros_dv_for_online_resize,
     second_cirros_dv_for_online_resize,
@@ -314,6 +315,7 @@ def test_disk_expand_then_clone_fail(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_expand_then_clone_success(
     cirros_dv_for_online_resize,
     cirros_vm_after_expand,
@@ -343,6 +345,7 @@ def test_disk_expand_then_clone_success(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_disk_expand_then_migrate(cpu_for_migration, cirros_vm_after_expand, orig_cksum):
     migrate_vm_and_verify(
         vm=cirros_vm_after_expand,

--- a/tests/storage/test_priority_class.py
+++ b/tests/storage/test_priority_class.py
@@ -86,6 +86,7 @@ def importer_pod(admin_client, namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_dv_template_has_the_same_priority_as_vm_when_not_specified(
     priority_class,
     vm_with_priority_class,
@@ -111,6 +112,7 @@ def test_dv_template_has_the_same_priority_as_vm_when_not_specified(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_dv_template_has_the_different_priority_as_vm_when_specify(
     priority_class, vm_with_priority_class, importer_pod
 ):

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -179,6 +179,7 @@ def vm_from_uploaded_dv(namespace, uploaded_dv_via_virtctl_wffc, uploaded_wffc_d
 class TestWFFCUploadVirtctl:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-4711")
+    @pytest.mark.s390x
     def test_wffc_fail_to_upload_dv_via_virtctl(
         self,
         namespace,
@@ -206,6 +207,7 @@ class TestWFFCUploadVirtctl:
 
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-7413")
+    @pytest.mark.s390x
     def test_wffc_create_vm_from_uploaded_dv_via_virtctl(
         self,
         downloaded_cirros_image_full_path,
@@ -230,6 +232,7 @@ class TestWFFCUploadVirtctl:
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4739")
+@pytest.mark.s390x
 def test_wffc_import_registry_dv(
     namespace,
     storage_class_matrix_wffc_matrix__module__,
@@ -250,6 +253,7 @@ def test_wffc_import_registry_dv(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4741")
+@pytest.mark.s390x
 def test_wffc_upload_dv_via_token(
     unprivileged_client,
     namespace,
@@ -286,6 +290,7 @@ def test_wffc_upload_dv_via_token(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_wffc_import_http_dv(data_volume_multi_wffc_storage_scope_module):
     with create_vm_from_dv(
         dv=data_volume_multi_wffc_storage_scope_module, vm_name=data_volume_multi_wffc_storage_scope_module.name
@@ -304,6 +309,7 @@ def test_wffc_import_http_dv(data_volume_multi_wffc_storage_scope_module):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_wffc_clone_dv(data_volume_multi_wffc_storage_scope_module):
     with create_dv(
         source="pvc",
@@ -335,6 +341,7 @@ def test_wffc_clone_dv(data_volume_multi_wffc_storage_scope_module):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_wffc_add_dv_to_vm_with_data_volume_template(
     namespace,
     data_volume_multi_wffc_storage_scope_function,
@@ -360,6 +367,7 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-4743")
+@pytest.mark.s390x
 def test_wffc_vm_with_two_data_volume_templates(
     namespace,
     storage_class_matrix_wffc_matrix__module__,

--- a/tests/storage/vm_export/test_vm_export.py
+++ b/tests/storage/vm_export/test_vm_export.py
@@ -39,6 +39,7 @@ ERROR_MSG_USER_CANNOT_CREATE_VM_EXPORT = (
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_fail_to_vmexport_with_unprivileged_client_no_permissions(
     unprivileged_client,
     data_volume_scope_function,
@@ -74,6 +75,7 @@ def test_fail_to_vmexport_with_unprivileged_client_no_permissions(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vmexport_snapshot_manifests(
     namespace,
     vmexport_from_vmsnapshot,
@@ -91,6 +93,7 @@ def test_vmexport_snapshot_manifests(
     )
 
 
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-11597")
 def test_virtctl_vmexport_unprivileged(
     vmexport_download_path, blank_dv_created_by_specific_user, virtctl_unprivileged_client


### PR DESCRIPTION
##### Short description:
Add Tier2 storage changes for s390x.

##### More details:

##### What this PR does / why we need it:
This pr adds the s390x markers to the exising tier2 storage tests. This pr helps in enabling the tier2 storage pipeline for s390x.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to include the s390x architecture across a wide range of existing test cases related to storage, VM creation, migration, imports, uploads, cloning, snapshots, and configuration.
  * No changes to test logic or functionality; updates are limited to test annotations for architecture-specific execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->