### PR TITLE
Improve stability for TestDeployCNVOnSubsetOfClusterNodes gating tests

### DIFF
--- a/tests/install_upgrade_operators/node_component/conftest.py
+++ b/tests/install_upgrade_operators/node_component/conftest.py
@@ -16,6 +16,7 @@ from utilities.constants import (
     CDI_DEPLOYMENT,
     CDI_UPLOADPROXY,
     HCO_SUBSCRIPTION,
+    HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD,
     IMAGE_CRON_STR,
     KUBE_CNI_LINUX_BRIDGE_PLUGIN,
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
@@ -219,6 +220,7 @@ def hyperconverged_resource_before_np(admin_client, hco_namespace, hyperconverge
         hco_namespace=hco_namespace,
         infra_placement=initial_infra,
         workloads_placement=initial_workloads,
+        exclude_deployments=[HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD],
     )
 
 
@@ -244,6 +246,7 @@ def alter_np_configuration(
         hco_namespace=hco_namespace,
         infra_placement=infra_placement,
         workloads_placement=workloads_placement,
+        exclude_deployments=[HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD],
     )
     yield
 

--- a/tests/install_upgrade_operators/node_component/utils.py
+++ b/tests/install_upgrade_operators/node_component/utils.py
@@ -16,6 +16,7 @@ from utilities.constants import (
     CLUSTER_NETWORK_ADDONS_OPERATOR,
     HCO_OPERATOR,
     HCO_WEBHOOK,
+    HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD,
     IMAGE_CRON_STR,
     KUBE_CNI_LINUX_BRIDGE_PLUGIN,
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
@@ -407,6 +408,7 @@ def update_subscription_config(admin_client, hco_namespace, subscription, config
     wait_for_hco_post_update_stable_state(
         admin_client=admin_client,
         hco_namespace=hco_namespace,
+        exclude_deployments=[HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD],
     )
 
 


### PR DESCRIPTION
##### Short description:
Adapt HCO utility functions to be able to pass a new variable that will skip the waitings for the defined deployments.

This is needed in order to stabilize gating tests that are failing for non-critical deployments (hyperconverged-cluster-cli-download in this case) that are waiting a little bit longer to be available on the Node Placement tests.

##### More details:
N/A
##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-66599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test logic to exclude the "hyperconverged-cluster-cli-download" deployment from certain node placement and stability checks.

* **Chores**
  * Enhanced deployment verification to allow selective exclusion of specified deployments from automated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->