### PR TITLE
Add cache to get_test_artifact_server_url

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -3,6 +3,7 @@ import math
 import os
 import shlex
 from contextlib import contextmanager
+from functools import cache
 
 import kubernetes
 import requests
@@ -590,10 +591,13 @@ def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
     return dv.res
 
 
+@cache
 def get_test_artifact_server_url(schema="https"):
     """
     Verify https server server connectivity (regardless of schema).
     Return the requested "registry" or "https" server url.
+
+    Results are cached to avoid repeated connectivity checks.
 
     Args:
         schema (str): registry or https.


### PR DESCRIPTION
##### Short description:
Add cache to get_test_artifact_server_url

##### More details:
get_test_artifact_server_url is used to return the schema server url, which should be the same across all tests depending on the schema.
Adding a cache will reduce the API calls to verify the URL is accessible.

##### What this PR does / why we need it:
Reduce API calls to the artifactory server

##### Which issue(s) this PR fixes:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/2310/files#r2435979978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced artifact server performance through optimized URL retrieval with intelligent caching mechanisms. This eliminates redundant connectivity checks, reduces latency, and improves response times for artifact access operations. The optimization delivers faster testing cycles and more efficient resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->