### PR TITLE
Use explicit instruction for coderabbit to create a change request comment

### DIFF
--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -37,6 +37,9 @@ jobs:
             <details>
               <summary>Test execution plan request details</summary>
 
+              CRITICAL: You MUST respond with a review comment on the Files Changed tab, NOT as a regular PR comment.
+              If it cannot be on the 1st line of the 1st file, add it to any other changed file.
+
               As an expert software testing engineer, analyze all modified files in this PR and create a targeted test execution plan.
               You will create a change request comment on the 1st line of the 1st file in the pr with the test execution plan.
               If you fail to run or post a comment, retry.


### PR DESCRIPTION
##### Short description:
Currently coderabbit's test plan is not necessarily posted as a change request.
Based on https://github.com/RedHatQE/openshift-virtualization-tests/pull/2477#issuecomment-3495834551 - adding more explicit instructions.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow instructions for code review processes to clarify reviewer requirements and guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->