### PR TITLE
WIP: Remove scenario from module test_bridge_marker

### DIFF
--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -75,16 +75,6 @@ def bridge_attached_vmi_for_bridge_marker_no_device(namespace, bridge_marker_bri
 
 
 @pytest.fixture()
-def bridge_attached_vmi_for_bridge_marker_device_exists(namespace, bridge_marker_bridge_network):
-    with create_bridge_attached_vm_for_bridge_marker(
-        namespace=namespace, bridge_marker_bridge_network=bridge_marker_bridge_network
-    ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        yield vm.vmi
-
-
-@pytest.fixture()
 def multi_bridge_attached_vmi(namespace, bridge_networks, unprivileged_client):
     networks = {b.name: b.name for b in bridge_networks}
     name = _get_name(suffix="multi-bridge-vm")
@@ -98,16 +88,6 @@ def multi_bridge_attached_vmi(namespace, bridge_networks, unprivileged_client):
     ) as vm:
         vm.start()
         yield vm.vmi
-
-
-@pytest.fixture()
-def bridge_device_on_all_nodes():
-    with network_device(
-        interface_type=LINUX_BRIDGE,
-        nncp_name="bridge-marker1",
-        interface_name=BRIDGEMARKER1,
-    ) as dev:
-        yield dev
 
 
 @pytest.fixture()
@@ -145,16 +125,6 @@ def test_bridge_marker_no_device(bridge_marker_bridge_network, bridge_attached_v
     # validate the exact reason for VMI startup failure is missing bridge
     pod = bridge_attached_vmi_for_bridge_marker_no_device.virt_launcher_pod
     _assert_failure_reason_is_bridge_missing(pod=pod, bridge=bridge_marker_bridge_network)
-
-
-# note: the order of fixtures is important because we should first create the
-# device before attaching a VMI to it
-@pytest.mark.sno
-@pytest.mark.polarion("CNV-2235")
-@pytest.mark.s390x
-def test_bridge_marker_device_exists(bridge_device_on_all_nodes, bridge_attached_vmi_for_bridge_marker_device_exists):
-    """Check that VMI successfully starts when bridge device is present."""
-    bridge_attached_vmi_for_bridge_marker_device_exists.wait_until_running(timeout=_VM_RUNNING_TIMEOUT)
 
 
 @pytest.mark.polarion("CNV-2309")


### PR DESCRIPTION
These scenarios were useful early in the product but are now redundant and misclassified (they belong in tier1, not tier2). The behaviors they validate are already covered elsewhere in the codebase, multiple times across different suites.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed an internal end-to-end test that validated the bridge-marker device-present path. Remaining tests continue to verify behavior when the bridge device is missing and when attachments span different nodes. This is a test-suite simplification only and does not alter product behavior, features, performance, or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->