### PR TITLE
[virt] quarantine test_pause_unpause_vm (RHEL OS)

### DIFF
--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -15,7 +15,7 @@ from tests.virt.cluster.common_templates.utils import (
     vm_os_version,
 )
 from utilities import console
-from utilities.constants import LINUX_STR
+from utilities.constants import LINUX_STR, QUARANTINED
 from utilities.infra import validate_os_info_vmi_vs_linux_os
 from utilities.virt import (
     assert_linux_efi,
@@ -174,6 +174,7 @@ class TestCommonTemplatesRhel:
     def test_vm_smbios_default(self, smbios_from_kubevirt_config, matrix_rhel_os_vm_from_template):
         check_vm_xml_smbios(vm=matrix_rhel_os_vm_from_template, cm_values=smbios_from_kubevirt_config)
 
+    @pytest.mark.xfail(reason=f"{QUARANTINED}: Flake in pause VM checks; CNV-70033", run=False)
     @pytest.mark.arm64
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])


### PR DESCRIPTION
##### Short description:
test is flaky for some time

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70033


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked a failing VM pause/unpause test as expected-fail and quarantined, preventing it from running in standard pipelines.
  * Updated test annotations to reflect quarantine status.
  * No impact on product features, performance, or user workflows.
  * Build and verification runs will proceed without this test until it is re-enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->