### PR TITLE
[4.19]Changing test implementation for metric kubevirt_nodes_with_kvm (#1731)

### DIFF
--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -223,3 +223,13 @@ class TestAllocatableNodes:
         validate_metrics_value(
             prometheus=prometheus, metric_name="kubevirt_allocatable_nodes", expected_value=f"{len(allocatable_nodes)}"
         )
+
+
+class TestKubevirtNodesWithKvm:
+    @pytest.mark.polarion("CNV-11708")
+    def test_metric_kubevirt_nodes_with_kvm(self, prometheus, schedulable_nodes):
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name="kubevirt_nodes_with_kvm",
+            expected_value=f"{len(schedulable_nodes)}",
+        )

--- a/tests/observability/virt/conftest.py
+++ b/tests/observability/virt/conftest.py
@@ -13,7 +13,7 @@ from tests.observability.virt.utils import (
 )
 from utilities.constants import VIRT_HANDLER, VIRT_OPERATOR
 from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.infra import get_daemonset_by_name, get_pod_by_name_prefix
+from utilities.infra import get_daemonset_by_name
 
 LOGGER = logging.getLogger(__name__)
 
@@ -81,18 +81,6 @@ def virt_handler_daemonset_with_bad_image(virt_handler_daemonset_scope_class):
         list_resource_reconcile=[KubeVirt],
     ):
         yield
-
-
-@pytest.fixture(scope="class")
-def deleted_virt_handler_pods(admin_client, hco_namespace):
-    virt_handler_pods = get_pod_by_name_prefix(
-        dyn_client=admin_client,
-        pod_prefix=VIRT_HANDLER,
-        namespace=hco_namespace.name,
-        get_all=True,
-    )
-    for pod in virt_handler_pods:
-        pod.clean_up()
 
 
 @pytest.fixture(scope="class")

--- a/tests/observability/virt/test_virt_metrics_alerts.py
+++ b/tests/observability/virt/test_virt_metrics_alerts.py
@@ -128,39 +128,3 @@ class TestVirtHandlerDaemonSet:
             alert_dict=alert_tested,
             timeout=TIMEOUT_10MIN,
         )
-
-
-@pytest.mark.usefixtures("disabled_virt_operator", "virt_handler_daemonset_with_bad_image", "deleted_virt_handler_pods")
-class TestLowKvmCounts:
-    @pytest.mark.dependency(name="test_metric_kubevirt_nodes_with_kvm")
-    @pytest.mark.polarion("CNV-11708")
-    def test_metric_kubevirt_nodes_with_kvm(self, prometheus):
-        validate_metrics_value(
-            prometheus=prometheus,
-            metric_name="kubevirt_nodes_with_kvm",
-            expected_value="0",
-        )
-
-    @pytest.mark.dependency(depends=["test_metric_kubevirt_nodes_with_kvm"])
-    @pytest.mark.parametrize(
-        "alert_tested",
-        [
-            pytest.param(
-                {
-                    "alert_name": "LowKVMNodesCount",
-                    "labels": {
-                        "severity": WARNING_STR,
-                        "operator_health_impact": WARNING_STR,
-                        "kubernetes_operator_component": KUBEVIRT_STR_LOWER,
-                    },
-                },
-                marks=(pytest.mark.polarion("CNV-11053")),
-            )
-        ],
-    )
-    def test_low_kvm_nodes_count(
-        self,
-        prometheus,
-        alert_tested,
-    ):
-        validate_alerts(prometheus=prometheus, alert_dict=alert_tested)


### PR DESCRIPTION
##### Short description:
The test now is more simple then before, instead of changing image in daemonSet, I simply get the number of schedulable nodes and compare it with the prometheus result.
Also removed the alert that depends on this metric test since we are not testing alert in T2 anymore. first if a pod exists before deletion and in this way I make sure it won't fail in this part of the setup.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-67428