### PR TITLE
[Upgrade] Align EUS upgrade with additional channels

### DIFF
--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -340,10 +340,7 @@ def default_workload_update_strategy(hyperconverged_resource_scope_session):
 
 @pytest.fixture()
 def eus_paused_worker_mcp(
-    workers,
     worker_machine_config_pools,
-    worker_machine_config_pools_conditions,
-    eus_applied_all_icsp,
 ):
     LOGGER.info("Pausing worker MCP updates before starting EUS upgrade.")
     update_mcp_paused_spec(mcp=worker_machine_config_pools)
@@ -488,7 +485,7 @@ def triggered_non_eus_to_target_eus_ocp_upgrade(eus_ocp_image_urls):
 @pytest.fixture()
 def source_eus_to_non_eus_ocp_upgraded(
     admin_client,
-    masters,
+    control_plane_nodes,
     master_machine_config_pools,
     ocp_version_eus_to_non_eus_from_image_url,
     triggered_source_eus_to_non_eus_ocp_upgrade,
@@ -498,14 +495,14 @@ def source_eus_to_non_eus_ocp_upgraded(
         machine_config_pools_list=master_machine_config_pools,
         target_ocp_version=ocp_version_eus_to_non_eus_from_image_url,
         initial_mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=master_machine_config_pools),
-        nodes=masters,
+        nodes=control_plane_nodes,
     )
 
 
 @pytest.fixture()
 def non_eus_to_target_eus_ocp_upgraded(
     admin_client,
-    masters,
+    control_plane_nodes,
     master_machine_config_pools,
     ocp_version_non_eus_to_eus_from_image_url,
     triggered_non_eus_to_target_eus_ocp_upgrade,
@@ -515,7 +512,7 @@ def non_eus_to_target_eus_ocp_upgraded(
         machine_config_pools_list=master_machine_config_pools,
         target_ocp_version=ocp_version_non_eus_to_eus_from_image_url,
         initial_mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=master_machine_config_pools),
-        nodes=masters,
+        nodes=control_plane_nodes,
     )
 
 

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -18,7 +18,7 @@ from tests.install_upgrade_operators.product_upgrade.utils import (
     get_iib_images_of_cnv_versions,
     get_nodes_labels,
     get_nodes_taints,
-    get_shortest_upgrade_path,
+    get_shortest_upgrade_path_info,
     perform_cnv_upgrade,
     run_ocp_upgrade_command,
     set_workload_update_methods_hco,
@@ -31,7 +31,7 @@ from tests.install_upgrade_operators.product_upgrade.utils import (
 )
 from tests.install_upgrade_operators.utils import wait_for_operator_condition
 from tests.upgrade_params import EUS
-from utilities.constants import HCO_CATALOG_SOURCE, HOTFIX_STR, TIMEOUT_10MIN, NamespacesNames
+from utilities.constants import HCO_CATALOG_SOURCE, HOTFIX_STR, TIMEOUT_10MIN, TIMEOUT_180MIN, NamespacesNames
 from utilities.data_collector import (
     get_data_collector_base_directory,
 )
@@ -317,20 +317,46 @@ def fired_alerts_during_upgrade(fired_alerts_before_upgrade, alert_dir, promethe
 
 
 @pytest.fixture(scope="session")
-def eus_cnv_upgrade_path(eus_target_cnv_version):
-    # Get the shortest path to the target (EUS) version
-    upgrade_path_to_target_version = get_shortest_upgrade_path(target_version=eus_target_cnv_version)
-    # Get the shortest path to the intermediate (non-EUS) version
-    upgrade_path_to_intermediate_version = get_shortest_upgrade_path(
-        target_version=upgrade_path_to_target_version["startVersion"]
+def eus_shortest_upgrade_path_info(eus_target_cnv_version, cnv_current_version):
+    LOGGER.info(f"Getting shortest upgrade path info between target version: {eus_target_cnv_version} and current version: {cnv_current_version}")
+    return get_shortest_upgrade_path_info(
+        target_version=eus_target_cnv_version,
+        cnv_current_version=cnv_current_version,
     )
+
+
+@pytest.fixture(scope="session")
+def eus_target_channel(eus_shortest_upgrade_path_info):
+    return eus_shortest_upgrade_path_info["target_channel"]
+
+
+@pytest.fixture(scope="session")
+def eus_cnv_upgrade_path(eus_shortest_upgrade_path_info, eus_target_channel):
+    if not (
+        target_paths := get_iib_images_of_cnv_versions(
+            versions=eus_shortest_upgrade_path_info["target_versions"],
+            target_channel=eus_target_channel,
+        )
+    ):
+        target_paths = get_iib_images_of_cnv_versions(
+            versions=eus_shortest_upgrade_path_info["target_versions"],
+            errata_status="false",
+            target_channel=eus_target_channel,
+        )
+    intermediate_paths = get_iib_images_of_cnv_versions(
+        versions=eus_shortest_upgrade_path_info["intermediate_versions"],
+    )
+    assert intermediate_paths, (
+        f"Couldn't find build info for {eus_shortest_upgrade_path_info['intermediate_versions']} versions"
+    )
+
     # Return a dictionary with the versions and images for the EUS-to-EUS upgrade
-    upgrade_path = {
-        "non-eus": get_iib_images_of_cnv_versions(versions=upgrade_path_to_intermediate_version["versions"]),
-        EUS: get_iib_images_of_cnv_versions(versions=upgrade_path_to_target_version["versions"], errata_status="false"),
+    upgrade_path_dict = {
+        EUS: target_paths,
+        "non-eus": intermediate_paths,
     }
-    LOGGER.info(f"Upgrade path for EUS-to-EUS upgrade: {upgrade_path}")
-    return upgrade_path
+    LOGGER.info(f"Upgrade path for EUS-to-EUS upgrade: {upgrade_path_dict}")
+    return upgrade_path_dict
 
 
 @pytest.fixture(scope="session")
@@ -359,6 +385,7 @@ def eus_unpaused_worker_mcp(
         machine_config_pools_list=worker_machine_config_pools,
         initial_mcp_conditions=worker_machine_config_pools_conditions,
         nodes=workers,
+        timeout=TIMEOUT_180MIN,
     )
 
 
@@ -521,6 +548,7 @@ def source_eus_to_non_eus_cnv_upgraded(
     admin_client,
     hco_namespace,
     eus_cnv_upgrade_path,
+    eus_target_channel,
     hyperconverged_resource_scope_function,
     updated_cnv_subscription_source,
 ):
@@ -541,8 +569,10 @@ def non_eus_to_target_eus_cnv_upgraded(
     admin_client,
     hco_namespace,
     eus_cnv_upgrade_path,
+    eus_target_channel,
+    cnv_subscription_scope_session,
+    cnv_registry_source,
     hyperconverged_resource_scope_function,
-    updated_cnv_subscription_source,
 ):
     version, cnv_image = next(iter(eus_cnv_upgrade_path[EUS].items()))
     LOGGER.info(f"Cnv upgrade to version {version} using image: {cnv_image}")
@@ -552,6 +582,9 @@ def non_eus_to_target_eus_cnv_upgraded(
         cr_name=hyperconverged_resource_scope_function.name,
         hco_namespace=hco_namespace,
         cnv_target_version=version.lstrip("v"),
+        subscription=cnv_subscription_scope_session,
+        subscription_source=cnv_registry_source["cnv_subscription_source"],
+        subscription_channel=eus_target_channel,
     )
 
 

--- a/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
@@ -22,7 +22,7 @@ class TestEUSToEUSUpgrade:
         hco_namespace,
         eus_target_cnv_version,
         eus_cnv_upgrade_path,
-        workers_machine_config_pools_conditions,
+        worker_machine_config_pools_conditions,
         eus_applied_all_icsp,
         eus_paused_worker_mcp,
         eus_paused_workload_update,

--- a/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_eus_upgrade.py
@@ -22,6 +22,8 @@ class TestEUSToEUSUpgrade:
         hco_namespace,
         eus_target_cnv_version,
         eus_cnv_upgrade_path,
+        workers_machine_config_pools_conditions,
+        eus_applied_all_icsp,
         eus_paused_worker_mcp,
         eus_paused_workload_update,
         source_eus_to_non_eus_ocp_upgraded,

--- a/tests/install_upgrade_operators/product_upgrade/utils.py
+++ b/tests/install_upgrade_operators/product_upgrade/utils.py
@@ -17,6 +17,7 @@ from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.machine_config_pool import MachineConfigPool
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import Resource, ResourceEditor
+from ocp_resources.subscription import Subscription
 from packaging.version import Version
 from pyhelper_utils.shell import run_command
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -29,6 +30,7 @@ from utilities.constants import (
     FIRING_STATE,
     HCO_CATALOG_SOURCE,
     IMAGE_CRON_STR,
+    TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_10MIN,
     TIMEOUT_10SEC,
@@ -54,6 +56,7 @@ from utilities.operator import (
     approve_install_plan,
     get_hco_csv_name_by_version,
     update_image_in_catalog_source,
+    update_subscription_source,
     wait_for_mcp_update_completion,
 )
 
@@ -389,7 +392,7 @@ def wait_for_cluster_version_state_and_version(cluster_version, target_ocp_versi
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_180MIN,
-            sleep=10,
+            sleep=TIMEOUT_5MIN,
             func=_cluster_version_state_and_version,
             _cluster_version=cluster_version,
             _target_ocp_version=target_ocp_version,
@@ -553,58 +556,81 @@ def wait_for_pending_alerts_to_fire(pending_alerts, prometheus):
         LOGGER.error(f"Out of {pending_alerts}, following alerts did not get to {FIRING_STATE}: {_pending_alerts}")
 
 
-def get_upgrade_path(target_version: str) -> dict[str, list[dict[str, str | list[str]]]]:
-    return wait_for_version_explorer_response(
-        api_end_point="GetUpgradePath", query_string=f"targetVersion={target_version}"
+def get_upgrade_path(target_version: str, channel: str = "stable") -> list[dict[str, Any]]:
+    paths = wait_for_version_explorer_response(
+        api_end_point="GetUpgradePath",
+        query_string=f"targetVersion={target_version}&channel={channel}",
     )
+    return paths["path"]
 
 
-def get_shortest_upgrade_path(target_version: str) -> dict[str, str | list[str]]:
+def get_shortest_upgrade_path_info(target_version: str, cnv_current_version: str) -> dict[str, Any]:
     """
     Get the shortest upgrade path to a given CNV target version(latest z stream)
 
     Args:
         target_version (str): The target version of the upgrade path.
+        cnv_current_version (str): The current version of the upgrade path.
 
     Returns:
-        dict: The shortest upgrade path to the target version.
+        dict[str, Any]: The shortest upgrade path to the target version.
     """
-    upgrade_paths = get_upgrade_path(target_version=target_version)["path"]
-    assert upgrade_paths, f"Couldn't find upgrade path for {target_version} version"
-    upgrade_path = max(
-        upgrade_paths,
-        key=lambda path: Version(version="0")
-        if "-hotfix" in path["startVersion"]
-        else Version(version=str(path["startVersion"])),
+    # if cant get from stable - try candidate
+    if upgrade_paths_target_version := get_upgrade_path(target_version=target_version):
+        target_channel = "stable"
+    else:
+        target_channel = "candidate"
+        upgrade_paths_target_version = get_upgrade_path(target_version=target_version, channel=target_channel)
+    assert upgrade_paths_target_version, f"Couldn't find upgrade path for {target_version} version"
+
+    sorted_upgrade_paths = sorted(
+        upgrade_paths_target_version, key=lambda path: Version(version=str(path["startVersion"])), reverse=True
     )
-    return upgrade_path
+    for path in sorted_upgrade_paths:
+        if intermediate_upgrade_paths := get_upgrade_path(target_version=path["startVersion"]):
+            if intermediate_path_dict := next(
+                (item for item in intermediate_upgrade_paths if item["startVersion"] == f"v{cnv_current_version}"), None
+            ):
+                return {
+                    "target_versions": path["versions"],
+                    "intermediate_versions": intermediate_path_dict["versions"],
+                    "target_channel": target_channel,
+                }
+    raise AssertionError(f"Couldn't find upgrade path for {target_version} version from {cnv_current_version}")
 
 
-def get_iib_images_of_cnv_versions(versions: list[str], errata_status: str = "true") -> dict[str, str]:
-    version_images = {}
+def get_iib_images_of_cnv_versions(
+    versions: list[str], errata_status: str = "true", target_channel: str = "stable"
+) -> dict[str, Any] | None:
+    def _find_channel_build(channels_dict: list[dict], channel: str) -> dict | None:
+        return next((build_dict for build_dict in channels_dict if build_dict["channel"] == channel), None)
+
+    target_version_images = {}
+
     for version in versions:
-        iib = get_successful_fbc_build_iib(
-            build_info=get_build_info_by_version(version=version, errata_status=errata_status)["successful_builds"]
-        )
-        version_images[version] = f"{BREW_REGISTERY_SOURCE}/rh-osbs/iib:{iib}"
-    return version_images
+        successful_builds = get_build_info_by_version(version=version, errata_status=errata_status)["successful_builds"]
 
+        if errata_status == "true":
+            # Look for builds with QE or SHIPPED_LIVE errata status
+            if not (successful_builds or successful_builds[0]["errata_status"] in ["QE", "SHIPPED_LIVE"]):
+                return None
+        else:
+            successful_builds = get_build_info_by_version(version=version, errata_status=errata_status)[
+                "successful_builds"
+            ]
+        for build in successful_builds:
+            if build_info_dict := _find_channel_build(channels_dict=build["channels"], channel=target_channel):
+                break
+        assert build_info_dict, f"Couldn't find build info for {version} version in {target_channel} channel"
+        target_version_images[version] = f"{BREW_REGISTERY_SOURCE}/rh-osbs/iib:{build_info_dict['iib'].split(':')[-1]}"
 
-def get_successful_fbc_build_iib(build_info: list[dict[str, str]]) -> str:
-    LOGGER.info(f"Build info found: {build_info}")
-    for build in build_info:
-        if build["pipeline"] == "RHTAP FBC":
-            return build["iib"]
-    raise AssertionError("Should have a fbc build")
+    assert target_version_images, f"Couldn't find build info for {versions} versions"
+    return target_version_images
 
 
 def get_build_info_by_version(version: str, errata_status: str = "true") -> dict[str, Any]:
-    query_string = f"version={version}"
-    if errata_status:
-        query_string = f"{query_string}&errata_status={errata_status}"
     return wait_for_version_explorer_response(
-        api_end_point="GetSuccessfulBuildsByVersion",
-        query_string=query_string,
+        api_end_point="GetSuccessfulBuildsByVersion", query_string=f"version={version}&errata_status={errata_status}"
     )
 
 
@@ -631,6 +657,9 @@ def perform_cnv_upgrade(
     cr_name: str,
     hco_namespace: Namespace,
     cnv_target_version: str,
+    subscription: Subscription | None = None,
+    subscription_source: str | None = None,
+    subscription_channel: str = "",
 ) -> None:
     hco_target_csv_name = get_hco_csv_name_by_version(cnv_target_version=cnv_target_version)
 
@@ -641,6 +670,12 @@ def perform_cnv_upgrade(
         catalog_source_name=HCO_CATALOG_SOURCE,
         cr_name=cr_name,
     )
+    if subscription and subscription_source:
+        update_subscription_source(
+            subscription=subscription,
+            subscription_source=subscription_source,
+            subscription_channel=subscription_channel,
+        )
     LOGGER.info("Approving CNV InstallPlan")
     approve_cnv_upgrade_install_plan(
         dyn_client=admin_client,

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -235,8 +235,8 @@ def consecutive_checks_for_mcp_condition(mcp_sampler, machine_config_pools_list)
         raise
 
 
-def wait_for_mcp_update_end(machine_config_pools_list):
-    wait_for_mcp_updated_condition_true(machine_config_pools_list=machine_config_pools_list)
+def wait_for_mcp_update_end(machine_config_pools_list, timeout=TIMEOUT_75MIN):
+    wait_for_mcp_updated_condition_true(machine_config_pools_list=machine_config_pools_list, timeout=timeout)
     wait_for_mcp_ready_machine_count(machine_config_pools_list=machine_config_pools_list)
 
 
@@ -498,7 +498,7 @@ def wait_for_csv_successful_state(admin_client, namespace_name, subscription_nam
     raise ResourceNotFoundError(f"Subscription {subscription_name} not found in namespace: {namespace_name}")
 
 
-def wait_for_mcp_update_completion(machine_config_pools_list, initial_mcp_conditions, nodes):
+def wait_for_mcp_update_completion(machine_config_pools_list, initial_mcp_conditions, nodes, timeout=TIMEOUT_75MIN):
     initial_updating_transition_times = get_mcp_updating_transition_times(mcp_conditions=initial_mcp_conditions)
 
     wait_for_mcp_update_start(
@@ -507,6 +507,7 @@ def wait_for_mcp_update_completion(machine_config_pools_list, initial_mcp_condit
     )
     wait_for_mcp_update_end(
         machine_config_pools_list=machine_config_pools_list,
+        timeout=timeout,
     )
     wait_for_nodes_to_have_same_kubelet_version(nodes=nodes)
     wait_for_all_nodes_ready(nodes=nodes)


### PR DESCRIPTION
##### Short description:
With  channels being added, we need extra logic to the EUS upgrade process.

##### More details:
What we need:

1. GetUpgradePath query modified to support channel, use it accordingly.
2. the target version can be from stable/candidate channel. ( for example 4.20.0). QE/ShippedLive versions are getting prioritized.
3.  The intermediate version should be from the stable channel.

The path is getting generated considering that.

Afterwards, we need to change the cnv subscription channel for the target version if its not "stable".

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Started from 4.18 and not main to allow consistent 4.18 -> 4.20 testing.
will cherry pick to other branches afterwards

##### jira-ticket:
https://issues.redhat.com/browse/CNV-62122