### PR TITLE
Add wait for boot sources reimported

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2492,9 +2492,11 @@ def migrated_vm_multiple_times(request, vm_for_migration_test):
 
 
 @pytest.fixture()
-def removed_default_storage_classes(cluster_storage_classes):
+def removed_default_storage_classes(admin_client, golden_images_namespace, cluster_storage_classes):
     with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
         yield
+    if not verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name):
+        pytest.fail("Failed to reimport all boot sources at teardown")
 
 
 @pytest.fixture(scope="session")

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -19,7 +19,6 @@ from tests.infrastructure.golden_images.constants import (
 from tests.infrastructure.golden_images.update_boot_source.utils import get_all_dic_volume_names
 from utilities.constants import (
     BIND_IMMEDIATE_ANNOTATION,
-    QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,
@@ -328,10 +327,6 @@ class TestDataImportCronDefaultStorageClass:
         )
 
 
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: This test still fail in some cases ; tracked in CNV-62615",
-    run=False,
-)
 @pytest.mark.polarion("CNV-7532")
 def test_data_import_cron_deletion_on_opt_out(
     admin_client,


### PR DESCRIPTION
##### Short description:
Add wait for boot sources re-imported after changing the default storage class in the cluster

##### More details:
After changing the default storage class, the data import crons re-import the data sources using the new storage class. this causes issues in following tests if we do not wait for the sources to complete the import.

##### What this PR does / why we need it:
Stabilise `test_data_import_cron_deletion_on_opt_out` by waiting for data sources import


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixture validation with improved cleanup verification during teardown
  * Enabled previously skipped test for normal execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->