### PR TITLE
Storage: quarantine storage migration test with a Stopped VM

### DIFF
--- a/tests/storage/storage_migration/test_mtc_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_mtc_storage_class_migration.py
@@ -16,6 +16,7 @@ from tests.storage.storage_migration.utils import (
     verify_vm_storage_class_updated,
     verify_vms_boot_time_after_storage_migration,
 )
+from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 TESTS_CLASS_NAME_A_TO_B = "TestStorageClassMigrationAtoB"
@@ -85,6 +86,10 @@ class TestStorageClassMigrationAtoB:
         assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"
 
 
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: Bug: can't Storage migrate a Stopped VM; fixed in MTC 1.8.10; MIG-1762",
+    run=False,
+)
 @pytest.mark.parametrize(
     "source_storage_class, target_storage_class, data_volume_scope_class, "
     "vm_for_storage_class_migration_from_template_with_existing_dv, "


### PR DESCRIPTION
##### Short description:
Bug fixed in MTC 1.8.10, which is expected to be released in two weeks: https://issues.redhat.com/browse/MIG-1762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Quarantined a VM storage class migration scenario by marking the affected test as expected to fail and skipping its execution due to a known upstream issue pending a fix.
  * Improves test suite stability and signal by isolating the flaky case without altering functionality or release behavior.
  * No user-facing changes; this update only impacts internal test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->