### PR TITLE
Quarantine runbook Downstream urls test

### DIFF
--- a/tests/observability/runbook_url/test_runbook_url.py
+++ b/tests/observability/runbook_url/test_runbook_url.py
@@ -4,7 +4,7 @@ import pytest
 from ocp_resources.prometheus_rule import PrometheusRule
 
 from tests.utils import validate_runbook_url_exists
-from utilities.constants import CNV_PROMETHEUS_RULES
+from utilities.constants import CNV_PROMETHEUS_RULES, QUARANTINED
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,6 +63,10 @@ def test_runbook_upstream_urls(cnv_prometheus_rules_unique_alert_names_runbook):
         raise AssertionError("CNV alerts with unreachable runbook urls found.")
 
 
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: New alerts runbooks added to upstream and not merged yet for downstream, CNV-67890",
+    run=False,
+)
 @pytest.mark.polarion("CNV-10084")
 def test_runbook_downstream_urls(cnv_prometheus_rules_unique_alert_names_runbook):
     error_messages = []


### PR DESCRIPTION
##### Short description:
There is new runbooks for new alerts that not merged for downstream and make the lanes unstable, until these PRs will be merged on DS, this test will be quarantined.
##### More details:
For PersistentVolumeFillingUp : https://github.com/openshift/runbooks/pull/273
For HCOGoldenImageWithNoSupportedArchitecture: https://github.com/openshift/runbooks/pull/317
For HighNodeCPUFrequency: https://github.com/openshift/runbooks/pull/277
For HCOGoldenImageWithNoArchitectureAnnotation: https://github.com/openshift/runbooks/pull/316
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Quarantined a flaky runbook-related test to prevent false CI failures until upstream changes propagate, improving pipeline reliability.
* **Chores**
  * Improved test stability by marking an unstable scenario as expected to fail without running, reducing noise in test reports.

No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->