### PR TITLE
Disable flake8 extansions PID,UFN for python 3.14

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -82,9 +82,11 @@ nit_exclude_imports =
     tests.utils
 
 
+# PID and UFN extensions are temporarily disabled due to Python 3.14 compatibility issues
+# in flake8-plugins. These should be re-enabled once the plugins are updated.
 enable-extensions =
-    PID,
+#    PID,
     FCN,
-    UFN,
+#    UFN,
     NIC,
     NIT,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         args: [--config=.flake8]
         additional_dependencies:
           [
-            "git+https://github.com/RedHatQE/flake8-plugins.git@v0.0.10",
+            "git+https://github.com/RedHatQE/flake8-plugins.git@main",
             "flake8-mutable",
             "pep8-naming",
           ]


### PR DESCRIPTION
##### Short description:
Disable flake8 extansions PID,UFN for python 3.14

##### More details:
 - Disabled PID (PolarionIds) and UFN (UniqueFixturesNames) extensions due to Python 3.14 compatibility issues
 - Changed the flake8-plugins version from v0.0.10 to main to get the latest code.

##### What this PR does / why we need it:
Fix pre-commit run
