### PR TITLE
[4.19] utilities/console: make VM console connect resilient with bounded retries

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -10,7 +10,7 @@ from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm import affinity
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
-from utilities.constants import PUBLIC_DNS_SERVER_IP, QUARANTINED, TIMEOUT_1MIN
+from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
 from utilities.infra import create_ns
 from utilities.virt import migrate_vm_and_verify
 
@@ -145,10 +145,6 @@ class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11427")
     @pytest.mark.single_nic
     @pytest.mark.gating
-    @pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Flaky test, fails on connecting to VM console; tracked in CNV-66779",
-        run=False,
-    )
     def test_connectivity_is_preserved_after_live_migration(self, vma_udn, server, client):
         migrate_vm_and_verify(vm=vma_udn)
         assert is_tcp_connection(server=server, client=client)

--- a/utilities/console.py
+++ b/utilities/console.py
@@ -3,10 +3,11 @@ import os
 
 import pexpect
 from ocp_resources.virtual_machine import VirtualMachine
-from timeout_sampler import TimeoutSampler
+from timeout_sampler import TimeoutSampler, retry
 
 from utilities.constants import (
     TIMEOUT_5MIN,
+    TIMEOUT_10SEC,
     TIMEOUT_30SEC,
     VIRTCTL,
 )
@@ -51,6 +52,7 @@ class Console(object):
         self.cmd = self._generate_cmd()
         self.base_dir = get_data_collector_base_directory()
 
+    @retry(wait_timeout=TIMEOUT_5MIN, sleep=TIMEOUT_10SEC)
     def connect(self):
         LOGGER.info(f"Connect to {self.vm.name} console")
         self.console_eof_sampler(func=pexpect.spawn, command=self.cmd, timeout=self.timeout)
@@ -62,7 +64,7 @@ class Console(object):
     def _connect(self):
         self.child.send("\n\n")
         if self.username:
-            self.child.expect(self.login_prompt, timeout=TIMEOUT_5MIN)
+            self.child.expect(self.login_prompt)
             LOGGER.info(f"{self.vm.name}: Using username {self.username}")
             self.child.sendline(self.username)
             if self.password:
@@ -70,7 +72,8 @@ class Console(object):
                 LOGGER.info(f"{self.vm.name}: Using password {self.password}")
                 self.child.sendline(self.password)
 
-        self.child.expect(self.prompt, timeout=150)
+        LOGGER.info(f"{self.vm.name}: waiting for terminal prompt '{self.prompt}'")
+        self.child.expect(self.prompt)
         LOGGER.info(f"{self.vm.name}: Got prompt {self.prompt}")
 
     def disconnect(self):


### PR DESCRIPTION
Manual backport for https://github.com/RedHatQE/openshift-virtualization-tests/pull/2428 based partially on openshift-virtualization-qe-bot-3 bot instructions, the provided sha was wrong - used the correct one (https://github.com/RedHatQE/openshift-virtualization-tests/commit/471e9d9a643edf8bdcb701bb7995d601c0e616f5).

* net,tests,udn: Un-quarentine scenario

Fixed in the next commit.



* utilities/console: Improve connection resilience and refactor timeouts

Make console connection resilient to brief spawn failures and non-deterministic prompts using bounded retries.

Refactor the connection timeout mechanism:
- Overall retry timeout in connect() reduced from 10 minutes to 5 minutes.
- In _connect(), login and terminal prompts use pexpect default timeout (30 seconds).
- If any prompt times out, the retry mechanism will kick in.
- Add logging before waiting for terminal prompt.

This compromise balances the need for resilience with slow-booting VMs while keeping overall test times reasonable.



* Adjust console unittest to _connect() refactoring

The initial refactor to use the @retry decorator caused a test to hang for 10 minutes. This was due to a conflict between the decorator's logic and the test's mocking:
  The @retry decorator retries the function until it returns a truthy
value (not None).
  In test_console_connect, console_eof_sampler() is mocked. The mock is
empty.
  The real console_eof_sampler() sets self.child to a pexpect child
object.
  Because the mock does nothing, self.child remains None (its initial
value from __init__).
  The @retry decorator sees None as a failure and triggers a retry loop,
causing the test to hang.

This commit resolves the hang by ensuring mocks return appropriate values, and also adjusts the unittests to align with the removal of specific timeouts in the main _connect() method.



* [pre-commit.ci] auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci



---------

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
