### PR TITLE
[Storage] Update hotplug test for declarative hotplug

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -7,10 +7,12 @@ import shlex
 
 import pytest
 from ocp_resources.datavolume import DataVolume
+from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
 
 from tests.os_params import WINDOWS_LATEST, WINDOWS_LATEST_LABELS
 from utilities.constants import HOTPLUG_DISK_SERIAL
+from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist_optional_restart,
@@ -25,17 +27,33 @@ from utilities.virt import (
     migrate_vm_and_verify,
     running_vm,
     vm_instance_from_template,
-    wait_for_ssh_connectivity,
     wait_for_windows_vm,
 )
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.post_upgrade
+pytestmark = [
+    pytest.mark.usefixtures("enabled_feature_gate_for_declarative_hotplug_volumes"),
+    pytest.mark.post_upgrade,
+]
 
 
 def is_dv_migratable(dv):
     return StorageProfile(name=dv.storage_class).first_claim_property_set_access_modes()[0] == DataVolume.AccessMode.RWX
+
+
+@pytest.fixture(scope="module")
+def enabled_feature_gate_for_declarative_hotplug_volumes(
+    hyperconverged_resource_scope_module,
+):
+    with ResourceEditorValidateHCOReconcile(
+        patches={
+            hyperconverged_resource_scope_module: {"spec": {"featureGates": {"declarativeHotplugVolumes": True}}},
+        },
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
 
 
 @pytest.fixture(scope="class")
@@ -152,42 +170,6 @@ def blank_disk_dv_multi_storage_scope_class(namespace, param_substring_scope_cla
         consume_wffc=False,
     ) as dv:
         yield dv
-
-
-@pytest.mark.parametrize(
-    "hotplug_volume_scope_class",
-    [
-        pytest.param({"serial": HOTPLUG_DISK_SERIAL}),
-    ],
-    indirect=True,
-)
-@pytest.mark.conformance
-@pytest.mark.gating
-class TestHotPlugWithSerial:
-    @pytest.mark.sno
-    @pytest.mark.polarion("CNV-6013")
-    @pytest.mark.dependency(name="test_hotplug_volume_with_serial")
-    @pytest.mark.s390x
-    def test_hotplug_volume_with_serial(
-        self,
-        blank_disk_dv_multi_storage_scope_class,
-        fedora_vm_for_hotplug_scope_class,
-        hotplug_volume_scope_class,
-    ):
-        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class)
-        wait_for_ssh_connectivity(vm=fedora_vm_for_hotplug_scope_class)
-        assert_disk_serial(vm=fedora_vm_for_hotplug_scope_class)
-
-    @pytest.mark.polarion("CNV-11389")
-    @pytest.mark.dependency(depends=["test_hotplug_volume_with_serial"])
-    def test_hotplug_volume_with_serial_migrate(
-        self,
-        blank_disk_dv_multi_storage_scope_class,
-        fedora_vm_for_hotplug_scope_class,
-        hotplug_volume_scope_class,
-    ):
-        if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
-            migrate_vm_and_verify(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
 
 
 @pytest.mark.parametrize(

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -365,6 +365,7 @@ def virtctl_volume(
     # clean up:
     command = [
         "removevolume",
+        "--persist",
         f"{vm_name}",
         f"--volume-name={volume_name}",
     ]


### PR DESCRIPTION
  Hot plugged disks are persistent by default
  The use of non-persistent hot plugged disks is deprecated

  - Remove the non-peristent testing
  - Add --persist in teardown
  - Enable the declarative hotplug volume FG

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a module-level fixture to enable declarative hotplug volumes during test runs and updated test collection to apply it and post-upgrade checks.
  * Removed obsolete serial-specific hotplug tests and related SSH connectivity usage.

* **Bug Fixes**
  * Enforced persistence when removing volumes; add-volume behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->