### PR TITLE
Bump pre-commit flake8-plugins version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         args: [--config=.flake8]
         additional_dependencies:
           [
-            "git+https://github.com/RedHatQE/flake8-plugins.git@v0.0.10",
+            "git+https://github.com/RedHatQE/flake8-plugins.git@v1.0.0",
             "flake8-mutable",
             "pep8-naming",
           ]


### PR DESCRIPTION
##### Short description:
flake8-plugins now supports python 3.14; updating to support envs with python 3.14

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flake8-plugins dependency to v1.0.0 for enhanced code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->