### PR TITLE
[CNV-72975] Stabilize test_deprecated_apis_in_audit_logs by handling connection reset by peer errors

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -846,6 +846,7 @@ def get_node_audit_log_entries(log, node, log_entry):
     error_patterns_list = [
         r"^\s*error:",
         r"Unhandled Error.*couldn't get current server API group list.*i/o timeout",
+        r".*read tcp.*connection reset by peer",
     ]
     error_patterns = re.compile("|".join(f"({pattern})" for pattern in error_patterns_list))
 


### PR DESCRIPTION
##### Short description:
Update get_node_audit_log_entries to detect and retry TCP connection reset by peer errors.

##### More details:
This prevents test failures when the server (the API server or something in front of it) abruptly closed the TCP connection. The client was reading data, and the connection was suddenly terminated without a proper shutdown sequence.

##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-72975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded error detection to recognize additional types of connection failures, improving system reliability by enabling automatic retries for network-related issues that were previously undetected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->