### PR TITLE
Move self_contained_html to addopts section in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,21 @@
 [pytest]
 testpaths = tests
 
+# pytest-html configuration
+generate_report_on_test = True
+render_collapsed = all
+
+addopts =
+    -p no:logging
+    --basetemp=/tmp/pytest
+    --strict-markers
+    --tc-file=tests/global_config.py
+    --tc-format=python
+    --show-progress
+    --order-dependencies
+    --indulgent-ordering
+    --self-contained-html
+
 markers =
     # General
     polarion: Store polarion test ID
@@ -90,18 +105,3 @@ markers =
 
     # cluster_health_check
     cluster_health_check: cluster health check tests
-
-# pytest-html configuration
-generate_report_on_test = True
-render_collapsed = all
-self_contained_html = True
-
-addopts =
-    -p no:logging
-    --basetemp=/tmp/pytest
-    --strict-markers
-    --tc-file=tests/global_config.py
-    --tc-format=python
-    --show-progress
-    --order-dependencies
-    --indulgent-ordering


### PR DESCRIPTION
##### Short description:

Remove `self_contained_html = True` from pytest.ini and add it into the `addopts` option.

* ref: https://github.com/pytest-dev/pytest-html/issues/719

##### More details:

Also moved the config block up, to help the diff tool understand that this code block is under `[pytest]` and not under `markers`

##### What this PR does / why we need it:

This resolves the warning

    PytestConfigWarning: Unknown config option: self_contained_html


##### Which issue(s) this PR fixes:

##### Special notes for reviewer:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled HTML test reports with self-contained output and collapsible sections for easier review and sharing.
  * Expanded and standardized test markers to improve classification, filtering, ordering, and coverage across CI, clusters, hardware, install/upgrade flows, teams, and edge configurations.
  * Consolidated duplicate/overlapping test configuration entries for more consistent, predictable test runs and reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->