### PR TITLE
exit pytest if cnv-tests-utilities ns exists

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,11 +460,21 @@ def cnv_tests_utilities_namespace(admin_client, installing_cnv):
     if installing_cnv:
         yield
     else:
-        yield from create_ns(
-            admin_client=admin_client,
-            labels=POD_SECURITY_NAMESPACE_LABELS,
-            name="cnv-tests-utilities",
-        )
+        name = "cnv-tests-utilities"
+        if Namespace(client=admin_client, name=name).exists:
+            exit_pytest_execution(
+                message=f"{name} namespace already exists."
+                f"\nAfter verifying no one else is performing tests against the cluster, run:"
+                f"\n'oc delete namespace {name}'",
+                return_code=100,
+            )
+
+        else:
+            yield from create_ns(
+                admin_client=admin_client,
+                labels=POD_SECURITY_NAMESPACE_LABELS,
+                name=name,
+            )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
##### Short description:
`cnv-tests-utilities` namespace is created to hold test utilities related resources.
If the names exists when pytest start the execution, there was an ungraceful failure on resource conflict.
pytest will now exit gracefully if the namespace already exists before tests execution.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a pre-check to prevent reusing an existing test namespace during CNV test setup.
  * Test runs now exit early with a clear message and status code 100 if the namespace already exists.
  * If no namespace is found, it is created as before.
  * Improves test isolation and prevents accidental contamination from prior runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->