### PR TITLE
net,bgp: improve sanity check

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -326,7 +326,7 @@ def network_sanity(
         EXTERNAL_FRR_STATIC_IPV4: reserved IP in CIDR format for the external FRR pod inside
                                   PRIMARY_NODE_NETWORK_VLAN_TAG network.
         """
-        if any(test.get_closest_marker("bgp") for test in collected_tests):
+        if any(test.get_closest_marker("bgp") and not test.get_closest_marker("xfail") for test in collected_tests):
             LOGGER.info("Verifying if the cluster supports running BGP tests...")
             required_env_vars = [
                 "PRIMARY_NODE_NETWORK_VLAN_TAG",


### PR DESCRIPTION
##### Short description: 
We don't want to collect any BGP tests and check for the network tests sanity while the infra is not ready for BGP.  Test quarantining is not enough: `_verify_bgp_env_vars()` is run anyway, and this might fail the whole test run. We need to prevent it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Optimized BGP-related test prechecks to run only when there’s at least one non-expected-failure BGP test. Skips environment validation for BGP tests marked as expected to fail, reducing unnecessary setup and noise. This streamlines CI, lowers false negatives, and improves developer feedback loops, while preserving behavior for valid BGP tests and all non-BGP tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->