### PR TITLE
Fix the valid_cdi_certificate fn to fetch utc time instead of localtime.

### DIFF
--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -7,7 +7,6 @@ Automatic refresh of CDI certificates test suite
 import datetime
 import logging
 import subprocess
-import time
 
 import pytest
 from ocp_resources.cdi import CDI
@@ -83,14 +82,11 @@ def valid_cdi_certificates(secrets):
                 LOGGER.info(f"Checking {cdi_secret}...")
 
                 start = secret.certificate_not_before
-                start_timestamp = time.mktime(time.strptime(start, RFC3339_FORMAT))
-
                 end = secret.certificate_not_after
-                end_timestamp = time.mktime(time.strptime(end, RFC3339_FORMAT))
-
-                current_time = datetime.datetime.now().strftime(RFC3339_FORMAT)
-                current_timestamp = time.mktime(time.strptime(current_time, RFC3339_FORMAT))
-                assert start_timestamp <= current_timestamp <= end_timestamp, f"Certificate of {cdi_secret} expired"
+                start_dt = datetime.datetime.strptime(start, RFC3339_FORMAT).replace(tzinfo=datetime.timezone.utc)
+                end_dt = datetime.datetime.strptime(end, RFC3339_FORMAT).replace(tzinfo=datetime.timezone.utc)
+                now_dt = datetime.datetime.now(datetime.timezone.utc)
+                assert start_dt <= now_dt <= end_dt, f"Certificate of {cdi_secret} not valid at current time"
 
 
 @pytest.fixture()


### PR DESCRIPTION
##### Short description:
The Current implementation of valid_cdi_certificate assumes the local time on the server where we run the tests is utc. But the timezone can be different in machine we are running the tests. So I have changed the function to use utc timezone as the certificate before and after times are in utc.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected certificate validity checks to use timezone-aware UTC comparisons, avoiding incorrect expired/not-yet-valid results across time zones.

* **Tests**
  * Updated tests to use UTC-aware datetime parsing and comparisons for consistent, reliable validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->