### PR TITLE
Attempt to fix IP assignment flakiness

### DIFF
--- a/utilities/network.py
+++ b/utilities/network.py
@@ -37,8 +37,8 @@ from utilities.constants import (
     MTU_9000,
     OVS_BRIDGE,
     SRIOV,
-    TIMEOUT_2MIN,
     TIMEOUT_3MIN,
+    TIMEOUT_4MIN,
     TIMEOUT_8MIN,
     TIMEOUT_90SEC,
     WORKERS_TYPE,
@@ -498,7 +498,7 @@ def get_vmi_ip_v4_by_name(vm, name):
         utilities.virt.wait_for_vm_interfaces(vmi=vmi)
         return _extract_interface_ips()
 
-    sampler = TimeoutSampler(wait_timeout=TIMEOUT_2MIN, sleep=1, func=_get_interface_ips)
+    sampler = TimeoutSampler(wait_timeout=TIMEOUT_4MIN, sleep=1, func=_get_interface_ips)
     try:
         for ip_addresses in sampler:
             for ip_address in ip_addresses:


### PR DESCRIPTION
We occasionally see network tests failing on setup due to IP not assigned to an interface during the grace timeout we grant to it.
I tried debugging the logs in such failure, but didn't find any error or info regarding that interface - neither in the guest, the VMI or the pod. Therefore it seems that it might be worth waiting a bit more for the IP to get updated. Another reason is that if the problem is not with a insufficient timeout, then we will keep hitting this failure, which will bring to the conclusion that the problem is somewhere else, thus requires further debugging.
