### PR TITLE
net, fix: add required pod_selector to NetworkPolicy init call

### DIFF
--- a/tests/network/network_policy/test_network_policy.py
+++ b/tests/network/network_policy/test_network_policy.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.sno
 
 class ApplyNetworkPolicy(NetworkPolicy):
     def __init__(self, name, namespace, ports=None, teardown=True):
-        super().__init__(name=name, namespace=namespace, teardown=teardown)
+        super().__init__(name=name, namespace=namespace, teardown=teardown, pod_selector={})
         self.ports = ports
 
     def to_dict(self):
@@ -31,7 +31,6 @@ class ApplyNetworkPolicy(NetworkPolicy):
             for port in self.ports:
                 _ports.append({"protocol": "TCP", "port": port})
 
-        self.res["spec"] = {"podSelector": {}}
         if _ports:
             self.res["spec"]["ingress"] = [{"ports": _ports}]
 


### PR DESCRIPTION
`NetworkPolicy` class has been updated and `pod_selector` becomes mandatory 
even if it's empty. The current fix sets `pod_selector` in the child `ApplyNetworkPolicy` 
class and thus mends the network policy tests.


##### jira-ticket: https://issues.redhat.com/browse/CNV-71449


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network policy configuration to only apply pod selector and ingress rules when explicitly provided, rather than setting empty defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->