### PR TITLE
net, service mesh: Unquarantine service mesh tests

### DIFF
--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -6,17 +6,12 @@ from tests.network.service_mesh.utils import (
     inbound_request,
     run_console_command,
 )
-from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 pytestmark = pytest.mark.service_mesh
 
 
 @pytest.mark.s390x
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: Failing tests, in debug; tracked in CNV-67824",
-    run=False,
-)
 class TestSMTrafficManagement:
     @pytest.mark.polarion("CNV-5782")
     @pytest.mark.single_nic
@@ -51,10 +46,6 @@ class TestSMTrafficManagement:
 
 
 @pytest.mark.s390x
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: Failing test, in debug; tracked in CNV-67824",
-    run=False,
-)
 class TestSMPeerAuthentication:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-5784")


### PR DESCRIPTION
Quarantine service mesh tests PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/1980

Service mesh tests can now be unquarantined and run in CI.
Service mesh tests debugged, fixes include pod image fix and OSSM regress to v3.0.4 in cnv-4.20 deployment.

Previously failing tests now pass after:
- Pod image fix on quay server: version curl request of pod image returned v2 instead of v1 due to wrong image in quay server: quay.io/openshift-cnv/qe-cnv-service-mesh-server-demo:v1.0
- Regress of OSSM to v3.0  in deployment due to deprecated vm annotation in OSSM v3.1 which did not support backward compatability 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled previously quarantined service mesh test suites (traffic management and peer authentication) so they now run in the standard pipeline.
  * Simplified test setup by removing quarantine markers, reducing silent test skips and improving confidence in service mesh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->