### PR TITLE
Storage: retry vm migration

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1848,7 +1848,7 @@ def migrate_vm_and_verify(
             if sample:
                 break
     except TimeoutExpiredError:
-        raise RuntimeError(f"Migration for VM {vm.vmi.name} failed after TimeoutSampler wait")
+        raise RuntimeError(f"Migration for VM {vm.vmi.name} failed")
 
     verify_vm_migrated(
         vm=vm,


### PR DESCRIPTION
##### Short description:
VMI migration retry in case of failures

##### More details:
As part of our efforts to reduce test flakiness and improve visibility of real bugs, we aim to minimize environment-related failures.

During VM live migrations, we sometimes see errors like the following:

failureReason: "Live migration failed error encountered during MigrateToURI3 libvirt api call: virError(Code=1, Domain=10, Message='internal error: process exited while connecting to monitor: qemu-kvm: -blockdev {\"driver\":\"host_device\",\"filename\":\"/var/run/kubevirt/hotplug-disks/blank-dv-ocs\",\"aio\":\"native\",\"node-name\":\"libvirt-1-storage\",\"auto-read-only\":true,\"discard\":\"unmap\",\"cache\":{\"direct\":true,\"no-flush\":false}}: Could not open '/var/run/kubevirt/hotplug-disks/blank-dv-ocs': Operation not permitted')"


These failures are not caused by the environment, but are transient, timing-related issues. Retrying the migration helps avoid these temporary failures and ensures that tests reflect real bugs rather than intermittent migration timing conditions.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added retry semantics and clearer timeout behavior for virtual machine migrations to improve reliability.
  * Performs explicit wait for migration completion and stronger failure reporting when timeouts occur.
  * Updated documentation and parameter descriptions for clearer usage and expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->