### PR TITLE
Add basic windows tests using instance types and container images

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -55,6 +55,7 @@ class Windows:
     WIN2022_ISO_IMG: str | None = None
     WIN2025_ISO_IMG: str | None = None
     DIR: str = f"{BASE_IMAGES_DIR}/windows-images"
+    DOCKER_IMAGE_DIR = "docker/kubevirt-common-instancetypes"
     UEFI_WIN_DIR: str = f"{DIR}/uefi"
     HA_DIR: str = f"{DIR}/HA-images"
     ISO_BASE_DIR = f"{DIR}/install_iso"
@@ -62,6 +63,7 @@ class Windows:
     ISO_WIN11_DIR: str = f"{ISO_BASE_DIR}/win11"
     ISO_WIN2022_DIR: str = f"{ISO_BASE_DIR}/win2022"
     ISO_WIN2025_DIR: str = f"{ISO_BASE_DIR}/win2025"
+    CONTAINER_DISK_DV_SIZE = "40Gi"
     DEFAULT_DV_SIZE: str = "70Gi"
     DEFAULT_MEMORY_SIZE: str = "8Gi"
     DEFAULT_MEMORY_SIZE_WSL: str = "12Gi"

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -5,7 +5,6 @@ from tests.infrastructure.instance_types.supported_os.utils import golden_image_
 from utilities.constants import (
     CONTAINER_DISK_IMAGE_PATH_STR,
     DATA_SOURCE_NAME,
-    OS_FLAVOR_WINDOWS,
     RHEL8_PREFERENCE,
     TIMEOUT_15MIN,
     Images,
@@ -110,7 +109,6 @@ def golden_image_windows_data_source(
 def golden_image_windows_vm(
     unprivileged_client,
     namespace,
-    golden_images_namespace,
     modern_cpu_for_migration,
     golden_image_windows_data_source,
     windows_os_matrix__module__,
@@ -127,11 +125,9 @@ def golden_image_windows_vm(
             data_source=golden_image_windows_data_source,
             storage_class=[*storage_class_matrix__module__][0],
         ),
-        os_flavor=OS_FLAVOR_WINDOWS,
+        os_flavor="win-container-disk",
         disk_type=None,
         cpu_model=modern_cpu_for_migration,
-        password="Administrator",
-        username="Administrator",
     )
 
 

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -1,7 +1,22 @@
 import pytest
+from pytest_testconfig import config as py_config
 
 from tests.infrastructure.instance_types.supported_os.utils import golden_image_vm_with_instance_type
-from utilities.constants import DATA_SOURCE_NAME, RHEL8_PREFERENCE
+from utilities.constants import (
+    CONTAINER_DISK_IMAGE_PATH_STR,
+    DATA_SOURCE_NAME,
+    OS_FLAVOR_WINDOWS,
+    RHEL8_PREFERENCE,
+    TIMEOUT_15MIN,
+    Images,
+)
+from utilities.storage import (
+    create_dv,
+    create_or_update_data_source,
+    data_volume_template_with_source_ref_dict,
+    get_test_artifact_server_url,
+)
+from utilities.virt import VirtualMachineForTests
 
 
 @pytest.fixture(scope="class")
@@ -68,3 +83,58 @@ def golden_image_fedora_vm_with_instance_type(
         storage_class_name=[*storage_class_matrix__module__][0],
         data_source_name=instance_type_fedora_os_matrix__module__[os_name][DATA_SOURCE_NAME],
     )
+
+
+@pytest.fixture(scope="module")
+def golden_image_windows_data_source(
+    admin_client,
+    golden_images_namespace,
+    windows_os_matrix__module__,
+    artifact_docker_server_url,
+):
+    os_matrix_key = [*windows_os_matrix__module__][0]
+    os_params = windows_os_matrix__module__[os_matrix_key]
+    with create_dv(
+        dv_name=os_matrix_key,
+        namespace=golden_images_namespace.name,
+        source="registry",
+        url=f"{artifact_docker_server_url}/{os_params[CONTAINER_DISK_IMAGE_PATH_STR]}",
+        size=Images.Windows.CONTAINER_DISK_DV_SIZE,
+        storage_class=py_config["default_storage_class"],
+    ) as dv:
+        dv.wait_for_dv_success(timeout=TIMEOUT_15MIN)
+        yield from create_or_update_data_source(admin_client=admin_client, dv=dv)
+
+
+@pytest.fixture(scope="class")
+def golden_image_windows_vm(
+    unprivileged_client,
+    namespace,
+    golden_images_namespace,
+    modern_cpu_for_migration,
+    golden_image_windows_data_source,
+    windows_os_matrix__module__,
+    storage_class_matrix__module__,
+):
+    os_name = [*windows_os_matrix__module__][0]
+    return VirtualMachineForTests(
+        client=unprivileged_client,
+        name=f"{os_name}-vm-with-instance-type-2",
+        namespace=namespace.name,
+        vm_instance_type_infer=True,
+        vm_preference_infer=True,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=golden_image_windows_data_source,
+            storage_class=[*storage_class_matrix__module__][0],
+        ),
+        os_flavor=OS_FLAVOR_WINDOWS,
+        disk_type=None,
+        cpu_model=modern_cpu_for_migration,
+        password="Administrator",
+        username="Administrator",
+    )
+
+
+@pytest.fixture(scope="session")
+def artifact_docker_server_url():
+    return get_test_artifact_server_url(schema="registry")

--- a/tests/infrastructure/instance_types/supported_os/test_windows_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_windows_os.py
@@ -1,0 +1,33 @@
+import logging
+
+import pytest
+
+from utilities.virt import (
+    running_vm,
+)
+
+pytestmark = [pytest.mark.high_resource_vm]
+
+LOGGER = logging.getLogger(__name__)
+TESTS_CLASS_NAME = "TestCommonPreferenceWindows"
+
+
+class TestCommonPreferenceWindows:
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")
+    @pytest.mark.polarion("CNV-12269")
+    def test_create_vm(
+        self,
+        golden_image_windows_vm,
+    ):
+        LOGGER.info("Create VM from preference.")
+        golden_image_windows_vm.create(wait=True)
+
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::start_vm", depends=[f"{TESTS_CLASS_NAME}::create_vm"])
+    @pytest.mark.polarion("CNV-12270")
+    def test_start_vm(self, golden_image_windows_vm):
+        running_vm(vm=golden_image_windows_vm)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])
+    @pytest.mark.polarion("CNV-12271")
+    def test_vm_deletion(self, golden_image_windows_vm):
+        golden_image_windows_vm.delete(wait=True)

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -888,6 +888,7 @@ MONITORING_METRICS = [
 # Common templates matrix constants
 IMAGE_NAME_STR = "image_name"
 IMAGE_PATH_STR = "image_path"
+CONTAINER_DISK_IMAGE_PATH_STR = "container_disk_image_path"
 DV_SIZE_STR = "dv_size"
 TEMPLATE_LABELS_STR = "template_labels"
 OS_STR = "os"

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -6,6 +6,7 @@ from typing import Any
 from ocp_resources.template import Template
 
 from utilities.constants import (
+    CONTAINER_DISK_IMAGE_PATH_STR,
     DATA_SOURCE_NAME,
     DATA_SOURCE_STR,
     DV_SIZE_STR,
@@ -218,6 +219,8 @@ def generate_os_matrix_dict(os_name: str, supported_operating_systems: list[str]
                 OS_VERSION_STR: base_version_dict[OS_VERSION_STR],
                 IMAGE_NAME_STR: image_name,
                 IMAGE_PATH_STR: os.path.join(image_path_str, image_name),
+                CONTAINER_DISK_IMAGE_PATH_STR: f"{Images.Windows.DOCKER_IMAGE_DIR}/windows"
+                f"{base_dict[version][OS_STR].removeprefix('win')}-container-disk:4.99",
                 DV_SIZE_STR: dv_size,
                 TEMPLATE_LABELS_STR: {
                     OS_STR: base_version_dict[OS_STR],

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -126,8 +126,8 @@ def create_dv(
 ):
     artifactory_secret = None
     cert_created = None
-    if source in ("http", "https"):
-        if not utilities.infra.url_excluded_from_validation(url):
+    if source in ("http", "https", "registry"):
+        if source != "registry" and not utilities.infra.url_excluded_from_validation(url):
             # Make sure URL exists
             validate_file_exists_in_url(url=url)
         if not secret:

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -488,7 +488,7 @@ class VirtualMachineForTests(VirtualMachine):
 
             # VMs do not necessarily have self.cloud_init_data
             # cloud-init will not be set for OS in FLAVORS_EXCLUDED_FROM_CLOUD_INIT
-            if self.ssh and self.os_flavor not in FLAVORS_EXCLUDED_FROM_CLOUD_INIT:
+            if self.ssh and any(flavor in self.os_flavor for flavor in FLAVORS_EXCLUDED_FROM_CLOUD_INIT):
                 if self.ssh_secret is None:
                     template_spec = self.enable_ssh_in_cloud_init_data(template_spec=template_spec)
                 if self.ssh_secret:
@@ -696,7 +696,7 @@ class VirtualMachineForTests(VirtualMachine):
     def update_vm_memory_configuration(self, template_spec):
         # Faster VMI start time
         if (
-            self.os_flavor == OS_FLAVOR_WINDOWS
+            OS_FLAVOR_WINDOWS in self.os_flavor
             and not self.memory_guest
             and not self.memory_requests
             and not self.vm_instance_type
@@ -865,7 +865,7 @@ class VirtualMachineForTests(VirtualMachine):
 
         # Faster VMI start time
         if (
-            self.os_flavor == OS_FLAVOR_WINDOWS
+            OS_FLAVOR_WINDOWS in self.os_flavor
             and not self.cpu_threads
             and not self.vm_instance_type
             and not self.vm_instance_type_infer
@@ -1043,7 +1043,7 @@ class VirtualMachineForTests(VirtualMachine):
                 return
 
             # Do not modify the defaults to OS like Windows where the password is already defined in the image
-            if self.os_flavor not in FLAVORS_EXCLUDED_FROM_CLOUD_INIT:
+            if not any(flavor in self.os_flavor for flavor in FLAVORS_EXCLUDED_FROM_CLOUD_INIT):
                 if self.exists:
                     self.username, self.password = username_password_from_cloud_init(
                         vm_volumes=self.instance.spec.template.spec.volumes
@@ -1066,7 +1066,7 @@ class VirtualMachineForTests(VirtualMachine):
         host = Host(hostname=self.name)
         # For SSH using a key, the public key needs to reside on the server.
         # As the tests use a given set of credentials, this cannot be done in Windows/Cirros.
-        if self.os_flavor in FLAVORS_EXCLUDED_FROM_CLOUD_INIT:
+        if any(flavor in self.os_flavor for flavor in FLAVORS_EXCLUDED_FROM_CLOUD_INIT):
             host_user = user.User(name=self.username, password=self.password)
         else:
             host_user = user.UserWithPKey(name=self.username, private_key=os.environ[CNV_VM_SSH_KEY_PATH])


### PR DESCRIPTION
##### Short description:
Add basic windows tests using instance types and container images

##### More details:
- Add basic creation and running of VM with windows container disk images
- Add support for pulling the images from a registry 
- Added required fields under windows os_base_dict 
- Updated virt.py for allowing the use of os_flavor="win-container-disk" 

##### What this PR does / why we need it:
We have an automation to update and upload the windows images, we should use updated windows images instead of old ones, or instead of requiring to manually update them

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-51888


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support creating data volumes from container registries to source Windows golden images.
  - Add Windows container-disk support with a generated registry image path and a default container-disk data-volume size.
  - Broaden Windows OS-flavor detection to improve VM provisioning, memory/CPU defaults, and SSH/login handling.

- **Tests**
  - Add fixtures to provision Windows data sources and instantiate Windows VMs via the registry flow.
  - Add Windows VM lifecycle tests (create, start, delete) marked as high-resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->