### PR TITLE
Add test for no restart required status after NIC hot plug

### DIFF
--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+from timeout_sampler import TimeoutExpiredError
 
 from libs.net import netattachdef
 from tests.network.constants import IPV4_ADDRESS_SUBNET_PREFIX
@@ -19,6 +20,7 @@ from tests.network.l2_bridge.utils import (
     set_secondary_static_ip_address,
     wait_for_interface_hot_plug_completion,
 )
+from tests.utils import assert_restart_required_condition
 from utilities.constants import FLAT_OVERLAY_STR, SRIOV
 from utilities.network import (
     IfaceNotFound,
@@ -447,6 +449,20 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
             vmi=running_vm_for_nic_hot_plug.vmi,
             interface_name=hot_plugged_interface.name,
         )
+
+    @pytest.mark.polarion("CNV-12223")
+    @pytest.mark.dependency(
+        name="test_no_restart_needed_status_in_vm_after_hot_plug",
+        depends=["test_vmi_spec_updated_with_hot_plugged_interface"],
+    )
+    def test_no_restart_needed_status_in_vm_after_hot_plug(
+        self,
+        running_vm_for_nic_hot_plug,
+    ):
+        try:
+            assert_restart_required_condition(vm=running_vm_for_nic_hot_plug, expected_message="")
+        except TimeoutExpiredError:
+            pass
 
     @pytest.mark.polarion("CNV-10166")
     @pytest.mark.dependency(


### PR DESCRIPTION
- This test case is added after a bug - https://issues.redhat.com/browse/CNV-58395
- Tracking Jira for automation - https://issues.redhat.com/browse/CNV-60414

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
