### PR TITLE
Update rhel and fedora images for s390x.

### DIFF
--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -15,8 +15,14 @@ global config
 utilities.constants.OS_FLAVOR_CIRROS = "fedora"
 EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR] = f"rhel.9.{S390X}"
 
-rhel_os_matrix = generate_os_matrix_dict(os_name="rhel", supported_operating_systems=["rhel-9-5"])
-fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating_systems=["fedora-41"])
+rhel_os_matrix = generate_os_matrix_dict(
+    os_name="rhel",
+    supported_operating_systems=[
+        "rhel-8-10",
+        "rhel-9-6",
+    ],
+)
+fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating_systems=["fedora-42"])
 centos_os_matrix = generate_os_matrix_dict(os_name="centos", supported_operating_systems=["centos-stream-9"])
 
 instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -141,15 +141,22 @@ class ArchImages:
             QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
         )
 
-        Rhel = Rhel(RHEL9_5_IMG="rhel-95-s390x.qcow2")
-        Rhel.LATEST_RELEASE_STR = Rhel.RHEL9_5_IMG
+        Rhel = Rhel(
+            RHEL8_0_IMG="rhel-82-s390x.qcow2",
+            RHEL8_9_IMG="rhel-89-s390x.qcow2",
+            RHEL8_10_IMG="rhel-810-s390x.qcow2",
+            RHEL9_3_IMG="rhel-93-s390x.qcow2",
+            RHEL9_4_IMG="rhel-94-s390x.qcow2",
+            RHEL9_6_IMG="rhel-96-s390x.qcow2",
+        )
+        Rhel.LATEST_RELEASE_STR = Rhel.RHEL9_6_IMG
 
         Fedora = Fedora(
-            FEDORA41_IMG="Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2",
+            FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.s390x.qcow2",
             FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41-s390x",
             DISK_DEMO="fedora-cloud-registry-disk-demo",
         )
-        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA41_IMG
+        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG
 
         Centos = Centos(CENTOS_STREAM_9_IMG="CentOS-Stream-GenericCloud-9-latest.s390x.qcow2")
         Centos.LATEST_RELEASE_STR = Centos.CENTOS_STREAM_9_IMG


### PR DESCRIPTION
##### Short description:
Updated rhel and fedora images for s390x.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded s390x OS image support: added multiple RHEL 8/9 variants and updated Fedora to 42. Defaults now target RHEL 9.6 and Fedora 42 on s390x for improved compatibility and coverage.

- Tests
  - Updated OS matrices to align with new s390x coverage, including RHEL 8.10/9.6 and Fedora 42, ensuring CI reflects current supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->