### PR TITLE
tests, net, sanity: Add IPv6 family stack validation

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -224,6 +224,7 @@ def network_sanity(
     network_overhead,
     sriov_workers,
     ipv4_supported_cluster,
+    ipv6_supported_cluster,
     conformance_tests,
 ):
     """
@@ -310,13 +311,13 @@ def network_sanity(
                     f"has {len(sriov_workers)} SRIOV-capable worker nodes"
                 )
 
-    def _verify_ipv4():
-        if any(test.get_closest_marker("ipv4") for test in collected_tests):
-            LOGGER.info("Verifying if the cluster supports running IPV4 tests...")
-            if not ipv4_supported_cluster:
-                failure_msgs.append("IPv4 is not supported in this cluster")
+    def _verify_ip_family(family, is_supported_in_cluster):
+        if any(test.get_closest_marker(family) for test in collected_tests):
+            LOGGER.info(f"Verifying if the cluster supports running {family} tests...")
+            if not is_supported_in_cluster:
+                failure_msgs.append(f"{family} is not supported in this cluster")
             else:
-                LOGGER.info("Validated network lane is running against an IPV4 supported cluster")
+                LOGGER.info(f"Validated network lane is running against an {family} supported cluster")
 
     def _verify_bgp_env_vars():
         """Verify if the cluster supports running BGP tests.
@@ -343,7 +344,8 @@ def network_sanity(
     _verify_service_mesh()
     _verify_jumbo_frame()
     _verify_sriov()
-    _verify_ipv4()
+    _verify_ip_family(family="ipv4", is_supported_in_cluster=ipv4_supported_cluster)
+    _verify_ip_family(family="ipv6", is_supported_in_cluster=ipv6_supported_cluster)
     _verify_bgp_env_vars()
 
     if failure_msgs:


### PR DESCRIPTION
##### What this PR does / why we need it:

Tests which are marked with the `ipv6` marker are expecting the cluster to support IPv6. If it does not support IPv6, the infra is considered incorrect and therefore no tests should execute.

This change refactors the IPv4 sanity check and extends it to cover IPv6 as well.

Follow up changes should convert usages of
`fail_if_not_ipv6_supported_cluster` to a test marker.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Expanded network sanity checks to cover both IPv4 and IPv6 support.
  - Added per-family cluster support detection for each IP family.
  - Improved validation messages and logs to clearly indicate which IP family is being tested.

- Refactor
  - Consolidated IP-family verification into a single, family-agnostic flow to reduce duplication and simplify maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->