### PR TITLE
Quarantine test test_windows_hotplug.

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -270,8 +270,8 @@ class TestHotPlugWithSerialPersist:
 @pytest.mark.tier3
 class TestHotPlugWindows:
     @pytest.mark.xfail(
-    reason=f"{QUARANTINED}: fails to get DV status, most likely automation issue; CNV-72460",
-    run=False,
+        reason=f"{QUARANTINED}: fails to get DV status, most likely automation issue; CNV-72460",
+        run=False,
     )
     @pytest.mark.polarion("CNV-6525")
     @pytest.mark.dependency(name="test_windows_hotplug")


### PR DESCRIPTION
##### Short description:
Quarantine failing test `test_windows_hotplug` in **4.20** automation using `hostpath-csi-pvc-block` StorageClass. I have not been able to reproduce it. I have run the test 7 times without success to see the issue.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-72980
