### PR TITLE
Adjust inference config for windows machines

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -34,7 +34,7 @@ from utilities.ssp import (
     wait_for_deleted_data_import_crons,
 )
 from utilities.storage import DATA_IMPORT_CRON_SUFFIX, data_volume_template_with_source_ref_dict
-from utilities.virt import DV_DISK, VirtualMachineForTests, running_vm
+from utilities.virt import VirtualMachineForTests, running_vm
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -98,8 +98,8 @@ def create_vm_with_infer_from_volume(
         name="vm-with-infer-from-volume",
         namespace=namespace.name,
         client=client,
-        vm_instance_type_infer=DV_DISK,
-        vm_preference_infer=DV_DISK,
+        vm_instance_type_infer=True,
+        vm_preference_infer=True,
         data_volume_template=data_volume_template_with_source_ref_dict(data_source=data_source_for_test),
     ) as vm:
         return vm

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -698,6 +698,7 @@ class VirtualMachineForTests(VirtualMachine):
             and not self.memory_guest
             and not self.memory_requests
             and not self.vm_instance_type
+            and not self.vm_instance_type_infer
         ):
             self.memory_guest = Images.Windows.DEFAULT_MEMORY_SIZE
 
@@ -861,7 +862,12 @@ class VirtualMachineForTests(VirtualMachine):
             template_spec.setdefault("domain", {}).setdefault("cpu", {})["cores"] = self.cpu_cores
 
         # Faster VMI start time
-        if self.os_flavor == OS_FLAVOR_WINDOWS and not self.cpu_threads and not self.vm_instance_type:
+        if (
+            self.os_flavor == OS_FLAVOR_WINDOWS
+            and not self.cpu_threads
+            and not self.vm_instance_type
+            and not self.vm_instance_type_infer
+        ):
             self.cpu_threads = Images.Windows.DEFAULT_CPU_THREADS
 
         if self.cpu_threads:


### PR DESCRIPTION
##### Short description:
Adjust `vm_instance_type_infer` for cases when `os_flavor` is set to windows

##### More details:
When using `vm_instance_type_infer` with an `os_flavor` set to Windows, the `VirtualMachineForTests` class sets both the instance type and explicit memory/CPU values, which leads to conflicts during VM creation.
This PR resolves the issue by preventing the memory and CPU sizes from being set explicitly.

##### What this PR does / why we need it:
Fix failing creation of windows VM when using `vm_instance_type_infer`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of virtual machine configuration to prevent default memory and CPU values from being set when instance type inference is enabled.

* **Tests**
  * Updated test setup to use the correct parameters for instance type inference and removed unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->