### PR TITLE
CherryPicked: [cnv-4.18]: Stabilize test_deprecated_apis_in_audit_logs

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1067,12 +1067,19 @@ def generate_openshift_pull_secret_file(client: DynamicClient = None) -> str:
     exceptions_dict={RuntimeError: []},
 )
 def get_node_audit_log_entries(log, node, log_entry):
+    # Patterns to match errors that should trigger a retry
+    error_patterns_list = [
+        r"^\s*error:",
+        r"Unhandled Error.*couldn't get current server API group list.*i/o timeout",
+    ]
+    error_patterns = re.compile("|".join(f"({pattern})" for pattern in error_patterns_list))
+
     lines = subprocess.getoutput(
         f"{OC_ADM_LOGS_COMMAND} {node} {AUDIT_LOGS_PATH}/{log} | grep {shlex.quote(log_entry)}"
     ).splitlines()
-    has_errors = any(line.startswith("error:") for line in lines)
+    has_errors = any(error_patterns.search(line) for line in lines)
     if has_errors:
-        if any(line.startswith("404 page not found") for line in lines):
+        if any(line.strip().startswith("404 page not found") for line in lines):
             LOGGER.warning(f"Skipping {log} check as it was rotated:\n{lines}")
             return True, []
         LOGGER.warning(f"oc command failed for node {node}, log {log}:\n{lines}")


### PR DESCRIPTION
manual cherry-pick: https://github.com/RedHatQE/openshift-virtualization-tests/pull/1506 https://github.com/RedHatQE/openshift-virtualization-tests/pull/2144 https://github.com/RedHatQE/openshift-virtualization-tests/pull/2368  into cnv-4.18

cmd log:
```
$ git cherry-pick c278d2f79bb3d0c3a4e16294af1827c3173873aa bb226791d19cd35f4fb99fe7a723618078a92579 e7bacf69a02f51ed19f2e4c190a39b4cc1eeb8ec
Auto-merging utilities/infra.py
[depr-api-cherry-pick d3c2571] [CNV-66017]add retry mechanism to handle oc node-logs failures in audit log tests (#1506)
 Author: Ramon Lobillo Mateos <62110535+rlobillo@users.noreply.github.com>
 Date: Thu Jul 31 16:54:20 2025 +0200
 1 file changed, 13 insertions(+), 3 deletions(-)
Auto-merging utilities/infra.py
[depr-api-cherry-pick e92db20] skip log files that were rotated on the OCP nodes (#2144)
 Author: Ramon Lobillo Mateos <62110535+rlobillo@users.noreply.github.com>
 Date: Mon Sep 29 16:14:52 2025 +0200
 1 file changed, 3 insertions(+)
Auto-merging utilities/infra.py
[depr-api-cherry-pick 7b897e5] [CNV-70167] Stabilize test_deprecated_apis_in_audit_logs by handling API timeout errors (#2368)
 Author: Ramon Lobillo Mateos <62110535+rlobillo@users.noreply.github.com>
 Date: Sun Nov 2 11:38:05 2025 +0100
 1 file changed, 9 insertions(+), 2 deletions(-)

```

requested-by servolkov

Jira-ticket: https://issues.redhat.com/browse/CNV-71532