### PR TITLE
 Add basic windows tests using instance types and container images

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -72,6 +72,7 @@ class Windows:
     ISO_WIN11_DIR: str = f"{ISO_BASE_DIR}/win11"
     ISO_WIN2022_DIR: str = f"{ISO_BASE_DIR}/win2022"
     ISO_WIN2025_DIR: str = f"{ISO_BASE_DIR}/win2025"
+    CONTAINER_DISK_DV_SIZE = "40Gi"
     DEFAULT_DV_SIZE: str = "70Gi"
     DEFAULT_MEMORY_SIZE: str = "8Gi"
     DEFAULT_MEMORY_SIZE_WSL: str = "12Gi"

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -1,7 +1,24 @@
 import pytest
+from ocp_resources.datavolume import DataVolume
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+from pytest_testconfig import config as py_config
 
 from tests.infrastructure.instance_types.supported_os.utils import golden_image_vm_with_instance_type
-from utilities.constants import DATA_SOURCE_NAME, RHEL8_PREFERENCE
+from utilities.constants import (
+    CONTAINER_DISK_IMAGE_PATH_STR,
+    DATA_SOURCE_NAME,
+    DATA_SOURCE_STR,
+    RHEL8_PREFERENCE,
+    Images,
+)
+from utilities.infra import (
+    cleanup_artifactory_secret_and_config_map,
+    get_artifactory_config_map,
+    get_artifactory_secret,
+)
+from utilities.storage import get_test_artifact_server_url
+from utilities.virt import VirtualMachineForTests
 
 
 @pytest.fixture(scope="class")
@@ -67,4 +84,53 @@ def golden_image_fedora_vm_with_instance_type(
         modern_cpu_for_migration=modern_cpu_for_migration,
         storage_class_name=[*storage_class_matrix__module__][0],
         data_source_name=instance_type_fedora_os_matrix__module__[os_name][DATA_SOURCE_NAME],
+    )
+
+
+@pytest.fixture(scope="module")
+def windows_data_volume_template(
+    namespace,
+    windows_os_matrix__module__,
+):
+    os_matrix_key = [*windows_os_matrix__module__][0]
+    os_params = windows_os_matrix__module__[os_matrix_key]
+    secret = get_artifactory_secret(namespace=namespace.name)
+    cert = get_artifactory_config_map(namespace=namespace.name)
+    win_dv = DataVolume(
+        name=f"{os_matrix_key}-dv",
+        namespace=namespace.name,
+        api_name="storage",
+        source="registry",
+        size=Images.Windows.CONTAINER_DISK_DV_SIZE,
+        storage_class=py_config["default_storage_class"],
+        url=f"{get_test_artifact_server_url(schema='registry')}/{os_params[CONTAINER_DISK_IMAGE_PATH_STR]}",
+        secret=secret,
+        cert_configmap=cert.name,
+    )
+    win_dv.to_dict()
+    yield win_dv
+    cleanup_artifactory_secret_and_config_map(artifactory_secret=secret, artifactory_config_map=cert)
+
+
+@pytest.fixture(scope="class")
+def golden_image_windows_vm(
+    unprivileged_client,
+    namespace,
+    modern_cpu_for_migration,
+    windows_data_volume_template,
+    windows_os_matrix__module__,
+):
+    os_name = [*windows_os_matrix__module__][0]
+    return VirtualMachineForTests(
+        client=unprivileged_client,
+        name=f"{os_name}-vm-with-instance-type-2",
+        namespace=namespace.name,
+        vm_instance_type=VirtualMachineClusterInstancetype(name="u1.large"),
+        vm_preference=VirtualMachineClusterPreference(
+            name=windows_os_matrix__module__[os_name][DATA_SOURCE_STR].replace("win", "windows.")
+        ),
+        data_volume_template=windows_data_volume_template.res,
+        os_flavor="win-container-disk",
+        disk_type=None,
+        cpu_model=modern_cpu_for_migration,
     )

--- a/tests/infrastructure/instance_types/supported_os/test_windows_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_windows_os.py
@@ -1,0 +1,33 @@
+import logging
+
+import pytest
+
+from utilities.virt import (
+    running_vm,
+)
+
+pytestmark = [pytest.mark.high_resource_vm, pytest.mark.tier3]
+
+LOGGER = logging.getLogger(__name__)
+TESTS_CLASS_NAME = "TestCommonPreferenceWindows"
+
+
+class TestCommonPreferenceWindows:
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")
+    @pytest.mark.polarion("CNV-12269")
+    def test_create_vm(
+        self,
+        golden_image_windows_vm,
+    ):
+        LOGGER.info("Create VM from preference.")
+        golden_image_windows_vm.create(wait=True)
+
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::start_vm", depends=[f"{TESTS_CLASS_NAME}::create_vm"])
+    @pytest.mark.polarion("CNV-12270")
+    def test_start_vm(self, golden_image_windows_vm):
+        running_vm(vm=golden_image_windows_vm)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])
+    @pytest.mark.polarion("CNV-12271")
+    def test_vm_deletion(self, golden_image_windows_vm):
+        golden_image_windows_vm.delete(wait=True)


### PR DESCRIPTION
##### Short description:
Add basic windows tests using instance types and container images

##### More details:
 - Add tests using container images for windows images and the related constants for pulling the images.
 - A discussion about `get_test_artifact_server_url` related to a question raised here was discussed in this PR - https://github.com/RedHatQE/openshift-virtualization-tests/pull/2329

##### What this PR does / why we need it:
Add test coverage for windows OS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new test suite for Windows VM operations including creation, startup, and deletion scenarios.
  * Expanded test infrastructure to support comprehensive Windows instance-type testing and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->