### PR TITLE
Fixing test for metric kubevirt_nodes_with_kvm

### DIFF
--- a/tests/observability/virt/conftest.py
+++ b/tests/observability/virt/conftest.py
@@ -92,7 +92,8 @@ def deleted_virt_handler_pods(admin_client, hco_namespace):
         get_all=True,
     )
     for pod in virt_handler_pods:
-        pod.clean_up()
+        if pod.exists:
+            pod.clean_up()
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
The test was flaky becuase it was failing at the setup in the fixture deleted_virt_handler_pods.
This fixture deletes the virt-handler pods after the image for the daemonset replaced with fake one.
Sometime one of the pods already removed automatically which led to failure in this fixture when trying to delete it becuase it didn't found.
In this PR I am checking first if a pod exists before deletion and in this way I make sure it won't fail in this part of the setup.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-67032)