### PR TITLE
fix: dnf installs packages based on architecture

### DIFF
--- a/containers/fedora/user-data
+++ b/containers/fedora/user-data
@@ -22,7 +22,13 @@ write_files:
         WantedBy=cloud-init.service
 runcmd:
   - systemctl daemon-reload
-  - dnf install -y tcpdump qemu-guest-agent iperf3 dmidecode nginx lldpad kernel-modules nmap dhcp-server dhcp-relay sshpass podman ethtool libibverbs dpdk stress-ng iotop fio
+  - |
+    PACKAGES="tcpdump qemu-guest-agent iperf3 nginx lldpad kernel-modules nmap dhcp-server dhcp-relay sshpass podman ethtool libibverbs stress-ng iotop fio"
+    ARCH=$(uname -m)
+    if [ "${ARCH}" != "s390x" ]; then
+      PACKAGES="$PACKAGES dmidecode dpdk"
+    fi
+    dnf install -y ${PACKAGES}
   - dnf autoremove
   - dnf clean all
   - rpm -q kernel-core | sort | head -1 | xargs rpm -e


### PR DESCRIPTION
Due to the abscense of the dmidecode and dpdk packages on the s390x
architecture, attempting to install all packages results in
failure. By utilizing this option, other packages can still be
successfully installed, ensuring that functionality for amd64
remains intact.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability by switching to a resilient multi-package installation approach that detects system architecture and conditionally omits incompatible packages on certain platforms, preventing a single missing or incompatible package from causing the entire installation to fail and producing more consistent deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->