### PR TITLE
Fix bridge-marker negative tests

### DIFF
--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -139,9 +139,7 @@ def _assert_failure_reason_is_bridge_missing(vmi, bridge):
             assert cond.reason == "Unschedulable"
             assert f"Insufficient {bridge.resource_name}" in cond.message
             return
-    pytest.fail(
-        f"VMI {vmi.name} doesn't report {requested_condition}. Reported conditions:{conditions}"
-    )
+    pytest.fail(f"VMI {vmi.name} doesn't report {requested_condition}. Reported conditions:{conditions}")
 
 
 @pytest.mark.sno


### PR DESCRIPTION
1. Scan the VMI for the failure reason rather than the pod. THis is a VM, so expect the user to be reported about relevant status via the kubevirt resources.
2. Scan all the conditions, instead of assuming the relevant condition is the first one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test helpers updated to operate on virtual machine instances; all test call sites adjusted accordingly.
  * Validation improved to scan all status conditions for scheduling failures and assert Unschedulable with an "Insufficient …" bridge-related message.
  * Failure output made clearer when the expected scheduling condition is absent, aiding troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->