### PR TITLE
Correct extend and append in check_windows_vm_hvinfo

### DIFF
--- a/tests/virt/cluster/common_templates/utils.py
+++ b/tests/virt/cluster/common_templates/utils.py
@@ -531,7 +531,7 @@ def check_windows_vm_hvinfo(vm):
         ]
 
         if failed_vm_recommendations:
-            failed_recommendations.append(failed_vm_recommendations)
+            failed_recommendations.extend(failed_vm_recommendations)
 
         spinlocks = vm_recommendations_dict["SpinlockRetries"]
         if int(spinlocks) != 8191:
@@ -575,7 +575,7 @@ def check_windows_vm_hvinfo(vm):
     failed_windows_hyperv_list.extend(_check_hyperv_features())
 
     if not hvinfo_dict["HyperVsupport"]:
-        failed_windows_hyperv_list.extend("HyperVsupport")
+        failed_windows_hyperv_list.append("HyperVsupport")
 
     assert not failed_windows_hyperv_list, (
         f"The following hyperV flags are not set correctly in the guest: {failed_windows_hyperv_list}\n"


### PR DESCRIPTION
##### Short description:
Correct extend and append in check_windows_vm_hvinfo 

##### More details:
Extand should be used on lists while append should be used on strings, this PR aim to fix those in check_windows_vm_hvinfo

##### Which issue(s) this PR fixes:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/2624#discussion_r2517917335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VM recommendation failure reporting so all individual failures are listed clearly rather than grouped or nested.
  * Corrected Hyper‑V support validation so a single clear error is recorded when support is missing, avoiding fragmented or character-level error entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->