### PR TITLE
fix: stage conflicts for peter-evans action in cherry-pick workflow

### DIFF
--- a/.github/workflows/cherrypick-to-4.99.yml
+++ b/.github/workflows/cherrypick-to-4.99.yml
@@ -250,9 +250,12 @@ jobs:
 
             echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
 
-            # Stage all changes (including conflicts) for peter-evans to handle
+            # Refresh index and stage all changes (including conflicts) for peter-evans to handle
             # This resolves the "you need to resolve your current index first" error
-            git add .
+
+            git add -A :/
+
+            git update-index --refresh -q || true
           fi
 
       - name: Create PR for successful cherry-pick


### PR DESCRIPTION
Added `git add .` in conflict handling path to stage all changes including conflicts. This resolves the "you need to resolve your current index first" error that was preventing peter-evans from creating branches and commits when cherry-pick conflicts occurred.

🤖 Generated with [Claude Code](https://claude.ai/code)

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cherry-pick conflict handling by auto-staging conflicted changes to avoid index errors and make conflict resolution smoother.
  * Updated conflict-handling messaging to reflect staging behavior rather than leaving files in the working tree.

* **Chores**
  * Removed automatic PR creation for successful cherry-picks; draft PRs continue to be created for conflicted runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->