### PR TITLE
WIP: fedora 42 container image

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -90,7 +90,7 @@ class ArchImages:
 
         Fedora = Fedora(
             FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",
-            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41",
+            FEDORA_CONTAINER_IMAGE="quay.io/akrgupta/fedora:42-x86_64",
             DISK_DEMO="fedora-cloud-registry-disk-demo",
         )
         Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG


### PR DESCRIPTION
##### Short description:
This Pr is only for testing the image and is not to be merged 
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default Fedora container image for x86_64 to Fedora 42, aligning with the latest release and improving compatibility and security in container-based workflows.
  - No changes to associated VM disk images or release aliases; no user-facing functionality affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->