### PR TITLE
 fix - get latest Fedora version from upstream release.json

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
@@ -11,7 +11,7 @@ from tests.infrastructure.golden_images.utils import (
     assert_missing_golden_image_pvc,
     assert_os_version_mismatch_in_vm,
 )
-from utilities.constants import RHEL9_STR, TIMEOUT_5MIN, TIMEOUT_5SEC, Images
+from utilities.constants import OS_FLAVOR_FEDORA, RHEL9_STR, TIMEOUT_5MIN, TIMEOUT_5SEC, Images
 from utilities.infra import (
     cleanup_artifactory_secret_and_config_map,
     get_artifactory_config_map,
@@ -137,7 +137,7 @@ def test_vm_from_auto_update_boot_source(
     latest_fedora_release_version,
 ):
     LOGGER.info(f"Verify {auto_update_boot_source_vm.name} OS version and virtctl info")
-    if "fedora" in boot_source_os_from_data_source_dict and latest_fedora_release_version:
+    if OS_FLAVOR_FEDORA in boot_source_os_from_data_source_dict and latest_fedora_release_version:
         boot_source_os_from_data_source_dict = f"fedora{latest_fedora_release_version}"
     assert_os_version_mismatch_in_vm(
         vm=auto_update_boot_source_vm,


### PR DESCRIPTION
##### Short description:
Get fedora latest version from directly https://fedoraproject.org/releases.json
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-71694

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switches tests to a remote Fedora releases lookup for version detection, improving reliability.
  * Simplifies test fixtures to a no-argument signature to reflect the new data source.
  * Standardizes OS-flavor usage in boot-source tests for more consistent OS detection.
  * Improves error handling when no Fedora versions are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->