### PR TITLE
net: Quarantine test_connectivity_is_preserved_during_server_live_mig…

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -10,7 +10,7 @@ from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm import affinity
 from tests.network.libs.ip import random_ipv4_address
 from tests.network.libs.vm_factory import udn_vm
-from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
+from utilities.constants import PUBLIC_DNS_SERVER_IP, QUARANTINED, TIMEOUT_1MIN
 from utilities.infra import create_ns
 from utilities.virt import migrate_vm_and_verify
 
@@ -141,6 +141,10 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-12177")
     @pytest.mark.single_nic
+    @pytest.mark.xfail(
+        reason=(f"{QUARANTINED}: Flaky test due to a bug. Tracked in CNV-72782"),
+        run=False,
+    )
     def test_connectivity_is_preserved_during_server_live_migration(self, server, client):
         migrate_vm_and_verify(vm=server.vm)
         assert is_tcp_connection(server=server, client=client)


### PR DESCRIPTION
The test is flaky due to a bug and blocking verification of PRs
Tracked in https://issues.redhat.com/browse/CNV-72782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * One live-migration connectivity test has been marked as expected-to-fail and its execution is skipped pending issue resolution.
  * The other live-migration connectivity test remains active and will continue to run as before.
  * No user-facing functionality changes; this only adjusts test execution to reflect a known intermittent failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->