### PR TITLE
net, gating tests: Fix IP conflict

### DIFF
--- a/tests/network/connectivity/utils.py
+++ b/tests/network/connectivity/utils.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from tests.network.libs.ip import random_ipv4_address
 from utilities.constants import IPV6_STR
 from utilities.network import (
     compose_cloud_init_data_dict,
@@ -31,7 +32,10 @@ def create_running_vm(
         node_selector=node_selector,
         cloud_init_data=compose_cloud_init_data_dict(
             network_data={
-                "ethernets": {f"eth{i + 1}": {"addresses": [f"10.200.{i}.{end_ip_octet}/24"]} for i in range(0, 3)}
+                "ethernets": {
+                    f"eth{i + 1}": {"addresses": [f"{random_ipv4_address(net_seed=i, host_address=end_ip_octet)}/24"]}
+                    for i in range(0, 3)
+                }
             },
             ipv6_network_data=dual_stack_network_data,
         ),

--- a/tests/network/kubemacpool/test_kubemacpool.py
+++ b/tests/network/kubemacpool/test_kubemacpool.py
@@ -9,13 +9,14 @@ from . import utils as kmp_utils
 
 @pytest.mark.s390x
 class TestKMPConnectivity:
-    #: KMPTestConnectivity setup
-    # .........                                                                    ..........
-    # |       |---eth0:           : POD network                :auto:       eth0---|        |
-    # |       |---eth1:10.200.1.1: Manual MAC          from pool:10.200.1.2:eth1---|        |
-    # | VM-A  |---eth2:10.200.2.1: Automatic MAC       from pool:10.200.2.2:eth2---|  VM-B  |
-    # |       |---eth3:10.200.3.1: Manual MAC not      from pool:10.200.3.2:eth3---|        |
-    # |.......|---eth4:10.200.4.1: Automatic mac tuning network :10.200.4.2:eth4---|........|
+    # KMPTestConnectivity setup example
+    # Third octet is random
+    # .........                                                                       ..........
+    # |       |---eth0:           : POD network                   :auto       :eth0---|        |
+    # |       |---eth1:172.16.37.1: Manual MAC from pool          :172.16.37.2:eth1---|        |
+    # | VM-A  |---eth2:172.16.24.1: Automatic MAC from pool       :172.16.24.2:eth2---|  VM-B  |
+    # |       |---eth3:172.16.51.1: Manual MAC not from pool      :172.16.51.2:eth3---|        |
+    # |.......|---eth4:172.16.65.1: Automatic mac tuning network  :172.16.65.2:eth4---|........|
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-2154")
     def test_manual_mac_from_pool(self, namespace, running_vm_a, running_vm_b):

--- a/tests/network/kubemacpool/utils.py
+++ b/tests/network/kubemacpool/utils.py
@@ -2,6 +2,7 @@ import logging
 from collections import namedtuple
 from ipaddress import ip_interface
 
+from tests.network.libs.ip import random_ipv4_address
 from utilities.network import cloud_init_network_data, get_vmi_mac_address_by_iface_name
 from utilities.virt import (
     VirtualMachineForTests,
@@ -26,17 +27,25 @@ def vm_network_config(mac_pool, all_nads, end_ip_octet, mac_uid):
     """
     return {
         "eth1": IfaceTuple(
-            ip_address=f"10.200.1.{end_ip_octet}",
+            ip_address=random_ipv4_address(net_seed=0, host_address=end_ip_octet),
             mac_address=mac_pool.get_mac_from_pool(),
             name=all_nads[0],
         ),
-        "eth2": IfaceTuple(ip_address=f"10.200.2.{end_ip_octet}", mac_address="auto", name=all_nads[1]),
+        "eth2": IfaceTuple(
+            ip_address=random_ipv4_address(net_seed=1, host_address=end_ip_octet),
+            mac_address="auto",
+            name=all_nads[1],
+        ),
         "eth3": IfaceTuple(
-            ip_address=f"10.200.3.{end_ip_octet}",
+            ip_address=random_ipv4_address(net_seed=2, host_address=end_ip_octet),
             mac_address=f"02:0{mac_uid}:00:00:00:00",
             name=all_nads[2],
         ),
-        "eth4": IfaceTuple(ip_address=f"10.200.4.{end_ip_octet}", mac_address="auto", name=all_nads[3]),
+        "eth4": IfaceTuple(
+            ip_address=random_ipv4_address(net_seed=3, host_address=end_ip_octet),
+            mac_address="auto",
+            name=all_nads[3],
+        ),
     }
 
 

--- a/tests/network/libs/ip.py
+++ b/tests/network/libs/ip.py
@@ -1,0 +1,39 @@
+import random
+from functools import cache
+from typing import Final
+
+_MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION: Final[int] = 4
+_IPV4_ADDRESS_SUBNET_PREFIX_VMI: Final[str] = "172.16"
+
+
+def random_ipv4_address(net_seed: int, host_address: int) -> str:
+    """Construct a random IPv4 address using a cached list of random third octets.
+
+    Uses a pre-defined network address, a cached random third octet and the given
+    host address to generate deterministic yet randomized IPv4 addresses.
+
+    Args:
+        net_seed (int): The index used to select a random third octet from the cached list.
+        host_address (int): The last (fourth) octet of the IPv4 address.
+
+    Returns:
+        str: A string representing a randomized IPv4 address.
+    """
+    third_octets = _random_octets(count=_MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION)
+    return f"{_IPV4_ADDRESS_SUBNET_PREFIX_VMI}.{third_octets[net_seed]}.{host_address}"
+
+
+@cache
+def _random_octets(count: int) -> list[int]:
+    """Generate a list of random IPv4 octet values.
+
+    Randomly selects unique integers between 1 and 253 (inclusive) to be used
+    as the third octet in an IPv4 address.
+
+    Args:
+        count (int): The number of random octet values to generate.
+
+    Returns:
+        list[int]: A list of unique random integers representing octet values.
+    """
+    return random.sample(range(1, 254), count)

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -5,6 +5,7 @@ import pytest
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutSampler
 
+from tests.network.libs.ip import random_ipv4_address
 from tests.network.utils import (
     assert_nncp_successfully_configured,
     assert_ssh_alive,
@@ -94,7 +95,7 @@ def nmstate_linux_bridge_attached_vma(
     networks[nmstate_linux_nad.name] = nmstate_linux_nad.name
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": ["10.200.0.1/24"]},
+            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]},
         }
     }
 
@@ -128,7 +129,7 @@ def nmstate_linux_bridge_attached_vmb(
     networks[nmstate_linux_nad.name] = nmstate_linux_nad.name
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": ["10.200.0.2/24"]},
+            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]},
         }
     }
 


### PR DESCRIPTION
The following tests fail on CI when running on BM cluster under specified domain but pass on PSI cluster and other BM clusters:
- `connectivity.test_ovs_linux_bridge.TestConnectivityLinuxBridge.test_ipv4_linux_bridge[L2_bridge_network]`
- `tests.network.kubemacpool.test_kubemacpool.TestKMPConnectivity.test_automatic_mac_from_pool`
- `nmstate.test_connectivity_after_nmstate_changes.TestConnectivityAfterNmstateChanged.test_connectivity_after_nncp_change`

Problem: CI tests on bare-metal clusters frequently fail during VMI interfaces IP address retrieval Analysis showed the IP address assignment attempt for all ethernet interfaces is failing due to specified hard-coded IP addresses with IP prefix of `10.200.x.y` we tried to assign are already in use by unknown resource in the cluster, or the network, as some of cnv BM clusters are not isolated.

vmb journalctl log:
- `(eth1): IP address 10.200.0.2 cannot be configured because it is already in use in the network by host 02:B3:38:14:CB:06`
- `(eth2): IP address 10.200.1.2 cannot be configured because it is already in use in the network by host 02:8A:1D:00:00:18`
- `(eth3): IP address 10.200.2.2 cannot be configured because it is already in use in the network by host 02:8A:1D:00:00:19`
- `(eth2): IP address 10.200.2.2 cannot be configured because it is already in use in the network by host 02:B3:38:14:CB:07`
- `(eth4): IP address 10.200.4.2 cannot be configured because it is already in use in the network by host 02:B3:38:14:CB:09` According to DevOps: `10.x.x.x/8 is Redhat (and to some extended also IBM) internal network, and 10.200.x.y might be a real subnet in use.`

Fix: This PR will reduce IP address conflicts by updating the assignment logic to exclusively select addresses that are not reserved, by adding a fixture in network conftest.py to generate random IPv4 octet and change the IPv4 prefix assigned to VM's IP address.
This fix is the first part of this change, and eventually we will use this new `IPV4_ADDRESS_SUBNET_PREFIX_VMI` instead of 10.200.x.y in all the network tests.

##### jira-ticket: https://issues.redhat.com/browse/CNV-71207
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic IPv4 generator for test sessions to produce consistent, varied third-octets.

* **Tests**
  * Replaced static 10.200.x.x addresses with dynamically generated addresses across network connectivity tests for better isolation.
  * Updated test diagrams/comments to reflect the new 172.16.x.x example range and randomized third octet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->