### PR TITLE
Add bot's token to action for test plan comment

### DIFF
--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -31,6 +31,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.BOT3_TOKEN }}
           body: |
             @coderabbitai
             <details>


### PR DESCRIPTION
##### Short description:
To post the comment from an account with a repo's PAT, `token` was added

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI automation to use a dedicated authentication token for posting commit/PR comments, improving reliability and permission scoping of workflow-generated messages.
  * Reduces risk of rate limits and failed comment updates in pull requests and commits.
  * No changes to app features or UI; this improvement only affects developer tooling and release pipeline stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->