### PR TITLE
[4.20] utilities, console: Refactor Console.__init__() dosctring

### DIFF
--- a/utilities/console.py
+++ b/utilities/console.py
@@ -2,10 +2,12 @@ import logging
 import os
 
 import pexpect
+from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler
 
 from utilities.constants import (
     TIMEOUT_5MIN,
+    TIMEOUT_30SEC,
     VIRTCTL,
 )
 from utilities.data_collector import get_data_collector_base_directory
@@ -14,14 +16,23 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Console(object):
-    def __init__(self, vm, username=None, password=None, timeout=30, prompt=None):
+    def __init__(
+        self,
+        vm: VirtualMachine,
+        username: str | None = None,
+        password: str | None = None,
+        timeout: int = TIMEOUT_30SEC,
+        prompt: str | list[str] | None = None,
+    ) -> None:
         """
         Connect to VM console
 
         Args:
-            vm (VirtualMachine): VM resource
-            username (str): VM username
-            password (str): VM password
+            vm: VM resource
+            username: VM username
+            password: VM password
+            timeout: Connection timeout in seconds
+            prompt: Shell prompt pattern(s) to expect
 
         Examples:
             from utilities import console


### PR DESCRIPTION
- Add type annotations to Console.__init__ parameters.
- Use TIMEOUT_30SEC constant instead of hardcoded 30.
- Remove default values from docstring (now clear from signature).

Manual backport of #2400, done with _openshift-virtualization-qe-bot-2_ instructions.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
