### PR TITLE
Move nmstate namespace check to network sanity checks and `nodes_active_nics` to return `node_physical_nics` for cloud clusters

### DIFF
--- a/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
+++ b/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
@@ -61,12 +61,11 @@ def test_node_sanity(admin_client, nodes):
 
 
 @pytest.mark.cluster_health_check
-def test_pod_sanity(admin_client, hco_namespace, nmstate_namespace):
-    for namespace_obj in [hco_namespace, nmstate_namespace]:
-        wait_for_pods_running(
-            admin_client=admin_client,
-            namespace=namespace_obj,
-        )
+def test_pod_sanity(admin_client, hco_namespace):
+    wait_for_pods_running(
+        admin_client=admin_client,
+        namespace=hco_namespace,
+    )
 
 
 @pytest.mark.cluster_health_check

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -570,11 +570,7 @@ def node_physical_nics(workers_utility_pods):
 
 
 @pytest.fixture(scope="session")
-def nodes_active_nics(
-    workers,
-    workers_utility_pods,
-    node_physical_nics,
-):
+def nodes_active_nics(workers, workers_utility_pods, node_physical_nics, nmstate_required):
     # TODO: Reduce cognitive complexity
     def _bridge_ports(node_interface):
         ports = set()
@@ -590,6 +586,10 @@ def nodes_active_nics(
     Get nodes active NICs.
     First NIC is management NIC
     """
+    if not nmstate_required:
+        LOGGER.info("Running on cloud; NMState is not required")
+        return {}
+
     nodes_nics = {}
     for node in workers:
         nodes_nics[node.name] = {"available": [], "occupied": []}
@@ -1252,7 +1252,7 @@ def golden_images_edit_rolebinding(
 
 
 @pytest.fixture(scope="session")
-def hosts_common_available_ports(nodes_available_nics):
+def hosts_common_available_ports(nodes_available_nics, node_physical_nics):
     """
     Get list of common ports from nodes_available_nics.
 
@@ -1262,8 +1262,15 @@ def hosts_common_available_ports(nodes_available_nics):
     ['ens3', 'ens8', 'ens6', 'ens7']]
 
     will return ['ens3', 'ens6']
+
+    If running on cloud-based cluster, it will return node_physical_nics
     """
-    nics_list = list(set.intersection(*[set(_list) for _list in nodes_available_nics.values()]))
+    if not nodes_available_nics:
+        LOGGER.info("Using `node_physical_nics` instead of `nodes_available_nics`")
+
+    available_nics = nodes_available_nics if nodes_available_nics else node_physical_nics
+
+    nics_list = list(set.intersection(*[set(_list) for _list in available_nics.values()]))
     nics_list.sort()
     LOGGER.info(f"Hosts common available NICs: {nics_list}")
     return nics_list
@@ -2076,7 +2083,7 @@ def autouse_fixtures(
     leftovers_cleanup,  # Must be called first to avoid delete created resources.
     artifactory_setup,
     bin_directory_to_os_path,
-    cluster_info,
+    # cluster_info,
     term_handler_scope_function,
     term_handler_scope_class,
     term_handler_scope_module,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -587,7 +587,7 @@ def nodes_active_nics(workers, workers_utility_pods, node_physical_nics, nmstate
     First NIC is management NIC
     """
     if not nmstate_required:
-        LOGGER.info("Running on cloud; using `node_physical_nics`")
+        LOGGER.info(f"Running on cloud; using nodes physical NICs {node_physical_nics}")
         return node_physical_nics
 
     nodes_nics = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -587,8 +587,8 @@ def nodes_active_nics(workers, workers_utility_pods, node_physical_nics, nmstate
     First NIC is management NIC
     """
     if not nmstate_required:
-        LOGGER.info("Running on cloud; NMState is not required")
-        return {}
+        LOGGER.info("Running on cloud; using `node_physical_nics`")
+        return node_physical_nics
 
     nodes_nics = {}
     for node in workers:
@@ -1252,7 +1252,7 @@ def golden_images_edit_rolebinding(
 
 
 @pytest.fixture(scope="session")
-def hosts_common_available_ports(nodes_available_nics, node_physical_nics):
+def hosts_common_available_ports(nodes_available_nics):
     """
     Get list of common ports from nodes_available_nics.
 
@@ -1262,15 +1262,8 @@ def hosts_common_available_ports(nodes_available_nics, node_physical_nics):
     ['ens3', 'ens8', 'ens6', 'ens7']]
 
     will return ['ens3', 'ens6']
-
-    If running on cloud-based cluster, it will return node_physical_nics
     """
-    if not nodes_available_nics:
-        LOGGER.info("Using `node_physical_nics` instead of `nodes_available_nics`")
-
-    available_nics = nodes_available_nics if nodes_available_nics else node_physical_nics
-
-    nics_list = list(set.intersection(*[set(_list) for _list in available_nics.values()]))
+    nics_list = list(set.intersection(*[set(_list) for _list in nodes_available_nics.values()]))
     nics_list.sort()
     LOGGER.info(f"Hosts common available NICs: {nics_list}")
     return nics_list
@@ -2083,7 +2076,7 @@ def autouse_fixtures(
     leftovers_cleanup,  # Must be called first to avoid delete created resources.
     artifactory_setup,
     bin_directory_to_os_path,
-    # cluster_info,
+    cluster_info,
     term_handler_scope_function,
     term_handler_scope_class,
     term_handler_scope_module,

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -227,11 +227,7 @@ def network_sanity(
     failure_msgs = []
     collected_tests = request.session.items
 
-    def _verify_multi_nic(_request, _nmstate_required):
-        if not _nmstate_required:
-            LOGGER.info("Running on cloud-based cluster; Skipping multi-NIC verification")
-            return
-
+    def _verify_multi_nic(_request):
         marker_args = _request.config.getoption("-m")
         if marker_args and "single_nic" in marker_args and "not single_nic" not in marker_args:
             LOGGER.info("Running only single-NIC network cases, no need to verify multi NIC support")
@@ -312,13 +308,14 @@ def network_sanity(
         if pods := wait_for_pods_running(admin_client=_admin_client, namespace=namespace, raise_exception=False):
             failure_msgs.append(f"The {pods} pods are not running in nmstate namespace '{namespace.name}'")
 
-    _verify_multi_nic(_request=request, _nmstate_required=nmstate_required)
     _verify_dpdk()
     _verify_service_mesh()
     _verify_jumbo_frame()
     _verify_sriov()
     _verify_ipv4()
+
     if nmstate_required:
+        _verify_multi_nic(_request=request)
         _verify_nmstate_running_pods(_admin_client=admin_client, namespace=nmstate_namespace)
 
     if failure_msgs:


### PR DESCRIPTION
##### Short description:
nmstate is not a must for `cluster_health_check` tests. `test_pod_sanity` will only verify HCO pods.
As nmstate is not installed on cloud-based clusters, `nodes_active_nics` will return `node_physical_nics` for such clusters.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
