### PR TITLE
Remove false single_nic marker from bridge test that requires multi NICs

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -51,7 +51,6 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11125")
     @pytest.mark.ipv6
-    @pytest.mark.single_nic
     def test_ipv6_linux_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified IPv6 Linux bridge test to execute across a broader range of test conditions, expanding coverage beyond previous constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->