### PR TITLE
Quarentine test_connectivity_is_preserved_during_client_live_migration

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -142,6 +142,7 @@ class TestPrimaryUdn:
     @pytest.mark.gating
     @pytest.mark.xfail(
         reason=f"{QUARANTINED}: Flaky test, fails on connecting to VM console; tracked in CNV-67470",
+        run=False,
     )
     def test_connectivity_is_preserved_during_client_live_migration(self, server, client):
         migrate_vm_and_verify(vm=client.vm)


### PR DESCRIPTION
Until we have a fix of it - we have this task for it: https://issues.redhat.com/browse/CNV-67470

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked a previously expected-to-fail connectivity test to not run while retaining its xfail status, reducing noise in CI and improving test stability.
  * Prevents false negatives by skipping execution of a known failing scenario until it’s ready to be re-enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->