### PR TITLE
request-coderabbit-test-instructions use BOT3_TOKEN token and get pr owner to check membership

### DIFF
--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -21,8 +21,8 @@ jobs:
         uses: tspascoal/get-user-teams-membership@v3
         with:
           team: cnvqe-bot
-          username: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.event.pull_request.user.login }}
+          GITHUB_TOKEN: ${{ secrets.BOT3_TOKEN }}
 
       - name: Create or update comment
         if: steps.check-user-team.outputs.is-member == 'false'

--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -1,4 +1,6 @@
-name: Add comment for CodeRabbit to add tests instructions. A change-request comment will be added to the PR.
+# description: Add comment for CodeRabbit to add tests instructions. A change-request comment will be added to the PR.
+
+name: Request CodeRabbit tests instructions
 
 on:
   pull_request_target:


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow name and description for clarity.
  * Adjusted trigger to run on labeled pull request events.
  * CI now references the pull request author’s identity for membership checks and uses a dedicated bot token for authentication.
  * Improves automation reliability and auditability; no user-facing changes to app behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->