### PR TITLE
move `cache_admin_client` to be private

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1512,8 +1512,3 @@ def get_nodes_cpu_architecture(nodes: list[Node]) -> str:
     nodes_cpu_arch = {node.labels[KUBERNETES_ARCH_LABEL] for node in nodes}
     assert len(nodes_cpu_arch) == 1, "Mixed CPU architectures in the cluster is not supported"
     return next(iter(nodes_cpu_arch))
-
-
-@cache
-def cache_admin_client():
-    return get_client()

--- a/utilities/unittests/test_pytest_matrix_utils.py
+++ b/utilities/unittests/test_pytest_matrix_utils.py
@@ -119,7 +119,7 @@ class TestOnlineResizeMatrix:
 class TestHppMatrix:
     """Test cases for hpp_matrix function"""
 
-    @patch("utilities.pytest_matrix_utils.cache_admin_client")
+    @patch("utilities.pytest_matrix_utils._cache_admin_client")
     @patch("utilities.pytest_matrix_utils.StorageClass")
     def test_hpp_matrix_with_hpp_provisioner(self, mock_storage_class, mock_cache_admin_client):
         """Test hpp_matrix filters storage classes with HPP provisioner"""
@@ -155,7 +155,7 @@ class TestHppMatrix:
         assert len(result) == 1
         assert {"hpp-sc": {"other": "value"}} in result
 
-    @patch("utilities.pytest_matrix_utils.cache_admin_client")
+    @patch("utilities.pytest_matrix_utils._cache_admin_client")
     @patch("utilities.pytest_matrix_utils.StorageClass")
     def test_hpp_matrix_empty_matrix(self, mock_storage_class, mock_cache_admin_client):
         """Test hpp_matrix with empty matrix"""


### PR DESCRIPTION
##### Short description:
k8s client should always be passed to functions, where needed.
in `hpp_matrix`, the client is needed, however this function, being part of the matrix functions, is being dynamically called.
`_cache_admin_client` is used only for such cases.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Consolidated how the admin client is cached and removed a redundant accessor used internally.
- Tests
  - Updated test utilities to use the new cached helper and adjusted test patches accordingly.
- Documentation
  - Added docstrings and inline comments clarifying the caching behavior and dynamic client usage.

No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->