### PR TITLE
Remove closed jira marker

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -52,7 +52,6 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.polarion("CNV-11125")
     @pytest.mark.ipv6
     @pytest.mark.single_nic
-    @pytest.mark.jira("CNV-58529", run=True)
     def test_ipv6_linux_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,
@@ -149,7 +148,6 @@ class TestConnectivityOVSBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11128")
     @pytest.mark.ipv6
-    @pytest.mark.jira("CNV-58529", run=True)
     def test_ipv6_ovs_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -91,7 +91,6 @@ def cloud_init_ipv6_network_data(dual_stack_network_data):
             marks=[
                 pytest.mark.polarion("CNV-11845"),
                 pytest.mark.ipv6,
-                pytest.mark.jira("CNV-58529", run=True),
             ],
         ),
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up metadata in IPv6 networking connectivity tests by removing outdated internal tracking tags.
  * Test logic, inputs, assertions, and coverage remain unchanged.
* **Chores**
  * No user-facing changes; functionality, performance, and compatibility are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->