### PR TITLE
renovate - restrict updates only to `main` and `cnv-4.99`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,69 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":dependencyDashboard",
+    ":maintainLockFilesWeekly",
+    ":prHourlyLimitNone",
+    ":semanticCommitTypeAll(ci: )"
+  ],
+  "baseBranches": [
+    "main",
+    "cnv-4.99"
+  ],
+  "prConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": true
   },
-  "baseBranches": [
-    "main",
-    "cnv-4.18"
-  ],
-  "recreateWhen": "never",
+  "schedule": ["every Friday after 6pm"],
   "packageRules": [
     {
-      "matchDepPatterns": [
-        "pexpect",
-        "PyYAML",
-        "pytest",
-        "bitmath",
-        "urllib3",
-        "netaddr",
-        "bcrypt",
-        "pytest-testconfig",
-        "pytest-benchmark",
-        "sh",
-        "pytest-order",
-        "jinja2",
-        "requests",
-        "xmltodict",
-        "pytest-jira",
-        "jira",
-        "python-rrmngmnt",
-        "importlib-metadata",
-        "importlib-resources",
-        "click",
-        "docker",
-        "pyvmomi",
-        "pytest-dependency",
-        "pytest-progress",
-        "pytest-lazy-fixture",
-        "colorlog",
-        "dictdiffer",
-        "python-benedict",
-        "bs4",
-        "shortuuid",
-        "podman",
-        "jsons",
-        "deepdiff",
-        "python-utility-scripts",
-        "pyhelper-utils",
-        "openshift-python-utilities",
-        "timeout-sampler"
-      ],
-      "minimumReleaseAge": "5 days",
-      "groupName": "python dependencies"
-    },
-    {
-      "matchDepPatterns": ["openshift-python-wrapper", "kubernetes"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false,
-      "groupName": "Upstream dependencies"
-    },
-    {
-      "matchManagers": ["dockerfile"],
-      "enabled": false
+      "matchPackagePatterns": ["*"],
+      "groupName": "python-deps"
     }
-  ],
-  "extends": ["docker:disable"],
-  "schedule": ["after 7pm on wednesday"],
-  "timezone": "America/New_York"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     ":dependencyDashboard",
     ":maintainLockFilesWeekly",
     ":prHourlyLimitNone",
-    ":semanticCommitTypeAll(ci: )"
+    ":semanticCommitTypeAll(ci)"
   ],
   "baseBranches": [
     "main",


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified and restructured dependency update configuration.
  * Updated base branches for dependency updates.
  * Changed update schedule to every Friday after 6pm.
  * Broadened package grouping for Python dependencies.
  * Applied multiple preset configurations for improved automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->