### PR TITLE
Add Bitwarden's cli `bws` as a pre-requisite int the docs

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -60,6 +60,7 @@ The Complete list of environment dependencies can be found in [Dockerfile](../Do
 
 Bitwarden CLI should be installed on the machine running the tests. See [Secrets Manager CLI](https://bitwarden.com/help/secrets-manager-cli/#download-and-install).
 Bitwarden token should be set in the `ACCESS_TOKEN` environment variable.
+Ensure the `unzip` package is installed on your system, as it is required by the bws installation script.
 
 ```bash
 curl -fsSL https://bws.bitwarden.com/install | sh


### PR DESCRIPTION
##### Short description:
bws cli is a pre-requisite as the cli is used to interact with Bitwarden manager

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Bitwarden (bws) CLI installation and setup guide: download/install reference, curl-based install example, and unzip dependency note.
  * Notes on configuring ACCESS_TOKEN for Bitwarden access and pointers to the Secrets Manager CLI for additional installation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->