### PR TITLE
Common interface selection across nodes for creating NNCP in network tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1150,8 +1150,16 @@ def hosts_common_available_ports(nodes_available_nics):
 
     will return ['ens3', 'ens6']
     """
-    nics_list = list(set.intersection(*[set(_list) for _list in nodes_available_nics.values()]))
-    nics_list.sort()
+    nic_sets = [set(lst) for lst in nodes_available_nics.values()]
+    if not nic_sets:
+        LOGGER.warning("No available NICs found on any worker node.")
+        return []
+
+    nics_list = sorted(set.intersection(*nic_sets))
+    if not nics_list:
+        LOGGER.warning("No common NICs found across all nodes.")
+        return []
+
     LOGGER.info(f"Hosts common available NICs: {nics_list}")
     return nics_list
 

--- a/tests/network/bond/test_bond_modes.py
+++ b/tests/network/bond/test_bond_modes.py
@@ -66,7 +66,7 @@ def matrix_bond_modes_bond(
     admin_client,
     index_number,
     link_aggregation_mode_no_connectivity_matrix__function__,
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node1,
 ):
     """
@@ -77,7 +77,7 @@ def matrix_bond_modes_bond(
         name=f"matrix-bond{bond_index}-nncp",
         bond_name=f"mtx-bond{bond_index}",
         client=admin_client,
-        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        bond_ports=hosts_common_available_ports[-2:],
         mode=link_aggregation_mode_no_connectivity_matrix__function__,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
     ) as bond:
