### PR TITLE
Fix quarantined test_data_import_cron_deletion_on_opt_out

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2492,9 +2492,11 @@ def migrated_vm_multiple_times(request, vm_for_migration_test):
 
 
 @pytest.fixture()
-def removed_default_storage_classes(cluster_storage_classes):
+def removed_default_storage_classes(admin_client, golden_images_namespace, cluster_storage_classes):
     with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
         yield
+    if not verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name):
+        pytest.fail("Failed to reimport all boot sources at teardown")
 
 
 @pytest.fixture(scope="session")

--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -42,7 +42,7 @@ def fedora_vm_from_data_source(
     golden_images_namespace,
     namespace,
     fedora_data_source,
-    storage_class_from_config_different_from_data_source,
+    storage_class_from_config_different_from_default,
 ):
     with VirtualMachineForTests(
         name="fedora-vm-from-data-source",
@@ -51,28 +51,12 @@ def fedora_vm_from_data_source(
         memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=fedora_data_source,
-            storage_class=storage_class_from_config_different_from_data_source
+            storage_class=storage_class_from_config_different_from_default
             if request.param.get("set_storage_class")
             else None,
         ),
     ) as vm:
         yield vm
-
-
-@pytest.fixture(scope="module")
-def storage_class_from_config_different_from_data_source(fedora_data_source):
-    different_storage_class = next(
-        (
-            storage_class_name
-            for storage_class in py_config["storage_class_matrix"]
-            for storage_class_name in storage_class
-            if storage_class_name != fedora_data_source.source.instance.spec.storageClassName
-        ),
-        None,
-    )
-    if different_storage_class is None:
-        pytest.xfail("storage_class_matrix only has 1 storage class defined")
-    return different_storage_class
 
 
 @pytest.fixture(scope="module")

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -19,7 +19,6 @@ from tests.infrastructure.golden_images.constants import (
 from tests.infrastructure.golden_images.update_boot_source.utils import get_all_dic_volume_names
 from utilities.constants import (
     BIND_IMMEDIATE_ANNOTATION,
-    QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,
@@ -34,7 +33,10 @@ from utilities.ssp import (
     wait_for_condition_message_value,
     wait_for_deleted_data_import_crons,
 )
-from utilities.storage import DATA_IMPORT_CRON_SUFFIX, data_volume_template_with_source_ref_dict
+from utilities.storage import (
+    DATA_IMPORT_CRON_SUFFIX,
+    data_volume_template_with_source_ref_dict,
+)
 from utilities.virt import VirtualMachineForTests, running_vm
 
 LOGGER = logging.getLogger(__name__)
@@ -328,10 +330,6 @@ class TestDataImportCronDefaultStorageClass:
         )
 
 
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: This test still fail in some cases ; tracked in CNV-62615",
-    run=False,
-)
 @pytest.mark.polarion("CNV-7532")
 def test_data_import_cron_deletion_on_opt_out(
     admin_client,


### PR DESCRIPTION
##### Short description:
Fix quarantined test `test_data_import_cron_deletion_on_opt_out`

##### More details:
`test_data_import_cron_deletion_on_opt_out` was flaky because prior to it's run, the previous test would intiaite a re-import for all the PVC/SnapShotvVolume, this meant that when getting at the start the value for `existing_dic_volumes_before_disable` we need to first wait for all the imports to be finished.

 - in cases we run with --storage-class-matrix the test will be skipped every time, changed this to use an available FS storage class 
 - Changed `storage_class_from_config_different_from_data_source` to `storage_class_from_config_different_from_default`, this will give the same result since the data source storage class is the default one, while being more clear on the return value of the storage class.
 - Added a wait function after reverting the default storage class in `removed_default_storage_classes`. when a new default storage class is changed, all the data sources DV's are being re-imported to the new storage class, so we should wait for them to stabilise before continuing
 - Added an optional param to `verify_boot_sources_reimported` so we can also verify the sources are ready.

##### What this PR does / why we need it:
Remove quarantined test

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-62615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled a previously skipped data-import deletion test.
  * Added teardown validation to ensure boot sources are reimported as expected.
  * Adjusted tests to consistently use a selected non-default storage class.

* **Chores**
  * Renamed and refactored fixture interfaces for clearer intent.
  * Added a fixture to select a storage class different from the configured default and improved test setup robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->