### PR TITLE
Add client in infrastructure/golden_images folder

### DIFF
--- a/tests/infrastructure/golden_images/conftest.py
+++ b/tests/infrastructure/golden_images/conftest.py
@@ -17,7 +17,7 @@ def updated_default_storage_class_scope_function(
     removed_default_storage_classes,
 ):
     sc_name = [*storage_class_matrix__function__][0]
-    sc = StorageClass(name=sc_name)
+    sc = StorageClass(client=admin_client, name=sc_name)
     with ResourceEditor(
         patches={
             sc: {

--- a/tests/infrastructure/golden_images/update_boot_source/test_boot_sources_vm.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_boot_sources_vm.py
@@ -24,10 +24,15 @@ def boot_source_preference_from_data_source_dict(
 
 @pytest.fixture()
 def data_source_from_data_import_cron(
+    unprivileged_client,
     golden_images_namespace,
     data_import_cron_matrix__function__,
 ):
-    data_source = DataSource(name=[*data_import_cron_matrix__function__][0], namespace=golden_images_namespace.name)
+    data_source = DataSource(
+        client=unprivileged_client,
+        name=[*data_import_cron_matrix__function__][0],
+        namespace=golden_images_namespace.name,
+    )
     data_source.wait_for_condition(
         condition=data_source.Condition.READY, status=data_source.Condition.Status.TRUE, timeout=TIMEOUT_5SEC
     )

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
@@ -31,8 +31,9 @@ def boot_source_os_from_data_source_dict(auto_update_data_source_matrix__functio
 
 
 @pytest.fixture()
-def matrix_data_source(auto_update_data_source_matrix__function__, golden_images_namespace):
+def matrix_data_source(unprivileged_client, auto_update_data_source_matrix__function__, golden_images_namespace):
     return DataSource(
+        client=unprivileged_client,
         name=[*auto_update_data_source_matrix__function__][0],
         namespace=golden_images_namespace.name,
     )

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -189,7 +189,7 @@ def created_persistent_volume_claim(unprivileged_client, data_import_cron_namesp
             exceptions_dict={IndexError: []},
         ):
             if sample:
-                created_dv = DataVolume(name=sample.name, namespace=sample.namespace)
+                created_dv = DataVolume(client=unprivileged_client, name=sample.name, namespace=sample.namespace)
                 created_dv.wait_for_dv_success()
                 yield sample
                 created_dv.clean_up()
@@ -217,6 +217,7 @@ def created_data_import_cron(
 ):
     cron_template_spec = golden_images_data_import_cron_spec.template.spec
     with DataImportCron(
+        client=unprivileged_client,
         name="data-import-cron-for-test",
         namespace=data_import_cron_namespace.name,
         managed_data_source=golden_images_data_import_cron_spec.managedDataSource,
@@ -479,7 +480,9 @@ def test_data_source_instancetype_preference_label(
             with create_vm_with_infer_from_volume(
                 client=unprivileged_client,
                 namespace=namespace,
-                data_source_for_test=DataSource(name=data_source_name, namespace=golden_images_namespace.name),
+                data_source_for_test=DataSource(
+                    client=unprivileged_client, name=data_source_name, namespace=golden_images_namespace.name
+                ),
             ):
                 pass
         except Exception as exp:

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -247,21 +247,21 @@ def data_sources_names_from_templates_scope_function(base_templates):
 
 
 @pytest.fixture()
-def data_sources_from_templates_scope_function(data_sources_names_from_templates_scope_function):
+def data_sources_from_templates_scope_function(admin_client, data_sources_names_from_templates_scope_function):
     return [
-        DataSource(name=data_source_name, namespace=py_config["golden_images_namespace"])
+        DataSource(client=admin_client, name=data_source_name, namespace=py_config["golden_images_namespace"])
         for data_source_name in data_sources_names_from_templates_scope_function
     ]
 
 
 @pytest.fixture()
-def data_source_by_name_scope_function(request, admin_client, golden_images_namespace):
-    return DataSource(name=request.param, namespace=golden_images_namespace.name)
+def data_source_by_name_scope_function(request, unprivileged_client, golden_images_namespace):
+    return DataSource(client=unprivileged_client, name=request.param, namespace=golden_images_namespace.name)
 
 
 @pytest.fixture(scope="class")
 def data_source_by_name_scope_class(request, admin_client, golden_images_namespace):
-    return DataSource(name=request.param, namespace=golden_images_namespace.name)
+    return DataSource(client=admin_client, name=request.param, namespace=golden_images_namespace.name)
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### Short description:
Add client to wrapper resources in instancetype infrastructure folder

##### More details:
Add client field to resources from openshift-python-wrapper

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now explicitly pass client context (admin and unprivileged) when creating resources to ensure correct access levels.
  * Fixture interfaces updated across suites to accept and propagate the appropriate client for resource provisioning.
  * Resource initialization (data sources, data volumes, import cron jobs, storage class usage) standardized for more reliable golden-images tests and reduced flakiness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->