### PR TITLE
WIP: [Install] Add default sc test

### DIFF
--- a/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
+++ b/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
@@ -1,6 +1,8 @@
 import logging
 
 import pytest
+from ocp_resources.storage_class import StorageClass
+from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.product_install.constants import (
     CLUSTER_RESOURCE_ALLOWLIST,
@@ -26,6 +28,7 @@ from utilities.monitoring import (
     wait_for_firing_alert_clean_up,
     wait_for_gauge_metrics_value,
 )
+from utilities.storage import set_default_sc, verify_boot_sources_reimported
 
 CNV_INSTALLATION_TEST = "test_cnv_installation"
 CNV_ALERT_CLEANUP_TEST = "test_cnv_installation_alert_cleanup"
@@ -168,6 +171,18 @@ def test_cnv_resources_installed_namespace_scoped(
     if mismatch_namespaced:
         LOGGER.error(f"Mismatched namespaced resources: {mismatch_namespaced}")
         raise ResourceMismatch(f"Unexpected namespaced resources found post cnv installation: {mismatch_namespaced}")
+
+
+@pytest.mark.polarion("CNV-12375")
+@pytest.mark.order(after=CNV_INSTALLATION_TEST)
+@pytest.mark.dependency(depends=[CNV_INSTALLATION_TEST])
+def test_set_default_storage_class(admin_client, golden_images_namespace):
+    desired_sc = StorageClass(name=py_config["default_storage_class"], client=admin_client, ensure_exists=True)
+    LOGGER.info(f"Setting {desired_sc.name} as default storage class")
+    set_default_sc(default=True, storage_class=desired_sc)
+    assert verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name), (
+        "Failed to re-import boot sources"
+    )
 
 
 @pytest.mark.polarion("CNV-10528")

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1037,6 +1037,25 @@ def update_default_sc(default, storage_class):
         yield
 
 
+def set_default_sc(default: bool, storage_class: StorageClass) -> None:
+    is_default = str(default).lower()
+    editor = ResourceEditor(
+        patches={
+            storage_class: {
+                "metadata": {
+                    "annotations": {
+                        StorageClass.Annotations.IS_DEFAULT_CLASS: is_default,
+                        StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS: is_default,
+                    },
+                    "name": storage_class.name,
+                },
+            }
+        }
+    )
+    # Apply the changes permanently without backup for restoration
+    editor.update(backup_resources=False)
+
+
 def verify_dv_and_pvc_does_not_exist(name, namespace, timeout=TIMEOUT_10MIN):
     dv = DataVolume(namespace=namespace, name=name)
     pvc = PersistentVolumeClaim(namespace=namespace, name=name)


### PR DESCRIPTION
##### Short description:
Starting from 4.19 - ODF team doesn't set default sc, when fresh-installing openshift-virtalization.
Adding a test to cover that scenario

##### More details:

##### What this PR does / why we need it:
We use it in install lane, which running on prod before smoke.
Some smoke tests may fail if no default sc defined.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ability to set a default storage class with immediate application.
  * Boot sources are automatically re-imported when the default storage class changes.

* **Tests**
  * New test verifies default storage class configuration and automatic boot source re-import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->