### PR TITLE
Storage: remove virt-launchers cleanup from storage migration tests

### DIFF
--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -20,7 +20,7 @@ from tests.storage.storage_migration.constants import (
     WINDOWS_FILE_WITH_PATH,
     WINDOWS_TEST_DIRECTORY_PATH,
 )
-from tests.storage.storage_migration.utils import get_source_virt_launcher_pod, get_storage_class_for_storage_migration
+from tests.storage.storage_migration.utils import get_storage_class_for_storage_migration
 from tests.storage.utils import create_windows_directory
 from utilities.constants import (
     OS_FLAVOR_FEDORA,
@@ -287,17 +287,7 @@ def vms_boot_time_before_storage_migration(online_vms_for_storage_class_migratio
 
 
 @pytest.fixture(scope="class")
-def deleted_completed_virt_launcher_source_pod(unprivileged_client, online_vms_for_storage_class_migration):
-    for vm in online_vms_for_storage_class_migration:
-        source_pod = get_source_virt_launcher_pod(client=unprivileged_client, vm=vm)
-        source_pod.wait_for_status(status=source_pod.Status.SUCCEEDED)
-        source_pod.delete(wait=True)
-
-
-@pytest.fixture(scope="class")
-def deleted_old_dvs_of_online_vms(
-    unprivileged_client, online_vms_for_storage_class_migration, deleted_completed_virt_launcher_source_pod
-):
+def deleted_old_dvs_of_online_vms(unprivileged_client, online_vms_for_storage_class_migration):
     for vm in online_vms_for_storage_class_migration:
         dv_name = vm.instance.status.volumeUpdateState.volumeMigrationState.migratedVolumes[0].sourcePVCInfo.claimName
         dv = DataVolume(client=unprivileged_client, name=dv_name, namespace=vm.namespace, ensure_exists=True)

--- a/tests/storage/storage_migration/utils.py
+++ b/tests/storage/storage_migration/utils.py
@@ -1,9 +1,7 @@
 import shlex
 
 import pytest
-from kubernetes.dynamic import DynamicClient
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
-from ocp_resources.pod import Pod
 from pyhelper_utils.shell import run_ssh_commands
 
 from tests.storage.storage_migration.constants import (
@@ -15,12 +13,6 @@ from tests.storage.storage_migration.constants import (
 from utilities import console
 from utilities.constants import LS_COMMAND, TIMEOUT_20SEC
 from utilities.virt import VirtualMachineForTests, get_vm_boot_time
-
-
-def get_source_virt_launcher_pod(client: DynamicClient, vm: VirtualMachineForTests) -> Pod:
-    source_pod_name = vm.vmi.instance.to_dict().get("status", {}).get("migrationState", {}).get("sourcePod")
-    assert source_pod_name, f"Source pod name is not found in VMI status.migrationState.sourcePod for VM '{vm.name}'"
-    return Pod(client=client, name=source_pod_name, namespace=vm.namespace, ensure_exists=True)
 
 
 def check_file_in_vm(vm: VirtualMachineForTests, file_name: str, file_content: str) -> None:


### PR DESCRIPTION
##### Short description:
MTC 1.8.9 and newer - cleans up the virt-launcher pods itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - None.
- Tests
  - Simplified storage migration cleanup workflow to delete old volumes directly.
  - Improved reliability with explicit success assertions during cleanup.
  - Reduced test flakiness by removing dependency on source pod completion.
- Chores
  - Removed unused helper and related imports to streamline test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->