### PR TITLE
[4.18]Rename kubevirt_vmi_migration_disk_transfer_rate_bytes metric

### DIFF
--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -43,7 +43,9 @@ KUBEVIRT_VMI_INFO = "kubevirt_vmi_info{{name='{vm_name}'}}"
 KUBEVIRT_VMI_STATUS_ADDRESSES = "kubevirt_vmi_status_addresses{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES = "kubevirt_vmi_migration_data_processed_bytes{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES = "kubevirt_vmi_migration_data_remaining_bytes{{name='{vm_name}'}}"
-KUBEVIRT_VMI_MIGRATION_DISK_TRANSFER_RATE_BYTES = "kubevirt_vmi_migration_disk_transfer_rate_bytes{{name='{vm_name}'}}"
+KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES = (
+    "kubevirt_vmi_migration_memory_transfer_rate_bytes{{name='{vm_name}'}}"
+)
 KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES = "kubevirt_vmi_migration_dirty_memory_rate_bytes{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES = "kubevirt_vmi_migration_data_total_bytes{{name='{vm_name}'}}"
 BINDING_NAME = "binding_name"

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -10,7 +10,7 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES,
     KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES,
     KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
-    KUBEVIRT_VMI_MIGRATION_DISK_TRANSFER_RATE_BYTES,
+    KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES,
 )
 from tests.observability.metrics.utils import (
     get_metric_sum_value,
@@ -253,7 +253,7 @@ class TestKubevirtVmiMigrationMetrics:
                 marks=(pytest.mark.polarion("CNV-11600")),
             ),
             pytest.param(
-                KUBEVIRT_VMI_MIGRATION_DISK_TRANSFER_RATE_BYTES,
+                KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES,
                 marks=(pytest.mark.polarion("CNV-11598")),
             ),
             pytest.param(


### PR DESCRIPTION
##### Short description:
The metric kubevirt_vmi_migration_disk_transfer_rate_bytes renamed, this PR refactoring the old metric name to the new one.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-62624
