### PR TITLE
Introduce arch suffix to generate_linux_instance_type_os_matrix

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -57,16 +57,16 @@ rhel_os_matrix = generate_os_matrix_dict(os_name="rhel", supported_operating_sys
 latest_rhel_os_dict = get_latest_os_dict_list(os_list=[rhel_os_matrix])[0]
 
 # Modify instance_type_rhel_os_matrix for arm64
-instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(os_name="rhel", preferences=[RHEL10_PREFERENCE])
+instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
+    os_name="rhel", preferences=[RHEL10_PREFERENCE], arch_suffix=ARM_64
+)
 instance_type_centos_os_matrix = generate_linux_instance_type_os_matrix(
     os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE]
 )
 instance_type_fedora_os_matrix = generate_linux_instance_type_os_matrix(
-    os_name=OS_FLAVOR_FEDORA, preferences=[OS_FLAVOR_FEDORA]
+    os_name=OS_FLAVOR_FEDORA, preferences=[OS_FLAVOR_FEDORA], arch_suffix=ARM_64
 )
-for os_matrix_dict in instance_type_rhel_os_matrix + instance_type_centos_os_matrix + instance_type_fedora_os_matrix:
-    for os_params in os_matrix_dict.values():
-        os_params[PREFERENCE_STR] += f".{ARM_64}"
+
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -25,7 +25,7 @@ fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating
 centos_os_matrix = generate_os_matrix_dict(os_name="centos", supported_operating_systems=["centos-stream-9"])
 
 instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
-    os_name="rhel", preferences=[utilities.constants.RHEL9_PREFERENCE]
+    os_name="rhel", preferences=[utilities.constants.RHEL9_PREFERENCE], arch_suffix=S390X
 )
 
 latest_rhel_os_dict, latest_fedora_os_dict, latest_centos_os_dict = get_latest_os_dict_list(

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -241,7 +241,9 @@ def generate_os_matrix_dict(os_name: str, supported_operating_systems: list[str]
     return os_formatted_list
 
 
-def generate_linux_instance_type_os_matrix(os_name: str, preferences: list[str]) -> list[dict[str, dict[str, Any]]]:
+def generate_linux_instance_type_os_matrix(
+    os_name: str, preferences: list[str], arch_suffix: str | None = None
+) -> list[dict[str, dict[str, Any]]]:
     """
     Generate a list of dictionaries representing the instance type matrix for a Linux OS type.
     Each dictionary represents a specific instance type and its configuration.
@@ -249,6 +251,7 @@ def generate_linux_instance_type_os_matrix(os_name: str, preferences: list[str])
     Args:
         os_name (str): The name of the OS.
         preferences (list[str]): A list of preferences for the instance types. Preference format is "<os>.<version>".
+        arch_suffix: Optional architecture suffix. Example: "s390x", "arm64" . Omit to keep original preference.
 
     Returns:
         list[dict[str, dict[str, Any]]]: A list of dictionaries representing the instance type matrix.
@@ -269,13 +272,14 @@ def generate_linux_instance_type_os_matrix(os_name: str, preferences: list[str])
     instance_types: list[dict[str, dict[str, Any]]] = []
 
     for preference in preferences:
+        arch_preference = f"{preference}.{arch_suffix}" if arch_suffix else preference
         preference_config: dict[str, Any] = {
-            PREFERENCE_STR: preference,
+            PREFERENCE_STR: arch_preference,
             DATA_SOURCE_NAME: _format_data_source_name(preference_name=preference),
         }
 
         if preference == latest_os:
             preference_config[LATEST_RELEASE_STR] = True
 
-        instance_types.append({preference: preference_config})
+        instance_types.append({arch_preference: preference_config})
     return instance_types


### PR DESCRIPTION
Introduce arch suffix to generate_linux_instance_type_os_matrix
- tests/global_config_arm64.py pass arch_suffix=ARM_64 for rhel and fedora remove appending .arm64
- tests/global_config_s390x.py pass arch_suffix=S390X for rhel

##### Short description:
Update the generate_linux_instance_type_os_matrix function and related usage to support an optional architecture suffix (e.g., arm64, s390x). This allows instance type matrix for different architectures to be created with correctly suffixed preference Refactor the affected global config files to utilize this new parameter instead of appending suffixes manually.
##### More details:
user friendly
##### What this PR does / why we need it:
Simplifies test_global config files by removing manual string manipulation.
##### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-70384

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds architecture-specific OS instance type matrices: ARM64 for RHEL/Fedora and s390x for RHEL.
  * Automatically labels preferences with architecture, improving clarity and consistency.
  * Reduces configuration errors by eliminating manual post-processing of architecture suffixes.
  * Existing behavior for other OSes (e.g., CentOS) remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->