### PR TITLE
 T2 node test adopted for s390x arch #1519

### DIFF
--- a/tests/virt/constants.py
+++ b/tests/virt/constants.py
@@ -47,3 +47,7 @@ class MachineTypesNames:
     pc_q35_rhel7_4 = f"{pc_q35}-rhel7.4.0"
     pc_i440fx = "pc-i440fx"
     pc_i440fx_rhel7_6 = f"{pc_i440fx}-rhel7.6.0"
+    s390_ccw_virtio = "s390-ccw-virtio"
+    s390_ccw_virtio_rhel9_6 = f"{s390_ccw_virtio}-rhel9.6.0"
+    s390_ccw_virtio_rhel8_6 = f"{s390_ccw_virtio}-rhel8.6.0"
+    s390_ccw_virtio_rhel7_6 = f"{s390_ccw_virtio}-rhel7.6.0"

--- a/tests/virt/node/cpu_sockets_threads/test_cpu_support_sockets_threads.py
+++ b/tests/virt/node/cpu_sockets_threads/test_cpu_support_sockets_threads.py
@@ -21,7 +21,7 @@ def check_vm_dumpxml(vm, cores=None, sockets=None, threads=None):
 
 
 @pytest.fixture()
-def vm_with_cpu_support(request, namespace, unprivileged_client):
+def vm_with_cpu_support(request, is_s390x_cluster, namespace, unprivileged_client):
     """
     VM with CPU support (cores,sockets,threads)
     """
@@ -31,7 +31,7 @@ def vm_with_cpu_support(request, namespace, unprivileged_client):
         namespace=namespace.name,
         cpu_cores=request.param["cores"],
         cpu_sockets=request.param["sockets"],
-        cpu_threads=request.param["threads"],
+        cpu_threads=1 if is_s390x_cluster else request.param["threads"],
         cpu_max_sockets=request.param["sockets"] or 1,
         body=fedora_vm_body(name=name),
         client=unprivileged_client,
@@ -66,6 +66,7 @@ def vm_with_cpu_support(request, namespace, unprivileged_client):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_vm_with_cpu_support(vm_with_cpu_support):
     """
     Test VM with cpu support
@@ -97,6 +98,7 @@ def no_cpu_settings_vm(namespace, unprivileged_client):
 
 @pytest.mark.gating
 @pytest.mark.conformance
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-1485")
 def test_vm_with_no_cpu_settings(no_cpu_settings_vm):
     """
@@ -108,6 +110,7 @@ def test_vm_with_no_cpu_settings(no_cpu_settings_vm):
 
 
 @pytest.mark.gating
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-2818")
 def test_vm_with_cpu_limitation(namespace, unprivileged_client):
     """
@@ -130,6 +133,7 @@ def test_vm_with_cpu_limitation(namespace, unprivileged_client):
 
 
 @pytest.mark.polarion("CNV-2819")
+@pytest.mark.s390x
 def test_vm_with_cpu_limitation_negative(namespace, unprivileged_client):
     """
     Test VM with cpu limitation

--- a/tests/virt/node/general/test_custom_selinux_policy.py
+++ b/tests/virt/node/general/test_custom_selinux_policy.py
@@ -12,4 +12,4 @@ def test_customselinuxpolicy(workers_utility_pods, schedulable_nodes):
         out = pod_exec.exec(command="sudo semodule -l")
         if "virt_launcher" in out:
             nodes.append(node.name)
-    assert not nodes, f"node: {nodes} still have virt-launcher policies."
+    assert not nodes, f"node: {nodes} still have virt_launcher policies."

