### PR TITLE
[Gating]Fix test_workload_components_selection_change_allowed_after_workloads: insufficient wait timeout

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -66,6 +66,7 @@ from utilities.constants import (
     PROMETHEUS_K8S,
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
+    TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_6MIN,
     TIMEOUT_10MIN,
@@ -298,7 +299,7 @@ def wait_for_pods_running(
          state
     """
     samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_2MIN,
+        wait_timeout=TIMEOUT_5MIN,
         sleep=TIMEOUT_5SEC,
         func=get_pods,
         dyn_client=admin_client,


### PR DESCRIPTION
##### Short description:
Test fixture alter_np_configuration times out waiting for pods after HCO node placement update. The wait_for_pods_running() function uses 120-second timeout, insufficient for virt-api pod rolling update when rescheduling to different nodes.
Increasing it to 5 minutes.
##### More details:
N/A
##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-72662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the maximum wait time for pod initialization from 2 minutes to 5 minutes before timing out, allowing additional time for system resource allocation and pod startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->