### PR TITLE
Replace node_selector with build_node_affinity_dict in GPU tests

### DIFF
--- a/tests/virt/node/gpu/conftest.py
+++ b/tests/virt/node/gpu/conftest.py
@@ -5,8 +5,8 @@ GPU PCI Passthrough and vGPU Testing
 import pytest
 
 from tests.virt.node.gpu.utils import install_nvidia_drivers_on_windows_vm
+from tests.virt.utils import build_node_affinity_dict
 from utilities.constants import OS_FLAVOR_WINDOWS
-from utilities.infra import get_node_selector_dict
 from utilities.storage import create_or_update_data_source
 from utilities.virt import vm_instance_from_template
 
@@ -34,7 +34,7 @@ def gpu_vma(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_dv_scope_module_data_source_scope_class,
-        node_selector=get_node_selector_dict(node_selector=nodes_with_supported_gpus[0].name),
+        vm_affinity=build_node_affinity_dict(required_nodes=[nodes_with_supported_gpus[0].name]),
         host_device_name=supported_gpu_device.get(params.get("host_device")),
         gpu_name=supported_gpu_device.get(params.get("gpu_device")),
     ) as gpu_vm:

--- a/tests/virt/node/gpu/gpu_pci_passthrough/test_rhel_vm_with_gpu_pci_passthrough.py
+++ b/tests/virt/node/gpu/gpu_pci_passthrough/test_rhel_vm_with_gpu_pci_passthrough.py
@@ -15,12 +15,12 @@ from tests.virt.node.gpu.utils import (
     verify_gpu_expected_count_updated_on_node,
 )
 from tests.virt.utils import (
+    build_node_affinity_dict,
     running_sleep_in_linux,
     verify_gpu_device_exists_in_vm,
     verify_gpu_device_exists_on_node,
 )
 from utilities.constants import TIMEOUT_5SEC
-from utilities.infra import get_node_selector_dict
 from utilities.virt import (
     CIRROS_IMAGE,
     VirtualMachineForTests,
@@ -73,7 +73,7 @@ def non_permitted_hostdevices_vm(nodes_with_supported_gpus, unprivileged_client,
         name="passthrough-non-permitted-hostdevices-vm",
         namespace=namespace.name,
         image=CIRROS_IMAGE,
-        node_selector=get_node_selector_dict(node_selector=[*nodes_with_supported_gpus][0].name),
+        vm_affinity=build_node_affinity_dict(required_nodes=[[*nodes_with_supported_gpus][0].name]),
         host_device_name=supported_gpu_device[VGPU_DEVICE_NAME_STR],
         memory_requests="1Gi",
     ) as vm:

--- a/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
@@ -20,12 +20,12 @@ from tests.virt.node.gpu.utils import (
     verify_gpu_expected_count_updated_on_node,
 )
 from tests.virt.utils import (
+    build_node_affinity_dict,
     get_num_gpu_devices_in_rhel_vm,
     running_sleep_in_linux,
     verify_gpu_device_exists_in_vm,
     verify_gpu_device_exists_on_node,
 )
-from utilities.infra import get_node_selector_dict
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
     pause_optional_migrate_unpause_and_check_connectivity,
@@ -62,7 +62,7 @@ def gpu_vmb(
         client=unprivileged_client,
         labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
         data_source=golden_image_dv_scope_module_data_source_scope_class,
-        node_selector=gpu_vma.node_selector,
+        vm_affinity=gpu_vma.vm_affinity,
         gpu_name=supported_gpu_device[VGPU_DEVICE_NAME_STR],
     ) as vm:
         running_vm(vm=vm)
@@ -90,7 +90,7 @@ def node_mdevtype_gpu_vm(
         namespace=namespace,
         unprivileged_client=unprivileged_client,
         data_source=golden_image_dv_scope_module_data_source_scope_class,
-        node_selector=get_node_selector_dict(node_selector=[*nodes_with_supported_gpus][1].name),
+        vm_affinity=build_node_affinity_dict(required_nodes=[[*nodes_with_supported_gpus][1].name]),
         gpu_name=supported_gpu_device[VGPU_GRID_NAME_STR],
     ) as vm:
         running_vm(vm=vm)

--- a/tests/virt/upgrade/utils.py
+++ b/tests/virt/upgrade/utils.py
@@ -208,6 +208,7 @@ def vm_from_template(
     run_strategy=VirtualMachine.RunStrategy.HALTED,
     eviction_strategy=None,
     node_selector=None,
+    vm_affinity=None,
     gpu_name=None,
 ):
     with VirtualMachineForTestsFromTemplate(
@@ -222,6 +223,7 @@ def vm_from_template(
         interfaces=sorted(networks.keys()) if networks else None,
         eviction_strategy=eviction_strategy,
         node_selector=node_selector,
+        vm_affinity=vm_affinity,
         gpu_name=gpu_name,
     ) as vm:
         yield vm

--- a/tests/virt/upgrade_custom/vgpu/conftest.py
+++ b/tests/virt/upgrade_custom/vgpu/conftest.py
@@ -7,9 +7,8 @@ from tests.virt.node.gpu.constants import (
     VGPU_DEVICE_NAME_STR,
 )
 from tests.virt.upgrade.utils import vm_from_template
-from tests.virt.utils import verify_gpu_device_exists_on_node
+from tests.virt.utils import build_node_affinity_dict, verify_gpu_device_exists_on_node
 from utilities.constants import ES_NONE, TIMEOUT_30MIN
-from utilities.infra import get_node_selector_dict
 from utilities.storage import (
     create_dv,
     generate_data_source_dict,
@@ -70,7 +69,7 @@ def rhel_vm_for_upgrade_session_scope(
         namespace=upgrade_namespace_scope_session.name,
         template_labels=RHEL_LATEST_LABELS,
         data_source=rhel_data_source,
-        node_selector=get_node_selector_dict(node_selector=nodes_with_supported_gpus[0].name),
+        vm_affinity=build_node_affinity_dict(required_nodes=[nodes_with_supported_gpus[0].name]),
         gpu_name=supported_gpu_device.get(VGPU_DEVICE_NAME_STR),
         eviction_strategy=ES_NONE,
     ) as vm:


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: https://issues.redhat.com/browse/CNV-5679


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated test configurations to use VM affinity constraints instead of node selector dictionaries for scheduling VMs with GPU support.
  * Unified utility function usage for specifying node affinity in test fixtures.
  * Enhanced VM creation utility to accept an optional VM affinity parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->