### PR TITLE
Allow flaky test_connectivity_is_preserved_after_live_migration to run

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -147,7 +147,6 @@ class TestPrimaryUdn:
     @pytest.mark.gating
     @pytest.mark.xfail(
         reason=f"{QUARANTINED}: Flaky test, fails on connecting to VM console; tracked in CNV-66779",
-        run=False,
     )
     def test_connectivity_is_preserved_after_live_migration(self, vma_udn, server, client):
         migrate_vm_and_verify(vm=vma_udn)


### PR DESCRIPTION
test_connectivity_is_preserved_after_live_migration usually pass, and when it fails - it's
not destructive, meaning that it doesn't leave the cluster broken.
Therefore, to allow better coverage until the issue is completely fixed, it should run.
