### PR TITLE
WIP: Change skip_if_no_common_modern_cpu to xfail_if_no_common_modern_cpu

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1216,9 +1216,9 @@ def skip_if_no_common_cpu(cluster_common_node_cpu, nodes_cpu_architecture):
 
 
 @pytest.fixture(scope="module")
-def skip_if_no_common_modern_cpu(cluster_common_modern_node_cpu):
+def xfail_if_no_common_modern_cpu(cluster_common_modern_node_cpu):
     if not cluster_common_modern_node_cpu and nodes_cpu_architecture != ARM_64:
-        pytest.skip("This is a heterogeneous cluster")
+        pytest.xfail("This is a heterogeneous cluster")
 
 
 @pytest.fixture(scope="session")

--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -25,7 +25,7 @@ from utilities.virt import (
     running_vm,
 )
 
-pytestmark = pytest.mark.usefixtures("skip_if_no_common_modern_cpu", "skip_access_mode_rwo_scope_module")
+pytestmark = pytest.mark.usefixtures("xfail_if_no_common_modern_cpu", "skip_access_mode_rwo_scope_module")
 
 TESTS_CLASS_NAME = "TestCPUHotPlugInstancetype"
 


### PR DESCRIPTION
##### Short description:
Change skip_if_no_common_modern_cpu to xfail_if_no_common_modern_cpu

##### More details:
Change the skip to xfail to raise more awareness

##### Special notes for reviewer:
Referenced here - https://github.com/RedHatQE/openshift-virtualization-tests/pull/2350#discussion_r2469367137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reporting for CPU compatibility scenarios by marking incompatible test conditions as expected failures instead of skipping them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->