### PR TITLE
Remove duplicate rhel9 data source fixtures and change scope to session

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -901,8 +901,8 @@ def golden_image_data_source_scope_function(admin_client, golden_image_data_volu
     yield from create_or_update_data_source(admin_client=admin_client, dv=golden_image_data_volume_scope_function)
 
 
-@pytest.fixture(scope="module")
-def rhel9_data_source_scope_module(golden_images_namespace):
+@pytest.fixture(scope="session")
+def rhel9_data_source_scope_session(golden_images_namespace):
     return DataSource(
         client=golden_images_namespace.client,
         name=RHEL9_STR,

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
@@ -76,13 +76,13 @@ def auto_update_boot_source_vm(
 
 
 @pytest.fixture()
-def vm_without_boot_source(unprivileged_client, namespace, rhel9_data_source_scope_module):
+def vm_without_boot_source(unprivileged_client, namespace, rhel9_data_source_scope_session):
     with VirtualMachineForTestsFromTemplate(
-        name=f"{rhel9_data_source_scope_module.name}-vm",
+        name=f"{rhel9_data_source_scope_session.name}-vm",
         namespace=namespace.name,
         client=unprivileged_client,
         labels=template_labels(os="rhel9.0"),
-        data_source=rhel9_data_source_scope_module,
+        data_source=rhel9_data_source_scope_session,
         non_existing_pvc=True,
     ) as vm:
         vm.start()
@@ -91,28 +91,28 @@ def vm_without_boot_source(unprivileged_client, namespace, rhel9_data_source_sco
 
 
 @pytest.fixture()
-def opted_out_rhel9_data_source(rhel9_data_source_scope_module):
-    LOGGER.info(f"Wait for DataSource {rhel9_data_source_scope_module.name} to opt out")
+def opted_out_rhel9_data_source(rhel9_data_source_scope_session):
+    LOGGER.info(f"Wait for DataSource {rhel9_data_source_scope_session.name} to opt out")
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_5MIN,
             sleep=TIMEOUT_5SEC,
-            func=lambda: rhel9_data_source_scope_module.source.name == RHEL9_STR,
+            func=lambda: rhel9_data_source_scope_session.source.name == RHEL9_STR,
         ):
             if sample:
                 return
     except TimeoutExpiredError:
-        LOGGER.error(f"{rhel9_data_source_scope_module.name} DataSource source was not updated.")
+        LOGGER.error(f"{rhel9_data_source_scope_session.name} DataSource source was not updated.")
         raise
 
 
 @pytest.fixture()
-def rhel9_dv(admin_client, golden_images_namespace, rhel9_data_source_scope_module, rhel9_http_image_url):
+def rhel9_dv(admin_client, golden_images_namespace, rhel9_data_source_scope_session, rhel9_http_image_url):
     artifactory_secret = get_artifactory_secret(namespace=golden_images_namespace.name)
     artifactory_config_map = get_artifactory_config_map(namespace=golden_images_namespace.name)
     with DataVolume(
         client=admin_client,
-        name=rhel9_data_source_scope_module.source.name,
+        name=rhel9_data_source_scope_session.source.name,
         namespace=golden_images_namespace.name,
         url=rhel9_http_image_url,
         secret=artifactory_secret,

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -100,8 +100,8 @@ def rhel9_data_import_cron(admin_client, golden_images_namespace, updated_templa
 
 
 @pytest.fixture(scope="module")
-def original_rhel9_boot_source_pvc(rhel9_data_source_scope_module):
-    return isinstance(rhel9_data_source_scope_module.source, PersistentVolumeClaim)
+def original_rhel9_boot_source_pvc(rhel9_data_source_scope_session):
+    return isinstance(rhel9_data_source_scope_session.source, PersistentVolumeClaim)
 
 
 @pytest.fixture(scope="module")
@@ -120,8 +120,8 @@ def updated_rhel9_boot_source(
 
 
 @pytest.fixture(scope="module")
-def rhel9_boot_source_name(rhel9_data_source_scope_module):
-    return rhel9_data_source_scope_module.source.name
+def rhel9_boot_source_name(rhel9_data_source_scope_session):
+    return rhel9_data_source_scope_session.source.name
 
 
 @pytest.fixture(scope="module")
@@ -158,7 +158,7 @@ def disabled_data_import_cron_annotation_rhel9(
     admin_client,
     hco_namespace,
     rhel9_cached_snapshot,
-    rhel9_data_source_scope_module,
+    rhel9_data_source_scope_session,
     hyperconverged_status_templates_scope_function,
     hyperconverged_resource_scope_function,
 ):
@@ -172,9 +172,9 @@ def disabled_data_import_cron_annotation_rhel9(
         hyperconverged_resource=hyperconverged_resource_scope_function,
         updated_template=updated_template,
     )
-    rhel9_data_source_scope_module.wait_for_condition(
-        condition=rhel9_data_source_scope_module.Condition.READY,
-        status=rhel9_data_source_scope_module.Condition.Status.TRUE,
+    rhel9_data_source_scope_session.wait_for_condition(
+        condition=rhel9_data_source_scope_session.Condition.READY,
+        status=rhel9_data_source_scope_session.Condition.Status.TRUE,
         timeout=TIMEOUT_3MIN,
     )
 
@@ -184,7 +184,7 @@ def rhel9_golden_image_vm(
     request,
     snapshot_storage_class_name_scope_module,
     rhel9_cached_snapshot,
-    rhel9_data_source_scope_module,
+    rhel9_data_source_scope_session,
     unprivileged_client,
     namespace,
 ):
@@ -193,7 +193,7 @@ def rhel9_golden_image_vm(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=rhel9_data_source_scope_module,
+            data_source=rhel9_data_source_scope_session,
             storage_class=snapshot_storage_class_name_scope_module,
         ),
     ) as vm:
@@ -205,11 +205,11 @@ def rhel9_golden_image_vm(
 def test_automatic_update_for_system_cached_snapshot(
     rhel9_cached_snapshot,
     disabled_common_boot_image_import_hco_spec_rhel9_scope_function,
-    rhel9_data_source_scope_module,
+    rhel9_data_source_scope_session,
 ):
-    rhel9_data_source_scope_module.wait_for_condition(
-        condition=rhel9_data_source_scope_module.Condition.READY,
-        status=rhel9_data_source_scope_module.Condition.Status.FALSE,
+    rhel9_data_source_scope_session.wait_for_condition(
+        condition=rhel9_data_source_scope_session.Condition.READY,
+        status=rhel9_data_source_scope_session.Condition.Status.FALSE,
         timeout=TIMEOUT_3MIN,
     )
 
@@ -219,12 +219,12 @@ def test_automatic_update_for_system_cached_snapshot(
 def test_disable_automatic_update_using_annotation(
     disabled_data_import_cron_annotation_rhel9,
     rhel9_data_import_cron,
-    rhel9_data_source_scope_module,
+    rhel9_data_source_scope_session,
 ):
     wait_for_deleted_data_import_crons(data_import_crons=[rhel9_data_import_cron])
-    rhel9_data_source_scope_module.wait_for_condition(
-        condition=rhel9_data_source_scope_module.Condition.READY,
-        status=rhel9_data_source_scope_module.Condition.Status.FALSE,
+    rhel9_data_source_scope_session.wait_for_condition(
+        condition=rhel9_data_source_scope_session.Condition.READY,
+        status=rhel9_data_source_scope_session.Condition.Status.FALSE,
         timeout=TIMEOUT_3MIN,
     )
 

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -54,13 +54,6 @@ DEFAULT_DV_SIZE = "1Gi"
 
 
 @pytest.fixture(scope="module")
-def golden_images_rhel9_data_source(golden_images_namespace):
-    return DataSource(
-        namespace=golden_images_namespace.name, name="rhel9", client=golden_images_namespace.client, ensure_exists=True
-    )
-
-
-@pytest.fixture(scope="module")
 def mig_cluster(admin_client):
     return MigCluster(name="host", namespace=OPENSHIFT_MIGRATION_NAMESPACE, client=admin_client, ensure_exists=True)
 
@@ -165,7 +158,7 @@ def vm_for_storage_class_migration_with_instance_type(
 
 @pytest.fixture(scope="class")
 def vm_for_storage_class_migration_from_template_with_data_source(
-    unprivileged_client, namespace, golden_images_rhel9_data_source, source_storage_class, cpu_for_migration
+    unprivileged_client, namespace, rhel9_data_source_scope_session, source_storage_class, cpu_for_migration
 ):
     with VirtualMachineForTests(
         name="vm-from-template-and-data-source",
@@ -173,7 +166,7 @@ def vm_for_storage_class_migration_from_template_with_data_source(
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_RHEL,
         data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=golden_images_rhel9_data_source,
+            data_source=rhel9_data_source_scope_session,
             storage_class=source_storage_class,
         ),
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,


### PR DESCRIPTION
##### Short description:
Remove duplicate rhel9 data source fixtures and change scope to session

##### More details:
The rhel9 data source object is created in several fixtures used across the repository, this PR thrive to merge those.
Since the rhel9 data source object is constant, and it is used as an object to call the `.instance` method, there is no risk in changing the fixture scope to `session` 

##### What this PR does / why we need it:
 - Remove redundant fixtures
 - Minimize object creation and fixture calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use session-scoped lifecycle instead of module-scoped for improved test isolation and lifecycle management.
  * Enhanced data source initialization with additional configuration parameters.
  * Removed redundant fixture and consolidated data source test infrastructure across test modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->