### PR TITLE
Add s390x test markers to IUO install tests

### DIFF
--- a/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
+++ b/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
@@ -31,7 +31,7 @@ CNV_INSTALLATION_TEST = "test_cnv_installation"
 CNV_ALERT_CLEANUP_TEST = "test_cnv_installation_alert_cleanup"
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.install]
+pytestmark = [pytest.mark.install, pytest.mark.s390x]
 
 
 @pytest.mark.polarion("CNV-10072")


### PR DESCRIPTION
##### Short description:

This change adds the @pytest.mark.s390x marker to iuo-install tests. The marker is applied to annotate tests for the s390x architecture, with no modifications to test logic, parameters, or control flow.

##### More details:

The marker helps identify tests relevant for the s390x environment. This is useful for running architecture-specific test suites as needed.

##### What this PR does / why we need it:

This PR adds s390x architecture-specific markers to identify tests that are relevant to the s390x platform.

##### Which issue(s) this PR fixes:

None

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test selection to include s390x architecture for OpenShift Virtualization install/upgrade scenarios.
  * Ensures relevant test suites run on s390x CI environments without altering test logic or behavior.
  * No impact on product functionality, performance, or UI; change only affects test targeting.
  * Improves cross-platform CI validation and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->