### PR TITLE
WIP: [STORSGE] [MAIN] Increase PVC Bound wait timeout to 2 minutes in test_delete_pvc_after_successful_import

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -35,6 +35,7 @@ from utilities import console
 from utilities.constants import (
     OS_FLAVOR_RHEL,
     TIMEOUT_1MIN,
+    TIMEOUT_2MIN,
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_12MIN,
@@ -144,7 +145,7 @@ def test_delete_pvc_after_successful_import(
     storage_class = data_volume_multi_storage_scope_function.storage_class
     if sc_volume_binding_mode_is_wffc(sc=storage_class):
         create_dummy_first_consumer_pod(pvc=pvc)
-    data_volume_multi_storage_scope_function.wait_for_dv_success()
+    data_volume_multi_storage_scope_function.wait_for_dv_success(pvc_wait_for_bound_timeout=TIMEOUT_2MIN)
     with create_pod_for_pvc(
         pvc=data_volume_multi_storage_scope_function.pvc,
         volume_mode=StorageProfile(name=storage_class).instance.status["claimPropertySets"][0]["volumeMode"],


### PR DESCRIPTION
##### Short description:

Increase PVC Bound wait timeout in test_delete_pvc_after_successful_import to reduce test flakiness caused by delayed PVC binding.



##### More details:
Some PVCs can take slightly longer than 1 minute to reach the Bound phase, especially when scratch PVCs are recreated.
This timing issue caused occasional flakes in the test_delete_pvc_after_successful_import test.
To fix this, we now pass a custom pvc_wait_for_bound_timeout value of 2 minutes to wait_for_dv_success, ensuring the test remains stable even when PVC binding takes longer than usual.



##### What this PR does / why we need it:

Updates the test_delete_pvc_after_successful_import test to use a 2-minute timeout for PVC Bound wait.

Prevents test flakiness due to delayed PVC binding, especially in scenarios involving scratch PVC recreation.

Improves test reliability for environments where PVC binding can be slow.



##### Which issue(s) this PR fixes:
Fixes flaky behavior in test_delete_pvc_after_successful_import caused by PVCs taking more than 1 minute to bind.
 CNV-675


##### Special notes for reviewer:
https://redhat-internal.slack.com/archives/C01B610HL81/p1755006925664399

https://github.com/RedHatQE/openshift-python-wrapper/pull/2479

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Increased wait timeout to 2 minutes for PVC binding in import workflow tests.
  - Updated test utilities to accept a configurable bound timeout.

- Chores
  - Introduced a reusable 2-minute timeout constant for consistency across suites.
  - Standardized timeout handling in import success checks via a keyword parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->