### PR TITLE
skip flaky test test_data_import_cron_deletion_on_opt_out

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -19,6 +19,7 @@ from tests.infrastructure.golden_images.constants import (
 from tests.infrastructure.golden_images.update_boot_source.utils import get_all_dic_volume_names
 from utilities.constants import (
     BIND_IMMEDIATE_ANNOTATION,
+    QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,
@@ -327,6 +328,10 @@ class TestDataImportCronDefaultStorageClass:
         )
 
 
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: This test still fail in some cases ; tracked in CNV-62615",
+    run=False,
+)
 @pytest.mark.polarion("CNV-7532")
 def test_data_import_cron_deletion_on_opt_out(
     admin_client,


### PR DESCRIPTION
##### Short description:
Quarantining this test again, this fails still sometimes 
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Marked an existing test as expected-to-fail (xfail) with run=False and a quarantined reason referencing CNV-62615.
  - Added the quarantine marker to test annotations; no changes to test logic or to user-facing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->