### PR TITLE
Fix failed test_connectivity_of_hot_plugged_jumbo_interface

### DIFF
--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -534,7 +534,7 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
             src_vm=running_vm_for_jumbo_nic_hot_plug,
             dst_ip=get_vmi_ip_v4_by_name(
                 vm=running_utility_vm_for_connectivity_check,
-                name=hot_plugged_jumbo_interface_in_utility_vm,
+                name=hot_plugged_jumbo_interface_in_utility_vm.name,
             ),
             packet_size=cluster_hardware_mtu,
         )


### PR DESCRIPTION
get_vmi_ip_v4_by_name always failed due to getting the interface structure as an input rather than its name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected the connectivity test for hot-plugged jumbo interfaces by passing the interface name instead of the object, improving accuracy and reducing false negatives in L2 bridge NIC hot-plug scenarios.
  * Enhances reliability of CI by validating IPv4 retrieval during hot-plug operations with clearer intent.
  * No changes to runtime behavior; this update strictly improves test robustness and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->