### PR TITLE
fix(constants): align s390x Fedora image name with x86band internal http server

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -144,7 +144,7 @@ class ArchImages:
 
         Cdi = Cdi(
             # TODO: S390X does not support Cirros; this is a workaround until tests are moved to Fedora
-            QCOW2_IMG="Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2",
+            QCOW2_IMG="Fedora-qcow2.img",
             DIR=f"{BASE_IMAGES_DIR}/fedora-images",
             DEFAULT_DV_SIZE="10Gi",
         )


### PR DESCRIPTION
fix(constants): align s390x Fedora image name with x86band internal http server.

Updated `QCOW2_IMG` for s390x from
`Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2` to `Fedora-qcow2.img` to match the format used on x86 and the image name in the internal HTTP server. This ensures consistency and allows test cases to pass.

Reference (x86 implementation):
https://github.com/RedHatQE/openshift-virtualization-tests/blob/8abf57e3d9d153c1d64ffcfca989e60bccff2f7c/utilities/constants.py#L101

Signed-off-by: Nekkunti Anand




