### PR TITLE
[STORAGE]{MAIN] Wait for PVC to be bound before accessing pod for SHA calculation

### DIFF
--- a/tests/storage/vm_export/test_vm_export.py
+++ b/tests/storage/vm_export/test_vm_export.py
@@ -82,6 +82,8 @@ def test_vmexport_snapshot_manifests(
     vm_from_vmexport,
 ):
     pvc_name = vm_from_vmexport.instance.to_dict()["spec"]["dataVolumeTemplates"][0]["metadata"]["name"]
+    target_pvc = PersistentVolumeClaim(name=pvc_name, namespace=vm_from_vmexport.namespace)
+    target_pvc.wait_for_status(status=PersistentVolumeClaim.Status.BOUND, timeout=300)
     source_pvc_sha256sum = get_pvc_sha256sum(
         pvc_name=f"{vmexport_from_vmsnapshot.name}-{pvc_name}",
         pvc_namespace=namespace.name,


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for VM export operations by adding synchronization to wait for exported storage resources to reach a ready state before performing checksum validation, reducing flakes and race conditions during export tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->