### PR TITLE
fix the get_resize_count fn to work with fedora vms.

### DIFF
--- a/tests/storage/test_online_resize.py
+++ b/tests/storage/test_online_resize.py
@@ -106,7 +106,7 @@ def expand_pvc(dv, size_change):
 
 
 def get_resize_count(vm):
-    commands = shlex.split("dmesg | grep -c 'new size' || true")
+    commands = shlex.split(f"{'sudo' if vm.os_flavor == 'fedora' else ''} dmesg | grep -c 'new size' || true")
     return int(run_ssh_commands(host=vm.ssh_exec, commands=commands)[0])
 
 


### PR DESCRIPTION
##### Short description:
The Test_online_resize tests are failing for s390x. The reason is the below
```
File "/root/openshift-virtualization-tests/.venv/lib/python3.12/site-packages/pyhelper_utils/shell.py", line 123, in run_ssh_commands
    raise CommandExecFailed(name=" ".join(cmd), err=err)
pyhelper_utils.exceptions.CommandExecFailed: Command: dmesg - exec failed. Error: dmesg: read kernel buffer failed: Operation not permitted
```
Since s390x is using fedora we have to execute the dmesg with sudo. After adding the sudo the tests are passing.


This pr depends on the changes from the https://github.com/RedHatQE/openshift-virtualization-tests/pull/2139
Once the 2139 gets merged. Then only this pr can be merged.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of online resize tests by running system log checks with elevated privileges automatically on Fedora-based images when needed.
  * Reduces CI and developer flakiness and improves cross-distro consistency.
  * No user-facing functionality or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->