### PR TITLE
Remove apiserver-proxy-ns component label skip

### DIFF
--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -12,8 +12,7 @@ from tests.install_upgrade_operators.relationship_labels.constants import (
 from tests.install_upgrade_operators.relationship_labels.utils import (
     verify_component_labels_by_resource,
 )
-from utilities.constants import KUBEVIRT_APISERVER_PROXY_NP, VERSION_LABEL_KEY
-from utilities.infra import is_jira_open
+from utilities.constants import VERSION_LABEL_KEY
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 LOGGER = logging.getLogger(__name__)
@@ -100,9 +99,6 @@ class TestRelationshipLabels:
         expected_label_dictionary,
         ocp_resource_by_name,
     ):
-        if ocp_resource_by_name.name == KUBEVIRT_APISERVER_PROXY_NP and is_jira_open(jira_id="CNV-68999"):
-            pytest.skip(f"Currently {KUBEVIRT_APISERVER_PROXY_NP} resource have the wrong relationship labels")
-
         verify_component_labels_by_resource(
             component=ocp_resource_by_name,
             expected_component_labels=expected_label_dictionary,


### PR DESCRIPTION
##### Short description: 

Kubevirt-apiserver-proxy-np used to have the wrong component label. This was fixed in https://issues.redhat.com/browse/CNV-68999. This PR removes the temporary skip since the CNV is verified.

##### More details:

NONE

##### What this PR does / why we need it:

It removes an if-statement skip that will never be run because CNV-68999 will be closed.

##### Which issue(s) this PR fixes:

https://issues.redhat.com/browse/CNV-68999

##### Special notes for reviewer:

NONE

##### jira-ticket:

https://issues.redhat.com/browse/CNV-69982


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed a conditional skip so relationship-label verification tests now always run for all relevant components.
  * Eliminated unused test dependencies and simplified test flow.
  * Improves coverage and consistency, helping surface label regressions earlier and increasing test-suite reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->