--- a/tests/virt/node/general/test_disable_pvspinlock.py
+++ b/tests/virt/node/general/test_disable_pvspinlock.py
@@ -20,7 +20,7 @@ def vm_for_test_pvspinlock(
 
 
 @pytest.mark.polarion("CNV-6877")
-def test_disable_pvcpinlock(vm_for_test_pvspinlock):
+def test_disable_pvspinlock(vm_for_test_pvspinlock):
     assert vm_for_test_pvspinlock.privileged_vmi.xml_dict["domain"]["features"]["pvspinlock"]["@state"] == "off", (
         "pvspinlock is not disabled in domain xml."
     )

--- a/tests/virt/node/general/test_linux_label.py
+++ b/tests/virt/node/general/test_linux_label.py
@@ -14,9 +14,9 @@ def assert_linux_label_was_added_in_nodes(nodes):
     assert not no_os_labels_nodes, f"Following Nodes {no_os_labels_nodes} does not have Linux label."
 
 
-@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.conformance
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-5758")
 def test_linux_label_was_added(schedulable_nodes):
     assert_linux_label_was_added_in_nodes(nodes=schedulable_nodes)

--- a/tests/virt/node/general/test_networkinterfacemultiqueue_feature.py
+++ b/tests/virt/node/general/test_networkinterfacemultiqueue_feature.py
@@ -99,21 +99,28 @@ class TestLatestRHEL:
 
     @pytest.mark.dependency(name=f"{RHEL_TESTS_CLASS_NAME}::rhel_default_cpu_values")
     @pytest.mark.polarion("CNV-8891")
-    def test_default_cpu_values(self, network_interface_multiqueue_vm):
+    @pytest.mark.s390x
+    def test_default_cpu_values(
+        self,
+        network_interface_multiqueue_vm,
+    ):
         network_interface_multiqueue_vm.ssh_exec.executor().is_connective(tcp_timeout=TIMEOUT_2MIN)
 
     @pytest.mark.dependency(depends=[f"{RHEL_TESTS_CLASS_NAME}::rhel_default_cpu_values"])
     @pytest.mark.polarion("CNV-8892")
+    @pytest.mark.s390x
     def test_feature_disabled(self, network_interface_multiqueue_vm):
         update_validate_cpu_in_vm(vm=network_interface_multiqueue_vm, network_multiqueue=False)
 
     @pytest.mark.dependency(depends=[f"{RHEL_TESTS_CLASS_NAME}::rhel_default_cpu_values"])
     @pytest.mark.polarion("CNV-8893")
+    @pytest.mark.s390x
     def test_four_cores(self, network_interface_multiqueue_vm):
         update_validate_cpu_in_vm(vm=network_interface_multiqueue_vm, cores=4)
 
     @pytest.mark.dependency(depends=[f"{RHEL_TESTS_CLASS_NAME}::rhel_default_cpu_values"])
     @pytest.mark.polarion("CNV-8894")
+    @pytest.mark.s390x
     def test_four_sockets(self, network_interface_multiqueue_vm):
         update_validate_cpu_in_vm(vm=network_interface_multiqueue_vm, sockets=4)
 

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -56,6 +56,7 @@ def hotplug_vm_snapshot(hotplugged_vm):
             {"os_dict": RHEL_LATEST},
             {"template_labels": RHEL_LATEST_LABELS, "vm_name": "rhel-latest-cpu-hotplug-vm"},
             id="RHEL-VM",
+            marks=pytest.mark.s390x,
         ),
         pytest.param(
             {"os_dict": WINDOWS_LATEST},

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -20,7 +20,10 @@ def vm_with_fio(
     unprivileged_client,
     namespace,
     golden_image_data_volume_template_for_test_scope_class,
+    is_s390x_cluster,
 ):
+    if is_s390x_cluster:
+        request.param["cpu_threads"] = 1
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
@@ -87,6 +90,7 @@ def get_disk_usage(ssh_exec):
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 @pytest.mark.rwx_default_storage
 def test_fedora_vm_load_migration(vm_with_fio, running_fio_in_vm):
     LOGGER.info("Test migrate VM with disk load")

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -59,6 +59,7 @@ class TestMigrationVMWithMemoryLoad:
         ],
         indirect=True,
     )
