### PR TITLE
Apply dependency between positive and negative VLAN tests

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -75,6 +75,9 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.polarion("CNV-11123")
     @pytest.mark.ipv4
     @pytest.mark.s390x
+    @pytest.mark.dependency(
+        name="test_positive_vlan_linux_bridge",
+    )
     def test_positive_vlan_linux_bridge(
         self,
         nad_linux_bridge_vlan_1,
@@ -92,6 +95,7 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.polarion("CNV-11131")
     @pytest.mark.ipv4
     @pytest.mark.s390x
+    @pytest.mark.dependency(depends=["test_positive_vlan_linux_bridge"])
     def test_negative_vlan_linux_bridge(
         self,
         nad_linux_bridge_vlan_3,


### PR DESCRIPTION
test_negative_vlan_linux_bridge might pass as a false-negative. It eventually verifies no-connectivity between different VLANs, so it mgith pass even if, for example, VLAN is not supported on the cluster.
That's why this test is significant only if the positive scenario passes, hence they should be depended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved stability of VLAN connectivity test suite by enforcing execution order and dependencies. The negative scenario now depends on the positive scenario and is skipped if prerequisites fail, reducing false negatives and CI noise. This speeds up feedback and clarifies pass/fail signals. No changes to runtime behavior or network functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->