### PR TITLE
Manual cherry-pick to 4.18: Quarantine flaky test_dhcp_broadcast[#ovs-bridge#] (#2215)

### DIFF
--- a/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
+++ b/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
@@ -7,7 +7,7 @@ from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutSampler
 
 from tests.network.constants import DHCP_IP_RANGE_START
-from utilities.constants import TIMEOUT_2MIN
+from utilities.constants import QUARANTINED, TIMEOUT_2MIN
 from utilities.network import assert_ping_successful, get_vmi_ip_v4_by_name, ping
 
 LOGGER = logging.getLogger(__name__)
@@ -72,10 +72,13 @@ class TestL2LinuxBridge:
         l2_bridge_running_vm_b,
         dhcp_nad,
         started_vmb_dhcp_client,
+        request,
     ):
         """
         Test broadcast traffic via L2 linux bridge. VM_A has dhcp server installed. VM_B dhcp client.
         """
+        if "ovs-bridge" in request.node.name:
+            pytest.xfail(reason=f"{QUARANTINED}: Test is flaky over OVS bridge, tracked in CNV-70028")
         current_ip = TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
             sleep=2,


### PR DESCRIPTION
Backport of https://github.com/RedHatQE/openshift-virtualization-tests/pull/2215 to cnv-4.18
`test_dhcp_broadcast[#ovs-bridge#]` test is flaky, quarantined in 4.20,
was backported to 4.19 and needs backporting to 4.18 as well.
