### PR TITLE
Add instance_type_os_matrix for s390x in global_config_s390x

### DIFF
--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -5,12 +5,17 @@ from utilities.constants import (
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
     PREFERENCE_STR,
     S390X,
+    CENTOS_STREAM9_PREFERENCE,
+    CENTOS_STREAM10_PREFERENCE,
+    RHEL8_PREFERENCE,
+    RHEL9_PREFERENCE,
+    RHEL10_PREFERENCE,
+    OS_FLAVOR_FEDORA,
 )
 from utilities.infra import get_latest_os_dict_list
 from utilities.os_utils import generate_linux_instance_type_os_matrix, generate_os_matrix_dict
 
 global config
-
 
 EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR] = f"rhel.9.{S390X}"
 
@@ -25,7 +30,13 @@ fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating
 centos_os_matrix = generate_os_matrix_dict(os_name="centos", supported_operating_systems=["centos-stream-9"])
 
 instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
-    os_name="rhel", preferences=[utilities.constants.RHEL9_PREFERENCE]
+    os_name="rhel", preferences=[RHEL8_PREFERENCE, RHEL9_PREFERENCE, RHEL10_PREFERENCE]
+)
+instance_type_centos_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name="centos.stream", preferences=[CENTOS_STREAM9_PREFERENCE, CENTOS_STREAM10_PREFERENCE]
+)
+instance_type_fedora_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name=OS_FLAVOR_FEDORA, preferences=[f"fedora.{S390X}"]
 )
 
 latest_rhel_os_dict, latest_fedora_os_dict, latest_centos_os_dict = get_latest_os_dict_list(


### PR DESCRIPTION
This change adds the instance_type_os_matrix for the s390x architecture in the global_config_s390x file.

It includes the following OS preferences:

- RHEL: RHEL8, RHEL9, RHEL10
- CentOS: CENTOS_STREAM9, CENTOS_STREAM10
- Fedora: fedora.s390x

These additions aim to ensure that tests and configurations for RHEL, CentOS, and Fedora can run smoothly on the s390x architecture.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
