### PR TITLE
Storage: fix import registry test for s390x.

### DIFF
--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
     [
         pytest.param(
             "cnv-2198",
-            "docker://quay.io/openshift-cnv/qe-cnv-tests-registry-official-cirros",
+            "docker://quay.io/openshift-cnv/qe-cnv-tests-alpine-no-disk",
             marks=pytest.mark.polarion("CNV-2198"),
             id="image-registry-not-conform-registrydisk",
         ),


### PR DESCRIPTION
##### Short description:
The test disk_image_not_conform_to_registy_disk uses cirros image which i not supported for s390x. Because of this the test is not able to pull the image and it is failing on s390x. So i have build a new image alpine for all the architectures. I have replaced the cirros image with alpine.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a registry import test to use an Alpine-based image instead of a Cirros image.
  * Improves CI stability and reduces flakiness when interacting with external container registries.
  * No impact on user-facing functionality; production behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->