### PR TITLE
net: use routes.running instead of routes.config in nns lookup

### DIFF
--- a/tests/network/libs/nodenetworkstate.py
+++ b/tests/network/libs/nodenetworkstate.py
@@ -28,7 +28,7 @@ def lookup_br_ex_gateway_v4(node_name: str, client: DynamicClient) -> str:
     """
     nns_state = NodeNetworkState(name=node_name, client=client, ensure_exists=True).instance.status.currentState
 
-    for route in nns_state.routes.config:
+    for route in nns_state.routes.running:
         if route.destination == DEFAULT_ROUTE_V4.dst and route["next-hop-interface"] == DEFAULT_OVN_EXTERNAL_BRIDGE:
             return route["next-hop-address"]
 


### PR DESCRIPTION
##### Short description:
Using routes.running instead of routes.config in nns lookup

##### More details:
Previously, the code accessed `routes.config` to retrieve route information from the `NodeNetworkState` resource. However, `routes.config` represents the desired configuration, not the actual state of the node's network routes. To ensure that the lookup reflects the real, currently active routes on the node, the code now uses `routes.running`. This change improves accuracy by querying the live state, which is essential for operations that depend on the actual network setup.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved network gateway detection test validation by utilizing active route state instead of configuration-only routes, ensuring more accurate testing of external bridge network setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->