### PR TITLE
[storage][t2] Increase DataVolume size in test_public_registry_data_volume_low_capacity to 6Gi to avoid import failure

### DIFF
--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -150,6 +150,7 @@ def test_public_registry_data_volume_low_capacity(namespace, storage_class_name_
         namespace=namespace.name,
         url=dv_param["url"],
         storage_class=dv_param["storage_class"],
+        size="6Gi",
     ) as dv:
         dv.wait_for_dv_success()
         with create_vm_from_dv(


### PR DESCRIPTION
##### Short description:
increase def create_dv size to 6Gi 

virtual image size 5368709120 is larger than the reported available storage 5368381440
A larger PVC is required 
test fail because of this test_public_registry_data_volume_low_capacity  for gcnv-flex sc



##### More details:

Same virtual image can appear slightly larger or smaller depending on SC.
Ceph RBD: forgiving, thin-provisioned → import succeeds.
Trident Flex: strict, exact allocation → may require larger PVC.

##### What this PR does / why we need it:

The test `test_public_registry_data_volume_low_capacity` failed due to insufficient PVC capacity:

  Virtual image size 5368709120 is larger than the reported available storage 5368381440
  → "A larger PVC is required"

Since the same virtual image can appear slightly larger or smaller depending on the storage backend 
(e.g., Ceph RBD is forgiving and thin-provisioned, while Trident Flex is strict and requires exact allocation),
the DV size was increased to 6Gi to ensure the import succeeds across all environments.

No functional change to the test logic — only size adjustment to prevent false negatives.


##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70958
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced data volume storage tests by specifying a 6Gi size for low-capacity scenarios and verifying recreated volumes in the positive flow honor the specified size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->