### PR TITLE
xfailed test_must_gather_and_vm_same_node in non-compact clusters

### DIFF
--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -27,6 +27,7 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     create_ns,
     get_node_selector_dict,
+    is_jira_open,
 )
 from utilities.must_gather import collect_must_gather, run_must_gather
 from utilities.network import (
@@ -597,6 +598,7 @@ def disks_from_multiple_disks_vm(multiple_disks_vm):
 
 @pytest.fixture(scope="class")
 def collected_vm_details_must_gather_from_vm_node(
+    xfail_if_non_compact_cluster_and_ocpbugs_65594_is_open,
     request,
     must_gather_tmpdir_scope_module,
     must_gather_image_url,
@@ -699,3 +701,9 @@ def must_gather_for_test(
         return collected_cluster_must_gather
     else:
         return cnv_image_path_must_gather_all_images
+
+
+@pytest.fixture(scope="session")
+def xfail_if_non_compact_cluster_and_ocpbugs_65594_is_open(compact_cluster, sno_cluster):
+    if not compact_cluster and not sno_cluster and is_jira_open("OCPBUGS-65594"):
+        pytest.xfail(reason="OCPBUGS-65594")


### PR DESCRIPTION
##### Short description:
The test `test_must_gather_and_vm_same_node` should not run due to an
existing bug in oc, as detailed on
[CNV-70614](https://issues.redhat.com/browse/CNV-70614)

##### More details:
OCPBUGS-65594

##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
N/A