### PR TITLE
[4.99] fix virtcl port-forward command

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1023,7 +1023,7 @@ class VirtualMachineForTests(VirtualMachine):
 
     @property
     def virtctl_port_forward_cmd(self):
-        return f"{VIRTCTL} port-forward --stdio=true vm/{self.name}.{self.namespace} {SSH_PORT_22}"
+        return f"{VIRTCTL} port-forward --stdio=true vm/{self.name}/{self.namespace} {SSH_PORT_22}"
 
     @property
     def login_params(self):


### PR DESCRIPTION
##### Short description:
command syntax changed
the old syntax type/name.namespace
it should be type/name/namespace

##### More details:
upstream change: https://github.com/kubevirt/kubevirt/pull/15475

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

