### PR TITLE
[4.18] Remove false single_nic marker from bridge test that requires multi NICs

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -51,7 +51,6 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.polarion("CNV-11125")
     @pytest.mark.ipv6
     @pytest.mark.jira("CNV-58530", run=True)
-    @pytest.mark.single_nic
     def test_ipv6_linux_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,


### PR DESCRIPTION
`test_ipv6_linux_bridge` requires secondary node interfaces for bridging, but was mistakenly marked as a single-NIC test.
This is a back-port from https://github.com/RedHatQE/openshift-virtualization-tests/pull/2691