### PR TITLE
[virt] update tests to use client explicitly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2508,9 +2508,10 @@ def hyperconverged_status_templates_scope_class(
 
 
 @pytest.fixture()
-def cloning_job_scope_function(request, namespace):
+def cloning_job_scope_function(request, unprivileged_client, namespace):
     with create_vm_cloning_job(
         name=f"clone-job-{request.param['source_name']}",
+        client=unprivileged_client,
         namespace=namespace.name,
         source_name=request.param["source_name"],
         label_filters=request.param.get("label_filters"),
@@ -2520,8 +2521,8 @@ def cloning_job_scope_function(request, namespace):
 
 
 @pytest.fixture()
-def target_vm_scope_function(cloning_job_scope_function):
-    with target_vm_from_cloning_job(cloning_job=cloning_job_scope_function) as target_vm:
+def target_vm_scope_function(unprivileged_client, cloning_job_scope_function):
+    with target_vm_from_cloning_job(client=unprivileged_client, cloning_job=cloning_job_scope_function) as target_vm:
         yield target_vm
 
 

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -90,8 +90,9 @@ def updated_hco_memory_overcommit(hyperconverged_resource_scope_class):
 
 
 @pytest.fixture(scope="class")
-def first_pod_for_aaq_test(namespace):
+def first_pod_for_aaq_test(admin_client, namespace):
     with Pod(
+        client=admin_client,
         name="first-pod-for-aaq-test",
         namespace=namespace.name,
         security_context=POD_SECURITY_CONTEXT_SPEC,
@@ -102,8 +103,9 @@ def first_pod_for_aaq_test(namespace):
 
 
 @pytest.fixture(scope="class")
-def second_pod_for_aaq_test_in_gated_state(namespace):
+def second_pod_for_aaq_test_in_gated_state(admin_client, namespace):
     with Pod(
+        client=admin_client,
         name="second-pod-for-aaq-test",
         namespace=namespace.name,
         security_context=POD_SECURITY_CONTEXT_SPEC,

--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -19,6 +19,7 @@ class CustomTemplate(Template):
     def __init__(
         self,
         name,
+        client,
         namespace,
         source_template,
         vm_validation_rule=None,
@@ -33,6 +34,7 @@ class CustomTemplate(Template):
         """
         super().__init__(
             name=name,
+            client=client,
             namespace=namespace,
         )
         self.source_template = source_template
@@ -64,10 +66,13 @@ class CustomTemplate(Template):
 
 
 @pytest.fixture()
-def custom_template_from_base_template(request, namespace):
-    base_template = Template(namespace=NamespacesNames.OPENSHIFT, name=request.param["base_template_name"])
+def custom_template_from_base_template(request, admin_client, unprivileged_client, namespace):
+    base_template = Template(
+        client=admin_client, namespace=NamespacesNames.OPENSHIFT, name=request.param["base_template_name"]
+    )
     with CustomTemplate(
         name=request.param["new_template_name"],
+        client=unprivileged_client,
         namespace=namespace.name,
         source_template=base_template,
         vm_validation_rule=request.param.get("validation_rule"),

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -208,8 +208,9 @@ class TestCustomWindowsOptions:
     @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-7886")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::migration", depends=[f"{TESTS_CLASS_NAME}::boot"])
-    def test_windows_custom_options_migration(self, custom_windows_vm):
+    def test_windows_custom_options_migration(self, admin_client, custom_windows_vm):
         with VirtualMachineInstanceMigration(
+            client=admin_client,
             name="custom-windows-vm-migration",
             namespace=custom_windows_vm.namespace,
             vmi_name=custom_windows_vm.vmi.name,

--- a/tests/virt/cluster/vm_cloning/conftest.py
+++ b/tests/virt/cluster/vm_cloning/conftest.py
@@ -4,10 +4,11 @@ from utilities.virt import VirtualMachineForCloning, fedora_vm_body, running_vm
 
 
 @pytest.fixture(scope="class")
-def fedora_vm_for_cloning(request, namespace, cpu_for_migration):
+def fedora_vm_for_cloning(request, unprivileged_client, namespace, cpu_for_migration):
     name = request.param["vm_name"]
     with VirtualMachineForCloning(
         name=name,
+        client=unprivileged_client,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
         vm_labels=request.param.get("labels"),

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_manifest.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_manifest.py
@@ -20,8 +20,8 @@ VIRTCTL_CREATE_CLONE_COMMAND = (
 )
 
 
-def create_cloning_job_from_manifest_and_wait_for_success(manifest):
-    with VirtualMachineClone(yaml_file=manifest) as vmc:
+def create_cloning_job_from_manifest_and_wait_for_success(client, manifest):
+    with VirtualMachineClone(client=client, yaml_file=manifest) as vmc:
         vmc.wait_for_status(status=VirtualMachineClone.Status.SUCCEEDED)
 
 
@@ -53,13 +53,7 @@ def vmsnapshot_created(fedora_vm_for_cloning):
 
 @pytest.mark.parametrize(
     "fedora_vm_for_cloning",
-    [
-        pytest.param(
-            {
-                "vm_name": "fedora-vm-for-manifest-clone-test",
-            },
-        )
-    ],
+    [pytest.param({"vm_name": "fedora-vm-for-manifest-clone-test"})],
     indirect=True,
 )
 @pytest.mark.usefixtures(
@@ -68,22 +62,24 @@ def vmsnapshot_created(fedora_vm_for_cloning):
 class TestVMCloneVirtctlManifest:
     @pytest.mark.parametrize(
         "virtctl_cloning_manifest",
-        [
-            pytest.param("vm"),
-        ],
+        [pytest.param("vm")],
         indirect=True,
     )
     @pytest.mark.polarion("CNV-10300")
-    def test_clone_vm_with_virtctl_manifest(self, virtctl_cloning_manifest):
-        create_cloning_job_from_manifest_and_wait_for_success(manifest=virtctl_cloning_manifest)
+    def test_clone_vm_with_virtctl_manifest(self, unprivileged_client, virtctl_cloning_manifest):
+        create_cloning_job_from_manifest_and_wait_for_success(
+            client=unprivileged_client, manifest=virtctl_cloning_manifest
+        )
 
     @pytest.mark.parametrize(
         "virtctl_cloning_manifest",
-        [
-            pytest.param("vmsnapshot"),
-        ],
+        [pytest.param("vmsnapshot")],
         indirect=True,
     )
     @pytest.mark.polarion("CNV-10301")
-    def test_clone_vmsnapshot_with_virtctl_manifest(self, vmsnapshot_created, virtctl_cloning_manifest):
-        create_cloning_job_from_manifest_and_wait_for_success(manifest=virtctl_cloning_manifest)
+    def test_clone_vmsnapshot_with_virtctl_manifest(
+        self, unprivileged_client, vmsnapshot_created, virtctl_cloning_manifest
+    ):
+        create_cloning_job_from_manifest_and_wait_for_success(
+            client=unprivileged_client, manifest=virtctl_cloning_manifest
+        )

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning_negative.py
@@ -27,10 +27,11 @@ LOGGER = logging.getLogger(__name__)
         ),
     ],
 )
-def test_cloning_job_if_source_not_exist_negative(namespace, cloning_job_bad_params):
+def test_cloning_job_if_source_not_exist_negative(unprivileged_client, namespace, cloning_job_bad_params):
     with VirtualMachineClone(
         name="clone-job-negative-test",
         namespace=namespace.name,
+        client=unprivileged_client,
         source_name=cloning_job_bad_params["source_name"],
         source_kind=cloning_job_bad_params["source_kind"],
     ) as vmc:

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -108,7 +108,7 @@ def virt_special_infra_sanity(
     def _verify_rwx_default_storage():
         storage_class = py_config["default_storage_class"]
         LOGGER.info(f"Verifing default storage class {storage_class} supports RWX mode")
-        access_modes = StorageProfile(name=storage_class).first_claim_property_set_access_modes()
+        access_modes = StorageProfile(client=admin_client, name=storage_class).first_claim_property_set_access_modes()
         if not access_modes or access_modes[0] != DataVolume.AccessMode.RWX:
             failed_verifications_list.append(f"Default storage class {storage_class} doesn't support RWX mode")
 

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -71,6 +71,7 @@ def vm_for_migration_progress_test(
     name = "vm-for-migration-progress-test"
     with VirtualMachineForTests(
         name=name,
+        client=unprivileged_client,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
         additional_labels=MIGRATION_POLICY_VM_LABEL,

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2044,6 +2044,7 @@ def node_mgmt_console(node, node_mgmt):
 @contextmanager
 def create_vm_cloning_job(
     name,
+    client,
     namespace,
     source_name,
     source_kind=None,
@@ -2068,6 +2069,7 @@ def create_vm_cloning_job(
     """
     with VirtualMachineClone(
         name=name,
+        client=client,
         namespace=namespace,
         source_name=source_name,
         source_kind=source_kind,
@@ -2428,9 +2430,10 @@ class VirtualMachineForCloning(VirtualMachineForTests):
 
 
 @contextmanager
-def target_vm_from_cloning_job(cloning_job):
+def target_vm_from_cloning_job(client, cloning_job):
     cloning_job_spec = cloning_job.instance.spec
     target_vm = VirtualMachineForTests(
+        client=client,
         name=cloning_job_spec.target.name,
         namespace=cloning_job.namespace,
         os_flavor=cloning_job_spec.source.name.split("-")[0],


### PR DESCRIPTION
##### Short description:
Updated class instance creations to pass client param

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-68532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized client-scoped operations across VM cloning and migration paths, and added support for annotation filters and VM metadata propagation to improve permission-context fidelity.

* **Tests**
  * Updated fixtures and helpers to pass unprivileged/admin client contexts and thread vm annotations, smbios_serial, cpu_model and manifest usage through cloning, migration, template, DataVolume and storage-profile scenarios for more accurate permission and behavior testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->