### PR TITLE
[cnv-4.20]Fix gating upgrade for non-EUS versions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,7 +228,6 @@ ACCESS_TOKEN = {
     "accessTokenInactivityTimeout": None,
 }
 CNV_NOT_INSTALLED = "CNV not yet installed."
-EUS_ERROR_CODE = 98
 RWX_FS_STORAGE_CLASS_NAMES_LIST = [
     StorageClassNames.CEPHFS,
     StorageClassNames.TRIDENT_CSI_FSX,
@@ -1906,6 +1905,9 @@ def hco_target_csv_name(cnv_target_version):
 
 @pytest.fixture(scope="session")
 def eus_hco_target_csv_name(eus_target_cnv_version):
+    if eus_target_cnv_version is None:
+        LOGGER.warning("Cannot determine EUS HCO target CSV name: EUS target version is None (non-EUS version)")
+        return None
     return get_hco_csv_name_by_version(cnv_target_version=eus_target_cnv_version)
 
 
@@ -1918,12 +1920,10 @@ def cnv_target_version(pytestconfig):
 def eus_target_cnv_version(pytestconfig, cnv_current_version):
     cnv_current_version = Version(version=cnv_current_version)
     minor = cnv_current_version.minor
-    # EUS-to-EUS upgrades are only viable between even-numbered minor versions, exit if non-eus version
+    # EUS-to-EUS upgrades are only viable between even-numbered minor versions, return None if non-eus version
     if minor % 2:
-        exit_pytest_execution(
-            message=f"EUS upgrade can not be performed from non-eus version: {cnv_current_version}",
-            return_code=EUS_ERROR_CODE,
-        )
+        LOGGER.warning(f"EUS upgrade can not be performed from non-eus version: {cnv_current_version}")
+        return None
     return pytestconfig.option.eus_cnv_target_version or f"{cnv_current_version.major}.{minor + 2}.0"
 
 

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -36,6 +36,7 @@ from utilities.data_collector import (
     get_data_collector_base_directory,
 )
 from utilities.infra import (
+    exit_pytest_execution,
     generate_openshift_pull_secret_file,
     get_csv_by_name,
     get_prometheus_k8s_token,
@@ -55,6 +56,7 @@ from utilities.virt import get_oc_image_info
 
 LOGGER = logging.getLogger(__name__)
 POD_STR_NOT_MANAGED_BY_HCO = "hostpath-"
+EUS_ERROR_CODE = 98
 
 
 @pytest.fixture(scope="session")
@@ -318,6 +320,10 @@ def fired_alerts_during_upgrade(fired_alerts_before_upgrade, alert_dir, promethe
 
 @pytest.fixture(scope="session")
 def eus_cnv_upgrade_path(eus_target_cnv_version):
+    if eus_target_cnv_version is None:
+        exit_pytest_execution(
+            message="EUS upgrade can not be performed from non-eus version", return_code=EUS_ERROR_CODE
+        )
     # Get the shortest path to the target (EUS) version
     upgrade_path_to_target_version = get_shortest_upgrade_path(target_version=eus_target_cnv_version)
     # Get the shortest path to the intermediate (non-EUS) version

--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -90,10 +90,10 @@ def vms_for_upgrade(
                 vms_list.append(vm)
                 vm.start(timeout=TIMEOUT_40MIN, wait=False)
 
-            for vm in vms_list:
-                running_vm(vm=vm, wait_for_cloud_init=True)
+        for vm in vms_list:
+            running_vm(vm=vm, wait_for_cloud_init=True)
 
-            yield vms_list
+        yield vms_list
 
     finally:
         for vm in vms_list:


### PR DESCRIPTION
Manual cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/1710

* Fix gating upgrade to yield the vms_list

Moving the running_vm check and yield vms_list statements outside of the non-gating conditional block, so the vms_for_upgrade fixture will:

- Always yield the vms_list containing at least the vm_with_instancetypes_for_upgrade VM.
- For non-gating tests, it will create additional VMs from the data sources and add them to the list.

This ensures that the vms_for_upgrade fixture always yields a value regardless of whether the test is marked with @pytest.mark.gating or not, resolving the
  ValueError: vms_for_upgrade did not yield a value error.

* Fix gating upgrade for non-EUS versions