+    @pytest.mark.s390x
     def test_fedora_vm_migrate_with_memory_load(
         self,
         vm_with_memory_load,

--- a/tests/virt/node/node_labeller/cpu_features/test_node_feature_discovery.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_node_feature_discovery.py
@@ -64,17 +64,26 @@ def updated_kubevirt_cpus(
 
 def node_label_checker(node_label_dict, label_list, dict_key):
     """
-    Check node labels for cpu models/features/kvm-info.
-    Return dict:
-    {'<node_name>': [<cpu_models/features/kvm-info>]}
+    Checks node labels for either cpu_models, cpu_features, or kvm-info.
+
+    The specific check depends on the dict_key value.
+
+    Args:
+        node_label_dict: Dictionary mapping node names to their labels.
+        label_list: List of label values to search for.
+        dict_key: Key indicating which label category to check (cpu_models, cpu_features, or kvm-info).
+
+    Returns:
+        dict: A dictionary mapping node names to the list of retrieved values.
+                Format: {'<node_name>': [<cpu_models | cpu_features | kvm-info>]}
     """
     return {
         node: [value for value in label_list if value in node_label_dict[node][dict_key]] for node in node_label_dict
     }
 
 
-@pytest.mark.polarion("CNV-2797")
 @pytest.mark.s390x
+@pytest.mark.polarion("CNV-2797")
 def test_obsolete_cpus_in_node_labels(nodes_labels_dict, kubevirt_config):
     """
     Test obsolete CPUs. Obsolete CPUs don't appear in node labels.
@@ -113,9 +122,9 @@ def test_hardware_required_node_labels(nodes_labels_dict):
     assert any(test_dict.values()), f"KVM info not found in labels\n{test_dict}"
 
 
-@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.conformance
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-6088")
 def test_hardware_non_required_node_labels(nodes_labels_dict):
     hw_supported_hyperv_features = [
@@ -134,8 +143,8 @@ def test_hardware_non_required_node_labels(nodes_labels_dict):
     assert not any(test_dict.values()), f"Some nodes have non required KVM labels: {test_dict}"
 
 
-@pytest.mark.s390x
 @pytest.mark.gating
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-6103")
 def test_updated_obsolete_cpus_in_node_labels(updated_kubevirt_cpus, nodes_labels_dict, kubevirt_config):
     """

--- a/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_flag.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_flag.py
@@ -62,6 +62,7 @@ def test_vm_with_cpu_flag_negative(cpu_flag_vm_negative):
 
 
 @pytest.mark.polarion("CNV-1269")
+@pytest.mark.s390x
 @pytest.mark.gating
 @pytest.mark.conformance
 def test_vm_with_cpu_flag_positive_case(cpu_flag_vm_positive, cluster_common_node_cpu):

--- a/tests/virt/node/owner_references/test_vm_owner_references.py
+++ b/tests/virt/node/owner_references/test_vm_owner_references.py
@@ -27,6 +27,7 @@ def fedora_vm(unprivileged_client, namespace):
 
 @pytest.mark.gating
 @pytest.mark.conformance
+@pytest.mark.s390x
 @pytest.mark.polarion("CNV-1275")
 def test_owner_references_on_vm(fedora_vm):
     """

--- a/tests/virt/node/workload_density/test_free_page_reporting.py
+++ b/tests/virt/node/workload_density/test_free_page_reporting.py
@@ -87,6 +87,7 @@ def disabled_free_page_reporting_in_vm(free_page_reporting_vm):
 
 
 @pytest.mark.gating
+@pytest.mark.s390x
 class TestFreePageReporting:
     @pytest.mark.dependency()
     @pytest.mark.polarion("CNV-10540")

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -844,9 +844,43 @@ POD_CONTAINER_SPEC = {
         "capabilities": {"drop": ["ALL"]},
     },
 }
+
+EXCLUDED_CPU_MODELS_S390X = [
+    # Below are deprecated & usable models, but violate RHEL 9 ALS (min z14) causing guest to crash (disable-wait)
+    # Ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/automatically_installing_rhel/preparing-a-rhel-installation-on-64-bit-ibm-z_rhel-installer#planning-for-installation-on-ibm-z_preparing-a-rhel-installation-on-64-bit-ibm-z # noqa: E501
+    "z114",
+    "z114-base",
+    "z13",
+    "z13-base",
+    "z13.2",
+    "z13.2-base",
+    "z13s",
+    "z13s-base",
+    "z196",
+    "z196-base",
+    "z196.2",
+    "z196.2-base",
+    "zBC12",
+    "zBC12-base",
+    "zEC12",
+    "zEC12-base",
+    "zEC12.2",
+    "zEC12.2-base",
+    # Below are usable (non-deprecated) models, but base models doesn't work on RHEL guests
+    # unless required features are appended (ex: 'gen15b-base,vx=on,..'),
+    "z14ZR1-base",
+    "z14.2-base",
+    "z14-base",
+    "gen15a-base",
+    "gen15b-base",
+    "gen16a-base",
+    "gen16b-base",
+    "gen17a-base",
+    "gen17b-base",
+]
 # Opteron - Windows image can't boot
 # Penryn - does not support WSL2
-EXCLUDED_CPU_MODELS = ["Opteron", "Penryn"]
+EXCLUDED_CPU_MODELS = [*EXCLUDED_CPU_MODELS_S390X, "Opteron", "Penryn"]
 # Latest windows can't boot with old cpu models
 EXCLUDED_OLD_CPU_MODELS = [*EXCLUDED_CPU_MODELS, "Westmere", "SandyBridge", "Nehalem", "IvyBridge", "Skylake"]
 

--- a/utilities/cpu.py
+++ b/utilities/cpu.py
@@ -122,7 +122,9 @@ def get_common_cpu_from_nodes(cluster_cpus: Set[str]) -> str | None:
     Returns:
         A single CPU model string from the set if available, None if the set is empty.
     """
-    return next(iter(cluster_cpus)) if cluster_cpus else None
+    common_cpu_model = next(iter(cluster_cpus)) if cluster_cpus else None
+    LOGGER.info(f"Common CPU used is {common_cpu_model}")
+    return common_cpu_model
 
 
 def get_nodes_cpu_architecture(nodes: list[Node]) -> str:


### PR DESCRIPTION
##### Short description:
Updated Node Tier2 tests after adopting to work for s390x

##### More details:
Earlier I've created a [PR](https://github.com/RedHatQE/openshift-virtualization-tests/pull/1519), which I couldn't finish due to other release priorities. So, I've addressed all the review comments there in this PR.

##### What this PR does / why we need it:
To run node tier2 tests in s390x in the pipeline

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

@rnetser @vsibirsk 

##### jira-ticket:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added s390x mainframe machine type constants and explicit machine type selection.

* **Bug Fixes**
  * Corrected test names and reordered markers for consistency.
  * Adjusted CPU/thread behavior and memory handling for s390x clusters.

* **Refactor**
  * Simplified architecture configuration handling and removed conditional branches.

* **Tests**
  * Broadened s390x test coverage and updated fixtures/markers across multiple suites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->