### PR TITLE
Change implementation of kubevirt_vmi_status_addresses test

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -739,18 +739,7 @@ def modified_vm_cpu_requests(vm_with_cpu_spec):
 
 
 @pytest.fixture()
-def vm_ip_address(vm_for_test):
-    vm_ip = re.search(
-        IP_RE_PATTERN_FROM_INTERFACE,
-        vm_for_test.privileged_vmi.virt_launcher_pod.execute(command=IP_ADDR_SHOW_COMMAND),
-        re.DOTALL,
-    )
-    assert vm_ip, f"Failed to find {vm_for_test.name} vm ip."
-    return vm_ip.group(1)
-
-
-@pytest.fixture()
-def metric_validate_metric_labels_values_ip_labels(request, prometheus, vm_for_test):
+def kubevirt_vmi_status_addresses_ip_labels_values(prometheus, vm_for_test):
     samples = TimeoutSampler(
         wait_timeout=TIMEOUT_4MIN,
         sleep=TIMEOUT_15SEC,
@@ -771,22 +760,16 @@ def metric_validate_metric_labels_values_ip_labels(request, prometheus, vm_for_t
 
 
 @pytest.fixture()
-def vm_virt_controller_ip_address(
-    prometheus, admin_client, hco_namespace, metric_validate_metric_labels_values_ip_labels
-):
-    virt_controller_pod_name = metric_validate_metric_labels_values_ip_labels.get("pod")
+def vm_virt_controller_ip_address(admin_client, hco_namespace, kubevirt_vmi_status_addresses_ip_labels_values):
+    virt_controller_pod_name = kubevirt_vmi_status_addresses_ip_labels_values.get("pod")
     assert virt_controller_pod_name, "virt-controller not found"
-    virt_controller_pod_ip = re.search(
-        IP_RE_PATTERN_FROM_INTERFACE,
-        get_pod_by_name_prefix(
-            dyn_client=admin_client,
-            pod_prefix=virt_controller_pod_name,
-            namespace=hco_namespace.name,
-        ).execute(command=IP_ADDR_SHOW_COMMAND),
-        re.DOTALL,
-    )
+    virt_controller_pod_ip = get_pod_by_name_prefix(
+        dyn_client=admin_client,
+        pod_prefix=virt_controller_pod_name,
+        namespace=hco_namespace.name,
+    ).ip
     assert virt_controller_pod_ip, f"virt-controller: {virt_controller_pod_name} ip not found."
-    return virt_controller_pod_ip.group(1)
+    return virt_controller_pod_ip
 
 
 @pytest.fixture()

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -413,12 +413,12 @@ class TestVmiStatusAddresses:
         self,
         prometheus,
         vm_for_test,
-        metric_validate_metric_labels_values_ip_labels,
+        kubevirt_vmi_status_addresses_ip_labels_values,
         vm_virt_controller_ip_address,
-        vm_ip_address,
     ):
-        instance_value = metric_validate_metric_labels_values_ip_labels.get("instance").split(":")[0]
-        address_value = metric_validate_metric_labels_values_ip_labels.get("address")
+        instance_value = kubevirt_vmi_status_addresses_ip_labels_values.get("instance").split(":")[0]
+        address_value = kubevirt_vmi_status_addresses_ip_labels_values.get("address")
+        vm_ip_address = vm_for_test.vmi.interface_ip(interface="eth0")
         assert instance_value == vm_virt_controller_ip_address, (
             f"Expected value: {vm_virt_controller_ip_address}, Actual: {instance_value}"
         )


### PR DESCRIPTION
##### Short description:
The test was using virt launcher and pod execution in order to get the ip addresses, changed it to use api.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-67471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated observability metrics tests to use metric-reported pod/address labels and derive the VM IP within the test.
  - Replaced in-pod IP parsing with pod IP retrieval and metric-based identification of the relevant controller pod.
  - Added validation ensuring the metric’s address matches the VM’s interface IP.
  - Removed redundant helpers/fixtures to simplify setup and reduce test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->