### PR TITLE
  Virt: Add test cases to confirm that guest agent online when reboot the vm

### DIFF
--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -14,6 +14,7 @@ from tests.virt.cluster.common_templates.utils import (
     vm_os_version,
 )
 from utilities import console
+from utilities.constants import LINUX_STR
 from utilities.infra import validate_os_info_vmi_vs_linux_os
 from utilities.virt import (
     check_vm_xml_smbios,
@@ -21,6 +22,7 @@ from utilities.virt import (
     running_vm,
     validate_libvirt_persistent_domain,
     validate_pause_optional_migrate_unpause_linux_vm,
+    validate_virtctl_guest_agent_after_guest_reboot,
     validate_virtctl_guest_agent_data_over_time,
     wait_for_console,
 )
@@ -78,7 +80,9 @@ class TestCommonTemplatesCentos:
             tcp_timeout=120
         ), "Failed to login via SSH"
 
-    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"])
+    @pytest.mark.dependency(
+        name=f"{TESTS_CLASS_NAME}::vmi_guest_agent_info", depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"]
+    )
     @pytest.mark.polarion("CNV-5346")
     def test_vmi_guest_agent_info(self, matrix_centos_os_vm_from_template):
         """Test Guest OS agent info."""
@@ -138,6 +142,11 @@ class TestCommonTemplatesCentos:
         assert validate_virtctl_guest_agent_data_over_time(vm=matrix_centos_os_vm_from_template), (
             "Guest agent stopped responding"
         )
+
+    @pytest.mark.polarion("CNV-12222")
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent_info"])
+    def test_vmi_guest_agent_info_after_guest_reboot(self, matrix_centos_os_vm_from_template):
+        validate_virtctl_guest_agent_after_guest_reboot(vm=matrix_centos_os_vm_from_template, os_type=LINUX_STR)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])
     @pytest.mark.polarion("CNV-5351")

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -16,6 +16,7 @@ from tests.virt.cluster.common_templates.utils import (
     vm_os_version,
 )
 from utilities import console
+from utilities.constants import LINUX_STR
 from utilities.infra import validate_os_info_vmi_vs_linux_os
 from utilities.virt import (
     assert_linux_efi,
@@ -24,6 +25,7 @@ from utilities.virt import (
     running_vm,
     validate_libvirt_persistent_domain,
     validate_pause_optional_migrate_unpause_linux_vm,
+    validate_virtctl_guest_agent_after_guest_reboot,
     validate_virtctl_guest_agent_data_over_time,
     wait_for_console,
 )
@@ -155,7 +157,9 @@ class TestCommonTemplatesFedora:
         ), "Failed to login via SSH"
 
     @pytest.mark.sno
-    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"])
+    @pytest.mark.dependency(
+        name=f"{TESTS_CLASS_NAME}::vmi_guest_agent_info", depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"]
+    )
     @pytest.mark.polarion("CNV-3937")
     def test_vmi_guest_agent_info(self, matrix_fedora_os_vm_from_template):
         """Test Guest OS agent info."""
@@ -217,6 +221,11 @@ class TestCommonTemplatesFedora:
         assert validate_virtctl_guest_agent_data_over_time(vm=matrix_fedora_os_vm_from_template), (
             "Guest agent stopped responding"
         )
+
+    @pytest.mark.polarion("CNV-12219")
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent_info"])
+    def test_vmi_guest_agent_info_after_guest_reboot(self, matrix_fedora_os_vm_from_template):
+        validate_virtctl_guest_agent_after_guest_reboot(vm=matrix_fedora_os_vm_from_template, os_type=LINUX_STR)
 
     @pytest.mark.sno
     @pytest.mark.ibm_bare_metal

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -15,6 +15,7 @@ from tests.virt.cluster.common_templates.utils import (
     vm_os_version,
 )
 from utilities import console
