### PR TITLE
Fix PytestDeprecationWarning for optionalhook

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -832,7 +832,7 @@ def pytest_exception_interact(node: Item | Collector, call: CallInfo[Any], repor
                 LOGGER.warning(f"Failed to collect logs: {test_name}: {current_exception} {traceback.format_exc()}")
 
 
-@pytest.mark.optionalhook
+@pytest.hookimpl(optionalhook=True)
 def pytest_html_results_table_header(cells):
     cells.pop()  # Remove the `Links` column
 
@@ -841,7 +841,7 @@ def pytest_html_results_table_header(cells):
     cells.append(f"<th>{QUARANTINED.title()} Reason</th>")
 
 
-@pytest.mark.optionalhook
+@pytest.hookimpl(optionalhook=True)
 def pytest_html_results_table_row(report, cells):
     cells.pop()  # Remove the `Links` entry
 


### PR DESCRIPTION
##### Short description:
Fix PytestDeprecationWarning warning showing on runs

##### More details:
The following error appears in the runs. This PR updates the method to the supported version to address it

```
conftest.py:835
  /home/cloud-user/roni_cnv_tests/openshift-virtualization-tests/conftest.py:835: PytestDeprecationWarning: The hookimpl pytest_html_results_table_header uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.optionalhook

conftest.py:844
  /home/cloud-user/roni_cnv_tests/openshift-virtualization-tests/conftest.py:844: PytestDeprecationWarning: The hookimpl pytest_html_results_table_row uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.optionalhook
```

##### What this PR does / why we need it:
Remove deprecated method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Migrated HTML reporting hooks to the modern implementation decorator to align with current Pytest/pytest-html conventions.

- Chores
  - Improved compatibility with newer Pytest releases and reduced deprecation warnings.
  - No changes to report content or behavior; existing HTML report layout remains the same for users.
  - Internal maintenance to keep test reporting infrastructure up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->