### PR TITLE
Virt: Drop CNV-66366 as the win-2016 guest agent disconnected bug was fixed

### DIFF
--- a/tests/virt/cluster/common_templates/conftest.py
+++ b/tests/virt/cluster/common_templates/conftest.py
@@ -10,7 +10,6 @@ from tests.virt.cluster.common_templates.utils import (
     xfail_old_guest_agent_version,
 )
 from utilities.constants import REGEDIT_PROC_NAME
-from utilities.infra import is_jira_open
 from utilities.virt import (
     start_and_fetch_processid_on_linux_vm,
     start_and_fetch_processid_on_windows_vm,
@@ -176,9 +175,3 @@ def regedit_process_in_windows_os(matrix_windows_os_vm_from_template):
     return start_and_fetch_processid_on_windows_vm(
         vm=matrix_windows_os_vm_from_template, process_name=REGEDIT_PROC_NAME
     )
-
-
-@pytest.fixture()
-def xfail_guest_agent_on_win2016(windows_os_matrix__class__):
-    if "win-2016" in [*windows_os_matrix__class__][0] and is_jira_open(jira_id="CNV-66366"):
-        pytest.xfail(reason="Windows 2016 VM guest agent is running inside the VM but not visible from libvirt/VMI")

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -47,7 +47,6 @@ class TestCommonTemplatesWindows:
 
     @pytest.mark.sno
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::start_vm", depends=[f"{TESTS_CLASS_NAME}::create_vm"])
-    @pytest.mark.usefixtures("xfail_guest_agent_on_win2016")
     @pytest.mark.polarion("CNV-3785")
     def test_start_vm(self, matrix_windows_os_vm_from_template):
         """Test CNV common templates VM initiation"""


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified Windows Server 2016 guest agent test handling by removing a conditional expected-fail mechanism.
  * Updated a Windows VM startup test to run without the implicit xfail fixture.
  * No impact on product functionality; changes are limited to test behavior and stability.
* **Chores**
  * Cleaned up an unused test dependency to reduce noise and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->