### PR TITLE
Add client in infrastructure/instancetype folder

### DIFF
--- a/tests/infrastructure/instance_types/conftest.py
+++ b/tests/infrastructure/instance_types/conftest.py
@@ -11,18 +11,20 @@ COMMON_INSTANCETYPE_SELECTOR = f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/ve
 
 
 @pytest.fixture(scope="session")
-def base_vm_cluster_preferences():
+def base_vm_cluster_preferences(unprivileged_client):
     return list(
         VirtualMachineClusterPreference.get(
+            client=unprivileged_client,
             label_selector=COMMON_INSTANCETYPE_SELECTOR,
         )
     )
 
 
 @pytest.fixture(scope="session")
-def base_vm_cluster_instancetypes():
+def base_vm_cluster_instancetypes(unprivileged_client):
     return list(
         VirtualMachineClusterInstancetype.get(
+            client=unprivileged_client,
             label_selector=COMMON_INSTANCETYPE_SELECTOR,
         )
     )

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -89,6 +89,7 @@ def golden_image_fedora_vm_with_instance_type(
 
 @pytest.fixture(scope="module")
 def windows_data_volume_template(
+    unprivileged_client,
     namespace,
     windows_os_matrix__module__,
 ):
@@ -97,6 +98,7 @@ def windows_data_volume_template(
     secret = get_artifactory_secret(namespace=namespace.name)
     cert = get_artifactory_config_map(namespace=namespace.name)
     win_dv = DataVolume(
+        client=unprivileged_client,
         name=f"{os_matrix_key}-dv",
         namespace=namespace.name,
         api_name="storage",
@@ -125,9 +127,10 @@ def golden_image_windows_vm(
         client=unprivileged_client,
         name=f"{os_name}-vm-with-instance-type-2",
         namespace=namespace.name,
-        vm_instance_type=VirtualMachineClusterInstancetype(name="u1.large"),
+        vm_instance_type=VirtualMachineClusterInstancetype(client=unprivileged_client, name="u1.large"),
         vm_preference=VirtualMachineClusterPreference(
-            name=windows_os_matrix__module__[os_name][DATA_SOURCE_STR].replace("win", "windows.")
+            client=unprivileged_client,
+            name=windows_os_matrix__module__[os_name][DATA_SOURCE_STR].replace("win", "windows."),
         ),
         data_volume_template=windows_data_volume_template.res,
         os_flavor="win-container-disk",

--- a/tests/infrastructure/instance_types/supported_os/utils.py
+++ b/tests/infrastructure/instance_types/supported_os/utils.py
@@ -21,6 +21,7 @@ def golden_image_vm_with_instance_type(
         vm_preference_infer=True,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=DataSource(
+                client=client,
                 name=data_source_name,
                 namespace=golden_images_namespace_name,
             ),

--- a/tests/infrastructure/instance_types/test_common_vm_instancetype.py
+++ b/tests/infrastructure/instance_types/test_common_vm_instancetype.py
@@ -27,7 +27,7 @@ def test_cx1_instancetype_profile(xfail_if_no_huge_pages, unprivileged_client, n
         name="rhel-vm-with-cx1",
         namespace=namespace.name,
         image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
-        vm_instance_type=VirtualMachineClusterInstancetype(name="cx1.medium1gi"),
+        vm_instance_type=VirtualMachineClusterInstancetype(client=unprivileged_client, name="cx1.medium1gi"),
     ) as vm:
         running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 

--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -53,10 +53,12 @@ def instance_type_hotplug_vm(
 
 
 @pytest.fixture(scope="module")
-def available_rwx_storage_class_name(available_storage_classes_names):
+def available_rwx_storage_class_name(unprivileged_client, available_storage_classes_names):
     for storage_class_name in available_storage_classes_names:
         if (
-            StorageProfile(name=storage_class_name).first_claim_property_set_access_modes()[0]
+            StorageProfile(client=unprivileged_client, name=storage_class_name).first_claim_property_set_access_modes()[
+                0
+            ]
             == DataVolume.AccessMode.RWX
         ):
             return storage_class_name
@@ -97,8 +99,9 @@ def hotplugged_six_sockets_instance_type(admin_client, instance_type_hotplug_vm,
 
 
 @pytest.fixture(scope="class")
-def hotplug_vm_snapshot_instance_type(instance_type_hotplug_vm):
+def hotplug_vm_snapshot_instance_type(instance_type_hotplug_vm, unprivileged_client):
     with VirtualMachineSnapshot(
+        client=unprivileged_client,
         name=f"{instance_type_hotplug_vm.name}-snapshot",
         namespace=instance_type_hotplug_vm.namespace,
         vm_name=instance_type_hotplug_vm.name,

--- a/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
+++ b/tests/infrastructure/instance_types/test_update_vm_with_instancetype_preference.py
@@ -41,10 +41,11 @@ def get_mismatched_fields_list(
 
 
 @pytest.fixture()
-def vm_cluster_instance_type_to_update():
+def vm_cluster_instance_type_to_update(unprivileged_client):
     cluster_instancetype_list = list(
         VirtualMachineClusterInstancetype.get(
-            label_selector="instancetype.kubevirt.io/memory=4Gi, instancetype.kubevirt.io/cpu=1"
+            client=unprivileged_client,
+            label_selector="instancetype.kubevirt.io/memory=4Gi, instancetype.kubevirt.io/cpu=1",
         )
     )
     assert cluster_instancetype_list, "No cluster instance type found on the cluster"
@@ -52,8 +53,8 @@ def vm_cluster_instance_type_to_update():
 
 
 @pytest.fixture()
-def rhel_9_vm_cluster_preference():
-    return VirtualMachineClusterPreference(name="rhel.9")
+def rhel_9_vm_cluster_preference(unprivileged_client):
+    return VirtualMachineClusterPreference(client=unprivileged_client, name="rhel.9")
 
 
 @pytest.fixture()

--- a/tests/infrastructure/instance_types/utils.py
+++ b/tests/infrastructure/instance_types/utils.py
@@ -31,6 +31,7 @@ def get_controller_revision(
     }
 
     return ControllerRevision(
+        client=vm_instance.client,
         name=ref_mapping[ref_type],
         namespace=vm_instance.namespace,
     )


### PR DESCRIPTION
##### Short description:
Add client to wrapper resources in instancetype infrastructure folder

##### More details:
Add client field to resources from openshift-python-wrapper

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures and utilities to accept and propagate an unprivileged client context across VM and cluster resource scenarios.
  * Test setups now pass client context into resource constructions and lookups, improving isolation and consistency when validating instance types, preferences, snapshots, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->