### PR TITLE
[CNV-70167] Stabilize test_deprecated_apis_in_audit_logs by handling API timeout errors

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1068,12 +1068,19 @@ def generate_openshift_pull_secret_file(client: DynamicClient = None) -> str:
     exceptions_dict={RuntimeError: []},
 )
 def get_node_audit_log_entries(log, node, log_entry):
+    # Patterns to match errors that should trigger a retry
+    error_patterns_list = [
+        r"^\s*error:",
+        r"Unhandled Error.*couldn't get current server API group list.*i/o timeout",
+    ]
+    error_patterns = re.compile("|".join(f"({pattern})" for pattern in error_patterns_list))
+
     lines = subprocess.getoutput(
         f"{OC_ADM_LOGS_COMMAND} {node} {AUDIT_LOGS_PATH}/{log} | grep {shlex.quote(log_entry)}"
     ).splitlines()
-    has_errors = any(line.startswith("error:") for line in lines)
+    has_errors = any(error_patterns.search(line) for line in lines)
     if has_errors:
-        if any(line.startswith("404 page not found") for line in lines):
+        if any(line.strip().startswith("404 page not found") for line in lines):
             LOGGER.warning(f"Skipping {log} check as it was rotated:\n{lines}")
             return True, []
         LOGGER.warning(f"oc command failed for node {node}, log {log}:\n{lines}")


### PR DESCRIPTION
##### Short description:
Update get_node_audit_log_entries to detect and retry on transient OpenShift API timeout errors.

This prevents test failures when the API server is temporarily unavailable, allowing the existing retry mechanism to handle these transient errors too.

##### More details:
N/A

##### What this PR does / why we need it:
N/A

##### Which issue(s) this PR fixes:
N/A

##### Special notes for reviewer:
N/A

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened detection of error conditions so more transient failures are recognized and handled, improving reliability.
  * Switched to line-by-line pattern matching for error detection to reduce missed cases.
  * Made "page not found" checks tolerant of leading/trailing whitespace to avoid false negatives while preserving retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->