### PR TITLE
[IUO] update 4.20 csv perm

### DIFF
--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/csv-permissions.yaml
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/csv-permissions.yaml
@@ -3518,6 +3518,17 @@ ssp-operator:
     - update
     - watch
   - apiGroups:
+    - policy
+    resources:
+    - poddisruptionbudgets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
     - rbac.authorization.k8s.io
     resources:
     - clusterrolebindings


### PR DESCRIPTION
##### Short description:
at https://github.com/kubevirt/ssp-operator/pull/1512, SSP added rbac for pdb.
Adding to automation
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded operator permissions to manage PodDisruptionBudgets (policy API group), including create, delete, get, list, update, and watch. This enables full management of disruption policies associated with workloads, supporting safer rollouts and controlled evictions during maintenance or node drains, and aligning permissions with expected functionality. No existing permissions were removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->