### PR TITLE
Storage: Replace unprivileged_client with admin_client in storage checkups test

### DIFF
--- a/tests/storage/checkups/conftest.py
+++ b/tests/storage/checkups/conftest.py
@@ -111,7 +111,7 @@ def checkup_configmap(checkups_namespace):
 
 @pytest.fixture(scope="function")
 def checkup_job(
-    unprivileged_client,
+    admin_client,
     request,
     checkups_namespace,
     checkup_image_url,
@@ -140,7 +140,7 @@ def checkup_job(
         restart_policy="Never",
         backoff_limit=0,
         containers=containers,
-        client=unprivileged_client,
+        client=admin_client,
     ) as job:
         try:
             job.wait_for_condition(
@@ -150,7 +150,7 @@ def checkup_job(
             )
         except TimeoutExpiredError:
             job_pods = get_pods(
-                dyn_client=unprivileged_client,
+                dyn_client=admin_client,
                 namespace=checkups_namespace,
                 label=f"job-name={job.name}",
             )


### PR DESCRIPTION
##### Short description:
Replaced unprivileged_client with admin_client.
Storage checkups test fails with unprivileged-user
https://jenkins-csb-cnvqe-main.dno.corp.redhat.com/view/Test%20Jobs/view/4.21/job/test-pytest-cnv-4.21-storage-ocs/1/testReport/tests.storage.checkups.test_checkups/TestCheckupPositive/test_overriden_storage_profile_claim_propertyset_checkup_job0_/

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture configuration for improved client handling in storage checkup tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->