### PR TITLE
net: Update reviewers list

### DIFF
--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -6,3 +6,4 @@ reviewers:
   - Anatw
   - EdDev
   - servolkov
+  - azhivovk


### PR DESCRIPTION
Asia Khromov has joined the CNV Network team and should be in the list of reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated code ownership reviewers for network-related test areas.
  - No functional or UI changes.
  - No impact on performance or user workflows.
  - Internal process update only; end-users do not need to take any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->