### PR TITLE
tests, net, secondary_network_dns: Make the cmd exec verbose

### DIFF
--- a/tests/network/secondary_network_dns/test_secondary_network_dns.py
+++ b/tests/network/secondary_network_dns/test_secondary_network_dns.py
@@ -197,8 +197,9 @@ def created_dns_nodeport_service(
     oc_expose_command = f"oc {expose_command} -n {hco_namespace.name}"
     res, out, err = run_command(
         command=shlex.split(oc_expose_command),
+        check=False,
     )
-    assert res, f"Command {oc_expose_command} failed. \nOutpus: {out}\nError: {err}"
+    assert res, f"Command {oc_expose_command} failed. \nOutput: {out}\nError: {err}"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Problem: In case a shell command within run_command fails,
stderr is not printed and it's difficult to debug.
When the `created_dns_nodeport_service` is executed, a failure provides little information. 

Fix: In order to report the exact command that failed and its output, make sure the assertion line is reached. That is accomplished by instructing the `run_command` helper not to raise on non-successful execution of the shell command, by adding `check=False` param and get more information in case the command fails.

##### jira-ticket: https://issues.redhat.com/browse/CNV-71474
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made DNS nodeport creation test more robust by allowing the command to return non-zero without crashing and validating the resulting output explicitly.
  * Corrected and clarified the error message text for clearer debugging feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->