### PR TITLE
[IUO] add retry to crd.get

### DIFF
--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -3,25 +3,43 @@ import shlex
 from subprocess import check_output
 
 import pytest
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.resource import Resource
+from timeout_sampler import retry
+
+from utilities.constants import BASE_EXCEPTIONS_DICT, TIMEOUT_3MIN, TIMEOUT_10SEC
 
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x, pytest.mark.conformance]
 
 
-@pytest.fixture()
-def crds(admin_client):
-    target_suffixes = (Resource.ApiGroup.KUBEVIRT_IO, Resource.ApiGroup.NMSTATE_IO)
-    return [crd for crd in CustomResourceDefinition.get(dyn_client=admin_client) if crd.name.endswith(target_suffixes)]
+@retry(
+    wait_timeout=TIMEOUT_3MIN,
+    sleep=TIMEOUT_10SEC,
+    exceptions_dict=BASE_EXCEPTIONS_DICT,
+)
+def get_cnv_crds(admin_client: DynamicClient) -> list[CustomResourceDefinition]:
+    """
+    Fetch CNV-related CRDs with retry logic to handle large responses and network instability.
+
+    Large CRD listings (10MB+) can trigger ProtocolError/IncompleteRead under unstable
+    network conditions. Retries mitigate transient failures; repeated failures may indicate
+    cluster or network issues.
+    """
+    return [
+        crd
+        for crd in CustomResourceDefinition.get(dyn_client=admin_client)
+        if crd.name.endswith(Resource.ApiGroup.KUBEVIRT_IO)
+    ]
 
 
 @pytest.mark.polarion("CNV-8263")
-def test_crds_cluster_readers_role(crds):
+def test_crds_cluster_readers_role(admin_client):
     cluster_readers = "system:cluster-readers"
     unreadable_crds = []
-    for crd in crds:
+    for crd in get_cnv_crds(admin_client=admin_client):
         can_read = check_output(shlex.split(f"oc adm policy who-can get {crd.name}"))
         if cluster_readers not in str(can_read):
             unreadable_crds.append(crd.name)


### PR DESCRIPTION
##### Short description:
Listing all CRDs can be heavy http request - 10MB+, and if the cluster/jenkins network is unstable - we can get the following error:

> failed on setup with "urllib3.exceptions.ProtocolError: ('Connection broken: IncompleteRead(10768901 bytes read)', IncompleteRead(10768901 bytes read))"

 

##### More details:
the fix:

Fetches CRDs with retry logic to handle large API responses and transient network errors.
If repeated failures occur, this may indicate network instability or cluster issues.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-71376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added retry-wrapped CRD retrieval to make cluster-readers role verification more resilient against transient API issues.
  * Test now filters to KubeVirt-related CRDs for more focused validation.
  * Replaced the previous fixture-based CRD source with a direct fetch that includes retry and clearer docstring guidance.
  * Minor typing and documentation clarifications to improve test maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->