### PR TITLE
[IUO] add jira cnv-70251

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -21,12 +21,13 @@ from tests.install_upgrade_operators.utils import (
     get_resource_by_name,
     get_resource_from_module_name,
 )
-from utilities.constants import HPP_POOL
+from utilities.constants import HCO_BEARER_AUTH, HPP_POOL
 from utilities.hco import ResourceEditorValidateHCOReconcile, get_hco_version
 from utilities.infra import (
     get_daemonset_by_name,
     get_deployment_by_name,
     get_pod_by_name_prefix,
+    is_jira_open,
 )
 from utilities.operator import (
     disable_default_sources_in_operatorhub,
@@ -204,10 +205,17 @@ def ocp_resource_by_name(admin_client, ocp_resources_submodule_list, related_obj
 
 
 @pytest.fixture()
-def related_object_from_hco_status(hco_status_related_objects, cnv_related_object_matrix__function__):
+def related_object_from_hco_status(
+    is_jira_70251_open,
+    hco_status_related_objects,
+    cnv_related_object_matrix__function__,
+):
     LOGGER.info(cnv_related_object_matrix__function__)
     kind_name = list(cnv_related_object_matrix__function__.values())[0]
     related_object_name = list(cnv_related_object_matrix__function__.keys())[0]
+
+    if related_object_name == HCO_BEARER_AUTH and is_jira_70251_open:
+        pytest.xfail(f"Skipping related object {related_object_name}, kind {kind_name} because of CNV-70251")
     LOGGER.info(f"Looking for related object {related_object_name}, kind {kind_name}")
     for obj in hco_status_related_objects:
         if obj.name == related_object_name and obj.kind == kind_name:
@@ -235,3 +243,8 @@ def updated_resource(
         wait_for_reconcile_post_update=True,
     ):
         yield cr
+
+
+@pytest.fixture(scope="session")
+def is_jira_70251_open():
+    return is_jira_open(jira_id="CNV-70251")


### PR DESCRIPTION
##### Short description:
Add specific skip for hco-bearer-auth resource, who might be missing from hco-related-objects because of this bug https://issues.redhat.com/browse/CNV-70251

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Conditionally mark a specific related-object validation as expected-to-fail when Jira CNV-70251 is open, preventing misleading failures.
  * Apply this runtime guard earlier (before searching for the related object) and extend it to an additional related-object case to further improve install/upgrade test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->