### PR TITLE
net: Fix test_l2_ovs_linux_bridge tests

### DIFF
--- a/tests/network/l2_bridge/test_ovs_bridge.py
+++ b/tests/network/l2_bridge/test_ovs_bridge.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import pytest
 
 from tests.network.constants import BRCNV
+from tests.network.libs.ip import random_ipv4_address
 from tests.network.utils import vm_for_brcnv_tests
 from utilities.constants import OVS_BRIDGE
 from utilities.infra import get_node_selector_dict
@@ -15,8 +16,8 @@ from utilities.network import (
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 OVS_BR = "test-ovs-br"
-SEC_IFACE_SUBNET = "10.0.200"
-DST_IP_ADDR = SEC_IFACE_SUBNET + ".2"
+SRC_SEC_IFACE_IP_ADDR = random_ipv4_address(net_seed=0, host_address=1)
+DST_SEC_IFACE_IP_ADDR = random_ipv4_address(net_seed=0, host_address=2)
 
 
 @pytest.fixture()
@@ -102,7 +103,7 @@ def vma_with_ovs_based_l2(
     networks[ovs_bridge_nad.name] = ovs_bridge_nad.name
     network_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{SEC_IFACE_SUBNET}.1/24"]},
+            "eth1": {"addresses": [f"{SRC_SEC_IFACE_IP_ADDR}/24"]},
         }
     }
     cloud_init_data = compose_cloud_init_data_dict(network_data=network_data)
@@ -140,7 +141,7 @@ def vmb_with_ovs_based_l2(
     networks[ovs_bridge_nad.name] = ovs_bridge_nad.name
     network_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{DST_IP_ADDR}/24"]},
+            "eth1": {"addresses": [f"{DST_SEC_IFACE_IP_ADDR}/24"]},
         }
     }
     cloud_init_data = compose_cloud_init_data_dict(network_data=network_data)
@@ -175,7 +176,7 @@ def test_ovs_bridge_sanity(
     running_vma_with_ovs_based_l2,
     running_vmb_with_ovs_based_l2,
 ):
-    assert_ping_successful(src_vm=running_vma_with_ovs_based_l2, dst_ip=DST_IP_ADDR)
+    assert_ping_successful(src_vm=running_vma_with_ovs_based_l2, dst_ip=DST_SEC_IFACE_IP_ADDR)
 
 
 @pytest.mark.ovs_brcnv

--- a/tests/network/libs/dhcpd.py
+++ b/tests/network/libs/dhcpd.py
@@ -1,15 +1,17 @@
 import shlex
+from typing import Final
 
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.network.libs.ip import random_ipv4_address
 from utilities.constants import TIMEOUT_5SEC, TIMEOUT_30SEC
 from utilities.network import LOGGER
 from utilities.virt import VirtualMachineForTests
 
-DHCP_IP_SUBNET = "10.200.3"
-DHCP_IP_RANGE_START = f"{DHCP_IP_SUBNET}.3"
-DHCP_IP_RANGE_END = f"{DHCP_IP_SUBNET}.10"
+DHCP_IP_SUBNET: Final[str] = random_ipv4_address(net_seed=3, host_address=0).rpartition(".")[0]
+DHCP_IP_RANGE_START: Final[str] = random_ipv4_address(net_seed=3, host_address=3)
+DHCP_IP_RANGE_END: Final[str] = random_ipv4_address(net_seed=3, host_address=10)
 DHCP_SERVICE_RESTART = "sudo systemctl restart dhcpd"
 DHCP_SERVER_CONF_FILE = """
 cat <<EOF >> /etc/dhcp/dhcpd.conf

--- a/tests/network/libs/ip.py
+++ b/tests/network/libs/ip.py
@@ -2,7 +2,7 @@ import random
 from functools import cache
 from typing import Final
 
-_MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION: Final[int] = 4
+_MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION: Final[int] = 16
 _IPV4_ADDRESS_SUBNET_PREFIX_VMI: Final[str] = "172.16"
 
 


### PR DESCRIPTION
Problem: Many tests in `test_l2_ovs_linux_bridge.py` module were failing because of the IP conflict. The hard-coded IPv4 address assignment failed and caused `assert_ping_successful` to fail.

Fix: Remove conflicting IPv4 address from l2 ovs linux bridge tests and generate IP addresses using the new ip module.


##### jira-ticket: https://issues.redhat.com/browse/CNV-71445
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Network tests now use dynamically generated IPv4 addresses for interfaces, loopbacks and MPLS next-hops to reduce conflicts.
  * DHCP test configuration computes subnet and range values at runtime.
  * Increased random IP generation capacity (third-octet pool expanded) for greater variability.
  * Added public test constants for secondary interface addresses and updated related test flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->