### PR TITLE
Storage: remove duplicate public registry test

### DIFF
--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -77,12 +77,7 @@ def test_public_registry_multiple_data_volume(
         pytest.param(
             "import-public-registry-no-content-type-dv",
             None,
-            marks=(pytest.mark.polarion("CNV-2195")),
-        ),
-        pytest.param(
-            "import-public-registry-empty-content-type-dv",
-            "",
-            marks=(pytest.mark.polarion("CNV-2197"), pytest.mark.smoke()),
+            marks=(pytest.mark.polarion("CNV-2195"), pytest.mark.smoke()),
         ),
         pytest.param(
             "import-public-registry-quay-dv",
@@ -92,7 +87,6 @@ def test_public_registry_multiple_data_volume(
     ],
     ids=[
         "import-public-registry-no-content-type-dv",
-        "import-public-registry-empty-content-type-dv",
         "import-public-registry-quay-dv",
     ],
 )
@@ -117,7 +111,6 @@ def test_public_registry_data_volume(
             vm_name="fedora-vm-from-dv",
             os_flavor=OS_FLAVOR_FEDORA,
             memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-            wait_for_cloud_init=True,
         ) as vm_dv:
             check_disk_count_in_vm(vm=vm_dv)
 
@@ -140,7 +133,6 @@ def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_
         dv_name=dv_param["dv_name"],
         namespace=namespace.name,
         url=dv_param["url"],
-        content_type="",
         size="16Mi",
         storage_class=dv_param["storage_class"],
     ) as dv:
@@ -164,7 +156,6 @@ def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_
             vm_name="fedora-vm-from-dv",
             os_flavor=OS_FLAVOR_FEDORA,
             memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-            wait_for_cloud_init=True,
         ) as vm_dv:
             check_disk_count_in_vm(vm=vm_dv)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Simplified import-from-public-registry test scenarios by removing the “empty content type” DataVolume case.
  - Reduced parameter sets to run only relevant DataVolume variants.
  - Stopped waiting for cloud-init during VM creation in applicable tests to streamline execution.
  - Adjusted negative/positive flows accordingly for low-capacity scenarios.
  - Overall, tests run faster and with clearer coverage while maintaining expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->