### PR TITLE
Remove test for kube_daemonset_status_number_ready

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -4,7 +4,6 @@ import shlex
 
 import bitmath
 import pytest
-from ocp_resources.daemonset import DaemonSet
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.deployment import Deployment
@@ -80,7 +79,6 @@ from utilities.constants import (
     TWO_CPU_SOCKETS,
     TWO_CPU_THREADS,
     VERSION_LABEL_KEY,
-    VIRT_HANDLER,
     VIRT_TEMPLATE_VALIDATOR,
     Images,
 )
@@ -736,16 +734,6 @@ def vm_for_test_with_resource_limits(namespace):
     ) as vm:
         running_vm(vm=vm)
         yield vm
-
-
-@pytest.fixture()
-def virt_handler_pods_count(hco_namespace):
-    return str(
-        DaemonSet(
-            name=VIRT_HANDLER,
-            namespace=hco_namespace.name,
-        ).instance.status.numberReady
-    )
 
 
 @pytest.fixture()

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -9,10 +9,8 @@ from tests.observability.metrics.utils import (
     assert_vm_metric_virt_handler_pod,
     compare_kubevirt_vmi_info_metric_with_vm_info,
 )
-from tests.observability.utils import validate_metrics_value
 from utilities.constants import (
     KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS,
-    VIRT_HANDLER,
 )
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
@@ -130,14 +128,4 @@ class TestVMIMetricsWindowsVms:
             query=KUBEVIRT_VM_INFO.format(vm_name=windows_vm_for_test.name),
             expected_value="1",
             values_to_compare=windows_vm_info_to_compare,
-        )
-
-
-class TestKubeDaemonsetStatusNumberReady:
-    @pytest.mark.polarion("CNV-11727")
-    def test_kube_daemonset_status_number_ready(self, prometheus, virt_handler_pods_count):
-        validate_metrics_value(
-            prometheus=prometheus,
-            metric_name=f"kube_daemonset_status_number_ready{{daemonset='{VIRT_HANDLER}'}}",
-            expected_value=virt_handler_pods_count,
         )


### PR DESCRIPTION
##### Short description:
The metric kube_daemonset_status_number_ready is kubernetes metric and not related to cnv and need to be removed.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Removed observability test for the virt-handler DaemonSet readiness metric.
  - Dropped related test fixture and constants tied to virt-handler.
  - All other metrics tests remain unchanged.

- Chores
  - Cleaned up unused references and imports associated with virt-handler in the testing suite.
  - Reduced maintenance overhead by removing obsolete test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->