### PR TITLE
net, service mesh: remove wait_for_console helper

### DIFF
--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -342,7 +342,7 @@ def traffic_management_service_mesh_convergence(
     gateway_service_mesh,
     destination_rule_service_mesh,
     virtual_service_mesh_service,
-    service_mesh_ingress_service_addr
+    service_mesh_ingress_service_addr,
 ):
     wait_service_mesh_components_convergence(
         func=traffic_management_request,

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -91,7 +91,7 @@ class TestSMPeerAuthentication:
         self,
         outside_mesh_vm_fedora_with_service_mesh_annotation,
         peer_authentication_service_mesh_deployment,
-        httpbin_service_service_mesh
+        httpbin_service_service_mesh,
     ):
         # We must specify the full service DNS name since the VM is outside the mesh in a different namespace
         # Format: http://<service_name>.<service_namespace>.svc.cluster.local


### PR DESCRIPTION
##### What this PR does / why we need it:
`wait_for_console` helper can be removed: all fixtures and helpers using `wait_for_console` contain `run_console_command` utility which ensures connection to vm console.

`wait_for_console` was removed from all fixtures and service mesh related tests.

Use of `wait_for_console` in tests/network/migration/test_masquerade_connectivity_after_migration.py was removed in this PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/1908/

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Simplified service mesh test setup by removing redundant console-readiness steps and unused fixtures.
  - Streamlined test signatures without changing assertions or outcomes.
  - Expected improvements in test stability and execution time.

- Chores
  - General cleanup to align test utilities and reduce maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->