### PR TITLE
Add `sig-storage` labeling for cross_cluster_live_migration sub-dir

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,9 +33,8 @@ sig-scale:
 sig-storage:
   - changed-files:
     - any-glob-to-any-file:
-      - 'tests/{data_protection,storage}/**'
+      - 'tests/{data_protection,storage,cross_cluster_live_migration}/**'
       - 'utilities/storage.py'
-      - 'tests/cross_cluster_live_migration/**'
 
 sig-virt:
   - changed-files:


### PR DESCRIPTION
##### Short description:
Currently the storage team is responsible for this sub-dir. Once other teams start to work on it, they should be added as well

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal testing configuration to support additional test paths for label automation.

---

**Note:** This release contains no user-visible changes. This update improves internal development infrastructure only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->