### PR TITLE
 Add automated infrastructure sanity checks for special infra tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -118,6 +118,7 @@ def pytest_addoption(parser):
     session_group = parser.getgroup(name="Session")
     csv_group = parser.getgroup(name="CSV")
     ci_group = parser.getgroup(name="CI")
+    component_sanity_group = parser.getgroup(name="ComponentSanity")
     csv_group.addoption("--update-csv", action="store_true")
 
     # Upgrade addoption
@@ -301,12 +302,7 @@ def pytest_addoption(parser):
         default=False,
         help="Skip artifactory environment variable checks. To be used for tests that does not need articatory access",
     )
-    session_group.addoption(
-        "--skip-virt-sanity-check",
-        action="store_true",
-        default=False,
-        help="Skip verification that cluster has all required capabilities for virt special_infra marked tests",
-    )
+
     session_group.addoption(
         "--remote_cluster_host",
         help="Host address of the remote cluster for cross-cluster tests",
@@ -335,6 +331,19 @@ def pytest_addoption(parser):
         help="Disable Bitwarden secret fetching; use local/environment secrets instead.",
         action="store_true",
         default=False,
+    )
+
+    component_sanity_group.addoption(
+        "--skip-virt-sanity-check",
+        action="store_true",
+        default=False,
+        help="Skip virtualization infrastructure sanity checks",
+    )
+    component_sanity_group.addoption(
+        "--skip-infra-sanity-check",
+        action="store_true",
+        default=False,
+        help="Skip infrastructure prerequisite sanity checks",
     )
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -66,6 +66,7 @@ markers =
     descheduler: Tests that require kube-descheduler on nodes
     remote_cluster: Tests that require a remote cluster
     ovs_brcnv: Test functionality of existing ovs bridge with primary, secondary node ifaces
+    tekton: Tests that depend on openshift-pipelines-operator
 
     ## Required operators
     mtv: Tests that require the MTV operator to be installed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from signal import SIGINT, SIGTERM, getsignal, signal
 from subprocess import check_output
 
 import bcrypt
+import bitmath
 import paramiko
 import pytest
 import requests
