### PR TITLE
[Chaos][OADP] Automate Polarion TC CNV-12020: Drain the node where the VM is located during OADP Backup

### DIFF
--- a/tests/chaos/oadp/test_oadp.py
+++ b/tests/chaos/oadp/test_oadp.py
@@ -39,3 +39,32 @@ def test_reboot_vm_node_during_backup(
     oadp_backup_in_progress.wait_for_status(
         status=oadp_backup_in_progress.Backup.Status.PARTIALLYFAILED, timeout=TIMEOUT_10MIN
     )
+
+
+@pytest.mark.destructive
+@pytest.mark.chaos
+@pytest.mark.parametrize(
+    "rhel_vm_with_dv_running",
+    [
+        pytest.param(
+            {
+                "vm_name": "vm-node-drain-12020",
+                "rhel_image": RHEL_LATEST["image_name"],
+            },
+            marks=pytest.mark.polarion("CNV-12020"),
+        ),
+    ],
+    indirect=True,
+)
+def test_drain_vm_node_during_backup(
+    oadp_backup_in_progress,
+    drain_vm_source_node,
+):
+    """
+    Drain the worker node where the VM is located during OADP backup using DataMover.
+    Validate that backup eventually Completed.
+    """
+    LOGGER.info(f"Waiting for backup to reach '{oadp_backup_in_progress.Backup.Status.COMPLETED}' during node drain.")
+    oadp_backup_in_progress.wait_for_status(
+        status=oadp_backup_in_progress.Backup.Status.COMPLETED, timeout=TIMEOUT_10MIN
+    )


### PR DESCRIPTION
##### Short description:
It needs https://github.com/RedHatQE/openshift-virtualization-tests/pull/1678 as its dependence.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a chaos test that drains a VM’s host node during an in-progress backup and verifies the backup completes within the expected timeout.
  - Added a supporting fixture to automate draining the host and verifying node schedulability during backup chaos scenarios.
  - Confirmed the existing reboot-during-backup chaos test behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->