### PR TITLE
net, traffic_generator: improve naming + retry decorator using

### DIFF
--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -13,8 +13,8 @@ from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 
 from libs.net import netattachdef as libnad
-from libs.net.traffic_generator import PodClient as TcpClient
-from libs.net.traffic_generator import Server as TcpServer
+from libs.net.traffic_generator import PodTcpClient as TcpClient
+from libs.net.traffic_generator import TcpServer
 from libs.net.udn import create_udn_namespace
 from libs.net.vmspec import IP_ADDRESS, lookup_iface_status, lookup_primary_network
 from libs.vm.vm import BaseVirtualMachine

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -6,7 +6,8 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
 
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
-from libs.net.traffic_generator import Client, Server
+from libs.net.traffic_generator import TcpServer
+from libs.net.traffic_generator import VMTcpClient as TcpClient
 from libs.net.vmspec import lookup_iface_status
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cluster_user_defined_network as libcudn
@@ -129,14 +130,14 @@ def localnet_running_vms(
 
 
 @pytest.fixture()
-def localnet_server(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[Server]:
+def localnet_server(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[TcpServer]:
     with create_traffic_server(vm=localnet_running_vms[0]) as server:
         assert server.is_running()
         yield server
 
 
 @pytest.fixture()
-def localnet_client(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[Client]:
+def localnet_client(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> Generator[TcpClient]:
     with create_traffic_client(
         server_vm=localnet_running_vms[0],
         client_vm=localnet_running_vms[1],
@@ -275,7 +276,7 @@ def ovs_bridge_localnet_running_vms(
 @pytest.fixture()
 def localnet_ovs_bridge_server(
     ovs_bridge_localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
-) -> Generator[Server]:
+) -> Generator[TcpServer]:
     with create_traffic_server(vm=ovs_bridge_localnet_running_vms[0]) as server:
         assert server.is_running()
         yield server
@@ -284,7 +285,7 @@ def localnet_ovs_bridge_server(
 @pytest.fixture()
 def localnet_ovs_bridge_client(
     ovs_bridge_localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
-) -> Generator[Client]:
+) -> Generator[TcpClient]:
     with create_traffic_client(
         server_vm=ovs_bridge_localnet_running_vms[0],
         client_vm=ovs_bridge_localnet_running_vms[1],

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -4,7 +4,8 @@ from typing import Generator
 
 from kubernetes.client import ApiException
 
-from libs.net.traffic_generator import Client, Server
+from libs.net.traffic_generator import TcpServer
+from libs.net.traffic_generator import VMTcpClient as TcpClient
 from libs.net.vmspec import IP_ADDRESS, add_network_interface, add_volume_disk, lookup_iface_status
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
@@ -37,14 +38,14 @@ def run_vms(vms: tuple[BaseVirtualMachine, ...]) -> tuple[BaseVirtualMachine, ..
     return vms
 
 
-def create_traffic_server(vm: BaseVirtualMachine) -> Server:
-    return Server(vm=vm, port=_IPERF_SERVER_PORT)
+def create_traffic_server(vm: BaseVirtualMachine) -> TcpServer:
+    return TcpServer(vm=vm, port=_IPERF_SERVER_PORT)
 
 
 def create_traffic_client(
     server_vm: BaseVirtualMachine, client_vm: BaseVirtualMachine, spec_logical_network: str
-) -> Client:
-    return Client(
+) -> TcpClient:
+    return TcpClient(
         vm=client_vm,
         server_ip=lookup_iface_status(vm=server_vm, iface_name=spec_logical_network)[IP_ADDRESS],
         server_port=_IPERF_SERVER_PORT,
@@ -147,9 +148,9 @@ def client_server_active_connection(
     server_vm: BaseVirtualMachine,
     spec_logical_network: str,
     port: int = _IPERF_SERVER_PORT,
-) -> Generator[tuple[Client, Server], None, None]:
-    with Server(vm=server_vm, port=port) as server:
-        with Client(
+) -> Generator[tuple[TcpClient, TcpServer], None, None]:
+    with TcpServer(vm=server_vm, port=port) as server:
+        with TcpClient(
             vm=client_vm,
             server_ip=lookup_iface_status(vm=server_vm, iface_name=spec_logical_network)[IP_ADDRESS],
             server_port=port,

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -4,7 +4,8 @@ import pytest
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
-from libs.net.traffic_generator import Client, Server, is_tcp_connection
+from libs.net.traffic_generator import TcpServer, is_tcp_connection
+from libs.net.traffic_generator import VMTcpClient as TcpClient
 from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm import affinity
 from tests.network.libs.vm_factory import udn_vm
@@ -64,14 +65,14 @@ def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_
 
 @pytest.fixture(scope="class")
 def server(vmb_udn):
-    with Server(vm=vmb_udn, port=SERVER_PORT) as server:
+    with TcpServer(vm=vmb_udn, port=SERVER_PORT) as server:
         assert server.is_running()
         yield server
 
 
 @pytest.fixture(scope="class")
 def client(vma_udn, vmb_udn):
-    with Client(
+    with TcpClient(
         vm=vma_udn,
         server_ip=lookup_iface_status(vm=vmb_udn, iface_name=lookup_primary_network(vm=vmb_udn).name)[IP_ADDRESS],
         server_port=SERVER_PORT,


### PR DESCRIPTION
##### Short description:
Improve classes naming for traffic generator, and `retry` decorator using instead of 
`TimeoutSampler` to align the code.

##### More details:
1) Client\Server looks quite common and such naming does not reflect
the real intention. The usage `traffic_generator.Client` does not
solve the problem as well. It's crucial to explicitly point out that
we work with TCP traffic and the classes implement TCP client and
TCP server in reality. And this clarity is significant for tests also.

2) The commit also includes replacing TimeoutSampler with retry decorator,
that leads a little refactoring for classes to align the logic.
Retry-enabled `_ensure_is_running()` method is added to `__enter__()`.
PodTcpClient already uses a similar implementation. We need to make
sure once when entering into the context manager that the client\server
process is running, then it is enough (and more correctly) to use the 
atomic method `is_running()` without retry to determine the status of 
the process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added automatic readiness checks with retries for TCP endpoints.
  * Improved process monitoring and termination handling for traffic processes.

* **API Changes**
  * Public TCP client/server types renamed for clarity and consistency.
  * Function and fixture annotations updated to use the new TCP-specific types.

* **Tests**
  * Test fixtures and helpers updated to import and use the renamed TCP types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->