### PR TITLE
WIP:  Update data_volume_template_with_source_ref_dict

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -156,7 +156,10 @@ def vm_from_custom_data_import_cron(custom_data_source_scope_function, namespace
         namespace=namespace.name,
         client=unprivileged_client,
         memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-        data_volume_template=data_volume_template_with_source_ref_dict(data_source=custom_data_source_scope_function),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=custom_data_source_scope_function,
+            storage_class=custom_data_source_scope_function.source.instance.to_dict()["spec"].get("storageClassName"),
+        ),
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -133,7 +133,10 @@ def vm_with_instancetypes_for_upgrade(
         os_flavor=OS_FLAVOR_RHEL,
         vm_instance_type=vm_cluster_instancetype_for_upgrade,
         vm_preference=vm_cluster_preference_for_upgrade,
-        data_volume_template=data_volume_template_with_source_ref_dict(data_source=datasources_for_upgrade[0]),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=datasources_for_upgrade[0],
+            storage_class=datasources_for_upgrade[0].source.instance.to_dict()["spec"].get("storageClassName"),
+        ),
     ) as vm:
         yield vm
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -571,7 +571,7 @@ def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
         namespace=data_source.namespace,
         size=source_spec_dict.get("resources", {}).get("requests", {}).get("storage")
         or source_dict.get("status", {}).get("restoreSize"),
-        storage_class=storage_class or source_spec_dict.get("storageClassName"),
+        storage_class=storage_class,
         api_name="storage",
         source_ref={
             "kind": data_source.kind,


### PR DESCRIPTION
##### Short description:
Update data_volume_template_with_source_ref_dict so you can set an empty storage class

##### More details:
 - Previously data_volume_template_with_source_ref_dict would always set the field `storageClassName`, this prevent from us from running test cases where there is storage class defined.
This PR update the function so it is possible to define `None` in the storage class
 - removes the QUARANTINED state of test_vm_from_data_source_missing_default_storage_class
 - Change order of fixtures, this way the access_mode field for the VM object can be set before the default storage class is removed, thus preventing an error in `get_storage_configuration`

##### What this PR does / why we need it:
Fix quarantined test test_vm_from_data_source_missing_default_storage_class

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68779

BLOCKED BY: https://issues.redhat.com/browse/CNV-74930


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized timeout behavior across tests to a consistent 1-minute timeout and improved timeout assertions and error detection.
  * Removed a previously expected test failure, replacing it with explicit timeout-based validation.

* **Chores**
  * Data volume templates and test helpers now accept and propagate an explicit storage class parameter.
  * Template logic no longer silently falls back to the source's storage class; provided value is used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->