### PR TITLE
[CNV-66017]skip log files that were rotated on the OCP nodes

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1072,6 +1072,9 @@ def get_node_audit_log_entries(log, node, log_entry):
     ).splitlines()
     has_errors = any(line.startswith("error:") for line in lines)
     if has_errors:
+        if any(line.startswith("404 page not found") for line in lines):
+            LOGGER.warning(f"Skipping {log} check as it was rotated:\n{lines}")
+            return True, []
         LOGGER.warning(f"oc command failed for node {node}, log {log}:\n{lines}")
         raise RuntimeError
     return True, lines


### PR DESCRIPTION
##### Short description:

As a continuation of the work done in https://github.com/RedHatQE/openshift-virtualization-tests/pull/1506, add graceful handling for audit logs that have been rotated. It will return empty results to allow processing to continue when logs are unavailable due to rotation.

##### More details:
Observed on CI.

##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-66017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of audit log processing: when logs show errors alongside “404 page not found” entries (indicative of rotation), the system now skips processing and logs a warning instead of failing.
  * Users should see fewer false alerts and smoother audit runs.
  * No changes to workflows or settings required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->