### PR TITLE
[gating][Mian] fix test_successful_import_image 

### DIFF
--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -47,6 +47,7 @@ from utilities.constants import (
     SECURITY_CONTEXT,
     TIMEOUT_1MIN,
     TIMEOUT_5SEC,
+    TIMEOUT_20MIN,
     Images,
 )
 from utilities.hco import (
@@ -174,7 +175,7 @@ def internal_http_deployment(cnv_tests_utilities_namespace):
         template=INTERNAL_HTTP_TEMPLATE,
         replicas=1,
     ) as dep:
-        dep.wait_for_replicas()
+        dep.wait_for_replicas(timeout=TIMEOUT_20MIN)
         yield dep
 
 


### PR DESCRIPTION
**Short description:**

Fix internal-http deployment fixture to properly wait for deployment replicas, preventing setup timeouts in HTTP import tests.

**More details:**

Tests test_successful_import_image and test_successful_import_secure_image were intermittently failing during setup because the internal-http deployment sometimes didn’t have ready replicas in time.

**Changes in the fixture:**

Waits for deployment replicas to be ready using dep.wait_for_replicas(timeout=TIMEOUT_20MIN).


**Why this is needed:**

Ensures internal-http deployment replicas are ready before tests start.

Prevents flaky setup failures in HTTP import tests.

Improves logging and debugging when deployment readiness fails.

**Issue(s) this PR fixes:**

Fixes intermittent setup failures in tests.storage.cdi_import.test_import_http that caused these tests to be quarantined.

Special notes for reviewer:

Jira ticket: [CNV-70094](https://issues.redhat.com/browse/CNV-70094)
https://issues.redhat.com/browse/CNV-72268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding and applying a 20-minute timeout for waiting on deployment replicas, ensuring more consistent readiness checks during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->