### PR TITLE
CherryPicked: [cnv-4.18] Remove cdi metrics recording rules tests

### DIFF
--- a/tests/observability/metrics/test_cdi_metrics.py
+++ b/tests/observability/metrics/test_cdi_metrics.py
@@ -1,35 +1,6 @@
 import pytest
 
 from tests.observability.metrics.utils import expected_metric_labels_and_values
-from tests.observability.utils import validate_metrics_value
-from utilities.constants import CDI_OPERATOR
-
-
-@pytest.mark.polarion("CNV-10557")
-def test_kubevirt_cdi_clone_pods_high_restart(
-    skip_test_if_no_block_sc,
-    prometheus,
-    zero_clone_dv_restart_count,
-    restarted_cdi_dv_clone,
-):
-    validate_metrics_value(
-        prometheus=prometheus,
-        expected_value="1",
-        metric_name="kubevirt_cdi_clone_pods_high_restart",
-    )
-
-
-@pytest.mark.polarion("CNV-10717")
-def test_kubevirt_cdi_upload_pods_high_restart(
-    prometheus,
-    zero_upload_dv_restart_count,
-    restarted_cdi_dv_upload,
-):
-    validate_metrics_value(
-        prometheus=prometheus,
-        expected_value="1",
-        metric_name="kubevirt_cdi_upload_pods_high_restart",
-    )
 
 
 @pytest.mark.polarion("CNV-11744")
@@ -39,27 +10,4 @@ def test_metric_kubevirt_cdi_storageprofile_info(prometheus, storage_class_label
         metric_name=f"kubevirt_cdi_storageprofile_info"
         f"{{storageclass='{storage_class_labels_for_testing['storageclass']}'}}",
         expected_labels_and_values=storage_class_labels_for_testing,
-    )
-
-
-@pytest.mark.parametrize(
-    "scaled_deployment",
-    [
-        pytest.param(
-            {"deployment_name": CDI_OPERATOR, "replicas": 0},
-            marks=(pytest.mark.polarion("CNV-11722")),
-            id="Test_kubevirt_cdi_operator_up",
-        ),
-    ],
-    indirect=True,
-)
-def test_kubevirt_cdi_operator_up(
-    prometheus,
-    disabled_virt_operator,
-    scaled_deployment,
-):
-    validate_metrics_value(
-        prometheus=prometheus,
-        expected_value="0",
-        metric_name="kubevirt_cdi_operator_up",
     )

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -6,13 +6,11 @@ import urllib
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.datavolume import DataVolume
 from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_utilities.monitoring import Prometheus
-from pyhelper_utils.shell import run_command, run_ssh_commands
+from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.observability.constants import KUBEVIRT_VIRT_OPERATOR_READY
@@ -37,9 +35,7 @@ from utilities.constants import (
     USED,
     VIRT_HANDLER,
 )
-from utilities.infra import get_pod_by_name_prefix
 from utilities.monitoring import get_metrics_value
-from utilities.storage import wait_for_dv_expected_restart_count
 from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
@@ -312,29 +308,6 @@ def get_resource_object(
                 client=admin_client,
                 name=resource_name,
             )
-
-
-def restart_cdi_worker_pod(unprivileged_client: DynamicClient, dv: DataVolume, pod_prefix: str) -> None:
-    initial_dv_restartcount = dv.instance.get("status", {}).get("restartCount", 0)
-    for iteration in range(TOTAL_4_ITERATIONS - initial_dv_restartcount):
-        pod = get_pod_by_name_prefix(
-            dyn_client=unprivileged_client,
-            pod_prefix=pod_prefix,
-            namespace=dv.namespace,
-        )
-        dv_restartcount = dv.instance.get("status", {}).get("restartCount", 0)
-        run_command(
-            command=shlex.split(f"oc exec -n {dv.namespace} {pod.name} -- kill 1"),
-            check=False,
-        )
-        wait_for_dv_expected_restart_count(dv=dv, expected_result=dv_restartcount + 1)
-
-
-def fail_if_not_zero_restartcount(dv: DataVolume) -> None:
-    restartcount = dv.instance.get("status", {}).get("restartCount", 0)
-
-    if restartcount != 0:
-        pytest.fail(f"dv {dv.name} restartcount is not zero,\n actual restartcount: {restartcount}")
 
 
 def assert_virtctl_version_equal_metric_output(

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -972,23 +972,6 @@ def get_storage_class_with_specified_volume_mode(volume_mode, sc_names):
     LOGGER.error(f"No {sc_with_volume_mode} among {sc_names}")
 
 
-def wait_for_dv_expected_restart_count(dv, expected_result):
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_3MIN,
-            sleep=TIMEOUT_20SEC,
-            func=lambda: dv.instance.get("status", {}).get("restartCount"),
-        ):
-            if sample and sample >= expected_result:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(
-            f"error while restarting dv: {dv.name} ,expected restartCount: {expected_result}, "
-            f"actual restartCount: {sample}"
-        )
-        raise
-
-
 @contextmanager
 def create_vm_from_dv(
     dv,


### PR DESCRIPTION
##### Short description:
Removing tests for metrics
kubevirt_cdi_clone_pods_high_restart
kubevirt_cdi_upload_pods_high_restart
kubevirt_cdi_operator_up
kubevirt_cdi_import_pods_high_restart

These metrics is recording rules that rely on
kubernetes metrics and not cnv.
##### More details:
Original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/2025
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-69678
