### PR TITLE
Storage gating: test_vmexport_snapshot_manifests change pod execution logic

### DIFF
--- a/tests/storage/vm_export/utils.py
+++ b/tests/storage/vm_export/utils.py
@@ -7,7 +7,6 @@ import logging
 import shlex
 
 import yaml
-from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.virtual_machine import VirtualMachine
@@ -18,26 +17,26 @@ from utilities.storage import PodWithPVC, get_containers_for_pods_with_pvc
 LOGGER = logging.getLogger(__name__)
 
 
-def get_pvc_sha256sum(pvc_name, pvc_namespace):
+def check_pvc_data_in_pod(pvc_name, pvc_namespace, test_content):
     pvc = PersistentVolumeClaim(namespace=pvc_namespace, name=pvc_name)
     volume_mode = StorageProfile(name=pvc.instance.spec.storageClassName).instance.status["claimPropertySets"][0][
         "volumeMode"
     ]
     with PodWithPVC(
         namespace=pvc_namespace,
-        name=f"{pvc_name}-pod",
+        name=f"{pvc_name}-simple-test",
         pvc_name=pvc_name,
         containers=get_containers_for_pods_with_pvc(volume_mode=volume_mode, pvc_name=pvc_name),
     ) as pod:
         pod.wait_for_status(status=pod.Status.RUNNING)
-        pvc_disk_img = "/pvc/disk.img"
-        checksum = "sha256sum"
-        command = (
-            f"bash -c 'head -c 1000000 {pvc_disk_img} | {checksum}'"
-            if volume_mode == DataVolume.VolumeMode.BLOCK
-            else f"{checksum} {pvc_disk_img}"
-        )
-        return pod.execute(command=shlex.split(command))
+
+        create_command = f"bash -c 'echo \"{test_content}\" > /tmp/vmexport-test.txt'"
+        pod.execute(command=shlex.split(create_command))
+
+        read_command = "cat /tmp/vmexport-test.txt"
+        result = pod.execute(command=shlex.split(read_command))
+
+        return result.strip()
 
 
 def get_manifest_from_vmexport(vmexport_cert_file, url, token, kind, namespace_vmexport_target=None):


### PR DESCRIPTION
##### Short description:
Change pod execution logic into test test_vmexport_snapshot_manifest
##### More details:
The PR now checks for a file inside the pod, that match better to the end-user workflow
##### What this PR does / why we need it:
Change into test to check PVC data into source and target pod 
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-68892
