### PR TITLE
Fix Must-gather being OOMKilled

### DIFF
--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -604,9 +604,12 @@ def collected_vm_details_must_gather_from_vm_node(
 ):
     before_fail_count = request.session.testsfailed
     target_path = os.path.join(must_gather_tmpdir_scope_module, "collected_vm_gather_from_vm_node")
+    # Scope collection to only the test VM to avoid OOMKilled.
+    # Ref: https://github.com/kubevirt/must-gather?tab=readme-ov-file#specific-vm
     yield collect_must_gather(
         must_gather_tmpdir=target_path,
         must_gather_image_url=must_gather_image_url,
+        script_name=f"NS={must_gather_vm.namespace} VM={must_gather_vm.name} /usr/bin/gather",
         flag_names="vms_details",
         node_name=must_gather_vm.vmi.node.name,
     )


### PR DESCRIPTION
##### Short description:
The `test_must_gather_and_vm_same_node` test was failing with exit code 137 (SIGKILL/OOMKilled) because the combination of `--vms_details` and `--node-name` is extremely resource-intensive. When using `--node-name`, all VM details collection is concentrated in a single pod on one node instead of being distributed across multiple pods.

The fix is to scope the must-gather collection to only the VM being tested using NS and VM environment variables. This dramatically reduces memory usage by collecting details for only 1 VM instead of all VMs in the cluster.

##### More details:
https://github.com/kubevirt/must-gather?tab=readme-ov-file#specific-vm

##### What this PR does / why we need it:
Stabilize CI

##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-66823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Must-gather collection in VM-related upgrade tests now supports scoping to a specific VM (adds script_name to target NS/VM for collection).
  - Clarifying comments added to document the VM-scoped gathering approach and reference guidance.
  - No changes to test flow, error handling, or cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->