### PR TITLE
WIP:   [Storage][main] Add error handling for missing or failed virt-launcher pod deletion in migration fixture

### DIFF
--- a/tests/storage/storage_migration/test_mtc_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_mtc_storage_class_migration.py
@@ -242,7 +242,7 @@ class TestStorageClassMigrationWindowsWithVTPM:
         vms_boot_time_before_storage_migration,
         storage_mig_plan,
         storage_mig_migration,
-        deleted_old_dvs_of_online_vms,
+        # deleted_old_dvs_of_online_vms,
     ):
         pass
 


### PR DESCRIPTION
##### Short description:
Improve error handling when deleting completed virt-launcher pods in storage class migration tests

##### More details:
This PR wraps the deletion logic for virt-launcher pods in a try block to catch ResourceNotFoundError and other unexpected exceptions. Previously, the fixture failed if the pod wasn't found, which caused the entire test to break. With this change, missing pods are logged and skipped gracefully.

##### What this PR does / why we need it:
The PR makes the deleted_completed_virt_launcher_source_pod fixture more resilient. It avoids hard failures during test setup in scenarios where virt-launcher pods have already been deleted or were never created. This helps prevent unnecessary test flakiness and improves overall stability of storage migration tests.


##### Which issue(s) this PR fixes:
fix test:
tests.storage.storage_migration.test_mtc_storage_class_migration.TestStorageClassMigrationWindowsWithVTPM.test_migrate_windows_vm_with_vtpm_after_storage_migration

test_migrate_windows_vm_with_vtpm_after_storage_migration
    assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"
AssertionError: Failed VM migrations: {'windows-11-vm-1755194709-9157093': TimeoutExpiredError()}
assert not {'windows-11-vm-1755194709-9157093': TimeoutExpiredError()}

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64381
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added module-level logging to storage-migration tests for clearer diagnostics.
  * Cleanup fixtures now handle missing resources gracefully, logging warnings instead of failing.
  * Unexpected errors during cleanup are logged as errors to assist troubleshooting.
  * Simplified test signatures by removing an unused parameter to streamline test interfaces.
  * Improved reliability and reduced flakiness for more stable CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->