### PR TITLE
Allow conformance tests to run without JIRA credentials

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -358,6 +358,12 @@ def pytest_cmdline_main(config):
     py_config["cnv_source"] = config.getoption("--cnv-source")
     py_config["cnv_subscription_channel"] = config.getoption("--cnv-channel")
 
+    # Store conformance_tests value for access from utilities
+    marker_args = config.getoption("-m")
+    py_config["conformance_tests"] = (
+        marker_args and "conformance" in marker_args and "not conformance" not in marker_args
+    )
+
     # [rhel|fedora|windows|centos]-os-matrix and latest-[rhel|fedora|windows|centos] are mutually exclusive
     rhel_os_violation = config.getoption("rhel_os_matrix") and config.getoption("latest_rhel")
     windows_os_violation = config.getoption("windows_os_matrix") and config.getoption("latest_windows")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2895,6 +2895,7 @@ def nmstate_required(admin_client):
     return get_cluster_platform(admin_client=admin_client) in ("BareMetal", "OpenStack")
 
 
+# TODO: Replace this fixture with py_config.get("conformance_tests")
 @pytest.fixture(scope="session")
 def conformance_tests(request):
     return (

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -250,6 +250,11 @@ def authorized_key(private_key_path):
 def get_jira_status(jira):
     env_var = os.environ
     if not (env_var.get("PYTEST_JIRA_TOKEN") and env_var.get("PYTEST_JIRA_URL")):
+        # For conformance tests without JIRA credentials, assume the JIRA is open
+        if py_config.get("conformance_tests"):
+            LOGGER.info(f"Conformance tests without JIRA credentials: assuming {jira} is open")
+            return "open"
+
         raise MissingEnvironmentVariableError("Please set PYTEST_JIRA_TOKEN and PYTEST_JIRA_URL environment variables")
 
     jira_connection = JIRA(


### PR DESCRIPTION
##### Short description:
Assume JIRA issues are open when running conformance tests without PYTEST_JIRA_TOKEN/PYTEST_JIRA_URL configured, allowing tests to skip properly instead of failing during setup.

##### More details:
N/A
##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-70846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added logic to detect and expose a conformance-test flag to test configuration so test runs can select conformance suites.

* **Bug Fixes**
  * Conformance test runs now handle missing environment credentials gracefully by defaulting to an "open" status to avoid spurious failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->