### PR TITLE
Storage: remove skip_test_if_no_filesystem_sc fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2412,12 +2412,6 @@ def is_idms_cluster():
 
 
 @pytest.fixture(scope="session")
-def skip_test_if_no_filesystem_sc(storage_class_with_filesystem_volume_mode):
-    if not storage_class_with_filesystem_volume_mode:
-        pytest.skip("Skip the test: no Storage class with Filesystem volume mode")
-
-
-@pytest.fixture(scope="session")
 def available_storage_classes_names():
     return [[*sc][0] for sc in py_config["storage_class_matrix"]]
 

--- a/tests/observability/metrics/test_cdi_metrics.py
+++ b/tests/observability/metrics/test_cdi_metrics.py
@@ -8,7 +8,6 @@ from utilities.constants import CDI_OPERATOR
 
 @pytest.mark.polarion("CNV-10557")
 def test_kubevirt_cdi_clone_pods_high_restart(
-    skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,
     prometheus,
     zero_clone_dv_restart_count,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -294,7 +294,6 @@ def test_successful_snapshot_clone(
 @pytest.mark.polarion("CNV-5607")
 @pytest.mark.s390x
 def test_clone_from_fs_to_block_using_dv_template(
-    skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,
     unprivileged_client,
     namespace,
@@ -316,7 +315,6 @@ def test_clone_from_fs_to_block_using_dv_template(
 @pytest.mark.smoke()
 @pytest.mark.s390x
 def test_clone_from_block_to_fs_using_dv_template(
-    skip_test_if_no_filesystem_sc,
     skip_test_if_no_block_sc,
     unprivileged_client,
     namespace,

--- a/tests/storage/memory_dump/test_memory_dump.py
+++ b/tests/storage/memory_dump/test_memory_dump.py
@@ -30,7 +30,6 @@ from tests.storage.memory_dump.utils import wait_for_memory_dump_status_removed
     indirect=True,
 )
 def test_windows_memory_dump(
-    skip_test_if_no_filesystem_sc,
     namespace,
     windows_vm_for_memory_dump,
     pvc_for_windows_memory_dump,


### PR DESCRIPTION
##### Short description:
Remove skip_test_if_no_filesystem_sc fixture from the tests as redundant one. 
Every Kubernetes storage class supports Filesystem volume mode. Jira: https://issues.redhat.com/browse/CNV-69350 

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed conditional skips tied to filesystem storage availability across metrics, cloning, and memory dump tests.
  * Updated affected tests to run when applicable, improving coverage and reliability.
  * Streamlined test parameters for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->