### PR TITLE
quarantined_test_virtctl_image_upload_pvc_4.19

### DIFF
--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -19,7 +19,7 @@ from tests.storage.utils import (
     assert_use_populator,
     create_vm_and_verify_image_permission,
 )
-from utilities.constants import CDI_UPLOADPROXY, OS_FLAVOR_CIRROS, TIMEOUT_1MIN, Images
+from utilities.constants import CDI_UPLOADPROXY, OS_FLAVOR_CIRROS, QUARANTINED, TIMEOUT_1MIN, Images
 from utilities.storage import (
     ErrorMsg,
     check_disk_count_in_vm,
@@ -224,6 +224,10 @@ def test_virtctl_image_upload_with_exist_dv_image(
         )
 
 
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: Flaky test, artifactory connection failure; CNV-70271",
+    run=False,
+)
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-3728")


### PR DESCRIPTION
##### Short description:
quarantined test_virtctl_image_upload_pvc as xfail due to intermittent Artifactory connection failures.

##### More details:
The test sometimes fails because it cannot reach the CNV QE Artifactory server (503 errors).

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70271
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
