### PR TITLE
Fix kubevirt_virt_operator_ready test flakiness

### DIFF
--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -101,9 +101,10 @@ def virt_operator_deployment(hco_namespace):
 
 @pytest.fixture(scope="module")
 def initial_virt_operator_replicas(prometheus, virt_operator_deployment, hco_namespace):
-    virt_operator_deployment_initial_replicas = str(virt_operator_deployment.instance.status.replicas)
+    virt_operator_deployment.wait_for_replicas()
+    virt_operator_deployment_initial_replicas = virt_operator_deployment.instance.status.replicas
     assert virt_operator_deployment_initial_replicas, f"Not replicas found for {VIRT_OPERATOR}"
-    return virt_operator_deployment_initial_replicas
+    return str(virt_operator_deployment_initial_replicas)
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### Short description:
The test failing at the setup once in a while,
this happen because None passed as expected value
when not needed, added validation that virt_operator has replicas before proceeding.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-69870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of observability tests by verifying operator replicas reach the desired count before assertions, reducing intermittent failures.
  * Standardized replica count handling post-verification to ensure non-empty values and align with expected test inputs.
  * Results in more deterministic CI runs and clearer failure signals when replica states are unmet, aiding faster triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->