### PR TITLE
Return Namespace obj in create_ns

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -116,7 +116,6 @@ def label_project(name, label, admin_client):
     ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=TIMEOUT_2MIN)
     if label:
         ResourceEditor({ns: {"metadata": {"labels": label}}}).update()
-    return ns
 
 
 def create_ns(
@@ -142,7 +141,8 @@ def create_ns(
             yield ns
     else:
         ProjectRequest(name=name, client=unprivileged_client, teardown=teardown).deploy()
-        ns = label_project(name=name, label=labels, admin_client=admin_client)
+        label_project(name=name, label=labels, admin_client=admin_client)
+        ns = Namespace(client=admin_client, name=name, ensure_exists=True)
 
         yield ns
 

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -113,7 +113,9 @@ LOGGER = logging.getLogger(__name__)
 
 def label_project(name, label, admin_client):
     ns = Namespace(client=admin_client, name=name, ensure_exists=True)
-    ResourceEditor({ns: {"metadata": {"labels": label}}}).update()
+    ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=TIMEOUT_2MIN)
+    if label:
+        ResourceEditor({ns: {"metadata": {"labels": label}}}).update()
     return ns
 
 
@@ -144,7 +146,7 @@ def create_ns(
 
         yield ns
 
-        if not ns.clean_up():
+        if teardown and not ns.clean_up():
             raise ResourceTeardownError(resource=ns)
 
 

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -114,8 +114,7 @@ LOGGER = logging.getLogger(__name__)
 def label_project(name, label, admin_client):
     ns = Namespace(client=admin_client, name=name, ensure_exists=True)
     ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=TIMEOUT_2MIN)
-    if label:
-        ResourceEditor({ns: {"metadata": {"labels": label}}}).update()
+    ResourceEditor({ns: {"metadata": {"labels": label}}}).update()
 
 
 def create_ns(
@@ -142,10 +141,11 @@ def create_ns(
     else:
         ProjectRequest(name=name, client=unprivileged_client, teardown=teardown).deploy()
         label_project(name=name, label=labels, admin_client=admin_client)
-        ns = Namespace(client=admin_client, name=name, ensure_exists=True)
+        ns = Namespace(client=unprivileged_client, name=name, ensure_exists=True)
 
         yield ns
 
+        ns.client = admin_client
         if teardown and not ns.clean_up():
             raise ResourceTeardownError(resource=ns)
 


### PR DESCRIPTION
##### Short description:
To be consistent with function name return Namespace instead of Project in `create_ns` function

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unprivileged flows now operate on and yield actual workspace resources instead of temporary project requests, and labeling waits for the resource to become active before proceeding.
* **Bug Fixes**
  * Teardown in unprivileged flows now reliably cleans up the workspace resource and surfaces a clear error if removal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->