### PR TITLE
Add emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,3 +8,5 @@ reviewers:
   - vsibirsk
   - dshchedr
   - rnetser
+emeritus_approvers:
+  - dbasunag  # 2025-03-10

--- a/docs/OWNERS.md
+++ b/docs/OWNERS.md
@@ -1,0 +1,10 @@
+# Taken from https://www.kubernetes.dev/docs/guide/owners/#owners
+
+# OWNERS files
+Each directory that contains a unit of independent code or content may also contain an OWNERS file. This file applies to everything within the directory, including the OWNERS file itself, sibling files, and child directories.
+
+OWNERS files are in YAML format and support the following keys:
+
+- approvers: a list of GitHub usernames or aliases that can /approve a PR
+- reviewers: a list of GitHub usernames or aliases that are good candidates to /lgtm a PR
+- emeritus_approvers a list of GitHub usernames of folks who were previously in the approvers section, but are no longer actively approving code.

--- a/docs/OWNERS.md
+++ b/docs/OWNERS.md
@@ -1,4 +1,4 @@
-# Taken from https://www.kubernetes.dev/docs/guide/owners/#owners
+Taken from https://www.kubernetes.dev/docs/guide/owners/#owners
 
 # OWNERS files
 Each directory that contains a unit of independent code or content may also contain an OWNERS file. This file applies to everything within the directory, including the OWNERS file itself, sibling files, and child directories.


### PR DESCRIPTION
##### Short description:
As this repo is open-sourced and to not remove approvers history from the repo's OWNERS file, adding the option to keep them in the OWNERS file as `emeritus_approvers`
(see https://www.kubernetes.dev/docs/guide/owners/#emeritus)

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
