### PR TITLE
net, gating tests: Fix failed gating tests

### DIFF
--- a/utilities/network.py
+++ b/utilities/network.py
@@ -37,8 +37,8 @@ from utilities.constants import (
     MTU_9000,
     OVS_BRIDGE,
     SRIOV,
-    TIMEOUT_2MIN,
     TIMEOUT_3MIN,
+    TIMEOUT_4MIN,
     TIMEOUT_8MIN,
     TIMEOUT_90SEC,
     WORKERS_TYPE,
@@ -498,7 +498,7 @@ def get_vmi_ip_v4_by_name(vm, name):
         utilities.virt.wait_for_vm_interfaces(vmi=vmi)
         return _extract_interface_ips()
 
-    sampler = TimeoutSampler(wait_timeout=TIMEOUT_2MIN, sleep=1, func=_get_interface_ips)
+    sampler = TimeoutSampler(wait_timeout=TIMEOUT_4MIN, sleep=1, func=_get_interface_ips)
     try:
         for ip_addresses in sampler:
             for ip_address in ip_addresses:


### PR DESCRIPTION
https://jenkins-csb-cnvqe-main.dno.corp.redhat.com/job/test-pytest-cnv-4.20-network-gating/84/testReport/ The following tests fail on CI when running on BM cluster but pass os PSI cluster:
- connectivity.test_ovs_linux_bridge.TestConnectivityLinuxBridge.test_ipv4_linux_bridge[L2_bridge_network]
- nmstate.test_connectivity_after_nmstate_changes.TestConnectivityAfterNmstateChanged.test_connectivity_after_nncp_change

Increase `wait_timeout` when calling `get_vmi_ip_v4_by_name`, as VM `vm_linux_bridge_attached_vmb_destination` may take longer to obtain an IP address due to recent NNCP changes

Reducing wait_timeout to a very small value causes the test to fail on the PSI cluster, reproducing the same error seen in CI

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout duration for interface IP extraction operations from 2 minutes to 4 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->