### PR TITLE
WIP: Virt: Add Fedora42 arm64 qcow2 image

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -54,7 +54,7 @@ storage_class_b = StorageClassNames.IO2_CSI
 
 rhel_os_matrix = generate_os_matrix_dict(os_name="rhel", supported_operating_systems=["rhel-9-5", "rhel-9-6"])
 
-latest_rhel_os_dict = get_latest_os_dict_list(os_list=[rhel_os_matrix])[0]
+fedora_os_matrix = generate_os_matrix_dict(os_name="fedora", supported_operating_systems=["fedora-42"])
 
 # Modify instance_type_rhel_os_matrix for arm64
 instance_type_rhel_os_matrix = generate_linux_instance_type_os_matrix(
@@ -67,6 +67,10 @@ instance_type_fedora_os_matrix = generate_linux_instance_type_os_matrix(
     os_name=OS_FLAVOR_FEDORA, preferences=[OS_FLAVOR_FEDORA], arch_suffix=ARM_64
 )
 
+(
+    latest_rhel_os_dict,
+    latest_fedora_os_dict,
+) = get_latest_os_dict_list(os_list=[rhel_os_matrix, fedora_os_matrix])
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -125,7 +125,11 @@ class ArchImages:
         Rhel.LATEST_RELEASE_STR = Rhel.RHEL9_6_IMG
 
         Windows = Windows()
-        Fedora = Fedora()
+        Fedora = Fedora(
+            FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2",
+            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64",
+        )
+        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG
         Centos = Centos()
         Cdi = Cdi()
 


### PR DESCRIPTION

##### Short description:
Add Fedora42 arm64 qcow2 image 
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fedora 42 support alongside RHEL in the OS matrix, enabling Fedora targets in ARM64 test/config flows.
  * Updated ARM64 image selection to use Fedora 42 system and container images for Fedora targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->