### PR TITLE
Storage: remove unneeded tests and checks in import and hpp modules

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -22,7 +22,6 @@ from tests.storage.constants import (
 from tests.storage.utils import (
     assert_num_files_in_pod,
     assert_use_populator,
-    create_vm_and_verify_image_permission,
     create_vm_from_dv,
     get_file_url,
     get_importer_pod,
@@ -42,11 +41,8 @@ from utilities.infra import get_node_selector_dict
 from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.storage import (
     ErrorMsg,
-    PodWithPVC,
-    check_disk_count_in_vm,
     create_dummy_first_consumer_pod,
     create_dv,
-    get_containers_for_pods_with_pvc,
     get_test_artifact_server_url,
     sc_volume_binding_mode_is_wffc,
 )
@@ -62,12 +58,6 @@ ISO_IMG = "Core-current.iso"
 TAR_IMG = "archive.tar"
 DEFAULT_DV_SIZE = Images.Cirros.DEFAULT_DV_SIZE
 SMALL_DV_SIZE = "200Mi"
-
-DV_PARAMS = {
-    "file_name": Images.Cdi.QCOW2_IMG,
-    "source": HTTPS,
-    "configmap_name": INTERNAL_HTTP_CONFIGMAP_NAME,
-}
 
 LATEST_WINDOWS_OS_DICT = py_config.get("latest_windows_os_dict", {})
 
@@ -175,45 +165,11 @@ def test_empty_url(namespace, storage_class_name_scope_module):
             pass
 
 
-@pytest.mark.parametrize(
-    "dv_from_http_import",
-    [
-        pytest.param(
-            {
-                "dv_name": "cnv-2145",
-                "file_name": TAR_IMG,
-                "content_type": DataVolume.ContentType.ARCHIVE,
-            },
-        ),
-    ],
-    indirect=True,
-)
-@pytest.mark.sno
-@pytest.mark.polarion("CNV-2145")
-@pytest.mark.s390x
-def test_successful_import_archive(
-    skip_block_volumemode_scope_module,
-    running_pod_with_dv_pvc,
-):
-    """
-    Skip block volume mode - archive does not support block mode DVs,
-    https://github.com/kubevirt/containerized-data-importer/blob/main/doc/supported_operations.md
-    """
-    assert_num_files_in_pod(pod=running_pod_with_dv_pvc, expected_num_of_files=3)
-
-
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.parametrize(
     "dv_from_http_import",
     [
-        pytest.param(
-            {
-                "dv_name": "cnv-2143",
-                "file_name": Images.Cdi.QCOW2_IMG,
-            },
-            marks=pytest.mark.polarion("CNV-2143"),
-        ),
         pytest.param(
             {
                 "dv_name": "cnv-377",
@@ -225,7 +181,6 @@ def test_successful_import_archive(
     indirect=True,
 )
 def test_successful_import_image(
-    running_pod_with_dv_pvc,
     dv_from_http_import,
     storage_class_name_scope_module,
     cluster_csi_drivers_names,
@@ -269,7 +224,12 @@ def test_successful_import_secure_archive(
     "dv_from_http_import",
     [
         pytest.param(
-            DV_PARAMS,
+            {
+                "dv_name": "cnv-2719",
+                "file_name": Images.Cdi.QCOW2_IMG,
+                "source": HTTPS,
+                "configmap_name": INTERNAL_HTTP_CONFIGMAP_NAME,
+            },
             marks=pytest.mark.polarion("CNV-2719"),
         ),
     ],
@@ -283,20 +243,14 @@ def test_successful_import_secure_image(internal_http_configmap, dv_from_http_im
 
 @pytest.mark.sno
 @pytest.mark.parametrize(
-    ("content_type", "file_name"),
+    "content_type, file_name",
     [
-        pytest.param(
-            DataVolume.ContentType.ARCHIVE,
-            TAR_IMG,
-            marks=(pytest.mark.polarion("CNV-2339")),
-        ),
         pytest.param(
             DataVolume.ContentType.KUBEVIRT,
             Images.Cirros.RAW_IMG_XZ,
             marks=(pytest.mark.polarion("CNV-784"), pytest.mark.smoke()),
         ),
     ],
-    ids=["import_basic_auth_archive", "import_basic_auth_kubevirt"],
 )
 @pytest.mark.s390x
 def test_successful_import_basic_auth(
@@ -323,17 +277,6 @@ def test_successful_import_basic_auth(
         storage_class=storage_class_name_scope_module,
     ) as dv:
         dv.wait_for_dv_success()
-        pvc = dv.pvc
-        with PodWithPVC(
-            namespace=pvc.namespace,
-            name=f"{pvc.name}-pod",
-            pvc_name=pvc.name,
-            containers=get_containers_for_pods_with_pvc(
-                volume_mode=storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"],
-                pvc_name=pvc.name,
-            ),
-        ) as pod:
-            pod.wait_for_status(status=pod.Status.RUNNING)
 
 
 @pytest.mark.sno
@@ -403,21 +346,6 @@ def test_unpack_compressed(
         ),
         msg=ErrorMsg.EXIT_STATUS_2,
     )
-
-
-@pytest.mark.parametrize(
-    "dv_from_http_import",
-    [
-        pytest.param(
-            DV_PARAMS,
-            marks=pytest.mark.polarion("CNV-2811"),
-        ),
-    ],
-    indirect=True,
-)
-@pytest.mark.sno
-def test_certconfigmap(internal_http_configmap, running_pod_with_dv_pvc):
-    assert_num_files_in_pod(pod=running_pod_with_dv_pvc, expected_num_of_files=1)
 
 
 @pytest.mark.sno
@@ -516,7 +444,6 @@ def test_successful_concurrent_blank_disk_import(
 ):
     for vm in vm_list_created_by_multiprocess:
         running_vm(vm=vm)
-        check_disk_count_in_vm(vm=vm)
 
 
 @pytest.mark.parametrize(
@@ -637,13 +564,6 @@ def test_successful_vm_from_imported_dv_windows(
     validate_os_info_vmi_vs_windows_os(
         vm=vm_instance_from_template_multi_storage_scope_function,
     )
-
-
-@pytest.mark.polarion("CNV-4032")
-@pytest.mark.sno
-@pytest.mark.s390x
-def test_disk_image_after_import(skip_block_volumemode_scope_module, cirros_dv_unprivileged):
-    create_vm_and_verify_image_permission(dv=cirros_dv_unprivileged)
 
 
 @pytest.mark.polarion("CNV-4724")

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -62,9 +62,7 @@ from utilities.infra import (
 )
 from utilities.storage import (
     create_cirros_dv_for_snapshot_dict,
-    data_volume,
     get_downloaded_artifact,
-    sc_volume_binding_mode_is_wffc,
     write_file,
 )
 from utilities.virt import VirtualMachineForTests
@@ -209,12 +207,6 @@ def skip_test_if_no_hpp_sc(cluster_storage_classes):
     existing_hpp_sc = [sc.name for sc in cluster_storage_classes if sc.name in HPP_STORAGE_CLASSES]
     if not existing_hpp_sc:
         pytest.skip(f"This test runs only on one of the hpp storage classes: {HPP_STORAGE_CLASSES}")
-
-
-@pytest.fixture(scope="module")
-def skip_when_hpp_no_waitforfirstconsumer(storage_class_matrix_hpp_matrix__module__):
-    if not sc_volume_binding_mode_is_wffc(sc=[*storage_class_matrix_hpp_matrix__module__][0]):
-        pytest.skip("Test only run when volumeBindingMode is WaitForFirstConsumer")
 
 
 @pytest.fixture()
@@ -424,21 +416,6 @@ def hpp_daemonset_scope_module(hco_namespace, hpp_cr_suffix_scope_module):
 @pytest.fixture()
 def cirros_vm_name(request):
     return request.param["vm_name"]
-
-
-@pytest.fixture(scope="module")
-def data_volume_multi_hpp_storage(
-    request,
-    namespace,
-    schedulable_nodes,
-    storage_class_matrix_hpp_matrix__module__,
-):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class=[*storage_class_matrix_hpp_matrix__module__][0],
-        schedulable_nodes=schedulable_nodes,
-    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
##### Short description:
Import tests:
- removing steps of creating the pod that uses the imported PVC (VM is a better PVC consumer)
- removing check disk count in VM - no need in tier2 tests
- removing duplicate scenarios
- `test_successful_import_archive` - covered in tier1 https://github.com/kubevirt/containerized-data-importer/blob/main/tests/import_test.go#L576

HPP tests:
- HPP storage tests are covered in other import/clone/upload and wffc tests
- HPP is always WFFC in our setups; we never set it up with Immediate binding, so removing these test cases

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified storage test infrastructure by removing redundant test utilities and fixtures.
  * Streamlined storage-related test coverage, removing parameterized test scenarios and unused helper functions.
  * Removed unused imports and internal test configuration declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->