### PR TITLE
Storage: Increase DataImportCron PVC clone timeout to 10 minutes

### DIFF
--- a/tests/storage/data_import_cron/conftest.py
+++ b/tests/storage/data_import_cron/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.data_source import DataSource
 
-from utilities.constants import BIND_IMMEDIATE_ANNOTATION, OS_FLAVOR_RHEL, Images
+from utilities.constants import BIND_IMMEDIATE_ANNOTATION, OS_FLAVOR_RHEL, TIMEOUT_10MIN, Images
 from utilities.infra import create_ns
 from utilities.storage import create_dv, data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, running_vm
@@ -78,7 +78,9 @@ def data_import_cron_with_pvc_source(
             }
         },
     ) as data_import_cron:
-        data_import_cron.wait_for_condition(condition="UpToDate", status=data_import_cron.Condition.Status.TRUE)
+        data_import_cron.wait_for_condition(
+            condition="UpToDate", status=data_import_cron.Condition.Status.TRUE, timeout=TIMEOUT_10MIN
+        )
         yield data_import_cron
     imported_data_source.clean_up(wait=True)
 


### PR DESCRIPTION
##### Short description:
Increase the PVC clone timeout in DataImportCron from 5 minutes to 10 minutes to improve stability and prevent clone scheduling failures.

##### More details:
The 5-minute timeout was too short for PVC cloning on slower storage, causing test failures. Increasing it to 10 minutes improves reliability by allowing enough time for clone completion, especially with filesystem-based storage classes.

##### What this PR does / why we need it:
Increases the timeout for PVC cloning tests from 5 to 10 minutes to prevent false failures caused by slower clone operations on certain storage backends.

##### Which issue(s) this PR fixes:

Fixes intermittent PVC clone timeout failures due to slow snapshot cloning on filesystem-based storage classes.
T2 test failuers:: 
TestDataImportCronPvcSource::test_data_import_cron_with_pvc_source_ready
TestDataImportCronPvcSource::test_data_import_cron_vm_from_import_pvc
##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-66509
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding a fixed maximum wait duration (10 minutes) to the data import cron readiness checks, preventing indefinite waits and reducing flakiness in test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->