### PR TITLE
Enforce nmstate verification only on on-prem clusters

### DIFF
--- a/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
+++ b/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
@@ -61,8 +61,11 @@ def test_node_sanity(admin_client, nodes):
 
 
 @pytest.mark.cluster_health_check
-def test_pod_sanity(admin_client, hco_namespace, nmstate_namespace):
-    for namespace_obj in [hco_namespace, nmstate_namespace]:
+def test_pod_sanity(admin_client, hco_namespace, nmstate_namespace, nmstate_required):
+    namespaces = [hco_namespace]
+    if nmstate_required:
+        namespaces.append(nmstate_namespace)
+    for namespace_obj in namespaces:
         wait_for_pods_running(
             admin_client=admin_client,
             namespace=namespace_obj,

--- a/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
+++ b/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
@@ -61,11 +61,8 @@ def test_node_sanity(admin_client, nodes):
 
 
 @pytest.mark.cluster_health_check
-def test_pod_sanity(admin_client, hco_namespace, nmstate_namespace, nmstate_required):
-    namespaces = [hco_namespace]
-    if nmstate_required:
-        namespaces.append(nmstate_namespace)
-    for namespace_obj in namespaces:
+def test_pod_sanity(admin_client, hco_namespace, nmstate_namespace):
+    for namespace_obj in [hco_namespace, nmstate_namespace]:
         wait_for_pods_running(
             admin_client=admin_client,
             namespace=namespace_obj,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2907,9 +2907,7 @@ def machine_config_pools():
 @pytest.fixture(scope="session")
 def nmstate_namespace(admin_client, nmstate_required):
     if nmstate_required:
-        nmstate_ns = Namespace(name="openshift-nmstate")
-        assert nmstate_ns.exists, "Namespace openshift-nmstate doesn't exist"
-        return nmstate_ns
+        return Namespace(client=admin_client, name="openshift-nmstate", ensure_exists=True)
 
     return None
 
@@ -2935,15 +2933,6 @@ def ping_process_in_rhel_os():
 def smbios_from_kubevirt_config(kubevirt_config_scope_module):
     """Extract SMBIOS default from kubevirt CR."""
     return kubevirt_config_scope_module["smbios"]
-
-
-@pytest.fixture(scope="session")
-def conformance_tests(request):
-    return (
-        (marker_args := request.config.getoption("-m"))
-        and "conformance" in marker_args
-        and "not conformance" not in marker_args
-    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,6 +136,7 @@ from utilities.infra import (
     generate_namespace_name,
     generate_openshift_pull_secret_file,
     get_artifactory_header,
+    get_cluster_platform,
     get_clusterversion,
     get_common_cpu_from_nodes,
     get_daemonset_yaml_file_with_image_hash,
@@ -913,7 +914,7 @@ def vm_instance_from_template_multi_storage_scope_function(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_multi_storage_scope_function,
-        vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,
+        vm_cpu_model=(cpu_for_migration if request.param.get("set_vm_common_cpu") else None),
     ) as vm:
         yield vm
 
@@ -936,7 +937,7 @@ def golden_image_vm_instance_from_template_multi_storage_scope_function(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_multi_storage_scope_function,
-        vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,
+        vm_cpu_model=(cpu_for_migration if request.param.get("set_vm_common_cpu") else None),
     ) as vm:
         yield vm
 
@@ -959,7 +960,7 @@ def golden_image_vm_instance_from_template_multi_storage_scope_class(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_multi_storage_scope_class,
-        vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,
+        vm_cpu_model=(cpu_for_migration if request.param.get("set_vm_common_cpu") else None),
     ) as vm:
         yield vm
 
@@ -1985,7 +1986,7 @@ def golden_images_data_import_crons_scope_function(admin_client, golden_images_n
 
 @pytest.fixture(scope="session")
 def sno_cluster(admin_client):
-    return get_infrastructure().instance.status.infrastructureTopology == "SingleReplica"
+    return get_infrastructure(admin_client=admin_client).instance.status.infrastructureTopology == "SingleReplica"
 
 
 @pytest.fixture(scope="session")
@@ -2340,7 +2341,10 @@ def rhel_vm_with_instance_type_and_preference(
     instance_type_for_test_scope_class,
     vm_preference_for_test,
 ):
-    with instance_type_for_test_scope_class as vm_instance_type, vm_preference_for_test as vm_preference:
+    with (
+        instance_type_for_test_scope_class as vm_instance_type,
+        vm_preference_for_test as vm_preference,
+    ):
         with VirtualMachineForTests(
             client=unprivileged_client,
             name="rhel-vm-with-instance-type",
@@ -2675,7 +2679,7 @@ def dvs_for_upgrade(
             url=rhel_latest_os_params["rhel_image_path"],
             size=rhel_latest_os_params["rhel_dv_size"],
             bind_immediate_annotation=True,
-            hostpath_node=worker_node1.name if sc_is_hpp_with_immediate_volume_binding(sc=storage_class) else None,
+            hostpath_node=(worker_node1.name if sc_is_hpp_with_immediate_volume_binding(sc=storage_class) else None),
             api_name="storage",
         )
         dv.create()
@@ -2688,7 +2692,8 @@ def dvs_for_upgrade(
     for dv in dvs_list:
         dv.clean_up()
     utilities.infra.cleanup_artifactory_secret_and_config_map(
-        artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
+        artifactory_secret=artifactory_secret,
+        artifactory_config_map=artifactory_config_map,
     )
 
 
@@ -2743,8 +2748,8 @@ def kube_system_namespace():
 
 
 @pytest.fixture(scope="session")
-def is_aws_cluster():
-    return get_infrastructure().instance.status.platform == Infrastructure.Type.AWS
+def is_aws_cluster(admin_client):
+    return get_cluster_platform(admin_client=admin_client) == Infrastructure.Type.AWS
 
 
 @pytest.fixture(scope="session")
@@ -2927,3 +2932,17 @@ def ping_process_in_rhel_os():
 def smbios_from_kubevirt_config(kubevirt_config_scope_module):
     """Extract SMBIOS default from kubevirt CR."""
     return kubevirt_config_scope_module["smbios"]
+
+
+@pytest.fixture(scope="session")
+def conformance_tests(request):
+    return (
+        (marker_args := request.config.getoption("-m"))
+        and "conformance" in marker_args
+        and "not conformance" not in marker_args
+    )
+
+
+@pytest.fixture(scope="session")
+def nmstate_required(admin_client):
+    return get_cluster_platform(admin_client=admin_client) in ("BareMetal", "OpenStack")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2905,10 +2905,13 @@ def machine_config_pools():
 
 
 @pytest.fixture(scope="session")
-def nmstate_namespace(admin_client):
-    nmstate_ns = Namespace(name="openshift-nmstate")
-    assert nmstate_ns.exists, "Namespace openshift-nmstate doesn't exist"
-    return nmstate_ns
+def nmstate_namespace(admin_client, nmstate_required):
+    if nmstate_required:
+        nmstate_ns = Namespace(name="openshift-nmstate")
+        assert nmstate_ns.exists, "Namespace openshift-nmstate doesn't exist"
+        return nmstate_ns
+
+    return None
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -251,9 +251,9 @@ def alert_dictionary_hco_not_installed():
 
 
 @pytest.fixture(scope="module")
-def cluster_backend_storage():
+def cluster_backend_storage(admin_client):
     backend_storage = None
-    cluster_platform = get_cluster_platform()
+    cluster_platform = get_cluster_platform(admin_client=admin_client)
     if cluster_platform == "Azure":
         backend_storage = "managed-csi"
     elif cluster_platform == "AWS":

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1246,15 +1246,16 @@ def get_resources_by_name_prefix(prefix, namespace, api_resource_name):
     ]
 
 
-def get_infrastructure():
-    infrastructure = Infrastructure(name=CLUSTER)
+@cache
+def get_infrastructure(admin_client: DynamicClient) -> Infrastructure:
+    infrastructure = Infrastructure(client=admin_client, name=CLUSTER)
     if infrastructure.exists:
         return infrastructure
     raise ResourceNotFoundError(f"Infrastructure {CLUSTER} not found")
 
 
-def get_cluster_platform():
-    return get_infrastructure().instance.status.platform
+def get_cluster_platform(admin_client: DynamicClient) -> str:
+    return get_infrastructure(client=admin_client).instance.status.platform
 
 
 def query_version_explorer(api_end_point: str, query_string: str) -> Any:

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -338,7 +338,6 @@ def wait_for_pods_running(
         exceptions_dict={NotFoundError: []},
     )
 
-    sample = None
     not_running_pods = []
     try:
         current_check = 0

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1248,14 +1248,11 @@ def get_resources_by_name_prefix(prefix, namespace, api_resource_name):
 
 @cache
 def get_infrastructure(admin_client: DynamicClient) -> Infrastructure:
-    infrastructure = Infrastructure(client=admin_client, name=CLUSTER)
-    if infrastructure.exists:
-        return infrastructure
-    raise ResourceNotFoundError(f"Infrastructure {CLUSTER} not found")
+    return Infrastructure(client=admin_client, name=CLUSTER, ensure_exists=True)
 
 
 def get_cluster_platform(admin_client: DynamicClient) -> str:
-    return get_infrastructure(client=admin_client).instance.status.platform
+    return get_infrastructure(admin_client=admin_client).instance.status.platform
 
 
 def query_version_explorer(api_end_point: str, query_string: str) -> Any:


### PR DESCRIPTION
##### Short description:
nmstate is needed only on on-prem clusters.
skipping the checks if not running on BMs or PSI

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform detection is now more accurate and centralized, improving environment-specific behaviors.
  * Namespace provisioning for certain features is now conditional based on the detected platform.

* **Bug Fixes**
  * Improved reliability of environment detection, reducing the risk of misconfiguration in cluster-dependent tests.

* **Style**
  * Minor formatting improvements for better code clarity and consistency in test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->