### PR TITLE
Exceptional skip of IPv6 scenario on non-IPv4-single-stack cluster

### DIFF
--- a/tests/network/general/test_dhcp6_configurations_on_ipv4_single_stack_cluster.py
+++ b/tests/network/general/test_dhcp6_configurations_on_ipv4_single_stack_cluster.py
@@ -31,9 +31,9 @@ def vm_cirros(
 
 
 @pytest.fixture(scope="module")
-def fail_if_not_ipv4_single_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
+def skip_if_not_ipv4_single_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
     if not ipv4_supported_cluster or ipv6_supported_cluster:
-        pytest.fail(reason="Test should only run on an IPv4 single-stack cluster")
+        pytest.skip("Test should only run on an IPv4 single-stack cluster")
 
 
 @pytest.fixture()
@@ -76,7 +76,7 @@ def listening_dhcpv6_pid_in_virt_launcher_pod(worker_node1_pod_executor, virt_la
 @pytest.mark.single_nic
 @pytest.mark.s390x
 def test_dhcp6_disabled_on_ipv4_single_stack_cluster(
-    fail_if_not_ipv4_single_stack_cluster,
+    skip_if_not_ipv4_single_stack_cluster,
     vm_cirros,
     listening_dhcpv6_pid_in_virt_launcher_pod,
 ):


### PR DESCRIPTION
Although we avoid programmatic skips, this one is an exception where we must skip. The reason is that this test, which is a regression test of an old bug, is required to run only on a single-stack IPv4 cluster. We currenly don't have a way of marking a cluster as single-stack, and in addition - it wouldn't make sense to maintain a dedicated test lane just for this one test.
This is necessarily for stabilizing network test lanes, and avoid this test from erroneously fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a network test to skip on non-IPv4 single-stack environments instead of failing, reducing false negatives and CI noise.
  * Clarifies test outcomes across mixed-stack setups and eases triage.
  * Improves test-suite stability without changing runtime behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->