### PR TITLE
Exclude legacy Windows preferences from common VM preference test

### DIFF
--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -88,7 +88,10 @@ class TestCommonVmPreference:
     @pytest.mark.polarion("CNV-9894")
     def test_common_vm_preference_windows(self, unprivileged_client, namespace):
         run_general_vm_preferences(
-            client=unprivileged_client, namespace=namespace, preferences=VM_PREFERENCES_LIST["windows"]
+            client=unprivileged_client,
+            namespace=namespace,
+            # drop legacy preferences with pcihole
+            preferences=[pref for pref in VM_PREFERENCES_LIST["windows"] if pref not in {"windows.2k3", "windows.xp"}],
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The test now filters out windows.2k3 and windows.xp since they are legacy preferences.

##### Short description:
Exclude legacy Windows preferences  windows.2k3 and windows.xp from tests with modern images which causes long delays and prevents teardown from completing.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

