### PR TITLE
Fix ValueError in wait_for_spec_change when HCO spec contains keys with dots

### DIFF
--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -147,7 +147,7 @@ def wait_for_spec_change(expected, get_spec_func, base_path):
     samplers = TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=TIMEOUT_5SEC,
-        func=lambda: benedict(get_spec_func()),
+        func=lambda: benedict(get_spec_func(), keypath_separator=KEY_PATH_SEPARATOR),
     )
     current_value = None
     try:


### PR DESCRIPTION
##### Short description:
Problem:
The wait_for_spec_change() function was failing with:
  ValueError: Key should not contain keypath separator '.',
  found: 'cdi.kubevirt.io/storage.bind.immediate.requested'

This error occurred when the HCO spec contained dataImportCronTemplates with annotations that include dots (e.g., 'cdi.kubevirt.io/storage.bind.immediate.requested').

Root Cause:
The benedict library was instantiated without specifying a custom keypath_separator, causing it to use the default '.' separator. When benedict encountered keys containing dots in the spec (like annotation names), it incorrectly interpreted them as keypath separators and raised a ValueError.

Solution:
Add keypath_separator=KEY_PATH_SEPARATOR parameter to the benedict() call in wait_for_spec_change(), matching the pattern already used in get_resource_key_value(). This ensures benedict uses '->' as the separator instead of '.', allowing it to properly handle keys that contain dots.


##### More details:
This fixes 19 failing tests in the launcher_updates test suite that were timing out due to this ValueError.

##### What this PR does / why we need it:
Affected tests:
- tests/install_upgrade_operators/launcher_updates/test_default_launcher_updates.py
- tests/install_upgrade_operators/launcher_updates/test_negative_kubevirt_update.py
- tests/install_upgrade_operators/launcher_updates/test_reset_custom_values.py
- tests/install_upgrade_operators/launcher_updates/test_update_default_workload_strategy.py
- tests/install_upgrade_operators/launcher_updates/test_update_workload_strategy.py

##### Which issue(s) this PR fixes: N/A

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-38937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of spec-wait conditions in operator install/upgrade test utilities by using a custom key path separator for nested spec comparisons, ensuring consistent interpretation across environments.
  * Enhances consistency and maintainability of the test suite, reducing potential flakiness during CI runs.
  * No changes to user-facing behavior or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->