### PR TITLE
Storage: fix concurrent uploads test for s390x.

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -20,6 +20,14 @@ class Cirros:
 
 
 @dataclass
+class Alpine:
+    QCOW2_IMG: str | None = None
+    DIR: str = f"{BASE_IMAGES_DIR}/alpine-images"
+    DEFAULT_DV_SIZE: str = "1Gi"
+    DEFAULT_MEMORY_SIZE: str = "128M"
+
+
+@dataclass
 class Rhel:
     RHEL7_9_IMG: str | None = None
     RHEL8_0_IMG: str | None = None

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -298,6 +298,18 @@ def _upload_image(dv_name, namespace, storage_class, local_name, size=None):
 @pytest.mark.sno
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-2015")
+@pytest.mark.parametrize(
+    "upload_file_path",
+    [
+        pytest.param(
+            {
+                "remote_image_dir": Images.Alpine.DIR,
+                "remote_image_name": Images.Alpine.QCOW2_IMG,
+            },
+        ),
+    ],
+    indirect=True,
+)
 def test_successful_concurrent_uploads(
     upload_file_path,
     namespace,

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -25,6 +25,7 @@ from urllib3.exceptions import (
 
 from libs.infra.images import (
     BASE_IMAGES_DIR,
+    Alpine,
     Cdi,
     Centos,
     Cirros,
@@ -45,6 +46,7 @@ X86_64 = "x86_64"
 class ArchImages:
     class X86_64:  # noqa: N801
         BASE_CIRROS_NAME = "cirros-0.4.0-x86_64-disk"
+        BASE_ALPINE_NAME = "alpine-3.20.1-x86_64-disk"
         Cirros = Cirros(
             RAW_IMG=f"{BASE_CIRROS_NAME}.raw",
             RAW_IMG_GZ=f"{BASE_CIRROS_NAME}.raw.gz",
@@ -53,6 +55,10 @@ class ArchImages:
             QCOW2_IMG_GZ=f"{BASE_CIRROS_NAME}.qcow2.gz",
             QCOW2_IMG_XZ=f"{BASE_CIRROS_NAME}.qcow2.xz",
             DISK_DEMO="cirros-registry-disk-demo",
+        )
+
+        Alpine = Alpine(
+            QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
         )
 
         Rhel = Rhel(
@@ -97,7 +103,12 @@ class ArchImages:
         Cdi = Cdi(QCOW2_IMG="cirros-qcow2.img")
 
     class ARM64:
+        BASE_ALPINE_NAME = "alpine-3.20.1-aarch64-disk"
         Cirros = Cirros(RAW_IMG_XZ="cirros-0.4.0-aarch64-disk.raw.xz")
+
+        Alpine = Alpine(
+            QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
+        )
 
         Rhel = Rhel(
             RHEL9_5_IMG="rhel-95-aarch64.qcow2",
@@ -111,6 +122,7 @@ class ArchImages:
         Cdi = Cdi()
 
     class S390X:
+        BASE_ALPINE_NAME = "alpine-3.20.1-s390x-disk"
         Cirros = Cirros(
             # TODO: S390X does not support Cirros; this is a workaround until tests are moved to Fedora
             RAW_IMG="Fedora-Cloud-Base-Generic-41-1.4.s390x.raw",
@@ -123,6 +135,10 @@ class ArchImages:
             DIR=f"{BASE_IMAGES_DIR}/fedora-images",
             DEFAULT_DV_SIZE="10Gi",
             DEFAULT_MEMORY_SIZE="1Gi",
+        )
+
+        Alpine = Alpine(
+            QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
         )
 
         Rhel = Rhel(RHEL9_5_IMG="rhel-95-s390x.qcow2")


### PR DESCRIPTION
##### Short description:
The test_successful_concurrent_uploads is using the fedora qcow2 for s390x. The size of fedora is ~900mb and the test is timing out because it has to download the image from artifactory and create datavolumes concurrently.  The test is working fine in X86 because it is  using cirros which is ~12mb. I have replaced this test with alpine which will work on both x86 and s390x.  The alpine size ~ 80 mb. I have tested it on s390x and it is working fine.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Alpine VM images across architectures (new Alpine image variants available).

- **Tests**
  - Concurrent upload test now runs with Alpine image inputs to improve cross-platform coverage.

- **Chores**
  - Test data wiring updated to supply Alpine variants via fixtures; no public APIs or signatures changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->