### PR TITLE
Quarantine flaky test_dhcp_broadcast[#ovs-bridge#]

### DIFF
--- a/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
+++ b/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
@@ -7,7 +7,7 @@ from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutSampler
 
 from tests.network.libs.dhcpd import DHCP_IP_RANGE_START
-from utilities.constants import TIMEOUT_2MIN
+from utilities.constants import QUARANTINED, TIMEOUT_2MIN
 from utilities.network import assert_ping_successful, get_vmi_ip_v4_by_name, ping
 
 LOGGER = logging.getLogger(__name__)
@@ -73,10 +73,13 @@ class TestL2LinuxBridge:
         l2_bridge_running_vm_b,
         configured_l2_bridge_vm_a,
         started_vmb_dhcp_client,
+        request,
     ):
         """
         Test broadcast traffic via L2 linux bridge. VM_A has dhcp server installed. VM_B dhcp client.
         """
+        if "ovs-bridge" in request.node.name:
+            pytest.xfail(reason=f"{QUARANTINED}: Test is flaky over OVS bridge, tracked in CNV-70028")
         current_ip = TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
             sleep=2,


### PR DESCRIPTION
The PR makes sure only the ovs-bridge instance of this test is quauarntined, keeping the stable linux-bridge test running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Improved test stability by quarantining a flaky DHCP broadcast scenario on OVS bridge, marking it as an expected failure with a clear reason.
  - Enhanced CI signal by preventing intermittent failures from impacting test runs.
  - Updated test parameters to support the new quarantine behavior, aiding faster triage and more reliable test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->