@@ -158,13 +158,13 @@ def bridge_on_bond_fail_over_mac(
 
 
 @pytest.fixture()
-def active_backup_bond_with_fail_over_mac(admin_client, index_number, worker_node1, nodes_available_nics):
+def active_backup_bond_with_fail_over_mac(admin_client, index_number, worker_node1, hosts_common_available_ports):
     bond_index = next(index_number)
     with BondNodeNetworkConfigurationPolicy(
         client=admin_client,
         name=f"active-bond{bond_index}-nncp",
         bond_name=f"act-bond{bond_index}",
-        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        bond_ports=hosts_common_available_ports[-2:],
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         options={"fail_over_mac": "active"},
         success_timeout=TIMEOUT_9MIN,
@@ -191,13 +191,13 @@ def vm_with_fail_over_mac_bond(
 
 
 @pytest.fixture()
-def bond_resource(admin_client, index_number, nodes_available_nics, worker_node1):
+def bond_resource(admin_client, index_number, hosts_common_available_ports, worker_node1):
     bond_idx = next(index_number)
     with BondNodeNetworkConfigurationPolicy(
         client=admin_client,
         name=f"bond-with-port{bond_idx}nncp",
         bond_name=f"bond-w-port{bond_idx}",
-        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        bond_ports=hosts_common_available_ports[-2:],
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
     ) as bond:
         yield bond
@@ -222,7 +222,7 @@ def test_active_backup_bond_with_fail_over_mac(
     admin_client,
     index_number,
     worker_node1,
-    nodes_available_nics,
+    hosts_common_available_ports,
     workers_utility_pods,
 ):
     bond_index = next(index_number)
@@ -230,7 +230,7 @@ def test_active_backup_bond_with_fail_over_mac(
         name=f"test-active-bond{bond_index}-nncp",
         bond_name=f"test-act-bond{bond_index}",
         client=admin_client,
-        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        bond_ports=hosts_common_available_ports[-2:],
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         options={"fail_over_mac": "active"},
     ) as bond:

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -42,7 +42,7 @@ def ovs_linux_bond1_worker_1(
     admin_client,
     index_number,
     worker_node1,
-    nodes_available_nics,
+    hosts_common_available_ports,
 ):
     """
     Create BOND if setup support BOND
@@ -52,7 +52,7 @@ def ovs_linux_bond1_worker_1(
         client=admin_client,
         name=f"bond{bond_idx}nncp-worker-1",
         bond_name=f"bond{bond_idx}",
-        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        bond_ports=hosts_common_available_ports[-2:],
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
     ) as bond:
         yield bond
@@ -63,7 +63,7 @@ def ovs_linux_bond1_worker_2(
     admin_client,
     index_number,
     worker_node2,
-    nodes_available_nics,
+    hosts_common_available_ports,
     ovs_linux_bond1_worker_1,
 ):
     """
@@ -75,7 +75,7 @@ def ovs_linux_bond1_worker_2(
             name=f"bond{bond_idx}nncp-worker-2",
             client=admin_client,
             bond_name=ovs_linux_bond1_worker_1.bond_name,  # Use the same BOND name for each test.
-            bond_ports=nodes_available_nics[worker_node2.name][-2:],
+            bond_ports=hosts_common_available_ports[-2:],
             node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ) as bond
     ):

--- a/tests/network/connectivity/conftest.py
+++ b/tests/network/connectivity/conftest.py
@@ -30,7 +30,7 @@ def vlan_id_3(vlan_index_number):
 @pytest.fixture(scope="class")
 def nncp_linux_bridge_device_worker_1_source(
     admin_client,
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node1,
     bridge_device_name,
 ):
@@ -39,7 +39,7 @@ def nncp_linux_bridge_device_worker_1_source(
         nncp_name=f"linux-bridge-{name_prefix(worker_node1.name)}",
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br
@@ -48,7 +48,7 @@ def nncp_linux_bridge_device_worker_1_source(
 @pytest.fixture(scope="class")
 def nncp_ovs_bridge_device_worker_1_source(
     admin_client,
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node1,
     bridge_device_name,
 ):
@@ -57,7 +57,7 @@ def nncp_ovs_bridge_device_worker_1_source(
         nncp_name=f"ovs-bridge-{name_prefix(worker_node1.name)}",
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br
@@ -66,7 +66,7 @@ def nncp_ovs_bridge_device_worker_1_source(
 @pytest.fixture(scope="class")
 def nncp_linux_bridge_device_worker_2_destination(
     admin_client,
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node2,
     bridge_device_name,
 ):
@@ -75,7 +75,7 @@ def nncp_linux_bridge_device_worker_2_destination(
         nncp_name=f"linux-bridge-{name_prefix(worker_node2.name)}",
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br
@@ -84,7 +84,7 @@ def nncp_linux_bridge_device_worker_2_destination(
 @pytest.fixture(scope="class")
 def nncp_ovs_bridge_device_worker_2_destination(
     admin_client,
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node2,
     bridge_device_name,
 ):
@@ -93,7 +93,7 @@ def nncp_ovs_bridge_device_worker_2_destination(
         nncp_name=f"ovs-bridge-{name_prefix(worker_node2.name)}",
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -39,7 +39,7 @@ def jumbo_frame_bond1_worker_1(
     cluster_hardware_mtu,
     index_number,
     worker_node1,
-    nodes_available_nics,
+    hosts_common_available_ports,
 ):
     """
     Create BOND if setup support BOND
@@ -48,7 +48,7 @@ def jumbo_frame_bond1_worker_1(
         client=admin_client,
         name=f"jumbo-frame-bond{next(index_number)}-nncp",
         bond_name=BOND_NAME,
-        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        bond_ports=hosts_common_available_ports[-2:],
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         mtu=cluster_hardware_mtu,
     ) as bond:
@@ -61,7 +61,7 @@ def jumbo_frame_bond1_worker_2(
     cluster_hardware_mtu,
     index_number,
     worker_node2,
-    nodes_available_nics,
+    hosts_common_available_ports,
 ):
     """
     Create BOND if setup support BOND
@@ -70,7 +70,7 @@ def jumbo_frame_bond1_worker_2(
         client=admin_client,
         name=f"jumbo-frame-bond{next(index_number)}-nncp",
         bond_name=BOND_NAME,
-        bond_ports=nodes_available_nics[worker_node2.name][-2:],
+        bond_ports=hosts_common_available_ports[-2:],
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         mtu=cluster_hardware_mtu,
     ) as bond:

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -38,7 +38,7 @@ def jumbo_frame_bridge_device_worker_1(
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     worker_node1,
-    nodes_available_nics,
+    hosts_common_available_ports,
     jumbo_frame_bridge_device_name,
 ):
     with network_device(
@@ -46,7 +46,7 @@ def jumbo_frame_bridge_device_worker_1(
         nncp_name="jumbo-frame-bridge-nncp-1",
         interface_name=jumbo_frame_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         mtu=cluster_hardware_mtu,
         client=admin_client,
     ) as br:
@@ -59,7 +59,7 @@ def jumbo_frame_bridge_device_worker_2(
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     worker_node2,
-    nodes_available_nics,
+    hosts_common_available_ports,
     jumbo_frame_bridge_device_name,
 ):
     with network_device(
@@ -67,7 +67,7 @@ def jumbo_frame_bridge_device_worker_2(
         nncp_name="jumbo-frame-bridge-nncp-2",
         interface_name=jumbo_frame_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         mtu=cluster_hardware_mtu,
         client=admin_client,
     ) as br:

--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -21,14 +21,14 @@ def kubemacpool_bridge_device_worker_1(
     admin_client,
     worker_node1,
     kubemacpool_bridge_device_name,
-    nodes_available_nics,
+    hosts_common_available_ports,
 ):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"kubemacpool-{name_prefix(worker_node1.name)}",
         interface_name=kubemacpool_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as dev:
         yield dev
@@ -39,14 +39,14 @@ def kubemacpool_bridge_device_worker_2(
     admin_client,
     worker_node2,
     kubemacpool_bridge_device_name,
-    nodes_available_nics,
+    hosts_common_available_ports,
 ):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"kubemacpool-{name_prefix(worker_node2.name)}",
         interface_name=kubemacpool_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as dev:
         yield dev

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -55,7 +55,7 @@ def l2_bridge_device_name(index_number):
 def l2_bridge_device_worker_1(
     admin_client,
     bridge_device_matrix__class__,
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node1,
     l2_bridge_device_name,
 ):
@@ -64,7 +64,7 @@ def l2_bridge_device_worker_1(
         nncp_name=f"l2-bridge-{name_prefix(worker_node1.name)}",
         interface_name=l2_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br
@@ -74,7 +74,7 @@ def l2_bridge_device_worker_1(
 def l2_bridge_device_worker_2(
     admin_client,
     bridge_device_matrix__class__,
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node2,
     l2_bridge_device_name,
 ):
@@ -83,7 +83,7 @@ def l2_bridge_device_worker_2(
         nncp_name=f"l2-bridge-{name_prefix(worker_node2.name)}",
         interface_name=l2_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br

--- a/tests/network/macspoof/conftest.py
+++ b/tests/network/macspoof/conftest.py
@@ -58,26 +58,26 @@ def set_vm_interface_network_mac(vm, mac):
 
 
 @pytest.fixture(scope="class")
-def linux_bridge_device_worker_1(admin_client, nodes_available_nics, worker_node1):
+def linux_bridge_device_worker_1(admin_client, hosts_common_available_ports, worker_node1):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"bridge-{name_prefix(worker_node1.hostname)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.hostname][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br_dev:
         yield br_dev
 
 
 @pytest.fixture(scope="class")
-def linux_bridge_device_worker_2(admin_client, nodes_available_nics, worker_node2):
+def linux_bridge_device_worker_2(admin_client, hosts_common_available_ports, worker_node2):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"bridge-{name_prefix(worker_node2.hostname)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.hostname][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br_dev:
         yield br_dev

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -65,14 +65,14 @@ def http_port_accessible(vm, server_ip, server_port):
 def bridge_worker_1(
     admin_client,
     worker_node1,
-    nodes_available_nics,
+    hosts_common_available_ports,
 ):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="migration-worker-1",
         interface_name="migration-br",
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br
@@ -82,7 +82,7 @@ def bridge_worker_1(
 def bridge_worker_2(
     admin_client,
     worker_node2,
-    nodes_available_nics,
+    hosts_common_available_ports,
     bridge_worker_1,
 ):
     with network_device(
@@ -90,7 +90,7 @@ def bridge_worker_2(
         nncp_name="migration-worker-2",
         interface_name=bridge_worker_1.bridge_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br:
         yield br

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -46,26 +46,26 @@ def restart_nmstate_handler(admin_client, nmstate_ds, nmstate_namespace):
 
 
 @pytest.fixture(scope="class")
-def nmstate_linux_bridge_device_worker_1(admin_client, nodes_available_nics, worker_node1):
+def nmstate_linux_bridge_device_worker_1(admin_client, hosts_common_available_ports, worker_node1):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"restart-nmstate-{name_prefix(worker_node1.name)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        ports=[nodes_available_nics[worker_node1.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br_dev:
         yield br_dev
 
 
 @pytest.fixture(scope="class")
-def nmstate_linux_bridge_device_worker_2(admin_client, nodes_available_nics, worker_node2):
+def nmstate_linux_bridge_device_worker_2(admin_client, hosts_common_available_ports, worker_node2):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"restart-nmstate-{name_prefix(worker_node2.name)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        ports=[nodes_available_nics[worker_node2.name][-1]],
+        ports=[hosts_common_available_ports[-1]],
         client=admin_client,
     ) as br_dev:
         yield br_dev
@@ -230,7 +230,7 @@ def nncp_ready(nmstate_linux_bridge_device_worker_1, nmstate_linux_bridge_device
 
 @pytest.fixture()
 def modified_nncp(
-    nodes_available_nics,
+    hosts_common_available_ports,
     worker_node1,
     worker_node2,
     nmstate_linux_bridge_device_worker_1,
@@ -239,9 +239,9 @@ def modified_nncp(
     nncps = [nmstate_linux_bridge_device_worker_1, nmstate_linux_bridge_device_worker_2]
     for nncp, worker_node in zip(nncps, [worker_node1, worker_node2]):
         interfaces = nncp.desired_state["interfaces"]
-        interfaces[0]["bridge"]["port"][0]["name"] = nodes_available_nics[worker_node.name][
+        interfaces[0]["bridge"]["port"][0]["name"] = hosts_common_available_ports[
             -2
-        ]  # NNCP was created with nodes_available_nics[-1]
+        ]  # NNCP was created with hosts_common_available_ports[-1]
         ResourceEditor(
             patches={
                 nncp: {


### PR DESCRIPTION
##### Short description:
Updated test logic to use hosts_common_available_ports to select last common available interface in the list for network tests to ensure the same interface is used when creating NNCPs on the each nodes instead of selecting the last available NIC in nodes_available_nics. 

##### More details:

##### What this PR does / why we need it:
The connectivity tests defined in [test_ovs_linux_bridge.py](https://github.com/RedHatQE/openshift-virtualization-tests/blob/main/tests/network/connectivity/test_ovs_linux_bridge.py) and along with that the other network tests  currently create NNCP (NodeNetworkConfigurationPolicy) on two worker nodes by selecting the last available NIC on each node, this leads to inconsistency, as the two NNCPs are created using different interfaces, which breaks the test logic.
In this PR updated logic to use hosts_common_available_ports  to select common available NIC in the list to ensure same interface is used when creating NNCP on each node instead of selecting the last available NIC in nodes_available_nics. 

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized network tests to use a shared hosts_common_available_ports source for port selection; updated fixtures, test signatures, and port construction across bonding, bridging, jumbo frames, MAC spoofing, migration and connectivity suites.
* **Bug Fixes**
  * Added guards and warnings when no common ports are available to reduce flakiness and make test behavior more predictable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->