### PR TITLE
 Change openshift-python-wrapper to 4.19.4 from 4.19.1 & fixed tekton imports

### DIFF
--- a/tests/infrastructure/tekton/conftest.py
+++ b/tests/infrastructure/tekton/conftest.py
@@ -7,7 +7,7 @@ import yaml
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.pipeline import Pipeline
-from ocp_resources.pipelineruns import PipelineRun
+from ocp_resources.pipeline_run import PipelineRun
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
 from ocp_resources.task import Task
@@ -271,7 +271,7 @@ def configured_windows_efi_pipelinerun_parameters(
         **COMMON_PIPELINEREF_PARAMS[WINDOWS_EFI_INSTALLER_STR],
         **win_iso_download_url_for_pipelineref()[pipeline_dv_name],
     }
-    return params_dict
+    return [{"name": key, "value": value} for key, value in params_dict.items()]
 
 
 @pytest.fixture()
@@ -286,7 +286,7 @@ def pipelinerun_from_pipeline_template(
         namespace=custom_pipeline_namespace.name,
         client=admin_client,
         params=configured_windows_efi_pipelinerun_parameters,
-        pipelineref=WINDOWS_EFI_INSTALLER_STR,
+        pipeline_ref={"name": WINDOWS_EFI_INSTALLER_STR},
     ) as pipelinerun:
         pipelinerun.wait_for_conditions()
         yield pipelinerun
@@ -373,8 +373,8 @@ def pipelinerun_for_disk_uploader(
         name=f"pipelinerun-disk-uploader-{request.param}",
         namespace=custom_pipeline_namespace.name,
         client=admin_client,
-        params=pipeline_run_params,
-        pipelineref=pipeline_disk_uploader.name,
+        params=[{"name": key, "value": value} for key, value in pipeline_run_params.items()],
+        pipeline_ref={"name": pipeline_disk_uploader.name},
     ) as pipelinerun:
         pipelinerun.wait_for_conditions()
         yield pipelinerun

--- a/tests/infrastructure/tekton/utils.py
+++ b/tests/infrastructure/tekton/utils.py
@@ -10,7 +10,7 @@ import os
 import re
 
 from kubernetes.dynamic import ResourceInstance
-from ocp_resources.pipelineruns import PipelineRun
+from ocp_resources.pipeline_run import PipelineRun
 from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
@@ -703,7 +704,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/99/a1/c27ec9be241103ef7
 
 [[package]]
 name = "openshift-python-wrapper"
-version = "4.19.1"
+version = "4.19.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloup" },
@@ -721,7 +722,7 @@ dependencies = [
     { name = "timeout-sampler" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/d6/c5614f0fa530714a2c04e451bfbf449884471e46502afcf2bbdff2f89892/openshift_python_wrapper-4.19.1.tar.gz", hash = "sha256:5c3095033431c5620b3caa92a6beccd5a621f969c93480109401947d0d8ee912", size = 13128900 }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3e/eb7eadf44176500d6a4bf51d025f5a02e642ed7b9634465f556c327221f0/openshift_python_wrapper-4.19.4.tar.gz", hash = "sha256:4e267ba429d413c8bdaf68f3dbd2a57f7e8f6d77700a0387522a3dcf0c61d289", size = 13130077, upload-time = "2025-11-04T13:18:16.593Z" }
 
 [[package]]
 name = "openshift-python-wrapper-data-collector"


### PR DESCRIPTION
##### Short description:
We currently use 4.19.1 while https://pypi.org/project/openshift-python-wrapper/4.19.4/ has multiple changes including tekton ones https://github.com/RedHatQE/openshift-python-wrapper/blob/main/ocp_resources/pipeline_run.py which causes https://github.com/RedHatQE/openshift-virtualization-tests/pull/2463 to fail .
This PR also take care fixing tekton imports that are impacted by the change.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

