### PR TITLE
Rename storage_class_for_storage_migration_b to storage_class_b

### DIFF
--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -161,8 +161,8 @@ default_storage_class, default_storage_class_configuration = _get_default_storag
 default_volume_mode = default_storage_class_configuration["volume_mode"]
 default_access_mode = default_storage_class_configuration["access_mode"]
 
-storage_class_for_storage_migration_a = HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC
-storage_class_for_storage_migration_b = StorageClassNames.CEPH_RBD_VIRTUALIZATION
+storage_class_a = HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC
+storage_class_b = StorageClassNames.CEPH_RBD_VIRTUALIZATION
 
 link_aggregation_mode_matrix = [
     "active-backup",

--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -49,8 +49,8 @@ storage_class_matrix = [
     {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES},
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.IO2_CSI
-storage_class_for_storage_migration_b = StorageClassNames.IO2_CSI
+storage_class_a = StorageClassNames.IO2_CSI
+storage_class_b = StorageClassNames.IO2_CSI
 
 rhel_os_matrix = generate_os_matrix_dict(os_name="rhel", supported_operating_systems=["rhel-9-5", "rhel-9-6"])
 

--- a/tests/global_config_aro.py
+++ b/tests/global_config_aro.py
@@ -21,8 +21,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.CEPH_RBD_VIRTUALIZATION
-storage_class_for_storage_migration_b = StorageClassNames.CEPH_RBD_VIRTUALIZATION
+storage_class_a = StorageClassNames.CEPH_RBD_VIRTUALIZATION
+storage_class_b = StorageClassNames.CEPH_RBD_VIRTUALIZATION
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -41,8 +41,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.IO2_CSI
-storage_class_for_storage_migration_b = StorageClassNames.IO2_CSI
+storage_class_a = StorageClassNames.IO2_CSI
+storage_class_b = StorageClassNames.IO2_CSI
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_gcp.py
+++ b/tests/global_config_gcp.py
@@ -30,8 +30,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.GCP
-storage_class_for_storage_migration_b = StorageClassNames.GCP
+storage_class_a = StorageClassNames.GCP
+storage_class_b = StorageClassNames.GCP
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_ibm_spectrum_sc.py
+++ b/tests/global_config_ibm_spectrum_sc.py
@@ -20,8 +20,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.GPFS
-storage_class_for_storage_migration_b = StorageClassNames.GPFS
+storage_class_a = StorageClassNames.GPFS
+storage_class_b = StorageClassNames.GPFS
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_lvms.py
+++ b/tests/global_config_lvms.py
@@ -36,8 +36,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.TOPOLVM
-storage_class_for_storage_migration_b = StorageClassNames.TOPOLVM
+storage_class_a = StorageClassNames.TOPOLVM
+storage_class_b = StorageClassNames.TOPOLVM
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_nfs.py
+++ b/tests/global_config_nfs.py
@@ -21,8 +21,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.NFS
-storage_class_for_storage_migration_b = StorageClassNames.NFS
+storage_class_a = StorageClassNames.NFS
+storage_class_b = StorageClassNames.NFS
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_oci.py
+++ b/tests/global_config_oci.py
@@ -43,8 +43,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.OCI
-storage_class_for_storage_migration_b = StorageClassNames.OCI
+storage_class_a = StorageClassNames.OCI
+storage_class_b = StorageClassNames.OCI
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_rh_it.py
+++ b/tests/global_config_rh_it.py
@@ -23,8 +23,8 @@ storage_class_matrix = [
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.RH_INTERNAL_NFS
-storage_class_for_storage_migration_b = StorageClassNames.RH_INTERNAL_NFS
+storage_class_a = StorageClassNames.RH_INTERNAL_NFS
+storage_class_b = StorageClassNames.RH_INTERNAL_NFS
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/storage/storage_migration/constants.py
+++ b/tests/storage/storage_migration/constants.py
@@ -4,13 +4,13 @@ WINDOWS_TEST_DIRECTORY_PATH = r"C:\Users\TestFolder"
 WINDOWS_FILE_BEFORE_STORAGE_MIGRATION = f"{FILE_BEFORE_STORAGE_MIGRATION}.txt"
 WINDOWS_FILE_WITH_PATH = f"{WINDOWS_TEST_DIRECTORY_PATH}\\{WINDOWS_FILE_BEFORE_STORAGE_MIGRATION}"
 
-STORAGE_CLASS_A = "storage_class_for_storage_migration_a"
-STORAGE_CLASS_B = "storage_class_for_storage_migration_b"
+STORAGE_CLASS_A = "storage_class_a"
+STORAGE_CLASS_B = "storage_class_b"
 
 NO_STORAGE_CLASS_FAILURE_MESSAGE = (
     f"Test failed: {'{storage_class}'} storage class is not deployed. "
     f"Available storage classes: {'{cluster_storage_classes_names}'}. "
-    "Ensure the correct storage_class_for_storage_migration is set in the global_config, "
+    "Ensure the correct storage_class is set in the global_config, "
     "or override it with the pytest params: "
     f"--tc={STORAGE_CLASS_A}:<storage_class_name> "
     f"--tc={STORAGE_CLASS_B}:<storage_class_name>"


### PR DESCRIPTION
##### Short Description:
Rename `storage_class_for_storage_migration_b` to `storage_class_b`.

##### Detailed Description:
The renamed storage class is used in broader contexts beyond just migration. This is reflected in [PR #1641](https://github.com/RedHatQE/openshift-virtualization-tests/pull/1641), where it's applied in non-migration scenarios as well.

##### What This PR Does / Why It's Needed:
Updates the storage class name to better reflect its general-purpose usage, improving clarity and reducing confusion about its role.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified variable names related to storage class configuration across multiple environments for improved consistency and readability. No changes to functionality or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->