### PR TITLE
fix: update boot device for s390x using zipl

### DIFF
--- a/containers/fedora/user-data
+++ b/containers/fedora/user-data
@@ -38,4 +38,5 @@ runcmd:
   - systemctl enable nginx
   - systemctl enable sshd
   - grubby --args="net.ifnames=0" --update-kernel=ALL
+  - if [ $(uname -m) == "s390x" ]; then zipl; fi
   - shutdown


### PR DESCRIPTION
This change in the user-data configuration is essential to ensure that the Fedora image is bootable for the s390x architecture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added architecture-specific support for s390x systems, ensuring proper boot configuration on IBM Z systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->