### PR TITLE
add s390x marker for infrastructure tests

### DIFF
--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -96,6 +96,7 @@ def fedora_data_source(unprivileged_client, golden_images_namespace):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_from_golden_image_cluster_default_storage_class(
     updated_default_storage_class_scope_function,
     golden_image_data_volume_multi_storage_scope_function,
@@ -123,6 +124,7 @@ def test_vm_from_golden_image_cluster_default_storage_class(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_with_existing_dv(data_volume_scope_function, vm_from_template_with_existing_dv):
     vm_from_template_with_existing_dv.ssh_exec.executor().is_connective()
 
@@ -139,6 +141,7 @@ def test_vm_with_existing_dv(data_volume_scope_function, vm_from_template_with_e
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_dv_with_different_sc(
     fedora_vm_from_data_source,
 ):
@@ -162,7 +165,8 @@ def test_vm_dv_with_different_sc(
     ],
     indirect=True,
 )
-def test_vm_from_data_source_missing_default_storage_class(
+@pytest.mark.s390x
+def test_vm_from_golden_image_missing_default_storage_class(
     removed_default_storage_classes,
     fedora_vm_from_data_source,
 ):

--- a/tests/infrastructure/golden_images/test_golden_image_restricted_ns.py
+++ b/tests/infrastructure/golden_images/test_golden_image_restricted_ns.py
@@ -22,6 +22,7 @@ def check_pod_creation_failed(pod_name, client, namespace):
 
 
 @pytest.mark.polarion("CNV-4900")
+@pytest.mark.s390x
 def test_regular_user_cant_create_pod_in_ns(
     golden_images_namespace,
     unprivileged_client,
@@ -34,6 +35,7 @@ def test_regular_user_cant_create_pod_in_ns(
 
 
 @pytest.mark.polarion("CNV-5276")
+@pytest.mark.s390x
 def test_regular_user_with_dv_create_rolebinding_cannot_create_pod_in_golden_image_ns(
     golden_images_namespace,
     golden_images_edit_rolebinding,

--- a/tests/infrastructure/golden_images/update_boot_source/test_boot_sources_vm.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_boot_sources_vm.py
@@ -56,6 +56,7 @@ def auto_update_boot_source_instance_type_vm(
 
 
 @pytest.mark.polarion("CNV-11774")
+@pytest.mark.s390x
 def test_instance_type_vm_from_auto_update_boot_source(
     auto_update_boot_source_instance_type_vm,
     boot_source_preference_from_data_source_dict,

--- a/tests/infrastructure/golden_images/update_boot_source/test_latest_rhel_image.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_latest_rhel_image.py
@@ -85,6 +85,7 @@ def rhel_vm_minor_ver_num(rhel_vm):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_latest_minor_ver_rhel(libosinfo_rhel_minor_ver_num, rhel_vm_minor_ver_num):
     assert libosinfo_rhel_minor_ver_num == rhel_vm_minor_ver_num, (
         f"os versions mismatch, VM minor version: {rhel_vm_minor_ver_num}, "

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
@@ -131,6 +131,7 @@ def rhel9_dv(admin_client, golden_images_namespace, rhel9_data_source_scope_modu
 
 
 @pytest.mark.polarion("CNV-7586")
+@pytest.mark.s390x
 def test_vm_from_auto_update_boot_source(
     auto_update_boot_source_vm,
     boot_source_os_from_data_source_dict,
@@ -147,6 +148,7 @@ def test_vm_from_auto_update_boot_source(
 
 
 @pytest.mark.polarion("CNV-7565")
+@pytest.mark.s390x
 def test_common_templates_boot_source_reference(base_templates):
     source_ref_str = "sourceRef"
     LOGGER.info(f"Verify all common templates use {source_ref_str} in dataVolumeTemplates")
@@ -159,6 +161,7 @@ def test_common_templates_boot_source_reference(base_templates):
 
 
 @pytest.mark.polarion("CNV-7535")
+@pytest.mark.s390x
 def test_vm_with_uploaded_golden_image_opt_out(
     admin_client,
     golden_images_namespace,

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -246,6 +246,7 @@ def existing_dic_volumes_before_disable(admin_client, golden_images_namespace):
 
 
 @pytest.mark.polarion("CNV-7531")
+@pytest.mark.s390x
 def test_opt_in_data_import_cron_creation(
     admin_client,
     golden_images_namespace,
@@ -268,6 +269,7 @@ def test_opt_in_data_import_cron_creation(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_custom_data_import_cron_via_hco(
     updated_hco_with_custom_data_import_cron_scope_function,
     reconciled_custom_data_source,
@@ -294,6 +296,7 @@ def test_custom_data_import_cron_via_hco(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_opt_out_custom_data_import_cron_via_hco_not_deleted(
     admin_client,
     updated_hco_with_custom_data_import_cron_scope_function,
@@ -308,6 +311,7 @@ def test_opt_out_custom_data_import_cron_via_hco_not_deleted(
     ).exists, f"Custom DataImportCron {CUSTOM_DATA_IMPORT_CRON_NAME} not found after opt out"
 
 
+@pytest.mark.s390x
 class TestDataImportCronDefaultStorageClass:
     @pytest.mark.polarion("CNV-7594")
     def test_data_import_cron_using_default_storage_class(
@@ -333,6 +337,7 @@ class TestDataImportCronDefaultStorageClass:
     run=False,
 )
 @pytest.mark.polarion("CNV-7532")
+@pytest.mark.s390x
 def test_data_import_cron_deletion_on_opt_out(
     admin_client,
     golden_images_namespace,
@@ -353,6 +358,7 @@ def test_data_import_cron_deletion_on_opt_out(
 
 
 @pytest.mark.polarion("CNV-7569")
+@pytest.mark.s390x
 def test_data_import_cron_reconciled_after_deletion(
     golden_images_data_import_crons_scope_function,
 ):
@@ -377,6 +383,7 @@ def test_data_import_cron_reconciled_after_deletion(
 
 
 @pytest.mark.polarion("CNV-8032")
+@pytest.mark.s390x
 def test_data_import_cron_blocked_update(
     golden_images_data_import_crons_scope_function,
 ):
@@ -403,6 +410,7 @@ def test_data_import_cron_blocked_update(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_custom_data_import_cron_image_updated_via_hco(
     admin_client,
     updated_hco_with_custom_data_import_cron_scope_function,
@@ -415,6 +423,7 @@ def test_custom_data_import_cron_image_updated_via_hco(
 
 
 @pytest.mark.polarion("CNV-7669")
+@pytest.mark.s390x
 def test_data_import_cron_recreated_after_opt_out_opt_in(
     admin_client,
     golden_images_namespace,
@@ -439,6 +448,7 @@ def test_data_import_cron_recreated_after_opt_out_opt_in(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_data_import_cron_invalid_source_url_failed_creation(
     updated_hco_with_custom_data_import_cron_scope_function,
     ssp_resource_scope_function,
@@ -471,6 +481,7 @@ def test_data_import_cron_invalid_source_url_failed_creation(
 
 
 @pytest.mark.polarion("CNV-9917")
+@pytest.mark.s390x
 def test_data_source_instancetype_preference_label(
     unprivileged_client,
     namespace,

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -367,6 +367,7 @@ def updated_data_source_with_existing_pvc_scope_function(
 
 
 @pytest.mark.polarion("CNV-7578")
+@pytest.mark.s390x
 def test_opt_in_all_referenced_data_sources_in_templates_exist(
     data_sources_names_from_templates_scope_function,
     golden_images_data_sources_scope_function,
@@ -379,6 +380,7 @@ def test_opt_in_all_referenced_data_sources_in_templates_exist(
 
 
 @pytest.mark.polarion("CNV-8234")
+@pytest.mark.s390x
 def test_opt_out_all_referenced_data_sources_in_templates_exist(
     disabled_common_boot_image_import_hco_spec_scope_function,
     data_sources_names_from_templates_scope_function,
@@ -392,6 +394,7 @@ def test_opt_out_all_referenced_data_sources_in_templates_exist(
 
 
 @pytest.mark.polarion("CNV-7667")
+@pytest.mark.s390x
 def test_opt_in_data_source_reconciles_after_deletion(
     golden_images_data_sources_scope_function,
 ):
@@ -401,6 +404,7 @@ def test_opt_in_data_source_reconciles_after_deletion(
 
 
 @pytest.mark.polarion("CNV-8030")
+@pytest.mark.s390x
 def test_opt_in_data_source_reconciles_after_update(
     updated_opted_in_data_source_scope_function,
 ):
@@ -427,6 +431,7 @@ def test_opt_in_data_source_reconciles_after_update(
     ],
     indirect=["data_source_by_name_scope_function"],
 )
+@pytest.mark.s390x
 def test_upload_dv_for_auto_update_dangling_data_sources(
     data_source_by_name_scope_function,
     uploaded_dv_for_dangling_data_source_scope_function,
@@ -443,6 +448,7 @@ def test_upload_dv_for_auto_update_dangling_data_sources(
 
 
 @pytest.mark.polarion("CNV-7668")
+@pytest.mark.s390x
 def test_opt_out_data_source_reconciles_after_deletion(
     disabled_common_boot_image_import_hco_spec_scope_function,
     data_sources_from_templates_scope_function,
@@ -453,6 +459,7 @@ def test_opt_out_data_source_reconciles_after_deletion(
 
 
 @pytest.mark.polarion("CNV-8095")
+@pytest.mark.s390x
 def test_opt_out_data_source_reconciles_after_update(
     disabled_common_boot_image_import_hco_spec_scope_function,
     updated_opted_out_data_source_scope_function,
@@ -463,6 +470,7 @@ def test_opt_out_data_source_reconciles_after_update(
 
 
 @pytest.mark.polarion("CNV-8100")
+@pytest.mark.s390x
 def test_opt_out_data_source_update(
     disabled_common_boot_image_import_hco_spec_scope_function,
     data_sources_from_templates_scope_function,
@@ -489,6 +497,7 @@ def test_opt_out_data_source_update(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_opt_out_custom_data_sources_not_deleted(
     admin_client,
     golden_images_namespace,
@@ -515,6 +524,7 @@ def test_opt_out_custom_data_sources_not_deleted(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_data_source_with_existing_golden_image_pvc(
     disabled_common_boot_image_import_hco_spec_scope_function,
     data_source_by_name_scope_function,
@@ -551,6 +561,7 @@ def test_data_source_with_existing_golden_image_pvc(
     "enabled_common_boot_image_import_feature_gate_scope_class",
     "opted_in_data_source_scope_class",
 )
+@pytest.mark.s390x
 class TestDataSourcesOptInLabel:
     @pytest.mark.polarion("CNV-8029")
     @pytest.mark.dependency(name="TestDataSourcesOptInLabel::test_opt_in_label_data_source_when_pvc_exists")
@@ -607,6 +618,7 @@ class TestDataSourcesOptInLabel:
     "opted_in_data_source_scope_class",
     "opted_out_data_source_scope_class",
 )
+@pytest.mark.s390x
 class TestDataSourcesOptOutLabel:
     @pytest.mark.polarion("CNV-8244")
     @pytest.mark.dependency(name="TestDataSourcesOptOutLabel::test_remove_data_source_dic_label_when_pvc_exists")

--- a/tests/infrastructure/instance_types/supported_os/test_centos_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_centos_os.py
@@ -15,6 +15,7 @@ TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeCentos"
 
 @pytest.mark.arm64
 @pytest.mark.sno
+@pytest.mark.s390x
 class TestVMCreationAndValidation:
     @pytest.mark.dependency(name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}")
     @pytest.mark.polarion("CNV-12068")
@@ -48,6 +49,7 @@ class TestVMCreationAndValidation:
 @pytest.mark.arm64
 @pytest.mark.sno
 @pytest.mark.order(-1)
+@pytest.mark.s390x
 class TestVMDeletion:
     @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}"])
     @pytest.mark.polarion("CNV-12078")

--- a/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
@@ -22,6 +22,7 @@ TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeFedora"
 
 @pytest.mark.arm64
 @pytest.mark.sno
+@pytest.mark.s390x
 class TestVMCreationAndValidation:
     @pytest.mark.dependency(name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}")
     @pytest.mark.polarion("CNV-12068")
@@ -102,6 +103,7 @@ class TestVMFeatures:
 @pytest.mark.arm64
 @pytest.mark.sno
 @pytest.mark.order(-1)
+@pytest.mark.s390x
 class TestVMDeletion:
     @pytest.mark.dependency(depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}"])
     @pytest.mark.polarion("CNV-12078")

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -154,6 +154,7 @@ class TestVMMigrationAndState:
 
 
 @pytest.mark.arm64
+@pytest.mark.s390x
 @pytest.mark.smoke
 @pytest.mark.gating
 @pytest.mark.sno

--- a/tests/infrastructure/instance_types/test_common_vm_instancetype.py
+++ b/tests/infrastructure/instance_types/test_common_vm_instancetype.py
@@ -24,6 +24,7 @@ def xfail_if_no_huge_pages(workers):
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-10358")
+@pytest.mark.s390x
 def test_common_instancetype_vendor_labels(base_vm_cluster_instancetypes):
     assert_mismatch_vendor_label(resources_list=base_vm_cluster_instancetypes)
 
@@ -45,6 +46,7 @@ def test_cx1_instancetype_profile(xfail_if_no_huge_pages, unprivileged_client, n
 
 @pytest.mark.post_upgrade
 @pytest.mark.polarion("CNV-11288")
+@pytest.mark.s390x
 def test_common_instancetype_owner(base_vm_cluster_instancetypes):
     failed_ins_type = []
     for vm_cluster_instancetype in base_vm_cluster_instancetypes:

--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -69,6 +69,7 @@ def vm_cluster_preferences_expected_list():
 
 
 @pytest.mark.polarion("CNV-9981")
+@pytest.mark.s390x
 def test_base_preferences_common_annotation(base_vm_cluster_preferences, vm_cluster_preferences_expected_list):
     assert set([preference.name for preference in base_vm_cluster_preferences]) == set(
         vm_cluster_preferences_expected_list
@@ -78,6 +79,7 @@ def test_base_preferences_common_annotation(base_vm_cluster_preferences, vm_clus
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-10798")
+@pytest.mark.s390x
 def test_common_preferences_vendor_labels(base_vm_cluster_preferences):
     assert_mismatch_vendor_label(resources_list=base_vm_cluster_preferences)
 

--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -109,6 +109,7 @@ def hotplug_vm_snapshot_instance_type(instance_type_hotplug_vm):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestCPUHotPlugInstanceType:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::hotplug_cpu_instance_type")
     @pytest.mark.polarion("CNV-11401")

--- a/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
+++ b/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
@@ -88,6 +88,7 @@ def updated_vm_with_instancetype_and_preference(
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-9680")
+@pytest.mark.s390x
 def test_add_reference_to_existing_vm(
     updated_vm_with_instancetype_and_preference,
     vm_cluster_instance_type_to_update,

--- a/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
+++ b/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
@@ -88,6 +88,7 @@ def recreated_vm(rhel_vm_with_instance_type_and_preference):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestNegativeVmWithInstanceTypeAndPref:
     @pytest.mark.polarion("CNV-11525")
     def test_vm_start_fails_with_insufficient_cpu_for_spread_option(
@@ -131,6 +132,7 @@ class TestNegativeVmWithInstanceTypeAndPref:
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 class TestVmWithInstanceTypeAndPref:
     @pytest.mark.dependency(name="start_vm_with_instance_type_and_preference")
     @pytest.mark.polarion("CNV-9087")

--- a/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
+++ b/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
@@ -161,6 +161,7 @@ def vm_ready_for_tests(vm_parameters_for_virtio_downward_metrics):
 
 
 @pytest.mark.polarion("CNV-10937")
+@pytest.mark.s390x
 def test_downward_metrics_virtio_serial_port_default(
     vm_parameters_for_virtio_downward_metrics,
 ):
@@ -173,6 +174,7 @@ def test_downward_metrics_virtio_serial_port_default(
 
 
 @pytest.mark.polarion("CNV-10808")
+@pytest.mark.s390x
 def test_downward_metrics_virtio_serial_port(
     enabled_feature_gate_for_downward_metrics_scope_function, vm_ready_for_tests
 ):

--- a/tests/infrastructure/vhostmd/test_vhostmd.py
+++ b/tests/infrastructure/vhostmd/test_vhostmd.py
@@ -153,6 +153,7 @@ def run_vm_dump_metrics(vm):
     indirect=True,
 )
 @pytest.mark.polarion("CNV-6547")
+@pytest.mark.s390x
 def test_vhostmd_disk(
     vhostmd_vm1,
     vhostmd_vm2,

--- a/tests/infrastructure/vm_console_proxy/test_vm_console_proxy.py
+++ b/tests/infrastructure/vm_console_proxy/test_vm_console_proxy.py
@@ -10,6 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures("enabled_vm_console_proxy_spec")
+@pytest.mark.s390x
 class TestVmConsoleProxyEnablement:
     @pytest.mark.dependency(name="test_vm_proxy_cluster_resources_available")
     @pytest.mark.polarion("CNV-10416")


### PR DESCRIPTION
##### Short description:

Add Tier2 infrastructure marker changes for s390x.

##### More details:

##### What this PR does / why we need it:
This PR adds the s390x markers to the existing Tier2 infrastructure tests. This helps enable the Tier2 infrastructure pipeline for s390x.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added s390x architecture markers across multiple test suites (golden images, boot sources, data sources, instance types, vhostmd, VM console proxy) to refine test selection on s390x platforms.
  * Renamed one public test for clarity; no changes to test logic, parameters, or assertions.
  * No behavioral changes to the product; updates affect only test metadata and execution scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->