@@ -97,6 +98,7 @@ from utilities.constants import (
     KUBEMACPOOL_MAC_RANGE_CONFIG,
     LINUX_BRIDGE,
     MIGRATION_POLICY_VM_LABEL,
+    NODE_HUGE_PAGES_1GI_KEY,
     NODE_ROLE_KUBERNETES_IO,
     NODE_TYPE_WORKER_LABEL,
     OC_ADM_LOGS_COMMAND,
@@ -1031,11 +1033,6 @@ def _skip_access_mode_rwo(storage_class_matrix):
 @pytest.fixture()
 def skip_access_mode_rwo_scope_function(storage_class_matrix__function__):
     _skip_access_mode_rwo(storage_class_matrix=storage_class_matrix__function__)
-
-
-@pytest.fixture(scope="class")
-def skip_access_mode_rwo_scope_class(storage_class_matrix__class__):
-    _skip_access_mode_rwo(storage_class_matrix=storage_class_matrix__class__)
 
 
 @pytest.fixture(scope="session")
@@ -2739,3 +2736,13 @@ def application_aware_resource_quota(admin_client, namespace):
 @pytest.fixture(scope="session")
 def is_s390x_cluster(nodes_cpu_architecture):
     return nodes_cpu_architecture == S390X
+
+
+@pytest.fixture(scope="session")
+def hugepages_gib_values(workers):
+    """Return the list of hugepage sizes (in GiB) across all worker nodes."""
+    return [
+        int(bitmath.parse_string_unsafe(value).GiB)
+        for worker in workers
+        if (value := worker.instance.status.allocatable.get(NODE_HUGE_PAGES_1GI_KEY))
+    ]

--- a/tests/infrastructure/conftest.py
+++ b/tests/infrastructure/conftest.py
@@ -1,25 +1,98 @@
-import bitmath
+import logging
+from pathlib import Path
+
 import pytest
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from timeout_sampler import TimeoutExpiredError
+
+from tests.infrastructure.utils import (
+    verify_numa_enabled,
+    verify_tekton_operator_installed,
+)
+from tests.utils import verify_cpumanager_workers, verify_hugepages_1gi, verify_rwx_default_storage
+from utilities.exceptions import ResourceMissingFieldError, ResourceValueError
+from utilities.pytest_utils import exit_pytest_execution
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def hugepages_gib_values(workers):
-    """Return the list of hugepage sizes (in GiB) across all worker nodes."""
-    return [
-        int(bitmath.parse_string_unsafe(value).GiB)
-        for worker in workers
-        if (value := worker.instance.status.allocatable.get("hugepages-1Gi"))
-    ]
-
-
-@pytest.fixture(scope="session")
-def xfail_if_no_huge_pages(hugepages_gib_values):
-    """Mark tests as xfail if the cluster lacks 1Gi hugepages."""
-    if not hugepages_gib_values or max(hugepages_gib_values) < 1:
-        pytest.xfail("Requires at least 1Gi hugepages on some node")
-
-
-@pytest.fixture(scope="session")
-def hugepages_gib_max(xfail_if_no_huge_pages, hugepages_gib_values):
+def hugepages_gib_max(hugepages_gib_values):
     """Return the maximum 1Gi hugepage size, capped at 64Gi."""
+    if not hugepages_gib_values:
+        raise ResourceValueError("Cluster does not report any 1Gi hugepages")
     return min(max(hugepages_gib_values), 64)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def infrastructure_special_infra_sanity(
+    request,
+    admin_client,
+    junitxml_plugin,
+    schedulable_nodes,
+    hugepages_gib_values,
+):
+    """
+    Validates infrastructure requirements based on test markers.
+    """
+    skip_infra_sanity_check = "--skip-infra-sanity-check"
+
+    if request.session.config.getoption(skip_infra_sanity_check):
+        LOGGER.info(f"Sanity checks skipped because {skip_infra_sanity_check} was provided")
+        return
+
+    # Collect markers from infrastructure tests
+    infra_root = Path(request.config.rootpath) / "tests" / "infrastructure"
+    collected_marker_names = set()
+
+    for item in request.session.items:
+        if item.path.is_relative_to(infra_root):
+            collected_marker_names.update(marker.name for marker in item.iter_markers())
+    LOGGER.info(f"Collected markers from infrastructure tests: '{collected_marker_names}'")
+
+    # Collect all verification failures to report them together
+    failed_verifications = []
+
+    for marker in collected_marker_names:
+        try:
+            match marker:
+                case "cpu_manager":
+                    LOGGER.info("Running infrastructure sanity check for 'cpu_manager'")
+                    verify_cpumanager_workers(schedulable_nodes=schedulable_nodes)
+
+                case "hugepages":
+                    LOGGER.info("Running infrastructure sanity check for 'hugepages'")
+                    verify_hugepages_1gi(hugepages_gib_values=hugepages_gib_values)
+
+                case "numa":
+                    LOGGER.info("Running infrastructure sanity check for 'numa'")
+                    verify_numa_enabled(client=admin_client)
+
+                case "rwx_default_storage":
+                    LOGGER.info("Running infrastructure sanity check for 'rwx_default_storage'")
+                    verify_rwx_default_storage(client=admin_client)
+
+                case "tekton":
+                    LOGGER.info("Running infrastructure sanity check for 'tekton'")
+                    verify_tekton_operator_installed(client=admin_client)
+
+        except (ResourceNotFoundError, ResourceMissingFieldError, ResourceValueError, TimeoutExpiredError) as error:
+            failed_verifications.append((marker, str(error)))
+
+    if failed_verifications:
+        lines = [
+            "Infrastructure cluster verification failed.",
+            "The following requirements are not satisfied:",
+        ]
+        for marker, message in failed_verifications:
+            lines.append(f"  - [{marker}] {message}")
+        err_msg = "\n".join(lines)
+        LOGGER.error(err_msg)
+        exit_pytest_execution(
+            log_message=err_msg,
+            message="Infrastructure special_infra cluster verification failed",
+            return_code=97,
+            filename="infrastructure_special_infra_sanity_failure.txt",
+            junitxml_property=junitxml_plugin,
+            admin_client=admin_client,
+        )

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -36,6 +36,7 @@ TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeRhel"
 @pytest.mark.smoke
 @pytest.mark.gating
 @pytest.mark.sno
+@pytest.mark.rwx_default_storage
 class TestVMCreationAndValidation:
     @pytest.mark.dependency(name=f"{TESTS_MODULE_IDENTIFIER}::{TEST_CREATE_VM_TEST_NAME}")
     @pytest.mark.polarion("CNV-11710")
@@ -123,13 +124,14 @@ class TestVMFeatures:
 
 @pytest.mark.arm64
 @pytest.mark.s390x
+@pytest.mark.rwx_default_storage
 class TestVMMigrationAndState:
     @pytest.mark.polarion("CNV-11714")
     @pytest.mark.dependency(
         name=f"{TESTS_MODULE_IDENTIFIER}::{TESTS_MIGRATE_VM}",
         depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"],
     )
-    def test_migrate_vm(self, skip_access_mode_rwo_scope_class, golden_image_rhel_vm_with_instance_type):
+    def test_migrate_vm(self, golden_image_rhel_vm_with_instance_type):
         migrate_vm_and_verify(vm=golden_image_rhel_vm_with_instance_type, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=golden_image_rhel_vm_with_instance_type)
 

--- a/tests/infrastructure/instance_types/test_common_vm_instancetype.py
+++ b/tests/infrastructure/instance_types/test_common_vm_instancetype.py
@@ -21,7 +21,7 @@ def test_common_instancetype_vendor_labels(base_vm_cluster_instancetypes):
 @pytest.mark.special_infra
 @pytest.mark.tier3
 @pytest.mark.polarion("CNV-10387")
-def test_cx1_instancetype_profile(xfail_if_no_huge_pages, unprivileged_client, namespace):
+def test_cx1_instancetype_profile(unprivileged_client, namespace):
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="rhel-vm-with-cx1",

--- a/tests/infrastructure/tekton/test_tekton_custom_ns.py
+++ b/tests/infrastructure/tekton/test_tekton_custom_ns.py
@@ -12,7 +12,7 @@ from tests.infrastructure.tekton.utils import (
 )
 from utilities.constants import WIN_2K22, WIN_2K25, WIN_10, WIN_11
 
-pytestmark = [pytest.mark.tier3, pytest.mark.special_infra]
+pytestmark = [pytest.mark.tier3, pytest.mark.special_infra, pytest.mark.tekton]
 
 
 @pytest.mark.usefixtures("extracted_kubevirt_tekton_resources", "processed_yaml_files")

--- a/tests/infrastructure/tekton/test_tekton_pipeline_disk_uploader.py
+++ b/tests/infrastructure/tekton/test_tekton_pipeline_disk_uploader.py
@@ -3,7 +3,7 @@ from ocp_resources.resource import Resource
 
 from utilities.constants import PVC
 
-pytestmark = [pytest.mark.tier3, pytest.mark.special_infra]
+pytestmark = [pytest.mark.tier3, pytest.mark.special_infra, pytest.mark.tekton]
 
 
 @pytest.mark.parametrize(

--- a/tests/infrastructure/utils.py
+++ b/tests/infrastructure/utils.py
@@ -1,0 +1,57 @@
+import logging
+
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.kubelet_config import KubeletConfig
+
+from utilities.exceptions import ResourceMissingFieldError, ResourceValueError
+
+LOGGER = logging.getLogger(__name__)
+
+
+def verify_tekton_operator_installed(client: DynamicClient) -> None:
+    """Verify Tekton operator is installed and available.
+
+    Args:
+        client (DynamicClient): Kubernetes dynamic client used to query cluster resources.
+
+    Raises:
+        ResourceNotFoundError: If Tekton operator deployment is not found.
+        TimeoutExpiredError: If Tekton operator is not ready within the timeout period.
+    """
+    LOGGER.info("Verifying Tekton operator is installed and available")
+    tekton_deployment = Deployment(
+        name="openshift-pipelines-operator",
+        namespace="openshift-operators",
+        client=client,
+        ensure_exists=True,
+    )
+    tekton_deployment.wait_for_replicas()
+
+
+def verify_numa_enabled(client: DynamicClient) -> None:
+    """Verify cluster has static CPU manager policy configured.
+
+    Args:
+        client (DynamicClient): Kubernetes dynamic client used to query cluster resources.
+
+    Raises:
+        ResourceMissingFieldError: If required fields are missing.
+        ResourceValueError: If cpuManagerPolicy has wrong value.
+    """
+    LOGGER.info("Verifying cluster has nodes with NUMA topology and static CPU manager policy")
+    for config in KubeletConfig.get(client=client):
+        kubelet_config = getattr(config.instance.spec, "kubeletConfig", None)
+        if not kubelet_config:
+            raise ResourceMissingFieldError(f"KubeletConfig '{config.name}' missing spec.kubeletConfig")
+
+        policy = getattr(kubelet_config, "cpuManagerPolicy", None)
+        if not policy:
+            raise ResourceMissingFieldError(
+                f"KubeletConfig '{config.name}' missing spec.kubeletConfig.cpuManagerPolicy"
+            )
+
+        if policy != "static":
+            raise ResourceValueError(
+                f"KubeletConfig '{config.name}' has cpuManagerPolicy '{policy}', expected 'static'"
+            )

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -16,6 +16,7 @@ from tests.network.libs.ip import random_ipv4_address
 from utilities.constants import (
     CNV_SUPPLEMENTAL_TEMPLATES_URL,
     MTU_9000,
+    NODE_HUGE_PAGES_1GI_KEY,
     SRIOV,
     TIMEOUT_10MIN,
     TIMEOUT_20SEC,
@@ -37,7 +38,6 @@ from utilities.virt import (
 
 LOGGER = logging.getLogger(__name__)
 VM_SRIOV_IFACE_NAME = "sriov1"
-NODE_HUGE_PAGES_1GI_KEY = "hugepages-1Gi"
 
 
 def vm_sriov_mac(mac_suffix_index):

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -1019,3 +1019,6 @@ STRESS_CPU_MEM_IO_COMMAND = (
     "nohup stress-ng --vm {workers} --vm-bytes {memory} --vm-method all "
     "--verify -t {timeout} -v --hdd 1 --io 1 --vm-keep &> /dev/null &"
 )
+
+# High performance & Numa related constants
+NODE_HUGE_PAGES_1GI_KEY = "hugepages-1Gi"


### PR DESCRIPTION
- This update introduces infrastructure_special_infra_sanity
- Refactoring existing common code under virt_special_infra_sanity
- adding tekton and rwx_default_storage markers in infrastructure tests
- add  NODE_HUGE_PAGES_1GI_KEY = "hugepages-1Gi" in constants for global usage

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-71286


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI "ComponentSanity" group with options to skip virtualization and infrastructure sanity checks.
  * Added Tekton test marker and a public hugepage identifier constant.

* **Improvements**
  * Centralized autouse infrastructure sanity flow with per-marker verifications and consolidated reporting/exit.
  * Shared verification helpers and unified hugepage max-cap handling.

* **Tests**
  * Multiple tests adjusted: markers, fixtures, and test signatures updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->