+from utilities.constants import LINUX_STR
 from utilities.infra import validate_os_info_vmi_vs_linux_os
 from utilities.virt import (
     assert_linux_efi,
@@ -26,6 +27,7 @@ from utilities.virt import (
     update_vm_efi_spec_and_restart,
     validate_libvirt_persistent_domain,
     validate_pause_optional_migrate_unpause_linux_vm,
+    validate_virtctl_guest_agent_after_guest_reboot,
     validate_virtctl_guest_agent_data_over_time,
     wait_for_console,
 )
@@ -125,7 +127,9 @@ class TestCommonTemplatesRhel:
 
     @pytest.mark.arm64
     @pytest.mark.sno
-    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent"])
+    @pytest.mark.dependency(
+        name=f"{TESTS_CLASS_NAME}::vmi_guest_agent_info", depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent"]
+    )
     @pytest.mark.polarion("CNV-3513")
     def test_vmi_guest_agent_info(self, matrix_rhel_os_vm_from_template):
         validate_os_info_vmi_vs_linux_os(vm=matrix_rhel_os_vm_from_template)
@@ -208,6 +212,11 @@ class TestCommonTemplatesRhel:
         assert validate_virtctl_guest_agent_data_over_time(vm=matrix_rhel_os_vm_from_template), (
             "Guest agent stopped responding"
         )
+
+    @pytest.mark.polarion("CNV-12221")
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent_info"])
+    def test_vmi_guest_agent_info_after_guest_reboot(self, matrix_rhel_os_vm_from_template):
+        validate_virtctl_guest_agent_after_guest_reboot(vm=matrix_rhel_os_vm_from_template, os_type=LINUX_STR)
 
     @pytest.mark.polarion("CNV-6951")
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -16,6 +16,7 @@ from tests.virt.cluster.common_templates.utils import (
     validate_user_info_virtctl_vs_windows_os,
 )
 from tests.virt.utils import validate_pause_optional_migrate_unpause_windows_vm
+from utilities.constants import OS_FLAVOR_WINDOWS
 from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.virt import (
     assert_vm_xml_efi,
@@ -23,6 +24,7 @@ from utilities.virt import (
     migrate_vm_and_verify,
     running_vm,
     validate_libvirt_persistent_domain,
+    validate_virtctl_guest_agent_after_guest_reboot,
     validate_virtctl_guest_agent_data_over_time,
 )
 
@@ -62,7 +64,7 @@ class TestCommonTemplatesWindows:
         assert_windows_efi(vm=matrix_windows_os_vm_from_template)
 
     @pytest.mark.sno
-    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::vmi_guest_agent_info", depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-3512")
     def test_vmi_guest_agent_info(self, matrix_windows_os_vm_from_template):
         """Test Guest OS agent info."""
@@ -144,6 +146,13 @@ class TestCommonTemplatesWindows:
     def test_verify_virtctl_guest_agent_data_after_migrate(self, matrix_windows_os_vm_from_template):
         assert validate_virtctl_guest_agent_data_over_time(vm=matrix_windows_os_vm_from_template), (
             "Guest agent stopped responding"
+        )
+
+    @pytest.mark.polarion("CNV-12220")
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::vmi_guest_agent_info"])
+    def test_vmi_guest_agent_info_after_guest_reboot(self, matrix_windows_os_vm_from_template):
+        validate_virtctl_guest_agent_after_guest_reboot(
+            vm=matrix_windows_os_vm_from_template, os_type=OS_FLAVOR_WINDOWS
         )
 
     @pytest.mark.sno


### PR DESCRIPTION


##### Short description:
The Closed Loop Automation, we need to confirm that guest agent online when reboot the vm
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-65111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added cross-OS tests verifying guest-agent info persists after an in-guest reboot for CentOS, Fedora, RHEL, and Windows templates; tests reuse shared validation helpers and updated test dependency naming for clarity.

* **Refactor**
  * Moved in-guest reboot, remote command execution, and post-reboot guest-agent validation into shared utilities.
  * Standardized OS constants and OS-aware timeouts for more stable lifecycle tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->