### PR TITLE
[4.19] Quarantine another test that fails because of the console login

### DIFF
--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -2,6 +2,7 @@ import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
 from tests.network.localnet.liblocalnet import LOCALNET_BR_EX_NETWORK, client_server_active_connection
+from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 
@@ -10,6 +11,10 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.single_nic
 @pytest.mark.usefixtures("nncp_localnet")
 @pytest.mark.polarion("CNV-11775")
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: Flaky, occasionally fails during setup on console init; tracked in CNV-67470",
+    run=False,
+)
 def test_connectivity_over_migration_between_localnet_vms(localnet_server, localnet_client):
     migrate_vm_and_verify(vm=localnet_client.vm)
     assert is_tcp_connection(server=localnet_server, client=localnet_client)


### PR DESCRIPTION
Tracked on CNV-67470.
This test is quarantined only in 4.19 and not in main because so far we experienced it failing only in 4.19, so we wouldn't want to quarantine (another) gating test if it's not a must.
This test failed because of the issue handled in this [PR](https://github.com/RedHatQE/openshift-virtualization-tests/pull/1939), so once it is merged, this test will be un-quarantined.
##### jira-ticket:
https://issues.redhat.com/browse/CNV-67470