### PR TITLE
CherryPicked: [cnv-4.18] Changed virt-launcher usage in network metrics

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -228,11 +228,7 @@ def generated_network_traffic(vm_for_test):
 
 @pytest.fixture(scope="class")
 def vm_for_test_interface_name(vm_for_test):
-    interface_name = vm_for_test.privileged_vmi.virt_launcher_pod.execute(
-        command=shlex.split("bash -c \"virsh domiflist 1 | grep ethernet | awk '{print $1}'\"")
-    )
-    assert interface_name, f"Interface not found for vm {vm_for_test.name}"
-    return interface_name
+    return vm_for_test.vmi.interfaces[0].interfaceName
 
 
 @pytest.fixture()


### PR DESCRIPTION
##### Short description:
Change of the implementation of fixtures in
network metrics that used virt-launcher
under test class TestVmiNetworkMetrics
##### More details:
Original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/1822
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-69979
