### PR TITLE
WIP: [gating] [main] Add retry mechanism for DataVolume creation to handle urllib3 errors

### DIFF
--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -25,6 +25,7 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VERBS_SRC_SA,
     VM_FOR_TEST,
 )
+from tests.storage.restricted_namespace_cloning.utils import create_dv_with_retry
 from tests.storage.utils import (
     create_cluster_role,
     create_role_binding,
@@ -231,7 +232,7 @@ def dv_cloned_by_unprivileged_user_in_the_same_namespace(
     permissions_datavolume_source,
 ):
     namespace = data_volume_multi_storage_scope_module.namespace
-    with create_dv(
+    with create_dv_with_retry(
         dv_name=f"{request.param['dv_name']}-{storage_class_name_scope_module}",
         namespace=namespace,
         source=PVC,

--- a/tests/storage/restricted_namespace_cloning/utils.py
+++ b/tests/storage/restricted_namespace_cloning/utils.py
@@ -1,13 +1,17 @@
+import contextlib
 import logging
+from http.client import RemoteDisconnected
 
 import pytest
+import urllib3
 from kubernetes.client.rest import ApiException
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.datavolume import DataVolume
+from timeout_sampler import TimeoutSampler
 
 from tests.storage.restricted_namespace_cloning.constants import TARGET_DV
 from tests.storage.utils import assert_pvc_snapshot_clone_annotation
-from utilities.constants import PVC
+from utilities.constants import PVC, TIMEOUT_2MIN
 from utilities.storage import (
     ErrorMsg,
     create_dv,
@@ -50,3 +54,27 @@ def create_dv_negative(
             storage_class=storage_class,
         ):
             LOGGER.error("Target dv was created, but shouldn't have been")
+
+
+@contextlib.contextmanager
+def create_dv_with_retry(**kwargs):
+    sampler = TimeoutSampler(
+        wait_timeout=TIMEOUT_2MIN,
+        sleep=5,
+        func=lambda: None,
+        exceptions_dict={urllib3.exceptions.ProtocolError: [], RemoteDisconnected: []},
+    )
+    last_exception = None
+    for _ in sampler:
+        try:
+            with create_dv(**kwargs) as dv:
+                yield dv
+                return  # success - exit after yield
+        except (urllib3.exceptions.ProtocolError, RemoteDisconnected) as e:
+            last_exception = e
+            LOGGER.warning(f"DV creation failed with {type(e).__name__}, retrying...")
+
+    if last_exception:
+        LOGGER.error(f"DV creation failed after {TIMEOUT_2MIN}: {last_exception}")
+        raise last_exception
+    raise RuntimeError("DV creation failed - unknown reason")


### PR DESCRIPTION
##### Short description:
Add retry mechanism for DataVolume creation to handle transient urllib3 errors causing test failures

##### More details:
This PR introduces a create_dv_with_retry wrapper around the existing create_dv function. It retries the DataVolume creation if certain transient network-related errors occur, such as urllib3.exceptions.ProtocolError or RemoteDisconnected. Some tests were failing intermittently due to these transient errors, and this change ensures they pass more reliably.

##### What this PR does / why we need it:
Wraps create_dv with a retry decorator to reduce flakiness in tests

Fixes intermittent test failures in dv_cloned_by_unprivileged_user_in_the_same_namespace fixture

Improves reliability of test fixtures that create DataVolumes 

##### Which issue(s) this PR fixes:

Intermittent test failures caused by transient network errors during DataVolume creation
##### Special notes for reviewer:

failed on setup with "urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))"


##### jira-ticket:

https://issues.redhat.com/browse/CNV-72320

<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a retry-capable data-volume creation helper to improve stability of restricted-namespace cloning tests.
  * Updated test setup to use the new helper, reducing flaky failures by retrying transient connection/protocol errors within a configured timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->