### PR TITLE
[VIRT] Add fixture for migratable VMs in upgrade test

### DIFF
--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -292,9 +292,28 @@ def run_strategy_golden_image_data_source(admin_client, run_strategy_golden_imag
 
 
 @pytest.fixture(scope="session")
-def linux_boot_time_before_upgrade(vms_for_upgrade):
+def virt_migratable_vms(vms_for_upgrade):
+    def _vm_is_migrateable(vm):
+        vm_spec = vm.instance.spec
+        vm_access_modes = (
+            vm.get_storage_configuration()
+            if (vm_spec.get("instancetype") or vm_spec.get("preference"))
+            else vm.access_modes
+        )
+        if DataVolume.AccessMode.RWO in vm_access_modes:
+            return False
+        return True
+
+    migratable_vms = [vm for vm in vms_for_upgrade if _vm_is_migrateable(vm=vm)]
+
+    LOGGER.info(f"VIRT migratable vms: {[vm.name for vm in migratable_vms]}")
+    return migratable_vms
+
+
+@pytest.fixture(scope="session")
+def linux_boot_time_before_upgrade(virt_migratable_vms):
     boot_time_dict = {}
-    for vm in vms_for_upgrade:
+    for vm in virt_migratable_vms:
         boot_time_dict[vm.name] = get_vm_boot_time(vm=vm)
     yield boot_time_dict
 

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -20,7 +20,6 @@ from tests.virt.upgrade.utils import (
     verify_run_strategy_vmi_status,
     verify_vms_ssh_connectivity,
     verify_windows_boot_time,
-    vm_is_migrateable,
 )
 from tests.virt.utils import assert_migration_post_copy_mode
 from utilities.constants import DATA_SOURCE_NAME, DEPENDENCY_SCOPE_SESSION
@@ -102,10 +101,9 @@ class TestUpgradeVirt:
         depends=[VMS_RUNNING_BEFORE_UPGRADE_TEST_NODE_ID],
         scope=DEPENDENCY_SCOPE_SESSION,
     )
-    def test_migration_before_upgrade(self, vms_for_upgrade):
-        for vm in vms_for_upgrade:
-            if vm_is_migrateable(vm=vm):
-                migrate_vm_and_verify(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
+    def test_migration_before_upgrade(self, virt_migratable_vms):
+        for vm in virt_migratable_vms:
+            migrate_vm_and_verify(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno
@@ -180,10 +178,10 @@ class TestUpgradeVirt:
         ],
         scope=DEPENDENCY_SCOPE_SESSION,
     )
-    def test_is_vm_running_after_upgrade(self, vms_for_upgrade, linux_boot_time_before_upgrade):
+    def test_is_vm_running_after_upgrade(self, vms_for_upgrade, virt_migratable_vms, linux_boot_time_before_upgrade):
         for vm in vms_for_upgrade:
             vm.vmi.wait_until_running()
-        verify_linux_boot_time(vm_list=vms_for_upgrade, initial_boot_time=linux_boot_time_before_upgrade)
+        verify_linux_boot_time(vm_list=virt_migratable_vms, initial_boot_time=linux_boot_time_before_upgrade)
 
     @pytest.mark.gating
     @pytest.mark.ocp_upgrade
@@ -280,11 +278,10 @@ class TestUpgradeVirt:
         ],
         scope=DEPENDENCY_SCOPE_SESSION,
     )
-    def test_migration_after_upgrade(self, vms_for_upgrade):
-        for vm in vms_for_upgrade:
-            if vm_is_migrateable(vm=vm):
-                migrate_vm_and_verify(vm=vm)
-                vm_console_run_commands(vm=vm, commands=["ls"], timeout=1100)
+    def test_migration_after_upgrade(self, virt_migratable_vms):
+        for vm in virt_migratable_vms:
+            migrate_vm_and_verify(vm=vm)
+            vm_console_run_commands(vm=vm, commands=["ls"], timeout=1100)
 
     @pytest.mark.ocp_upgrade
     @pytest.mark.sno


### PR DESCRIPTION
store migratable VIRT VMs in fixture to reduce extra API calls

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Migration upgrade tests now run on a fixture-provided set of confirmed migratable VMs; migrations and follow-up checks run unconditionally for those VMs.
  - Boot-time checks updated and simplified for Linux and Windows to match the fixture-driven VM selection, reducing noisy failures and improving stability.

- Refactor
  - Migratability selection centralized into a shared fixture and test signatures streamlined for clearer, consistent test flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->