### PR TITLE
Add fedora support with common instance types

### DIFF
--- a/tests/global_config_x86_64.py
+++ b/tests/global_config_x86_64.py
@@ -3,6 +3,7 @@ from typing import Any
 from utilities.constants import (
     CENTOS_STREAM9_PREFERENCE,
     CENTOS_STREAM10_PREFERENCE,
+    OS_FLAVOR_FEDORA,
     RHEL8_PREFERENCE,
     RHEL9_PREFERENCE,
     RHEL10_PREFERENCE,
@@ -43,6 +44,9 @@ instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
 )
 instance_type_centos_os_matrix = generate_linux_instance_type_os_matrix(
     os_name="centos.stream", preferences=[CENTOS_STREAM9_PREFERENCE, CENTOS_STREAM10_PREFERENCE]
+)
+instance_type_fedora_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name=OS_FLAVOR_FEDORA, preferences=[OS_FLAVOR_FEDORA]
 )
 
 (

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -48,3 +48,23 @@ def golden_image_centos_vm_with_instance_type(
         storage_class_name=[*storage_class_matrix__module__][0],
         data_source_name=instance_type_centos_os_matrix__module__[os_name][DATA_SOURCE_NAME],
     )
+
+
+@pytest.fixture(scope="module")
+def golden_image_fedora_vm_with_instance_type(
+    unprivileged_client,
+    namespace,
+    golden_images_namespace,
+    modern_cpu_for_migration,
+    instance_type_fedora_os_matrix__module__,
+    storage_class_matrix__module__,
+):
+    os_name = next(iter(instance_type_fedora_os_matrix__module__))
+    return golden_image_vm_with_instance_type(
+        client=unprivileged_client,
+        namespace_name=namespace.name,
+        golden_images_namespace_name=golden_images_namespace.name,
+        modern_cpu_for_migration=modern_cpu_for_migration,
+        storage_class_name=[*storage_class_matrix__module__][0],
+        data_source_name=instance_type_fedora_os_matrix__module__[os_name][DATA_SOURCE_NAME],
+    )

--- a/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
@@ -1,0 +1,107 @@
+import pytest
+
+from tests.infrastructure.instance_types.supported_os.constants import TEST_CREATE_VM_TEST_NAME, TEST_START_VM_TEST_NAME
+from tests.infrastructure.instance_types.utils import (
+    assert_kernel_lockdown_mode,
+    assert_secure_boot_dmesg,
+    assert_secure_boot_mokutil_status,
+)
+from utilities.constants import PREFERENCE_STR, U1_MEDIUM_STR
+from utilities.virt import (
+    assert_linux_efi,
+    assert_vm_xml_efi,
+    check_qemu_guest_agent_installed,
+    check_vm_xml_smbios,
+    running_vm,
+    update_vm_efi_spec_and_restart,
+    wait_for_console,
+)
+
+TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeFedora"
+
+
+@pytest.mark.sno
+class TestVMCreationAndValidation:
+    @pytest.mark.dependency(name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}")
+    @pytest.mark.polarion("CNV-12068")
+    def test_create_vm(self, golden_image_fedora_vm_with_instance_type, instance_type_fedora_os_matrix__module__):
+        golden_image_fedora_vm_with_instance_type.create(wait=True)
+        os_param_dict = instance_type_fedora_os_matrix__module__[[*instance_type_fedora_os_matrix__module__][0]]
+        assert golden_image_fedora_vm_with_instance_type.instance.spec.instancetype.name == U1_MEDIUM_STR
+        assert golden_image_fedora_vm_with_instance_type.instance.spec.preference.name == os_param_dict[PREFERENCE_STR]
+
+    @pytest.mark.dependency(
+        name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}",
+        depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}"],
+    )
+    @pytest.mark.polarion("CNV-12069")
+    def test_start_vm(self, golden_image_fedora_vm_with_instance_type):
+        running_vm(vm=golden_image_fedora_vm_with_instance_type)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-12070")
+    def test_vm_console(self, golden_image_fedora_vm_with_instance_type):
+        wait_for_console(vm=golden_image_fedora_vm_with_instance_type)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-12071")
+    def test_vmi_guest_agent_exists(self, golden_image_fedora_vm_with_instance_type):
+        assert check_qemu_guest_agent_installed(ssh_exec=golden_image_fedora_vm_with_instance_type.ssh_exec), (
+            "qemu guest agent package is not installed"
+        )
+
+
+@pytest.mark.sno
+class TestVMFeatures:
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-11830")
+    def test_system_boot_mode(self, golden_image_fedora_vm_with_instance_type):
+        assert_linux_efi(vm=golden_image_fedora_vm_with_instance_type)
+
+    @pytest.mark.polarion("CNV-11831")
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    def test_efi_secureboot_enabled_initial_boot(self, golden_image_fedora_vm_with_instance_type):
+        assert_secure_boot_dmesg(vm=golden_image_fedora_vm_with_instance_type)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-11832")
+    def test_efi_secureboot_enabled_guest_os(self, golden_image_fedora_vm_with_instance_type):
+        assert_secure_boot_mokutil_status(vm=golden_image_fedora_vm_with_instance_type)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-11833")
+    def test_efi_secureboot_enabled_lockdown_state(self, golden_image_fedora_vm_with_instance_type):
+        assert_kernel_lockdown_mode(vm=golden_image_fedora_vm_with_instance_type)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-11834")
+    def test_efi_secureboot_disabled_and_enabled(
+        self,
+        golden_image_fedora_vm_with_instance_type,
+    ):
+        vm = golden_image_fedora_vm_with_instance_type
+
+        def _update_and_verify_secure_boot(vm, secure_boot_value):
+            update_vm_efi_spec_and_restart(vm=vm, spec={"secureBoot": secure_boot_value})
+            # assert vm config at hypervisor level
+            assert_vm_xml_efi(vm=vm, secure_boot_enabled=secure_boot_value)
+            assert_linux_efi(vm=vm)
+
+        # Disable secureboot
+        _update_and_verify_secure_boot(vm=vm, secure_boot_value=False)
+        # Re-enable Secure Boot
+        _update_and_verify_secure_boot(vm=vm, secure_boot_value=True)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-11835")
+    def test_vm_smbios_default(self, smbios_from_kubevirt_config, golden_image_fedora_vm_with_instance_type):
+        check_vm_xml_smbios(vm=golden_image_fedora_vm_with_instance_type, cm_values=smbios_from_kubevirt_config)
+
+
+@pytest.mark.sno
+@pytest.mark.order(-1)
+class TestVMDeletion:
+    @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}"])
+    @pytest.mark.polarion("CNV-12078")
+    def test_vm_deletion(self, golden_image_fedora_vm_with_instance_type):
+        golden_image_fedora_vm_with_instance_type.delete(wait=True)


### PR DESCRIPTION
##### Short description:
Add fedora tests with common instance types

##### More details:
 - Add `instance_type_fedora_os_matrix` to global_config
 - Added `test_fedora_os.py`

##### What this PR does / why we need it:
Add tests supporting fedora operating systems

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-54690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test coverage for Fedora OS virtual machines, including VM creation, startup, feature validation (EFI boot, secure boot, kernel lockdown, SMBIOS), and deletion.
  * Introduced new configuration and fixtures to support Fedora instance type testing.

* **Tests**
  * Implemented new test classes for Fedora VM lifecycle and feature validation, following patterns established for other Linux distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->