### PR TITLE
[gating][cnv-4.19] fix test_successful_import_image and unquarantine

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -37,7 +37,6 @@ from tests.storage.utils import (
 from utilities import console
 from utilities.constants import (
     OS_FLAVOR_RHEL,
-    QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_4MIN,
     TIMEOUT_5MIN,
@@ -210,10 +209,6 @@ def test_successful_import_archive(
     assert_num_files_in_pod(pod=running_pod_with_dv_pvc, expected_num_of_files=3)
 
 
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: regression, timeout failure; CNV-70094",
-    run=False,
-)
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.parametrize(
@@ -277,10 +272,6 @@ def test_successful_import_secure_archive(
     assert_num_files_in_pod(pod=running_pod_with_dv_pvc, expected_num_of_files=3)
 
 
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: regression, timeout failure; CNV-70094",
-    run=False,
-)
 @pytest.mark.parametrize(
     "dv_from_http_import",
     [

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -44,6 +44,7 @@ from utilities.constants import (
     CNV_TESTS_CONTAINER,
     OS_FLAVOR_CIRROS,
     SECURITY_CONTEXT,
+    TIMEOUT_20MIN,
     Images,
 )
 from utilities.hco import (
@@ -143,16 +144,18 @@ def internal_http_secret(namespace):
 def internal_http_deployment(cnv_tests_utilities_namespace):
     """
     Deploy internal HTTP server Deployment into the cnv_tests_utilities_namespace namespace.
-    This Deployment deploys a pod that runs an HTTP server
+    This Deployment deploys a pod that runs an HTTP server, Wait for deployment replicas to be ready.
     """
+    internal_hpp_str = "internal-http"
+    LOGGER.info(f"Creating {internal_hpp_str} deployment in {cnv_tests_utilities_namespace.name}")
     with Deployment(
-        name="internal-http",
+        name=internal_hpp_str,
         namespace=cnv_tests_utilities_namespace.name,
         selector=INTERNAL_HTTP_SELECTOR,
         template=INTERNAL_HTTP_TEMPLATE,
         replicas=1,
     ) as dep:
-        dep.wait_for_replicas()
+        dep.wait_for_replicas(timeout=TIMEOUT_20MIN)
         yield dep
 
 


### PR DESCRIPTION
**Short description:**

Fix internal-http deployment fixture to properly wait for deployment replicas, preventing setup timeouts in HTTP import tests.

**More details:**

Tests test_successful_import_image and test_successful_import_secure_image were intermittently failing during setup because the internal-http deployment sometimes didn’t have ready replicas in time.

Changes in the fixture:

Waits for deployment replicas to be ready using dep.wait_for_replicas(timeout=TIMEOUT_20MIN).


Removed the @pytest.mark.xfail(QUARANTINED) marker from tests, since the setup is now stable.

**Why this is needed:**

Ensures internal-http deployment replicas are ready before tests start.

Prevents flaky setup failures in HTTP import tests.

Improves logging and debugging when deployment readiness fails.

**Issue(s) this PR fixes:**

Fixes intermittent setup failures in tests.storage.cdi_import.test_import_http that caused these tests to be quarantined.

**Special notes for reviewer:**

Jira ticket: [CNV-70094](https://issues.redhat.com/browse/CNV-70094)