### PR TITLE
[Install] Add missing resources

### DIFF
--- a/tests/install_upgrade_operators/product_install/constants.py
+++ b/tests/install_upgrade_operators/product_install/constants.py
@@ -36,7 +36,7 @@ CLUSTER_RESOURCE_ALLOWLIST = {
         "kubevirt-hyperconverged-",
         "olm.og.openshift-cnv-",
         "kubevirt-ipam-controller-manager-role",
-        "kubevirt-synchronization-controller"
+        "kubevirt-synchronization-controller",
     ],
     "ClusterRoleBinding": [
         "hostpath-provisioner-operator-service-system:auth-delegator",

--- a/tests/install_upgrade_operators/product_install/constants.py
+++ b/tests/install_upgrade_operators/product_install/constants.py
@@ -36,6 +36,7 @@ CLUSTER_RESOURCE_ALLOWLIST = {
         "kubevirt-hyperconverged-",
         "olm.og.openshift-cnv-",
         "kubevirt-ipam-controller-manager-role",
+        "kubevirt-synchronization-controller"
     ],
     "ClusterRoleBinding": [
         "hostpath-provisioner-operator-service-system:auth-delegator",
@@ -57,6 +58,8 @@ CLUSTER_RESOURCE_ALLOWLIST = {
         "template-validator",
         "kubevirt-hyperconverged-",
         "olm.og.openshift-cnv-kubevirt-ipam-controller-manager-rolebinding",
+        "kubevirt-synchronization-controller",
+        "kubevirt-ipam-controller-manager-rolebinding",
     ],
     "Namespace": ["openshift-cnv", "openshift-virtualization-os-images"],
     "Project": ["openshift-cnv", "openshift-virtualization-os-images"],


### PR DESCRIPTION
##### Short description:
The following resources we're added to 4.20.0:

[{'ClusterRoleBinding': ['kubevirt-synchronization-controller', 'kubevirt-ipam-controller-manager-rolebinding']},

{'ClusterRole': ['kubevirt-synchronization-controller']}
]
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70027


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated installation/upgrade validation to allow kubevirt synchronization controller cluster roles and bindings, preventing false positives during checks of cluster-scoped resources.
  * Improves test stability and CI signal with environments that include kubevirt components.
  * No impact on runtime behavior or user-facing functionality; reduces noise and speeds up triage by avoiding unnecessary test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->