### PR TITLE
[virt] fix vm from template

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1175,6 +1175,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         """
         # Must be set here to set VM flavor (used to set username and password)
         self.template_labels = labels
+        self.template_object = template_object
         self.os_flavor = self._extract_os_from_template()
 
         super().__init__(
@@ -1235,7 +1236,6 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         self.use_full_storage_api = use_full_storage_api
         self.access_modes = None  # required for evictionStrategy policy
         self.template_params = template_params
-        self.template_object = template_object
         self.non_existing_pvc = non_existing_pvc
         self.data_volume_template_from_vm_spec = data_volume_template_from_vm_spec
         self.eviction_strategy = eviction_strategy


### PR DESCRIPTION
##### Short description:
fix creation of VirtualMachineForTestsFromTemplate if no template_labels params passed

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the initialization order of internal attributes for virtual machine test templates. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->