### PR TITLE
Remove deprecated minCPUModel field from testing

### DIFF
--- a/tests/install_upgrade_operators/strict_reconciliation/constants.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/constants.py
@@ -205,7 +205,6 @@ OBSOLETE_CPUS_VALUE_HCO_CR = {
         "pentium5",
         "pentiumhome",
     ],
-    "minCPUModel": "Haswell",
 }
 OBSOLETE_CPUS_VALUE_KUBEVIRT_CR = {
     "obsoleteCPUModels": {
@@ -213,7 +212,6 @@ OBSOLETE_CPUS_VALUE_KUBEVIRT_CR = {
         "pentium5": True,
         "pentiumhome": True,
     },
-    "minCPUModel": "Haswell",
 }
 RESOURCE_REQUIREMENTS = {
     "storageWorkloads": {

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2157,8 +2157,8 @@ def wait_for_updated_kv_value(admin_client, hco_namespace, path, value, timeout=
         timeout (int): timeout in seconds
 
     Example:
-        path - ['minCPUModel'], value - 'Haswell-noTSX'
-        {"configuration": {"minCPUModel": "Haswell-noTSX"}} will be matched against KV CR spec.
+        path - ['cpuModel'], value - 'Haswell-noTSX'
+        {"configuration": {"cpuModel": "Haswell-noTSX"}} will be matched against KV CR spec.
 
     Raises:
         TimeoutExpiredError: After timeout is reached if the expected key value does not match the actual value


### PR DESCRIPTION
##### Short description:
Remove deprecated minCPUModel field from testing

##### More details:
minCPUModel is no longer used in the code since this PR merged - https://github.com/kubevirt/kubevirt/pull/15263.
It is now marked as deprecated, and even though it can be used, it effect nothing in the configuration.

##### What this PR does / why we need it:
Remove deprecated field


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test constants to reflect CPU model field changes.

* **Documentation**
  * Updated code examples to reflect current CPU model configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->