### PR TITLE
[virt] virt-cluster tests to use golden data sources

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -871,11 +871,6 @@ def golden_image_data_volume_scope_module(request, admin_client, golden_images_n
     )
 
 
-@pytest.fixture(scope="module")
-def golden_image_data_source_scope_module(admin_client, golden_image_data_volume_scope_module):
-    yield from create_or_update_data_source(admin_client=admin_client, dv=golden_image_data_volume_scope_module)
-
-
 @pytest.fixture()
 def golden_image_data_volume_scope_function(request, admin_client, golden_images_namespace, schedulable_nodes):
     yield from data_volume(
@@ -966,17 +961,6 @@ def golden_image_vm_instance_from_template_multi_storage_scope_class(
         vm_cpu_model=(cpu_for_migration if request.param.get("set_vm_common_cpu") else None),
     ) as vm:
         yield vm
-
-
-@pytest.fixture()
-def vm_from_template_scope_function(request, unprivileged_client, namespace, golden_image_data_source_scope_function):
-    with vm_instance_from_template(
-        request=request,
-        unprivileged_client=unprivileged_client,
-        namespace=namespace,
-        data_source=golden_image_data_source_scope_function,
-    ) as vm_from_template:
-        yield vm_from_template
 
 
 """

--- a/tests/virt/cluster/common_templates/conftest.py
+++ b/tests/virt/cluster/common_templates/conftest.py
@@ -4,11 +4,11 @@ import pytest
 from packaging import version
 
 from tests.virt.cluster.common_templates.utils import (
-    get_data_volume_template_dict_with_default_storage_class,
     get_matrix_os_golden_image_data_source,
     matrix_os_vm_from_template,
     xfail_old_guest_agent_version,
 )
+from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import REGEDIT_PROC_NAME
 from utilities.infra import is_jira_open
 from utilities.virt import (
@@ -132,14 +132,17 @@ def tablet_device_vm(
     request,
     unprivileged_client,
     namespace,
-    golden_image_data_source_multi_storage_scope_class,
+    golden_image_data_source_for_test_scope_class,
     cpu_for_migration,
 ):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_multi_storage_scope_class,
+        data_source=golden_image_data_source_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class
+        ),
         vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,
     ) as vm:
         yield vm

--- a/tests/virt/cluster/common_templates/conftest.py
+++ b/tests/virt/cluster/common_templates/conftest.py
@@ -132,17 +132,14 @@ def tablet_device_vm(
     request,
     unprivileged_client,
     namespace,
-    golden_image_data_source_for_test_scope_class,
+    golden_image_data_volume_template_for_test_scope_class,
     cpu_for_migration,
 ):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_for_test_scope_class,
-        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-            data_source=golden_image_data_source_for_test_scope_class
-        ),
+        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,
     ) as vm:
         yield vm

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -5,7 +5,6 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.template import Template
 
 from tests.os_params import FEDORA_LATEST
-from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import NamespacesNames
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
@@ -115,7 +114,7 @@ class TestBaseCustomTemplates:
         self,
         unprivileged_client,
         namespace,
-        golden_image_data_source_for_test_scope_class,
+        golden_image_data_volume_template_for_test_scope_class,
         custom_template_from_base_template,
         vm_name,
     ):
@@ -124,10 +123,7 @@ class TestBaseCustomTemplates:
             namespace=namespace.name,
             client=unprivileged_client,
             template_object=custom_template_from_base_template,
-            data_source=golden_image_data_source_for_test_scope_class,
-            data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-                data_source=golden_image_data_source_for_test_scope_class
-            ),
+            data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         ) as custom_vm:
             running_vm(vm=custom_vm)
 
@@ -154,7 +150,7 @@ class TestBaseCustomTemplates:
     def test_custom_template_vm_validation(
         self,
         unprivileged_client,
-        golden_image_data_source_for_test_scope_class,
+        golden_image_data_volume_template_for_test_scope_class,
         custom_template_from_base_template,
     ):
         with pytest.raises(UnprocessibleEntityError, match=r".*This VM has too many cores.*"):
@@ -163,10 +159,7 @@ class TestBaseCustomTemplates:
                 namespace=custom_template_from_base_template.namespace,
                 client=unprivileged_client,
                 template_object=custom_template_from_base_template,
-                data_source=golden_image_data_source_for_test_scope_class,
-                data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-                    data_source=golden_image_data_source_for_test_scope_class
-                ),
+                data_volume_template=golden_image_data_volume_template_for_test_scope_class,
                 cpu_cores=3,
             ) as vm_from_template:
                 pytest.fail(f"VM validation failed on {vm_from_template.name}")

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -3,9 +3,9 @@ import logging
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.template import Template
-from pytest_testconfig import py_config
 
-from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_OS
+from tests.os_params import FEDORA_LATEST
+from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import NamespacesNames
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
@@ -77,17 +77,8 @@ def custom_template_from_base_template(request, namespace):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_class",
-    [
-        pytest.param(
-            {
-                "dv_name": FEDORA_LATEST_OS,
-                "image": FEDORA_LATEST.get("image_path"),
-                "dv_size": FEDORA_LATEST.get("dv_size"),
-                "storage_class": py_config["default_storage_class"],
-            },
-        ),
-    ],
+    "golden_image_data_source_scope_class",
+    [pytest.param({"os_dict": FEDORA_LATEST})],
     indirect=True,
 )
 class TestBaseCustomTemplates:
@@ -124,7 +115,7 @@ class TestBaseCustomTemplates:
         self,
         unprivileged_client,
         namespace,
-        golden_image_data_source_scope_class,
+        golden_image_data_source_for_test_scope_class,
         custom_template_from_base_template,
         vm_name,
     ):
@@ -133,7 +124,10 @@ class TestBaseCustomTemplates:
             namespace=namespace.name,
             client=unprivileged_client,
             template_object=custom_template_from_base_template,
-            data_source=golden_image_data_source_scope_class,
+            data_source=golden_image_data_source_for_test_scope_class,
+            data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+                data_source=golden_image_data_source_for_test_scope_class
+            ),
         ) as custom_vm:
             running_vm(vm=custom_vm)
 
@@ -160,8 +154,7 @@ class TestBaseCustomTemplates:
     def test_custom_template_vm_validation(
         self,
         unprivileged_client,
-        namespace,
-        golden_image_data_source_scope_class,
+        golden_image_data_source_for_test_scope_class,
         custom_template_from_base_template,
     ):
         with pytest.raises(UnprocessibleEntityError, match=r".*This VM has too many cores.*"):
@@ -170,7 +163,10 @@ class TestBaseCustomTemplates:
                 namespace=custom_template_from_base_template.namespace,
                 client=unprivileged_client,
                 template_object=custom_template_from_base_template,
-                data_source=golden_image_data_source_scope_class,
+                data_source=golden_image_data_source_for_test_scope_class,
+                data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+                    data_source=golden_image_data_source_for_test_scope_class
+                ),
                 cpu_cores=3,
             ) as vm_from_template:
                 pytest.fail(f"VM validation failed on {vm_from_template.name}")

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -77,7 +77,7 @@ def custom_template_from_base_template(request, namespace):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_source_scope_class",
+    "golden_image_data_source_for_test_scope_class",
     [pytest.param({"os_dict": FEDORA_LATEST})],
     indirect=True,
 )

--- a/tests/virt/cluster/common_templates/general/test_diskless_vm.py
+++ b/tests/virt/cluster/common_templates/general/test_diskless_vm.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
         pytest.param(
             {
                 "os_dict": {
-                    "dv_name": "cirros-dv",
+                    "data_source": "cirros-dv",
                     "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",
                     "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
                 },

--- a/tests/virt/cluster/common_templates/general/test_diskless_vm.py
+++ b/tests/virt/cluster/common_templates/general/test_diskless_vm.py
@@ -35,23 +35,14 @@ class TestDisklessVM:
         "vm_params",
         [
             pytest.param(
-                {
-                    "vm_name": "rhel-diskless-vm",
-                    "template_labels": RHEL_LATEST_LABELS,
-                    "diskless_vm": True,
-                },
+                {"vm_name": "rhel-diskless-vm", "template_labels": RHEL_LATEST_LABELS},
                 marks=(pytest.mark.polarion("CNV-4696"), pytest.mark.gating(), pytest.mark.s390x),
             ),
             pytest.param(
-                {
-                    "vm_name": "windows-diskless-vm",
-                    "template_labels": WINDOWS_LATEST_LABELS,
-                    "diskless_vm": True,
-                },
-                marks=(pytest.mark.polarion("CNV-4697"),),
+                {"vm_name": "windows-diskless-vm", "template_labels": WINDOWS_LATEST_LABELS},
+                marks=pytest.mark.polarion("CNV-4697"),
             ),
         ],
-        indirect=False,
     )
     def test_diskless_vm_creation(
         self,
@@ -67,6 +58,6 @@ class TestDisklessVM:
             client=unprivileged_client,
             labels=Template.generate_template_labels(**vm_params["template_labels"]),
             data_source=golden_image_data_source_for_test_scope_class,
-            diskless_vm=vm_params["diskless_vm"],
+            diskless_vm=True,
         ) as vm_from_template:
             assert vm_from_template.exists, f"{vm_from_template.name} VM was not created."

--- a/tests/virt/cluster/common_templates/general/test_diskless_vm.py
+++ b/tests/virt/cluster/common_templates/general/test_diskless_vm.py
@@ -8,7 +8,7 @@ import pytest
 from ocp_resources.template import Template
 
 from tests.os_params import RHEL_LATEST_LABELS, WINDOWS_LATEST_LABELS
-from utilities.constants import Images
+from tests.virt.constants import CIRROS_OS
 from utilities.virt import VirtualMachineForTestsFromTemplate
 
 LOGGER = logging.getLogger(__name__)
@@ -17,17 +17,7 @@ LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.parametrize(
     "golden_image_data_source_for_test_scope_class",
-    [
-        pytest.param(
-            {
-                "os_dict": {
-                    "data_source": "cirros-dv",
-                    "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",
-                    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-                },
-            },
-        ),
-    ],
+    [pytest.param({"os_dict": CIRROS_OS})],
     indirect=True,
 )
 class TestDisklessVM:

--- a/tests/virt/cluster/common_templates/general/test_diskless_vm.py
+++ b/tests/virt/cluster/common_templates/general/test_diskless_vm.py
@@ -5,57 +5,68 @@ Test diskless VM creation.
 import logging
 
 import pytest
-from pytest_testconfig import config as py_config
+from ocp_resources.template import Template
 
 from tests.os_params import RHEL_LATEST_LABELS, WINDOWS_LATEST_LABELS
 from utilities.constants import Images
+from utilities.virt import VirtualMachineForTestsFromTemplate
 
 LOGGER = logging.getLogger(__name__)
 # Image is not relevant - needed for VM creation with a template but will not be used
-SMALL_VM_IMAGE = f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}"
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_function, vm_from_template_scope_function",
+    "golden_image_data_source_for_test_scope_class",
     [
         pytest.param(
             {
-                "dv_name": "cirros-dv",
-                "image": SMALL_VM_IMAGE,
-                "storage_class": py_config["default_storage_class"],
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                "os_dict": {
+                    "dv_name": "cirros-dv",
+                    "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",
+                    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                },
             },
-            {
-                "vm_name": "rhel-diskless-vm",
-                "template_labels": RHEL_LATEST_LABELS,
-                "diskless_vm": True,
-                "start_vm": False,
-            },
-            marks=(pytest.mark.polarion("CNV-4696"), pytest.mark.gating(), pytest.mark.s390x),
-        ),
-        pytest.param(
-            {
-                "dv_name": "cirros-dv",
-                "image": SMALL_VM_IMAGE,
-                "storage_class": py_config["default_storage_class"],
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-            },
-            {
-                "vm_name": "windows-diskless-vm",
-                "template_labels": WINDOWS_LATEST_LABELS,
-                "diskless_vm": True,
-                "start_vm": False,
-            },
-            marks=(pytest.mark.polarion("CNV-4697"),),
         ),
     ],
     indirect=True,
 )
-def test_diskless_vm_creation(
-    unprivileged_client,
-    namespace,
-    golden_image_data_volume_scope_function,
-    vm_from_template_scope_function,
-):
-    LOGGER.info("Verify diskless VM is created.")
-    assert vm_from_template_scope_function.exists, f"{vm_from_template_scope_function.name} VM was not created."
+class TestDisklessVM:
+    @pytest.mark.parametrize(
+        "vm_params",
+        [
+            pytest.param(
+                {
+                    "vm_name": "rhel-diskless-vm",
+                    "template_labels": RHEL_LATEST_LABELS,
+                    "diskless_vm": True,
+                },
+                marks=(pytest.mark.polarion("CNV-4696"), pytest.mark.gating(), pytest.mark.s390x),
+            ),
+            pytest.param(
+                {
+                    "vm_name": "windows-diskless-vm",
+                    "template_labels": WINDOWS_LATEST_LABELS,
+                    "diskless_vm": True,
+                },
+                marks=(pytest.mark.polarion("CNV-4697"),),
+            ),
+        ],
+        indirect=False,
+    )
+    def test_diskless_vm_creation(
+        self,
+        vm_params,
+        unprivileged_client,
+        namespace,
+        golden_image_data_source_for_test_scope_class,
+    ):
+        LOGGER.info("Verify diskless VM is created.")
+        with VirtualMachineForTestsFromTemplate(
+            name=vm_params["vm_name"],
+            namespace=namespace.name,
+            client=unprivileged_client,
+            labels=Template.generate_template_labels(**vm_params["template_labels"]),
+            data_source=golden_image_data_source_for_test_scope_class,
+            diskless_vm=vm_params["diskless_vm"],
+        ) as vm_from_template:
+            assert vm_from_template.exists, f"{vm_from_template.name} VM was not created."

--- a/tests/virt/cluster/common_templates/general/test_template_validator.py
+++ b/tests/virt/cluster/common_templates/general/test_template_validator.py
@@ -11,7 +11,7 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.template import Template
 
 from tests.os_params import RHEL_LATEST_LABELS
-from utilities.constants import Images
+from tests.virt.constants import CIRROS_OS
 from utilities.virt import VirtualMachineForTestsFromTemplate
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
@@ -25,13 +25,7 @@ LOGGER = logging.getLogger(__name__)
     "golden_image_data_source_for_test_scope_function",
     [
         pytest.param(
-            {
-                "os_dict": {
-                    "data_source": "cirros-dv",
-                    "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",  # Negative test needs a dummy DV.
-                    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-                }
-            },
+            {"os_dict": CIRROS_OS},
             marks=pytest.mark.polarion("CNV-2960"),
         ),
     ],

--- a/tests/virt/cluster/common_templates/general/test_template_validator.py
+++ b/tests/virt/cluster/common_templates/general/test_template_validator.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
         pytest.param(
             {
                 "os_dict": {
-                    "dv_name": "cirros-dv",
+                    "data_source": "cirros-dv",
                     "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",  # Negative test needs a dummy DV.
                     "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
                 }

--- a/tests/virt/cluster/common_templates/general/test_template_validator.py
+++ b/tests/virt/cluster/common_templates/general/test_template_validator.py
@@ -22,13 +22,15 @@ LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.s390x
 @pytest.mark.parametrize(
-    "golden_image_data_volume_multi_storage_scope_function",
+    "golden_image_data_source_for_test_scope_function",
     [
         pytest.param(
             {
-                "dv_name": "cirros-dv",
-                "image": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",  # Negative tests require a dummy DV.
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                "os_dict": {
+                    "dv_name": "cirros-dv",
+                    "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",  # Negative test needs a dummy DV.
+                    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                }
             },
             marks=pytest.mark.polarion("CNV-2960"),
         ),
@@ -36,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
     indirect=True,
 )
 def test_template_validation_min_memory(
-    unprivileged_client, namespace, golden_image_data_source_multi_storage_scope_function
+    unprivileged_client, namespace, golden_image_data_source_for_test_scope_function
 ):
     LOGGER.info("Test template validator - minimum required memory")
 
@@ -45,7 +47,7 @@ def test_template_validation_min_memory(
             name="rhel-min-memory-validation",
             namespace=namespace.name,
             client=unprivileged_client,
-            data_source=golden_image_data_source_multi_storage_scope_function,
+            data_source=golden_image_data_source_for_test_scope_function,
             labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
             memory_guest="0.5G",
         ):

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -13,7 +13,7 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.template import Template
 from pyhelper_utils.shell import run_ssh_commands
 
-from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
+from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS
 from tests.virt.cluster.common_templates.utils import check_vm_xml_tablet_device, set_vm_tablet_device_dict
 from utilities.constants import VIRTIO, Images
 from utilities.virt import VirtualMachineForTestsFromTemplate, migrate_vm_and_verify
@@ -34,16 +34,8 @@ def check_vm_system_tablet_device(vm, expected_device):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_multi_storage_scope_class,",
-    [
-        pytest.param(
-            {
-                "dv_name": RHEL_LATEST_OS,
-                "image": RHEL_LATEST["image_path"],
-                "dv_size": RHEL_LATEST["dv_size"],
-            },
-        ),
-    ],
+    "golden_image_data_source_for_test_scope_class,",
+    [pytest.param({"os_dict": RHEL_LATEST})],
     indirect=True,
 )
 class TestRHELTabletDevice:
@@ -128,13 +120,15 @@ class TestRHELTabletDevice:
 
 @pytest.mark.s390x
 @pytest.mark.parametrize(
-    "golden_image_data_volume_multi_storage_scope_class",
+    "golden_image_data_source_for_test_scope_class",
     [
         pytest.param(
             {
-                "dv_name": "cirros-dv",
-                "image": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",  # Negative tests require a dummy DV.
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                "os_dict": {
+                    "data_source": "cirros-dv",
+                    "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",  # Negative tests needs a dummy DV.
+                    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+                },
             },
         ),
     ],
@@ -163,7 +157,7 @@ class TestRHELTabletDeviceNegative:
         indirect=False,
     )
     def test_tablet_invalid_usb_tablet_device(
-        self, vm_name, vm_dict, unprivileged_client, namespace, golden_image_data_source_multi_storage_scope_class
+        self, vm_name, vm_dict, unprivileged_client, namespace, golden_image_data_source_for_test_scope_class
     ):
         LOGGER.info("Test tablet device - wrong device bus.")
 
@@ -172,7 +166,7 @@ class TestRHELTabletDeviceNegative:
                 name=vm_name,
                 namespace=namespace.name,
                 client=unprivileged_client,
-                data_source=golden_image_data_source_multi_storage_scope_class,
+                data_source=golden_image_data_source_for_test_scope_class,
                 labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
                 vm_dict=vm_dict,
             ):
@@ -189,7 +183,7 @@ class TestRHELTabletDeviceNegative:
         indirect=False,
     )
     def test_tablet_invalid_type_tablet_device(
-        self, vm_dict, unprivileged_client, namespace, golden_image_data_source_multi_storage_scope_class
+        self, vm_dict, unprivileged_client, namespace, golden_image_data_source_for_test_scope_class
     ):
         LOGGER.info("Test tablet device - wrong device type.")
 
@@ -198,7 +192,7 @@ class TestRHELTabletDeviceNegative:
                 name="rhel-keyboard-tablet-device-vm",
                 namespace=namespace.name,
                 client=unprivileged_client,
-                data_source=golden_image_data_source_multi_storage_scope_class,
+                data_source=golden_image_data_source_for_test_scope_class,
                 labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
                 vm_dict=vm_dict,
             ):

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -34,7 +34,7 @@ def check_vm_system_tablet_device(vm, expected_device):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_source_for_test_scope_class,",
+    "golden_image_data_source_for_test_scope_class",
     [pytest.param({"os_dict": RHEL_LATEST})],
     indirect=True,
 )

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -15,7 +15,8 @@ from pyhelper_utils.shell import run_ssh_commands
 
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS
 from tests.virt.cluster.common_templates.utils import check_vm_xml_tablet_device, set_vm_tablet_device_dict
-from utilities.constants import VIRTIO, Images
+from tests.virt.constants import CIRROS_OS
+from utilities.constants import VIRTIO
 from utilities.virt import VirtualMachineForTestsFromTemplate, migrate_vm_and_verify
 
 LOGGER = logging.getLogger(__name__)
@@ -121,17 +122,7 @@ class TestRHELTabletDevice:
 @pytest.mark.s390x
 @pytest.mark.parametrize(
     "golden_image_data_source_for_test_scope_class",
-    [
-        pytest.param(
-            {
-                "os_dict": {
-                    "data_source": "cirros-dv",
-                    "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",  # Negative tests needs a dummy DV.
-                    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-                },
-            },
-        ),
-    ],
+    [pytest.param({"os_dict": CIRROS_OS})],
     indirect=True,
 )
 class TestRHELTabletDeviceNegative:

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -90,9 +90,7 @@ class CustomWindowsVM(VirtualMachineForTestsFromTemplate):
 
 def assert_firmware_uuid_in_domxml(vm, uuid):
     xml_domain = vm.privileged_vmi.xml_dict["domain"]
-    assert xml_domain.get("uuid", "").lower() == uuid.lower(), (
-        f"Firmware UUID not found in domxml for {custom_windows_vm.name}"
-    )
+    assert xml_domain.get("uuid", "").lower() == uuid.lower(), f"Firmware UUID not found in domxml for {vm.name}"
 
 
 def initialize_and_format_windows_drive(vm, disk_number, partition_number, drive_letter):

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -13,7 +13,6 @@ from tests.os_params import (
     WINDOWS_2019,
     WINDOWS_2019_OS,
 )
-from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import LINUX_BRIDGE, TCP_TIMEOUT_30SEC, TIMEOUT_12MIN, VIRTIO, Images
 from utilities.network import network_device, network_nad
 from utilities.storage import get_storage_class_dict_from_matrix
@@ -34,7 +33,7 @@ class CustomWindowsVM(VirtualMachineForTestsFromTemplate):
         name,
         namespace,
         client,
-        data_source,
+        data_volume_template,
         os_dict,
         nad,
         drive_d_pvc,
@@ -44,7 +43,7 @@ class CustomWindowsVM(VirtualMachineForTestsFromTemplate):
             name=name,
             namespace=namespace,
             client=client,
-            data_source=data_source,
+            data_volume_template=data_volume_template,
             labels=Template.generate_template_labels(**os_dict["template_labels"]),
             cpu_cores=1,
             cpu_sockets=2,
@@ -152,7 +151,7 @@ def windows_custom_drive_d(unprivileged_client, namespace):
 def custom_windows_vm(
     windows_custom_bridge_nad,
     windows_custom_drive_d,
-    golden_image_data_source_for_test_scope_class,
+    golden_image_data_volume_template_for_test_scope_class,
     unprivileged_client,
     modern_cpu_for_migration,
 ):
@@ -160,10 +159,7 @@ def custom_windows_vm(
         name="custom-windows-vm",
         namespace=windows_custom_bridge_nad.namespace,
         client=unprivileged_client,
-        data_source=golden_image_data_source_for_test_scope_class,
-        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-            data_source=golden_image_data_source_for_test_scope_class
-        ),
+        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         os_dict=WINDOWS_2019,
         nad=windows_custom_bridge_nad,
         drive_d_pvc=windows_custom_drive_d,

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -181,7 +181,7 @@ def custom_windows_vm(
         pytest.param(
             {
                 "os_dict": {
-                    "dv_name": WINDOWS_2019_OS,
+                    "data_source": WINDOWS_2019_OS,
                     "image_path": f"{Images.Windows.HA_DIR}/{Images.Windows.WIN2k19_HA_IMG}",
                     "dv_size": "100Gi",
                 }

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -13,6 +13,7 @@ from tests.os_params import (
     WINDOWS_2019,
     WINDOWS_2019_OS,
 )
+from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import LINUX_BRIDGE, TCP_TIMEOUT_30SEC, TIMEOUT_12MIN, VIRTIO, Images
 from utilities.network import network_device, network_nad
 from utilities.storage import get_storage_class_dict_from_matrix
@@ -151,10 +152,9 @@ def windows_custom_drive_d(unprivileged_client, namespace):
 
 @pytest.fixture(scope="class")
 def custom_windows_vm(
-    request,
     windows_custom_bridge_nad,
     windows_custom_drive_d,
-    golden_image_data_source_scope_class,
+    golden_image_data_source_for_test_scope_class,
     unprivileged_client,
     modern_cpu_for_migration,
 ):
@@ -162,8 +162,11 @@ def custom_windows_vm(
         name="custom-windows-vm",
         namespace=windows_custom_bridge_nad.namespace,
         client=unprivileged_client,
-        data_source=golden_image_data_source_scope_class,
-        os_dict=request.param,
+        data_source=golden_image_data_source_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class
+        ),
+        os_dict=WINDOWS_2019,
         nad=windows_custom_bridge_nad,
         drive_d_pvc=windows_custom_drive_d,
         cpu_model=modern_cpu_for_migration,
@@ -173,16 +176,16 @@ def custom_windows_vm(
 
 @pytest.mark.ibm_bare_metal
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_class, custom_windows_vm",
+    "golden_image_data_source_for_test_scope_class",
     [
         pytest.param(
             {
-                "dv_name": WINDOWS_2019_OS,
-                "image": f"{Images.Windows.HA_DIR}/{Images.Windows.WIN2k19_HA_IMG}",
-                "dv_size": "100Gi",
-                "storage_class": py_config["default_storage_class"],
+                "os_dict": {
+                    "dv_name": WINDOWS_2019_OS,
+                    "image_path": f"{Images.Windows.HA_DIR}/{Images.Windows.WIN2k19_HA_IMG}",
+                    "dv_size": "100Gi",
+                }
             },
-            WINDOWS_2019,
             id=WINDOWS_2019_OS,
             marks=pytest.mark.polarion("CNV-7496"),
         ),

--- a/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
@@ -46,7 +46,7 @@ def check_windows_vm_tablet_device(vm, driver_state):
 
 @pytest.mark.parametrize(
     "golden_image_data_source_for_test_scope_class",
-    [[pytest.param({"os_dict": WINDOWS_LATEST})]],
+    [pytest.param({"os_dict": WINDOWS_LATEST})],
     indirect=True,
 )
 class TestWindowsTabletDevice:

--- a/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
@@ -11,10 +11,9 @@ import shlex
 import pytest
 from pyhelper_utils.shell import run_ssh_commands
 
-from tests.os_params import WINDOWS_LATEST, WINDOWS_LATEST_LABELS, WINDOWS_LATEST_OS
+from tests.os_params import WINDOWS_10, WINDOWS_LATEST, WINDOWS_LATEST_LABELS
 from tests.virt.cluster.common_templates.utils import check_vm_xml_tablet_device, set_vm_tablet_device_dict
 from utilities.constants import TCP_TIMEOUT_30SEC, VIRTIO
-from utilities.virt import get_windows_os_dict
 
 pytestmark = [
     pytest.mark.special_infra,
@@ -24,7 +23,6 @@ pytestmark = [
 
 
 LOGGER = logging.getLogger(__name__)
-WINDOWS_DESKTOP_VERSION = get_windows_os_dict(windows_version="win-10")
 
 
 def check_windows_vm_tablet_device(vm, driver_state):
@@ -47,16 +45,8 @@ def check_windows_vm_tablet_device(vm, driver_state):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_multi_storage_scope_class",
-    [
-        pytest.param(
-            {
-                "dv_name": WINDOWS_LATEST_OS,
-                "image": WINDOWS_LATEST.get("image_path"),
-                "dv_size": WINDOWS_LATEST.get("dv_size"),
-            },
-        ),
-    ],
+    "golden_image_data_source_for_test_scope_class",
+    [[pytest.param({"os_dict": WINDOWS_LATEST})]],
     indirect=True,
 )
 class TestWindowsTabletDevice:
@@ -130,33 +120,26 @@ class TestWindowsTabletDevice:
         check_windows_vm_tablet_device(vm=vm, driver_state="Running")
         check_vm_xml_tablet_device(vm=vm)
 
+    @pytest.mark.parametrize(
+        "tablet_device_vm",
+        [
+            pytest.param(
+                {
+                    "vm_name": "windows-desktop-default-tablet-device",
+                    "template_labels": WINDOWS_10.get("template_labels"),
+                },
+                marks=pytest.mark.polarion("CNV-4150"),
+            ),
+        ],
+        indirect=True,
+    )
+    def test_windows_desktop_default_tablet_device(self, tablet_device_vm):
+        """Verify that when a Desktop Windows VM is configured by default with
+        tablet device
+        """
 
-@pytest.mark.parametrize(
-    "golden_image_data_volume_multi_storage_scope_function,"
-    "golden_image_vm_instance_from_template_multi_storage_scope_function,",
-    [
-        pytest.param(
-            {
-                "dv_name": WINDOWS_DESKTOP_VERSION.get("template_labels", {}).get("os"),
-                "image": WINDOWS_DESKTOP_VERSION.get("image_path"),
-                "dv_size": WINDOWS_DESKTOP_VERSION.get("dv_size"),
-            },
-            {
-                "vm_name": "windows-desktop-default-tablet-device",
-                "template_labels": WINDOWS_DESKTOP_VERSION.get("template_labels"),
-            },
-            marks=pytest.mark.polarion("CNV-4150"),
-        ),
-    ],
-    indirect=True,
-)
-def test_windows_desktop_default_tablet_device(golden_image_vm_instance_from_template_multi_storage_scope_function):
-    """Verify that when a Desktop Windows VM is configured by default with
-    tablet device
-    """
+        LOGGER.info("Test Windows Desktop tablet device - default table device.")
 
-    LOGGER.info("Test Windows Desktop tablet device - default table device.")
-
-    vm = golden_image_vm_instance_from_template_multi_storage_scope_function
-    check_windows_vm_tablet_device(vm=vm, driver_state="Running")
-    check_vm_xml_tablet_device(vm=vm)
+        vm = tablet_device_vm
+        check_windows_vm_tablet_device(vm=vm, driver_state="Running")
+        check_vm_xml_tablet_device(vm=vm)

--- a/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
@@ -67,9 +67,8 @@ class TestWindowsTabletDevice:
     def test_tablet_usb_tablet_device(self, tablet_device_vm):
         LOGGER.info("Test tablet device - USB bus.")
 
-        vm = tablet_device_vm
-        check_windows_vm_tablet_device(vm=vm, driver_state="Running")
-        check_vm_xml_tablet_device(vm=vm)
+        check_windows_vm_tablet_device(vm=tablet_device_vm, driver_state="Running")
+        check_vm_xml_tablet_device(vm=tablet_device_vm)
 
     @pytest.mark.parametrize(
         "tablet_device_vm",
@@ -92,9 +91,8 @@ class TestWindowsTabletDevice:
 
         LOGGER.info("Test tablet device - virtio bus.")
 
-        vm = tablet_device_vm
-        check_windows_vm_tablet_device(vm=vm, driver_state="Stopped")
-        check_vm_xml_tablet_device(vm=vm)
+        check_windows_vm_tablet_device(vm=tablet_device_vm, driver_state="Stopped")
+        check_vm_xml_tablet_device(vm=tablet_device_vm)
 
     @pytest.mark.parametrize(
         "tablet_device_vm",
@@ -116,9 +114,8 @@ class TestWindowsTabletDevice:
 
         LOGGER.info("Test Windows Server tablet device - default table device.")
 
-        vm = tablet_device_vm
-        check_windows_vm_tablet_device(vm=vm, driver_state="Running")
-        check_vm_xml_tablet_device(vm=vm)
+        check_windows_vm_tablet_device(vm=tablet_device_vm, driver_state="Running")
+        check_vm_xml_tablet_device(vm=tablet_device_vm)
 
     @pytest.mark.parametrize(
         "tablet_device_vm",
@@ -140,6 +137,5 @@ class TestWindowsTabletDevice:
 
         LOGGER.info("Test Windows Desktop tablet device - default table device.")
 
-        vm = tablet_device_vm
-        check_windows_vm_tablet_device(vm=vm, driver_state="Running")
-        check_vm_xml_tablet_device(vm=vm)
+        check_windows_vm_tablet_device(vm=tablet_device_vm, driver_state="Running")
+        check_vm_xml_tablet_device(vm=tablet_device_vm)

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -14,7 +14,6 @@ from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutSampler
 
 from tests.os_params import WINDOWS_2019
-from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.constants import BASE_IMAGES_DIR, OS_FLAVOR_WINDOWS, TCP_TIMEOUT_30SEC, TIMEOUT_5MIN
 from utilities.ssp import get_windows_timezone
@@ -122,7 +121,7 @@ def sysprep_resource(sysprep_source_matrix__class__, unprivileged_client, namesp
 @pytest.fixture(scope="class")
 def sysprep_vm(
     sysprep_source_matrix__class__,
-    golden_image_data_source_for_test_scope_class,
+    golden_image_data_volume_template_for_test_scope_class,
     modern_cpu_for_migration,
     unprivileged_client,
     namespace,
@@ -135,9 +134,7 @@ def sysprep_vm(
             client=unprivileged_client,
             vm_instance_type=vm_instance_type,
             vm_preference=VirtualMachineClusterPreference(name="windows.2k19"),
-            data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-                data_source=golden_image_data_source_for_test_scope_class
-            ),
+            data_volume_template=golden_image_data_volume_template_for_test_scope_class,
             os_flavor=OS_FLAVOR_WINDOWS,
             disk_type=None,
             cpu_model=modern_cpu_for_migration,

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -11,10 +11,9 @@ from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
 )
 from pyhelper_utils.shell import run_ssh_commands
-from pytest_testconfig import py_config
 from timeout_sampler import TimeoutSampler
 
-from tests.os_params import WINDOWS_2019, WINDOWS_2019_OS
+from tests.os_params import WINDOWS_2019
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.constants import BASE_IMAGES_DIR, OS_FLAVOR_WINDOWS, TCP_TIMEOUT_30SEC, TIMEOUT_5MIN
 from utilities.ssp import get_windows_timezone
@@ -122,7 +121,7 @@ def sysprep_resource(sysprep_source_matrix__class__, unprivileged_client, namesp
 @pytest.fixture(scope="class")
 def sysprep_vm(
     sysprep_source_matrix__class__,
-    golden_image_data_source_scope_class,
+    golden_image_data_source_for_test_scope_class,
     modern_cpu_for_migration,
     unprivileged_client,
     namespace,
@@ -136,7 +135,7 @@ def sysprep_vm(
             vm_instance_type=vm_instance_type,
             vm_preference=VirtualMachineClusterPreference(name="windows.2k19"),
             data_volume_template=data_volume_template_with_source_ref_dict(
-                data_source=golden_image_data_source_scope_class
+                data_source=golden_image_data_source_for_test_scope_class
             ),
             os_flavor=OS_FLAVOR_WINDOWS,
             disk_type=None,
@@ -248,19 +247,11 @@ def detached_sysprep_resource_and_restarted_vm(sysprep_vm, attached_sysprep_volu
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_class, common_instance_type_param_dict",
+    "golden_image_data_source_for_test_scope_class, common_instance_type_param_dict",
     [
         pytest.param(
-            {
-                "dv_name": WINDOWS_2019_OS,
-                "image": WINDOWS_2019.get("image_path"),
-                "dv_size": WINDOWS_2019.get("dv_size"),
-                "storage_class": py_config["default_storage_class"],
-            },
-            {
-                "name": "basic",
-                "memory_requests": "8Gi",
-            },
+            {"os_dict": WINDOWS_2019},
+            {"name": "basic", "memory_requests": "8Gi"},
         )
     ],
     indirect=True,

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -14,10 +14,11 @@ from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutSampler
 
 from tests.os_params import WINDOWS_2019
+from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.constants import BASE_IMAGES_DIR, OS_FLAVOR_WINDOWS, TCP_TIMEOUT_30SEC, TIMEOUT_5MIN
 from utilities.ssp import get_windows_timezone
-from utilities.storage import data_volume_template_with_source_ref_dict, get_downloaded_artifact
+from utilities.storage import get_downloaded_artifact
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
 
 LOGGER = logging.getLogger(__name__)
@@ -134,7 +135,7 @@ def sysprep_vm(
             client=unprivileged_client,
             vm_instance_type=vm_instance_type,
             vm_preference=VirtualMachineClusterPreference(name="windows.2k19"),
-            data_volume_template=data_volume_template_with_source_ref_dict(
+            data_volume_template=get_data_volume_template_dict_with_default_storage_class(
                 data_source=golden_image_data_source_for_test_scope_class
             ),
             os_flavor=OS_FLAVOR_WINDOWS,

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -15,7 +15,6 @@ from tests.virt.cluster.vm_cloning.utils import (
     assert_target_vm_has_new_pvc_disks,
     check_if_files_present_after_cloning,
 )
-from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import RHEL_WITH_INSTANCETYPE_AND_PREFERENCE, Images
 from utilities.storage import (
     add_dv_to_vm,
@@ -57,14 +56,12 @@ def dummy_dv_dict_for_vm_cloning(namespace):
 
 @pytest.fixture()
 def vm_with_dv_for_cloning(
-    skip_if_no_storage_class_for_snapshot, request, namespace, golden_image_data_source_for_test_scope_function
+    skip_if_no_storage_class_for_snapshot, request, namespace, golden_image_data_volume_template_for_test_scope_function
 ):
     with VirtualMachineForCloning(
         name=request.param["vm_name"],
         namespace=namespace.name,
-        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-            data_source=golden_image_data_source_for_test_scope_function
-        ),
+        data_volume_template=golden_image_data_volume_template_for_test_scope_function,
         memory_guest=request.param["memory_guest"],
         cpu_cores=request.param.get("cpu_cores", 1),
         os_flavor=request.param["vm_name"].split("-")[0],

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -3,7 +3,9 @@ import shlex
 import pytest
 from ocp_resources.datavolume import DataVolume
 from pyhelper_utils.shell import run_ssh_commands
+from pytest_testconfig import config as py_config
 
+from tests.os_params import RHEL_LATEST
 from tests.virt.cluster.vm_cloning.constants import (
     ROOT_DISK_TEST_FILE_STR,
     SECOND_DISK_PATH,
@@ -13,12 +15,11 @@ from tests.virt.cluster.vm_cloning.utils import (
     assert_target_vm_has_new_pvc_disks,
     check_if_files_present_after_cloning,
 )
+from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import RHEL_WITH_INSTANCETYPE_AND_PREFERENCE, Images
-from utilities.infra import get_artifactory_config_map, get_artifactory_secret
 from utilities.storage import (
     add_dv_to_vm,
     check_disk_count_in_vm,
-    get_test_artifact_server_url,
 )
 from utilities.virt import (
     VirtualMachineForCloning,
@@ -41,61 +42,38 @@ WINDOWS_VM_FOR_CLONING = "win-vm-for-cloning"
 FEDORA_VM_FOR_CLONING = "fedora-vm-with-labels-annotations-mac-smbios"
 
 
-def dv_dict_for_vm_cloning(namespace, storage_class, dv_template):
+def dummy_dv_dict_for_vm_cloning(namespace):
     dv = DataVolume(
-        name=dv_template["name"],
+        name="dummy-dv-for-clone",
         namespace=namespace.name,
-        source=dv_template["source"],
-        url=dv_template.get("url"),
-        size=dv_template["size"],
-        storage_class=storage_class,
+        source="blank",
+        size="10Gi",
+        storage_class=py_config["default_storage_class"],
         api_name="storage",
-        secret=get_artifactory_secret(namespace=namespace.name),
-        cert_configmap=get_artifactory_config_map(namespace=namespace.name).name,
     )
     dv.to_dict()
     return dv.res
 
 
 @pytest.fixture()
-def dv_template_for_vm_cloning(
-    skip_if_no_storage_class_for_snapshot,
-    request,
-    namespace,
-    storage_class_for_snapshot,
+def vm_with_dv_for_cloning(
+    skip_if_no_storage_class_for_snapshot, request, namespace, golden_image_data_source_for_test_scope_function
 ):
-    source = request.param["source"]
-    request.param["url"] = f"{get_test_artifact_server_url()}{request.param['image']}" if source == "http" else None
-
-    return dv_dict_for_vm_cloning(
-        namespace=namespace,
-        storage_class=storage_class_for_snapshot,
-        dv_template=request.param,
-    )
-
-
-@pytest.fixture()
-def vm_with_dv_for_cloning(request, namespace, dv_template_for_vm_cloning, storage_class_for_snapshot):
     with VirtualMachineForCloning(
         name=request.param["vm_name"],
         namespace=namespace.name,
-        data_volume_template=dv_template_for_vm_cloning,
-        memory_requests=request.param["memory_requests"],
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_function
+        ),
+        memory_guest=request.param["memory_guest"],
         cpu_cores=request.param.get("cpu_cores", 1),
         os_flavor=request.param["vm_name"].split("-")[0],
         smm_enabled=True,
         efi_params={"secureBoot": True},
     ) as vm:
         # Add second DV when needed
-        if request.param.get("dv_extra"):
-            add_dv_to_vm(
-                vm=vm,
-                template_dv=dv_dict_for_vm_cloning(
-                    namespace=namespace,
-                    storage_class=storage_class_for_snapshot,
-                    dv_template=request.param["dv_extra"],
-                ),
-            )
+        if request.param.get("extra_dv"):
+            add_dv_to_vm(vm=vm, template_dv=dummy_dv_dict_for_vm_cloning(namespace=namespace))
         running_vm(vm=vm)
         yield vm
 
@@ -144,24 +122,19 @@ def fedora_target_vm_instance(fedora_target_vm):
 
 
 @pytest.mark.parametrize(
-    "dv_template_for_vm_cloning, vm_with_dv_for_cloning, cloning_job_scope_function",
+    "golden_image_data_source_for_test_scope_function, vm_with_dv_for_cloning, cloning_job_scope_function",
     [
         pytest.param(
-            {
-                "name": "rhel-dv-root-disk",
-                "source": "http",
-                "image": f"{Images.Rhel.DIR}/{Images.Rhel.RHEL9_4_IMG}",
-                "size": Images.Rhel.DEFAULT_DV_SIZE,
-            },
+            {"os_dict": RHEL_LATEST},
             {
                 "vm_name": RHEL_VM_WITH_TWO_PVC,
-                "memory_requests": Images.Rhel.DEFAULT_MEMORY_SIZE,
-                "dv_extra": {"name": "dv-extra", "source": "blank", "size": "10Gi"},
+                "memory_guest": Images.Rhel.DEFAULT_MEMORY_SIZE,
+                "extra_dv": True,
             },
             {"source_name": RHEL_VM_WITH_TWO_PVC},
             marks=(
                 pytest.mark.polarion("CNV-10295"),
-                pytest.mark.gating(),
+                # pytest.mark.gating(),
             ),
         )
     ],
@@ -197,14 +170,15 @@ def test_clone_vm_with_instance_type_and_preference(
 
 
 @pytest.mark.parametrize(
-    "dv_template_for_vm_cloning, vm_with_dv_for_cloning, cloning_job_scope_function",
+    "golden_image_data_source_for_test_scope_function, vm_with_dv_for_cloning, cloning_job_scope_function",
     [
         pytest.param(
             {
-                "name": "windows-dv-root-disk",
-                "source": "http",
-                "image": f"{Images.Windows.HA_DIR}/{Images.Windows.WIN2k19_HA_IMG}",
-                "size": Images.Windows.DEFAULT_DV_SIZE,
+                "os_dict": {
+                    "data_source": "windows-dv-root-disk",
+                    "image_path": f"{Images.Windows.HA_DIR}/{Images.Windows.WIN2k19_HA_IMG}",
+                    "dv_size": Images.Windows.DEFAULT_DV_SIZE,
+                },
             },
             {
                 "vm_name": WINDOWS_VM_FOR_CLONING,

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -132,10 +132,7 @@ def fedora_target_vm_instance(fedora_target_vm):
                 "extra_dv": True,
             },
             {"source_name": RHEL_VM_WITH_TWO_PVC},
-            marks=(
-                pytest.mark.polarion("CNV-10295"),
-                # pytest.mark.gating(),
-            ),
+            marks=(pytest.mark.polarion("CNV-10295"), pytest.mark.gating()),
         )
     ],
     indirect=True,
@@ -182,7 +179,7 @@ def test_clone_vm_with_instance_type_and_preference(
             },
             {
                 "vm_name": WINDOWS_VM_FOR_CLONING,
-                "memory_requests": Images.Windows.DEFAULT_MEMORY_SIZE,
+                "memory_guest": Images.Windows.DEFAULT_MEMORY_SIZE,
                 "cpu_cores": Images.Windows.DEFAULT_CPU_CORES,
             },
             {"source_name": WINDOWS_VM_FOR_CLONING},

--- a/tests/virt/cluster/vm_lifecycle/conftest.py
+++ b/tests/virt/cluster/vm_lifecycle/conftest.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 import pytest
 from ocp_resources.virtual_machine import VirtualMachine
 
-from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import Images
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
@@ -11,7 +10,7 @@ default_run_strategy = VirtualMachine.RunStrategy.MANUAL
 
 
 @contextmanager
-def container_disk_vm(namespace, unprivileged_client, data_source=None):
+def container_disk_vm(namespace, unprivileged_client, data_volume_template=None):
     """lifecycle_vm is used to call this fixture and data_volume_vm; data_source is not needed in this use cases"""
     name = "fedora-vm-lifecycle"
     with VirtualMachineForTests(
@@ -25,14 +24,14 @@ def container_disk_vm(namespace, unprivileged_client, data_source=None):
 
 
 @contextmanager
-def data_volume_vm(unprivileged_client, namespace, data_source):
+def data_volume_vm(unprivileged_client, namespace, data_volume_template):
     with VirtualMachineForTests(
         name="rhel-vm-lifecycle",
         namespace=namespace.name,
         client=unprivileged_client,
         memory_requests=Images.Rhel.DEFAULT_MEMORY_SIZE,
         run_strategy=default_run_strategy,
-        data_volume_template=get_data_volume_template_dict_with_default_storage_class(data_source=data_source),
+        data_volume_template=data_volume_template,
     ) as vm:
         yield vm
 
@@ -43,7 +42,7 @@ def lifecycle_vm(
     unprivileged_client,
     namespace,
     vm_volumes_matrix__class__,
-    golden_image_data_source_for_test_scope_module,
+    golden_image_data_volume_template_for_test_scope_module,
 ):
     """Wrapper fixture to generate the desired VM
     vm_volumes_matrix returns a string.
@@ -53,6 +52,6 @@ def lifecycle_vm(
     with globals()[vm_volumes_matrix__class__](
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_for_test_scope_module,
+        data_volume_template=golden_image_data_volume_template_for_test_scope_module,
     ) as vm:
         yield vm

--- a/tests/virt/cluster/vm_lifecycle/conftest.py
+++ b/tests/virt/cluster/vm_lifecycle/conftest.py
@@ -3,8 +3,8 @@ from contextlib import contextmanager
 import pytest
 from ocp_resources.virtual_machine import VirtualMachine
 
+from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import Images
-from utilities.storage import data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 default_run_strategy = VirtualMachine.RunStrategy.MANUAL
@@ -32,7 +32,7 @@ def data_volume_vm(unprivileged_client, namespace, data_source):
         client=unprivileged_client,
         memory_requests=Images.Rhel.DEFAULT_MEMORY_SIZE,
         run_strategy=default_run_strategy,
-        data_volume_template=data_volume_template_with_source_ref_dict(data_source=data_source),
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(data_source=data_source),
     ) as vm:
         yield vm
 
@@ -43,7 +43,7 @@ def lifecycle_vm(
     unprivileged_client,
     namespace,
     vm_volumes_matrix__class__,
-    golden_image_data_source_scope_module,
+    golden_image_data_source_for_test_scope_module,
 ):
     """Wrapper fixture to generate the desired VM
     vm_volumes_matrix returns a string.
@@ -53,6 +53,6 @@ def lifecycle_vm(
     with globals()[vm_volumes_matrix__class__](
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_scope_module,
+        data_source=golden_image_data_source_for_test_scope_module,
     ) as vm:
         yield vm

--- a/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
@@ -6,7 +6,6 @@ import string
 
 import pytest
 from pyhelper_utils.shell import run_ssh_commands
-from pytest_testconfig import py_config
 
 from tests.os_params import (
     RHEL_LATEST,
@@ -14,6 +13,7 @@ from tests.os_params import (
     WINDOWS_LATEST,
     WINDOWS_LATEST_LABELS,
 )
+from tests.virt.utils import data_volume_template_with_source_ref_dict
 from utilities.constants import (
     LINUX_STR,
     OS_FLAVOR_RHEL,
@@ -49,12 +49,15 @@ def vm_generated_new_password():
 
 
 @pytest.fixture(scope="class")
-def persistence_vm(request, golden_image_data_source_scope_class, unprivileged_client, namespace):
+def persistence_vm(request, golden_image_data_source_for_test_scope_class, unprivileged_client, namespace):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_scope_class,
+        data_source=golden_image_data_source_for_test_scope_class,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=golden_image_data_source_for_test_scope_class
+        ),
     ) as vm:
         yield vm
 
@@ -183,19 +186,11 @@ def verify_changes(vm, os):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_class, persistence_vm",
+    "golden_image_data_source_for_test_scope_class, persistence_vm",
     [
         [
-            {
-                "dv_name": "persistence-rhel-dv",
-                "image": RHEL_LATEST["image_path"],
-                "dv_size": RHEL_LATEST["dv_size"],
-                "storage_class": py_config["default_storage_class"],
-            },
-            {
-                "vm_name": "persistence-rhel-vm",
-                "template_labels": RHEL_LATEST_LABELS,
-            },
+            {"os_dict": RHEL_LATEST},
+            {"vm_name": "persistence-rhel-vm", "template_labels": RHEL_LATEST_LABELS},
         ]
     ],
     indirect=True,
@@ -224,19 +219,11 @@ class TestRestartPersistenceLinux:
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_class, persistence_vm",
+    "golden_image_data_source_for_test_scope_class, persistence_vm",
     [
         [
-            {
-                "dv_name": "persistence-windows-dv",
-                "image": WINDOWS_LATEST.get("image_path"),
-                "dv_size": WINDOWS_LATEST.get("dv_size"),
-                "storage_class": py_config["default_storage_class"],
-            },
-            {
-                "vm_name": "persistence-windows-vm",
-                "template_labels": WINDOWS_LATEST_LABELS,
-            },
+            {"os_dict": WINDOWS_LATEST},
+            {"vm_name": "persistence-windows-vm", "template_labels": WINDOWS_LATEST_LABELS},
         ]
     ],
     indirect=True,

--- a/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
@@ -13,7 +13,7 @@ from tests.os_params import (
     WINDOWS_LATEST,
     WINDOWS_LATEST_LABELS,
 )
-from tests.virt.utils import data_volume_template_with_source_ref_dict
+from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import (
     LINUX_STR,
     OS_FLAVOR_RHEL,
@@ -55,7 +55,7 @@ def persistence_vm(request, golden_image_data_source_for_test_scope_class, unpri
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_for_test_scope_class,
-        data_volume_template=data_volume_template_with_source_ref_dict(
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
             data_source=golden_image_data_source_for_test_scope_class
         ),
     ) as vm:

--- a/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
@@ -13,7 +13,6 @@ from tests.os_params import (
     WINDOWS_LATEST,
     WINDOWS_LATEST_LABELS,
 )
-from tests.virt.utils import get_data_volume_template_dict_with_default_storage_class
 from utilities.constants import (
     LINUX_STR,
     OS_FLAVOR_RHEL,
@@ -49,15 +48,12 @@ def vm_generated_new_password():
 
 
 @pytest.fixture(scope="class")
-def persistence_vm(request, golden_image_data_source_for_test_scope_class, unprivileged_client, namespace):
+def persistence_vm(request, golden_image_data_volume_template_for_test_scope_class, unprivileged_client, namespace):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_for_test_scope_class,
-        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-            data_source=golden_image_data_source_for_test_scope_class
-        ),
+        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:
         yield vm
 

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -10,11 +10,10 @@ from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
-from pytest_testconfig import py_config
 from rrmngmnt import power_manager
 from timeout_sampler import TimeoutSampler
 
-from tests.os_params import RHEL_LATEST, RHEL_LATEST_OS
+from tests.os_params import RHEL_LATEST
 from utilities.constants import TIMEOUT_10MIN
 from utilities.virt import migrate_vm_and_verify, running_vm
 
@@ -197,15 +196,8 @@ def shutdown_vm_guest_os(vm):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_module",
-    [
-        {
-            "dv_name": RHEL_LATEST_OS,
-            "image": RHEL_LATEST["image_path"],
-            "dv_size": RHEL_LATEST["dv_size"],
-            "storage_class": py_config["default_storage_class"],
-        },
-    ],
+    "golden_image_data_source_for_test_scope_module",
+    [{"os_dict": RHEL_LATEST}],
     indirect=True,
 )
 @pytest.mark.arm64
@@ -234,15 +226,8 @@ class TestRunStrategyBaseActions:
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_module",
-    [
-        {
-            "dv_name": RHEL_LATEST_OS,
-            "image": RHEL_LATEST["image_path"],
-            "dv_size": RHEL_LATEST["dv_size"],
-            "storage_class": py_config["default_storage_class"],
-        },
-    ],
+    "golden_image_data_source_for_test_scope_module",
+    [{"os_dict": RHEL_LATEST}],
     indirect=True,
 )
 class TestRunStrategyAdvancedActions:

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -21,14 +21,16 @@ from tests.virt.node.gpu.utils import (
 )
 from tests.virt.utils import (
     get_allocatable_memory_per_node,
+    get_data_volume_template_dict_with_default_storage_class,
     get_non_terminated_pods,
+    get_or_create_golden_image_data_source,
     get_pod_memory_requests,
     patch_hco_cr_with_mdev_permitted_hostdevices,
 )
 from utilities.constants import AMD, INTEL, TIMEOUT_1MIN, TIMEOUT_5SEC, NamespacesNames
 from utilities.exceptions import UnsupportedGPUDeviceError
 from utilities.infra import ExecCommandOnPod, exit_pytest_execution, label_nodes
-from utilities.virt import get_nodes_gpu_info
+from utilities.virt import get_nodes_gpu_info, vm_instance_from_template
 
 LOGGER = logging.getLogger(__name__)
 
@@ -317,3 +319,43 @@ def node_with_most_available_memory(available_memory_per_node):
 @pytest.fixture(scope="class")
 def node_with_least_available_memory(available_memory_per_node):
     return min(available_memory_per_node, key=available_memory_per_node.get)
+
+
+@pytest.fixture(scope="module")
+def golden_image_data_source_for_test_scope_module(request, admin_client, golden_images_namespace):
+    yield from get_or_create_golden_image_data_source(
+        admin_client=admin_client, golden_images_namespace=golden_images_namespace, os_dict=request.param["os_dict"]
+    )
+
+
+@pytest.fixture(scope="class")
+def golden_image_data_source_for_test_scope_class(request, admin_client, golden_images_namespace):
+    yield from get_or_create_golden_image_data_source(
+        admin_client=admin_client, golden_images_namespace=golden_images_namespace, os_dict=request.param["os_dict"]
+    )
+
+
+@pytest.fixture()
+def golden_image_data_source_for_test_scope_function(request, admin_client, golden_images_namespace):
+    yield from get_or_create_golden_image_data_source(
+        admin_client=admin_client, golden_images_namespace=golden_images_namespace, os_dict=request.param["os_dict"]
+    )
+
+
+@pytest.fixture(scope="class")
+def vm_for_test_from_template_scope_class(
+    request,
+    unprivileged_client,
+    namespace,
+    golden_image_data_source_for_test_scope_class,
+):
+    with vm_instance_from_template(
+        request=request,
+        unprivileged_client=unprivileged_client,
+        namespace=namespace,
+        data_source=golden_image_data_source_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class
+        ),
+    ) as vm:
+        yield vm

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -328,10 +328,24 @@ def golden_image_data_source_for_test_scope_module(request, admin_client, golden
     )
 
 
+@pytest.fixture(scope="module")
+def golden_image_data_volume_template_for_test_scope_module(golden_image_data_source_for_test_scope_module):
+    return get_data_volume_template_dict_with_default_storage_class(
+        data_source=golden_image_data_source_for_test_scope_module
+    )
+
+
 @pytest.fixture(scope="class")
 def golden_image_data_source_for_test_scope_class(request, admin_client, golden_images_namespace):
     yield from get_or_create_golden_image_data_source(
         admin_client=admin_client, golden_images_namespace=golden_images_namespace, os_dict=request.param["os_dict"]
+    )
+
+
+@pytest.fixture(scope="class")
+def golden_image_data_volume_template_for_test_scope_class(golden_image_data_source_for_test_scope_class):
+    return get_data_volume_template_dict_with_default_storage_class(
+        data_source=golden_image_data_source_for_test_scope_class
     )
 
 
@@ -342,20 +356,24 @@ def golden_image_data_source_for_test_scope_function(request, admin_client, gold
     )
 
 
+@pytest.fixture()
+def golden_image_data_volume_template_for_test_scope_function(golden_image_data_source_for_test_scope_function):
+    return get_data_volume_template_dict_with_default_storage_class(
+        data_source=golden_image_data_source_for_test_scope_function
+    )
+
+
 @pytest.fixture(scope="class")
 def vm_for_test_from_template_scope_class(
     request,
     unprivileged_client,
     namespace,
-    golden_image_data_source_for_test_scope_class,
+    golden_image_data_volume_template_for_test_scope_class,
 ):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_for_test_scope_class,
-        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
-            data_source=golden_image_data_source_for_test_scope_class
-        ),
+        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:
         yield vm

--- a/tests/virt/constants.py
+++ b/tests/virt/constants.py
@@ -1,5 +1,7 @@
 import bitmath
 
+from utilities.constants import Images
+
 VIRT_PROCESS_MEMORY_LIMITS = {
     "virt-launcher-monitor": bitmath.MiB(25),
     "virt-launcher": bitmath.MiB(100),
@@ -12,6 +14,12 @@ STRESS_CPU_MEM_IO_COMMAND = (
     "nohup stress-ng --vm {workers} --vm-bytes {memory} --vm-method all "
     "--verify -t {timeout} -v --hdd 1 --io 1 --vm-keep &> /dev/null &"
 )
+
+CIRROS_OS = {
+    "data_source": "cirros-dv",
+    "image_path": f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}",
+    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
+}
 
 
 # ACRQ


### PR DESCRIPTION
##### Short description:
update virt-cluster tests to utilize golden image
datasources instead of all the time downloading image from artifactory server

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-66577


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized test inputs to an os_dict payload and moved many tests to a data-source/data-volume-template driven VM/DV flow.
  * Added scoped golden-image data-source and vm-from-template fixtures; removed two older public fixtures.
  * Converted several tests to class-based structures, updated parameterizations, and added Windows 10 desktop tablet coverage.

* **Refactor**
  * Centralized golden-image provisioning and data-volume-template generation into shared utilities; removed inline legacy provisioning.

* **Constants**
  * Added a CIRROS_OS test constant for Cirros image parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->