### PR TITLE
 [4.19] Quarantine a flaky gating test

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -10,7 +10,7 @@ from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm import affinity
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
-from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
+from utilities.constants import PUBLIC_DNS_SERVER_IP, QUARANTINED, TIMEOUT_1MIN
 from utilities.infra import create_ns
 from utilities.virt import migrate_vm_and_verify
 
@@ -145,6 +145,10 @@ class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11427")
     @pytest.mark.single_nic
     @pytest.mark.gating
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Flaky test, fails on connecting to VM console; tracked in CNV-66779",
+        run=False,
+    )
     def test_connectivity_is_preserved_after_live_migration(self, vma_udn, server, client):
         migrate_vm_and_verify(vm=vma_udn)
         assert is_tcp_connection(server=server, client=client)


### PR DESCRIPTION
test_connectivity_is_preserved_after_live_migration is flaky, and occasionally  fails when getting to providing the password for the console login. Until we stabilize it, it should not be part of gating. Currently we only observe it in 4.19; if needed, it will be handled in every relevant branch.
