### PR TITLE
add mandatory client parameter to fedora_vm

### DIFF
--- a/libs/vm/factory.py
+++ b/libs/vm/factory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from kubernetes.dynamic import DynamicClient
+
 from libs.vm.spec import CPU, Devices, Domain, Memory, Metadata, Template, VMISpec, VMSpec
 from libs.vm.vm import BaseVirtualMachine, container_image, containerdisk_storage
 from utilities.constants import OS_FLAVOR_FEDORA, Images
@@ -8,6 +10,7 @@ from utilities.constants import OS_FLAVOR_FEDORA, Images
 def fedora_vm(
     namespace: str,
     name: str,
+    client: DynamicClient,
     spec: VMSpec | None = None,
     vm_labels: dict[str, str] | None = None,
     vm_annotations: dict[str, str] | None = None,
@@ -21,6 +24,7 @@ def fedora_vm(
         vm_labels=vm_labels,
         vm_annotations=vm_annotations,
         os_distribution=OS_FLAVOR_FEDORA,
+        client=client,
     )
 
 

--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -211,8 +211,9 @@ def bgp_setup_ready(
 def vm_cudn(
     namespace_cudn: Namespace,
     cudn_layer2: libcudn.ClusterUserDefinedNetwork,
+    admin_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
-    with udn_vm(namespace_name=namespace_cudn.name, name="vm-cudn-bgp") as vm:
+    with udn_vm(namespace_name=namespace_cudn.name, name="vm-cudn-bgp", client=admin_client) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()
         yield vm

--- a/tests/network/libs/vm_factory.py
+++ b/tests/network/libs/vm_factory.py
@@ -1,12 +1,16 @@
 """This module provides various virtual machine configurations with a focus on network setups."""
 
+from kubernetes.dynamic import DynamicClient
+
 from libs.net.udn import udn_primary_network
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.vm import BaseVirtualMachine
 
 
-def udn_vm(namespace_name: str, name: str, template_labels: dict | None = None) -> BaseVirtualMachine:
+def udn_vm(
+    namespace_name: str, name: str, client: DynamicClient, template_labels: dict | None = None
+) -> BaseVirtualMachine:
     spec = base_vmspec()
     iface, network = udn_primary_network(name="udn-primary")
     spec.template.spec.domain.devices.interfaces = [iface]  # type: ignore
@@ -18,4 +22,4 @@ def udn_vm(namespace_name: str, name: str, template_labels: dict | None = None) 
         label, *_ = template_labels.items()
         spec.template.spec.affinity = new_pod_anti_affinity(label=label)
 
-    return fedora_vm(namespace=namespace_name, name=name, spec=spec)
+    return fedora_vm(namespace=namespace_name, name=name, client=client, spec=spec)

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -53,13 +53,23 @@ def nncp_localnet() -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
 
 
 @pytest.fixture(scope="module")
-def namespace_localnet_1(admin_client: DynamicClient) -> Generator[Namespace]:
-    yield from create_ns(admin_client=admin_client, name="test-localnet-ns1", labels=LOCALNET_TEST_LABEL)
+def namespace_localnet_1(admin_client: DynamicClient, unprivileged_client: DynamicClient) -> Generator[Namespace]:
+    yield from create_ns(
+        admin_client=admin_client,
+        unprivileged_client=unprivileged_client,
+        name="test-localnet-ns1",
+        labels=LOCALNET_TEST_LABEL,
+    )
 
 
 @pytest.fixture(scope="module")
-def namespace_localnet_2(admin_client: DynamicClient) -> Generator[Namespace]:
-    yield from create_ns(admin_client=admin_client, name="test-localnet-ns2", labels=LOCALNET_TEST_LABEL)
+def namespace_localnet_2(admin_client: DynamicClient, unprivileged_client: DynamicClient) -> Generator[Namespace]:
+    yield from create_ns(
+        admin_client=admin_client,
+        unprivileged_client=unprivileged_client,
+        name="test-localnet-ns2",
+        labels=LOCALNET_TEST_LABEL,
+    )
 
 
 @pytest.fixture(scope="module")
@@ -93,6 +103,7 @@ def vm_localnet_1(
     namespace_localnet_1: Namespace,
     ipv4_localnet_address_pool: Generator[str],
     cudn_localnet: libcudn.ClusterUserDefinedNetwork,
+    unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -100,6 +111,7 @@ def vm_localnet_1(
         physical_network_name=cudn_localnet.name,
         spec_logical_network=LOCALNET_BR_EX_NETWORK,
         cidr=next(ipv4_localnet_address_pool),
+        client=unprivileged_client,
     ) as vm:
         yield vm
 
@@ -109,6 +121,7 @@ def vm_localnet_2(
     namespace_localnet_2: Namespace,
     ipv4_localnet_address_pool: Generator[str],
     cudn_localnet: libcudn.ClusterUserDefinedNetwork,
+    unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_2.name,
@@ -116,6 +129,7 @@ def vm_localnet_2(
         physical_network_name=cudn_localnet.name,
         spec_logical_network=LOCALNET_BR_EX_NETWORK,
         cidr=next(ipv4_localnet_address_pool),
+        client=unprivileged_client,
     ) as vm:
         yield vm
 
@@ -206,6 +220,7 @@ def vm_ovs_bridge_localnet_link_down(
     namespace_localnet_1: Namespace,
     ipv4_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
+    unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -213,6 +228,7 @@ def vm_ovs_bridge_localnet_link_down(
         physical_network_name=cudn_localnet_ovs_bridge.name,
         spec_logical_network=LOCALNET_OVS_BRIDGE_NETWORK,
         cidr=next(ipv4_localnet_address_pool),
+        client=unprivileged_client,
         interface_state=LINK_STATE_DOWN,
     ) as vm:
         yield vm
@@ -223,6 +239,7 @@ def vm_ovs_bridge_localnet_1(
     namespace_localnet_1: Namespace,
     ipv4_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
+    unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -230,6 +247,7 @@ def vm_ovs_bridge_localnet_1(
         physical_network_name=cudn_localnet_ovs_bridge.name,
         spec_logical_network=LOCALNET_OVS_BRIDGE_NETWORK,
         cidr=next(ipv4_localnet_address_pool),
+        client=unprivileged_client,
     ) as vm:
         yield vm
 
@@ -239,6 +257,7 @@ def vm_ovs_bridge_localnet_2(
     namespace_localnet_1: Namespace,
     ipv4_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
+    unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -246,6 +265,7 @@ def vm_ovs_bridge_localnet_2(
         physical_network_name=cudn_localnet_ovs_bridge.name,
         spec_logical_network=LOCALNET_OVS_BRIDGE_NETWORK,
         cidr=next(ipv4_localnet_address_pool),
+        client=unprivileged_client,
     ) as vm:
         yield vm
 

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -3,6 +3,7 @@ import logging
 from typing import Generator
 
 from kubernetes.client import ApiException
+from kubernetes.dynamic import DynamicClient
 
 from libs.net.traffic_generator import Client, Server
 from libs.net.vmspec import IP_ADDRESS, add_network_interface, add_volume_disk, lookup_iface_status
@@ -57,6 +58,7 @@ def localnet_vm(
     physical_network_name: str,
     spec_logical_network: str,
     cidr: str,
+    client: DynamicClient,
     interface_state: str | None = None,
 ) -> BaseVirtualMachine:
     """
@@ -73,6 +75,7 @@ def localnet_vm(
         name (str): The name of the VM.
         physical_network_name (str): The name of the Multus network to attach.
         cidr (str): The CIDR address to assign to the VM's interface.
+        client (DynamicClient): The Kubernetes dynamic client for resource creation.
         spec_logical_network (str): The name of the localnet network to attach.
         interface_state (str): The state of the interface (optional).
             Possible values are "up" or "down". When not specified, it behaves as "up".
@@ -105,7 +108,7 @@ def localnet_vm(
     vmi_spec.affinity = new_pod_anti_affinity(label=next(iter(LOCALNET_TEST_LABEL.items())))
     vmi_spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].namespaceSelector = {}
 
-    return fedora_vm(namespace=namespace, name=name, spec=spec)
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
 
 
 def localnet_cudn(

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -47,16 +47,26 @@ def udn_affinity_label():
 
 
 @pytest.fixture(scope="class")
-def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
-    with udn_vm(namespace_name=udn_namespace.name, name="vma-udn", template_labels=dict((udn_affinity_label,))) as vm:
+def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+    with udn_vm(
+        namespace_name=udn_namespace.name,
+        name="vma-udn",
+        client=admin_client,
+        template_labels=dict((udn_affinity_label,)),
+    ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()
         yield vm
 
 
 @pytest.fixture(scope="class")
-def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label):
-    with udn_vm(namespace_name=udn_namespace.name, name="vmb-udn", template_labels=dict((udn_affinity_label,))) as vm:
+def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+    with udn_vm(
+        namespace_name=udn_namespace.name,
+        name="vmb-udn",
+        client=admin_client,
+        template_labels=dict((udn_affinity_label,)),
+    ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()
         yield vm


### PR DESCRIPTION
##### Short description:
The Kubernetes dynamic client should be mandatory and explicitly set.
This PR fixes the `fedora_vm` function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * VM creation utilities now accept and propagate a Kubernetes dynamic client, standardizing which client is used when creating and managing VM resources.

* **Tests**
  * Test fixtures updated to pass the appropriate client (admin/unprivileged) into VM helpers so tests create and manage VMs with the intended client context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->