### PR TITLE
Add arm64 mark to fedora support test

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -4,11 +4,11 @@ from ocp_resources.datavolume import DataVolume
 
 from utilities.constants import (
     ARM_64,
+    CENTOS_STREAM10_PREFERENCE,
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
     HPP_CAPABILITIES,
+    OS_FLAVOR_FEDORA,
     PREFERENCE_STR,
-    RHEL8_PREFERENCE,
-    RHEL9_PREFERENCE,
     RHEL10_PREFERENCE,
     Images,
     StorageClassNames,
@@ -57,13 +57,16 @@ rhel_os_matrix = generate_os_matrix_dict(os_name="rhel", supported_operating_sys
 latest_rhel_os_dict = get_latest_os_dict_list(os_list=[rhel_os_matrix])[0]
 
 # Modify instance_type_rhel_os_matrix for arm64
-instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
-    os_name="rhel", preferences=[RHEL8_PREFERENCE, RHEL9_PREFERENCE, RHEL10_PREFERENCE]
+instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(os_name="rhel", preferences=[RHEL10_PREFERENCE])
+instance_type_centos_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE]
 )
-for os_matrix_dict in instance_type_rhel_os_matrix:
+instance_type_fedora_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name=OS_FLAVOR_FEDORA, preferences=[OS_FLAVOR_FEDORA]
+)
+for os_matrix_dict in instance_type_rhel_os_matrix + instance_type_centos_os_matrix + instance_type_fedora_os_matrix:
     for os_params in os_matrix_dict.values():
         os_params[PREFERENCE_STR] += f".{ARM_64}"
-
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -1,12 +1,12 @@
 import pytest
 
 from tests.infrastructure.instance_types.supported_os.utils import golden_image_vm_with_instance_type
-from utilities.constants import DATA_SOURCE_NAME
+from utilities.constants import DATA_SOURCE_NAME, RHEL8_PREFERENCE
 
 
 @pytest.fixture(scope="class")
 def xfail_if_rhel8(instance_type_rhel_os_matrix__module__):
-    if [*instance_type_rhel_os_matrix__module__][0] == "rhel.8":
+    if [*instance_type_rhel_os_matrix__module__][0] == RHEL8_PREFERENCE:
         pytest.xfail("EFI is not enabled by default before RHEL9")
 
 

--- a/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
@@ -20,6 +20,7 @@ from utilities.virt import (
 TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeFedora"
 
 
+@pytest.mark.arm64
 @pytest.mark.sno
 class TestVMCreationAndValidation:
     @pytest.mark.dependency(name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}")
@@ -98,6 +99,7 @@ class TestVMFeatures:
         check_vm_xml_smbios(vm=golden_image_fedora_vm_with_instance_type, cm_values=smbios_from_kubevirt_config)
 
 
+@pytest.mark.arm64
 @pytest.mark.sno
 @pytest.mark.order(-1)
 class TestVMDeletion:


### PR DESCRIPTION
##### Short description:
Add arm64 mark to fedora support test

##### More details:
- Add matrix needed for fedora + centos runs on arm64
- Change "rhel.8" string to use constant `RHEL8_PREFERENCE`
##### What this PR does / why we need it: