### PR TITLE
net, sriov: Refactor wait_for_ready_sriov_nodes without waiting for InProgress state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1064,13 +1064,14 @@ def sriov_ifaces(sriov_nodes_states, workers_utility_pods):
 
 
 @pytest.fixture(scope="session")
-def sriov_node_policy(sriov_unused_ifaces, sriov_nodes_states, workers_utility_pods, sriov_namespace):
+def sriov_node_policy(admin_client, sriov_namespace, workers_utility_pods, sriov_nodes_states, sriov_unused_ifaces):
     yield from create_sriov_node_policy(
         nncp_name="test-sriov-policy",
         namespace=sriov_namespace.name,
         sriov_iface=sriov_unused_ifaces[0],
         sriov_nodes_states=sriov_nodes_states,
         sriov_resource_name="sriov_net",
+        admin_client=admin_client,
     )
 
 

--- a/tests/network/libs/sriovnetworknode.py
+++ b/tests/network/libs/sriovnetworknode.py
@@ -1,0 +1,220 @@
+import logging
+
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.node import Node
+from ocp_resources.sriov_network_node_policy import SriovNetworkNodePolicy
+from ocp_resources.sriov_network_node_state import SriovNetworkNodeState
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from utilities.exceptions import ResourceMismatch
+
+LOGGER = logging.getLogger(__name__)
+
+
+def wait_for_ready_sriov_nodes(
+    snns_list: list[SriovNetworkNodeState],
+    admin_client: DynamicClient,
+    policy: SriovNetworkNodePolicy | None = None,
+    nic_selector: dict[str, list[str]] | None = None,
+) -> None:
+    """Wait for SR-IOV nodes to be ready and verify interface configuration.
+
+    Usage:
+    1. Policy creation: Waits for SUCCEEDED status and verifies config matches policy.
+    2. Policy teardown: Verifies VFs are removed from specified interfaces.
+
+    Args:
+        snns_list: List of SriovNetworkNodeState objects.
+        admin_client: Kubernetes admin client for Node access.
+        policy: SriovNetworkNodePolicy for verification. None during teardown.
+        nic_selector: NIC selector dict with pfNames/rootDevices for teardown verification.
+
+    Raises:
+        TimeoutExpiredError: If sync status doesn't reach SUCCEEDED or verification times out.
+        ResourceMismatch: If interface config doesn't match policy spec.
+    """
+    for sriov_node_network_state in snns_list:
+        status_msg = f"to be {SriovNetworkNodePolicy.Status.SUCCEEDED}"
+        if policy:
+            status_msg += f" and configured per policy {policy.name}"
+        elif nic_selector:
+            status_msg += " with VFs removed"
+        LOGGER.info(f"Waiting for node {sriov_node_network_state.name} SriovNetworkNodeState {status_msg}")
+
+        sampler = TimeoutSampler(
+            wait_timeout=1000,
+            sleep=5,
+            func=_check_sriov_node_ready_and_configured,
+            sriov_node_network_state=sriov_node_network_state,
+            policy=policy,
+            admin_client=admin_client,
+            nic_selector=nic_selector,
+            exceptions_dict={ResourceMismatch: []} if (policy or nic_selector) else {},
+        )
+        try:
+            for sample in sampler:
+                if sample:
+                    success_msg = (
+                        f"Node {sriov_node_network_state.name} SriovNetworkNodeState is"
+                        f" {SriovNetworkNodePolicy.Status.SUCCEEDED}"
+                    )
+                    if policy:
+                        success_msg += " and configuration verified"
+                    LOGGER.info(success_msg)
+                    break
+        except TimeoutExpiredError:
+            current_status = sriov_node_network_state.instance.status.syncStatus
+            if current_status == SriovNetworkNodePolicy.Status.SUCCEEDED:
+                LOGGER.error(
+                    f"Timeout waiting for SR-IOV configuration to match policy on node {sriov_node_network_state.name}"
+                )
+            else:
+                LOGGER.error(
+                    f"Timeout waiting for node {sriov_node_network_state.name} "
+                    f"SriovNetworkNodeState to reach SUCCEEDED status. "
+                    f"Current status: {current_status}"
+                )
+            raise
+
+
+def _check_sriov_node_ready_and_configured(
+    sriov_node_network_state: SriovNetworkNodeState,
+    policy: SriovNetworkNodePolicy | None,
+    admin_client: DynamicClient,
+    nic_selector: dict[str, list[str]] | None = None,
+) -> bool:
+    """Check if SR-IOV node status is SUCCEEDED and verify configuration.
+
+    Performs two checks:
+    1. Verifies syncStatus reached SUCCEEDED.
+    2. Verifies interface config matches policy.
+
+    Args:
+        sriov_node_network_state: SriovNetworkNodeState object.
+        policy: SriovNetworkNodePolicy for verification. None during teardown.
+        admin_client: Kubernetes admin client for Node access.
+        nic_selector: NIC selector dict with pfNames/rootDevices for teardown verification.
+
+    Returns:
+        True if SUCCEEDED and config matches, False if not SUCCEEDED yet.
+
+    Raises:
+        ResourceMismatch: If config doesn't match policy spec. Retried by TimeoutSampler.
+    """
+    current_status = sriov_node_network_state.instance.status.syncStatus
+    if current_status != SriovNetworkNodePolicy.Status.SUCCEEDED:
+        return False
+
+    _verify_sriov_interface_config(
+        sriov_node_network_state=sriov_node_network_state,
+        policy=policy,
+        admin_client=admin_client,
+        nic_selector=nic_selector,
+    )
+
+    return True
+
+
+def _verify_sriov_interface_config(
+    sriov_node_network_state: SriovNetworkNodeState,
+    policy: SriovNetworkNodePolicy | None,
+    admin_client: DynamicClient,
+    nic_selector: dict[str, list[str]] | None = None,
+) -> None:
+    """Verify SR-IOV interfaces match policy config or are cleaned up.
+
+    Usage:
+    1. Setup: Verifies interfaces matching nicSelector have correct VFs and MTU.
+    2. Teardown: Verifies VFs are removed from specified interfaces.
+
+    Args:
+        sriov_node_network_state: SriovNetworkNodeState object.
+        policy: SriovNetworkNodePolicy with desired config. None during teardown.
+        admin_client: Kubernetes admin client for Node access.
+        nic_selector: NIC selector dict with pfNames/rootDevices for teardown verification.
+
+    Raises:
+        ResourceMismatch: If config doesn't match policy spec or VFs not removed.
+    """
+    node = Node(client=admin_client, name=sriov_node_network_state.name)
+
+    if policy and not _node_matches_policy_selector(node=node, policy=policy):
+        LOGGER.info(f"Skipping verification for node {node.name} - does not match policy {policy.name} nodeSelector")
+        return
+
+    if policy:
+        policy_spec = policy.instance.spec
+        pf_names = policy_spec.nicSelector.get("pfNames", [])
+        root_devices = policy_spec.nicSelector.get("rootDevices", [])
+        expected_num_vfs = policy_spec.numVfs
+        expected_mtu = policy_spec.get("mtu")
+
+        matching_interfaces = []
+        for iface in sriov_node_network_state.instance.status.interfaces:
+            if iface.name in pf_names or iface.pciAddress in root_devices:
+                matching_interfaces.append(iface)
+
+        if not matching_interfaces:
+            raise ResourceMismatch(
+                f"Node {sriov_node_network_state.name} matches policy {policy.name} nodeSelector "
+                f"but has no interfaces matching pfNames={pf_names}, rootDevices={root_devices})."
+            )
+
+        for iface in matching_interfaces:
+            LOGGER.info(
+                f"Verifying interface {iface.name} on node {sriov_node_network_state.name}: "
+                f"numVfs={iface.numVfs} (expected: {expected_num_vfs})"
+            )
+
+            if iface.numVfs != expected_num_vfs:
+                raise ResourceMismatch(
+                    f"SR-IOV interface {iface.name} on node {sriov_node_network_state.name}: "
+                    f"numVfs mismatch - got {iface.numVfs}, expected {expected_num_vfs}"
+                )
+
+            if expected_mtu:
+                iface_mtu = getattr(iface, "mtu", None)
+                if iface_mtu and iface_mtu != expected_mtu:
+                    raise ResourceMismatch(
+                        f"SR-IOV interface {iface.name} on node {sriov_node_network_state.name}: "
+                        f"MTU mismatch - got {iface_mtu}, expected {expected_mtu}"
+                    )
+
+            LOGGER.info(f"Interface {iface.name} configuration verified successfully")
+
+    elif nic_selector:
+        pf_names = nic_selector.get("pfNames", [])
+        root_devices = nic_selector.get("rootDevices", [])
+
+        for iface in sriov_node_network_state.instance.status.interfaces:
+            if iface.name in pf_names or iface.pciAddress in root_devices:
+                if iface.numVfs:
+                    raise ResourceMismatch(
+                        f"SR-IOV interface {iface.name} on node {sriov_node_network_state.name} still has "
+                        f"numVfs={iface.numVfs} after policy deletion. Expected numVfs=0 or None"
+                    )
+                LOGGER.info(
+                    f"Verified interface {iface.name} on node {sriov_node_network_state.name}: "
+                    f"numVfs={iface.numVfs} (VFs removed)"
+                )
+
+
+def _node_matches_policy_selector(node: Node, policy: SriovNetworkNodePolicy) -> bool:
+    """Check if a node matches the policy's nodeSelector.
+
+    Args:
+        node: Node object.
+        policy: SriovNetworkNodePolicy with nodeSelector.
+
+    Returns:
+        bool: True if all nodeSelector labels match node labels, False otherwise.
+    """
+    policy_spec = policy.instance.spec
+    node_selector = policy_spec.nodeSelector
+
+    node_labels = node.instance.metadata.labels
+    for key, value in node_selector.items():
+        if node_labels.get(key) != value:
+            return False
+
+    return True

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -28,6 +28,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 import utilities.infra
 import utilities.virt
+from tests.network.libs.sriovnetworknode import wait_for_ready_sriov_nodes
 from utilities.constants import (
     ACTIVE_BACKUP,
     FLAT_OVERLAY_STR,
@@ -1038,31 +1039,13 @@ def get_cluster_cni_type(admin_client):
     return Network(client=admin_client, name="cluster").instance.status.networkType
 
 
-def wait_for_ready_sriov_nodes(snns):
-    for status in (INPROGRESS, SriovNetworkNodePolicy.Status.SUCCEEDED):
-        for sriov_node_network_state in snns:
-            LOGGER.info(f"Checking state: {sriov_node_network_state.name}")
-            try:
-                sriov_node_network_state.wait_for_status_sync(wanted_status=status)
-            except TimeoutExpiredError:
-                if (
-                    status == INPROGRESS
-                    and sriov_node_network_state.instance.status.syncStatus == SriovNetworkNodePolicy.Status.SUCCEEDED
-                ):
-                    continue
-                else:
-                    LOGGER.error(
-                        f"Current status: {sriov_node_network_state.instance.status.syncStatus} expected: {status}"
-                    )
-                    raise
-
-
 def create_sriov_node_policy(
     nncp_name,
     namespace,
     sriov_iface,
     sriov_nodes_states,
     sriov_resource_name,
+    admin_client,
     mtu=MTU_9000,
 ):
     with network_device(
@@ -1075,9 +1058,11 @@ def create_sriov_node_policy(
         # so the mtu parameter only affects the PF. we need to change the mtu manually on the VM.
         mtu=mtu,
     ) as policy:
-        wait_for_ready_sriov_nodes(snns=sriov_nodes_states)
+        wait_for_ready_sriov_nodes(snns_list=sriov_nodes_states, admin_client=admin_client, policy=policy)
+        nic_selector = dict(policy.instance.spec.nicSelector)
         yield policy
-    wait_for_ready_sriov_nodes(snns=sriov_nodes_states)
+
+    wait_for_ready_sriov_nodes(snns_list=sriov_nodes_states, admin_client=admin_client, nic_selector=nic_selector)
 
 
 def wait_for_node_marked_by_bridge(bridge_nad: LinuxBridgeNetworkAttachmentDefinition, node: Node) -> None:


### PR DESCRIPTION
Problem:
SriovNetworkNodeState sometimes does not change, or not always caught in time by the automation, to `InProgress` after sriov configuration and stays in `Succeeded` state. This could lead to errors in setup and teardown of each node and declaration of the error might take 1000 seconds (~17 minutes).

Fix:
Waiting for SNNS status to be updated according to the test's SriovNetworkNodePolicy instead of waiting for state to change to `InProgress`.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-20564

<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added shared SR‑IOV readiness and verification utilities to validate node states and interface configurations (VF counts, MTU), supporting both policy-driven setup and NIC‑selector teardown modes with improved logging, timeouts and mismatch reporting.
  * Updated a test fixture to accept an administrative client and adjusted parameter ordering to integrate the new flow.
* **Chores**
  * Extracted SR‑IOV orchestration into a reusable test library and updated utilities to consume it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->