### PR TITLE
Storage: replace skip_if_sc_volume_binding_mode_is_wffc fixture with immediate_matrix

### DIFF
--- a/tests/storage/cdi_upload/conftest.py
+++ b/tests/storage/cdi_upload/conftest.py
@@ -38,10 +38,10 @@ def download_specified_image(request, tmpdir_factory):
 
 
 @pytest.fixture()
-def uploaded_dv(
+def uploaded_dv_with_immediate_binding(
     request,
     namespace,
-    storage_class_name_scope_module,
+    storage_class_name_immediate_binding_scope_module,
     tmpdir,
 ):
     image_file = request.param.get("image_file")
@@ -52,7 +52,7 @@ def uploaded_dv(
         namespace=namespace.name,
         name=dv_name,
         size=request.param.get("dv_size"),
-        storage_class=storage_class_name_scope_module,
+        storage_class=storage_class_name_immediate_binding_scope_module,
         image_path=local_path,
         insecure=True,
     ) as res:

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -157,20 +157,20 @@ def test_virtctl_image_upload_with_ca(
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3724")
 def test_virtctl_image_upload_dv(
-    storage_class_matrix_immediate_matrix__module__,
-    download_image,
     namespace,
+    storage_class_name_immediate_binding_scope_module,
+    download_image,
 ):
     """
     Check that upload a local disk image to a newly created DataVolume
     """
-    dv_name = f"cnv-3724-{[*storage_class_matrix_immediate_matrix__module__][0]}"
+    dv_name = f"cnv-3724-{storage_class_name_immediate_binding_scope_module}"
     with virtctl_upload_dv(
         namespace=namespace.name,
         name=dv_name,
         size=DEFAULT_DV_SIZE,
         image_path=LOCAL_PATH,
-        storage_class=[*storage_class_matrix_immediate_matrix__module__][0],
+        storage_class=storage_class_name_immediate_binding_scope_module,
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)
@@ -436,10 +436,10 @@ def test_virtctl_image_upload_dv_with_exist_pvc(
     indirect=["uploaded_dv_with_immediate_binding"],
 )
 def test_successful_vm_from_uploaded_dv_windows(
-    uploaded_dv_with_immediate_binding,
     unprivileged_client,
-    vm_params,
     namespace,
+    uploaded_dv_with_immediate_binding,
+    vm_params,
 ):
     storage_utils.create_windows_vm_validate_guest_agent_info(
         dv=uploaded_dv_with_immediate_binding,

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -157,21 +157,20 @@ def test_virtctl_image_upload_with_ca(
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3724")
 def test_virtctl_image_upload_dv(
-    skip_if_sc_volume_binding_mode_is_wffc,
+    storage_class_matrix_immediate_matrix__module__,
     download_image,
     namespace,
-    storage_class_name_scope_module,
 ):
     """
     Check that upload a local disk image to a newly created DataVolume
     """
-    dv_name = f"cnv-3724-{storage_class_name_scope_module}"
+    dv_name = f"cnv-3724-{[*storage_class_matrix_immediate_matrix__module__][0]}"
     with virtctl_upload_dv(
         namespace=namespace.name,
         name=dv_name,
         size=DEFAULT_DV_SIZE,
         image_path=LOCAL_PATH,
-        storage_class=storage_class_name_scope_module,
+        storage_class=[*storage_class_matrix_immediate_matrix__module__][0],
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)
@@ -417,7 +416,7 @@ def test_virtctl_image_upload_dv_with_exist_pvc(
 
 @pytest.mark.tier3
 @pytest.mark.parametrize(
-    ("uploaded_dv", "vm_params"),
+    ("uploaded_dv_with_immediate_binding", "vm_params"),
     [
         pytest.param(
             {
@@ -434,17 +433,16 @@ def test_virtctl_image_upload_dv_with_exist_pvc(
             marks=(pytest.mark.polarion("CNV-3410")),
         ),
     ],
-    indirect=["uploaded_dv"],
+    indirect=["uploaded_dv_with_immediate_binding"],
 )
 def test_successful_vm_from_uploaded_dv_windows(
-    skip_if_sc_volume_binding_mode_is_wffc,
-    uploaded_dv,
+    uploaded_dv_with_immediate_binding,
     unprivileged_client,
     vm_params,
     namespace,
 ):
     storage_utils.create_windows_vm_validate_guest_agent_info(
-        dv=uploaded_dv,
+        dv=uploaded_dv_with_immediate_binding,
         namespace=namespace,
         unprivileged_client=unprivileged_client,
         vm_params=vm_params,

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -401,12 +401,6 @@ def hpp_daemonset_scope_module(hco_namespace, hpp_cr_suffix_scope_module):
 
 
 @pytest.fixture()
-def skip_if_sc_volume_binding_mode_is_wffc(storage_class_name_scope_module):
-    if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_module):
-        pytest.skip("Test does not support storage class with WaitForFirstConsumer binding mode")
-
-
-@pytest.fixture()
 def cirros_vm_name(request):
     return request.param["vm_name"]
 
@@ -581,6 +575,11 @@ def storage_class_name_scope_function(storage_class_matrix__function__):
 @pytest.fixture(scope="module")
 def storage_class_name_scope_module(storage_class_matrix__module__):
     return [*storage_class_matrix__module__][0]
+
+
+@pytest.fixture(scope="module")
+def storage_class_name_immediate_binding_scope_module(storage_class_matrix_immediate_matrix__module__):
+    return [*storage_class_matrix_immediate_matrix__module__][0]
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -186,10 +186,10 @@ def test_dv_delete_from_vm(
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3667")
 def test_upload_after_certs_renewal(
-    storage_class_matrix_immediate_matrix__module__,
+    namespace,
+    storage_class_name_immediate_binding_scope_module,
     refresh_cdi_certificates,
     download_image,
-    namespace,
 ):
     """
     Check that CDI can do upload operation after certs get refreshed
@@ -200,7 +200,7 @@ def test_upload_after_certs_renewal(
         name=dv_name,
         size="1Gi",
         image_path=LOCAL_QCOW2_IMG_PATH,
-        storage_class=[*storage_class_matrix_immediate_matrix__module__][0],
+        storage_class=storage_class_name_immediate_binding_scope_module,
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)
@@ -250,10 +250,9 @@ def test_import_clone_after_certs_renewal(
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3977")
 def test_upload_after_validate_aggregated_api_cert(
-    storage_class_matrix_immediate_matrix__module__,
-    valid_aggregated_api_client_cert,
     namespace,
-    storage_class_name_scope_module,
+    storage_class_name_immediate_binding_scope_module,
+    valid_aggregated_api_client_cert,
     download_image,
 ):
     """
@@ -265,7 +264,7 @@ def test_upload_after_validate_aggregated_api_cert(
         name=dv_name,
         size="1Gi",
         image_path=LOCAL_QCOW2_IMG_PATH,
-        storage_class=[*storage_class_matrix_immediate_matrix__module__][0],
+        storage_class=storage_class_name_immediate_binding_scope_module,
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -186,11 +186,10 @@ def test_dv_delete_from_vm(
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3667")
 def test_upload_after_certs_renewal(
-    skip_if_sc_volume_binding_mode_is_wffc,
+    storage_class_matrix_immediate_matrix__module__,
     refresh_cdi_certificates,
     download_image,
     namespace,
-    storage_class_name_scope_module,
 ):
     """
     Check that CDI can do upload operation after certs get refreshed
@@ -201,7 +200,7 @@ def test_upload_after_certs_renewal(
         name=dv_name,
         size="1Gi",
         image_path=LOCAL_QCOW2_IMG_PATH,
-        storage_class=storage_class_name_scope_module,
+        storage_class=[*storage_class_matrix_immediate_matrix__module__][0],
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)
@@ -251,7 +250,7 @@ def test_import_clone_after_certs_renewal(
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3977")
 def test_upload_after_validate_aggregated_api_cert(
-    skip_if_sc_volume_binding_mode_is_wffc,
+    storage_class_matrix_immediate_matrix__module__,
     valid_aggregated_api_client_cert,
     namespace,
     storage_class_name_scope_module,
@@ -266,7 +265,7 @@ def test_upload_after_validate_aggregated_api_cert(
         name=dv_name,
         size="1Gi",
         image_path=LOCAL_QCOW2_IMG_PATH,
-        storage_class=storage_class_name_scope_module,
+        storage_class=[*storage_class_matrix_immediate_matrix__module__][0],
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)

--- a/utilities/pytest_matrix_utils.py
+++ b/utilities/pytest_matrix_utils.py
@@ -68,6 +68,15 @@ def wffc_matrix(matrix):
     return matrix_to_return
 
 
+def immediate_matrix(matrix):
+    matrix_to_return = []
+    for storage_class in matrix:
+        storage_class_name = [*storage_class][0]
+        if storage_class[storage_class_name]["wffc"] is False:
+            matrix_to_return.append(storage_class)
+    return matrix_to_return
+
+
 @cache
 def _cache_admin_client() -> DynamicClient:
     """Get admin_client once and reuse it

--- a/utilities/unittests/test_pytest_matrix_utils.py
+++ b/utilities/unittests/test_pytest_matrix_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from utilities.pytest_matrix_utils import (  # noqa: E402
     hpp_matrix,
+    immediate_matrix,
     online_resize_matrix,
     snapshot_matrix,
     wffc_matrix,
@@ -200,6 +201,44 @@ class TestWffcMatrix:
         ]
 
         result = wffc_matrix(matrix)
+
+        assert result == []
+
+
+class TestImmediateMatrix:
+    """Test cases for immediate_matrix function"""
+
+    def test_immediate_matrix_with_immediate_enabled(self):
+        """Test immediate_matrix filters storage classes with immediate enabled (WFFC disabled)"""
+        matrix = [
+            {"sc-with-immediate": {"wffc": False, "other": "value"}},
+            {"sc-without-immediate": {"wffc": True, "other": "value"}},
+            {"sc-with-immediate-2": {"wffc": False, "other": "value"}},
+        ]
+
+        result = immediate_matrix(matrix)
+
+        assert len(result) == 2
+        assert {"sc-with-immediate": {"wffc": False, "other": "value"}} in result
+        assert {"sc-with-immediate-2": {"wffc": False, "other": "value"}} in result
+        assert {"sc-without-immediate": {"wffc": True, "other": "value"}} not in result
+
+    def test_immediate_matrix_empty_matrix(self):
+        """Test immediate_matrix with empty matrix"""
+        matrix = []
+
+        result = immediate_matrix(matrix)
+
+        assert result == []
+
+    def test_immediate_matrix_no_immediate_enabled(self):
+        """Test immediate_matrix with no WFFC enabled storage classes"""
+        matrix = [
+            {"sc-without-immediate-1": {"wffc": True, "other": "value"}},
+            {"sc-without-immediate-2": {"wffc": True, "other": "value"}},
+        ]
+
+        result = immediate_matrix(matrix)
 
         assert result == []
 


### PR DESCRIPTION
##### Short description:

In order to get rid of skipped tests, the `skip_if_sc_volume_binding_mode_is_wffc` fixture has been replaced with `immediate_matrix`.

jira: https://issues.redhat.com/browse/CNV-69475

##### More details:
- Created a matrix of immediate volume binding mode `def immediate_matrix(matrix)`
- Added unit tests for `def immediate_matrix(matrix)`
- replaced `skip_if_sc_volume_binding_mode_is_wffc` fixture with `immediate_matrix`

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Standardized storage upload tests to use an immediate-binding storage class matrix, replacing skip-based gating for more consistent execution.
  - Introduced a utility to filter immediate-binding storage classes and added comprehensive unit tests to validate its behavior.
  - Streamlined test parameterization and fixtures to align with immediate-binding scenarios across relevant suites.
  - Updated Windows VM-from-upload flow to use the new immediate-binding upload path for consistency.
  - Removed legacy skip logic tied to deferred binding modes to reduce unnecessary test skips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->