### PR TITLE
tests, net, RDP: Refactor Windows RDP server VM

### DIFF
--- a/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
+++ b/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
@@ -6,20 +6,18 @@ import logging
 
 import pytest
 from ocp_resources.service import Service
+from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 
+from tests.os_params import WINDOWS_LATEST, WINDOWS_LATEST_OS
 from utilities.constants import (
     OS_FLAVOR_WINDOWS,
-    QUARANTINED,
     TIMEOUT_5MIN,
-    TIMEOUT_35MIN,
 )
-from utilities.virt import get_windows_os_dict, vm_instance_from_template
+from utilities.virt import VirtualMachineForTests, vm_instance_from_template, wait_for_windows_vm
 
 LOGGER = logging.getLogger(__name__)
-# TODO : Use once Win19 RDP issue resolved - WIN_LATEST_VERSION = py_config["latest_windows_os_dict"]["os_version"]
-WIN_VERSION_16_CONFIG = get_windows_os_dict(windows_version="win-2016")
-WIN_OS_VERSION_16 = WIN_VERSION_16_CONFIG.get("os_version")
+TCP_TIMEOUT_SEC = 60
 
 
 @pytest.fixture(scope="module")
@@ -35,6 +33,8 @@ def rdp_vm(
         data_source=golden_image_data_source_scope_function,
         unprivileged_client=unprivileged_client,
     ) as rdp_vm:
+        wait_for_windows_vm(vm=rdp_vm, version=request.param["os_version"])
+        configure_rdp_on_server_windows_vm(vm=rdp_vm)
         rdp_vm.custom_service_enable(service_name="rdp-svc-test", port=3389, service_type=Service.Type.NODE_PORT)
         LOGGER.info(
             f"{Service.Type.NODE_PORT} service created to expose VirtualMachine "
@@ -57,32 +57,54 @@ def rdp_pod(workers_utility_pods, rdp_vm):
     assert False, f"No Pod found on a different node than the one that runs the VirtualMachine {rdp_vm.name}."
 
 
+def configure_rdp_on_server_windows_vm(vm: VirtualMachineForTests) -> None:
+    LOGGER.info(f"Configuring RDP on Windows VM {vm.name}")
+    enable_rdp_cmds = [
+        # Allow RDP connections
+        (
+            "Set-ItemProperty "
+            "-Path 'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server' "
+            "-Name 'fDenyTSConnections' -Value 0"
+        ),
+        # Disable Network Level Authentication (NLA) for RDP
+        (
+            "Set-ItemProperty "
+            "-Path 'HKLM:\\System\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp' "
+            "-Name 'UserAuthentication' -Value 0"
+        ),
+        # Enable Windows Firewall rules for Remote Desktop
+        'Enable-NetFirewallRule -DisplayGroup "Remote Desktop"',
+        # Restart Remote Desktop service to apply changes
+        "Restart-Service TermService -Force",
+    ]
+    run_ssh_commands(
+        host=vm.ssh_exec,
+        commands=[["powershell", "-Command", cmd] for cmd in enable_rdp_cmds],
+        tcp_timeout=TCP_TIMEOUT_SEC,
+    )
+
+
 @pytest.mark.parametrize(
     "golden_image_data_volume_scope_function, rdp_vm",
     [
         pytest.param(
             {
-                "dv_name": WIN_VERSION_16_CONFIG.get("template_labels", {}).get("os"),
-                "image": WIN_VERSION_16_CONFIG.get("image_path"),
+                "dv_name": WINDOWS_LATEST_OS,
+                "image": WINDOWS_LATEST.get("image_path"),
                 "storage_class": py_config["default_storage_class"],
-                "dv_size": WIN_VERSION_16_CONFIG.get("dv_size"),
+                "dv_size": WINDOWS_LATEST.get("dv_size"),
             },
             {
-                "vm_name": f"win{WIN_OS_VERSION_16}-vm-test",
-                "os_version": WIN_OS_VERSION_16,
-                "template_labels": WIN_VERSION_16_CONFIG.get("template_labels"),
+                "vm_name": f"win{WINDOWS_LATEST.get('os_version')}-vm-test",
+                "os_version": WINDOWS_LATEST.get("os_version"),
+                "template_labels": WINDOWS_LATEST.get("template_labels"),
                 "network_model": "virtio",
-                "wait_for_interfaces_timeout": TIMEOUT_35MIN,
             },
             marks=(pytest.mark.polarion("CNV-235")),
             id="test_rdp_for_exposed_win_vm_svc",
         ),
     ],
     indirect=True,
-)
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: RDP test case must be fixed and implement a reliable client; tracked in CNV-43997",
-    run=False,
 )
 def test_rdp_for_exposed_win_vm_as_node_port_svc(
     rdp_vm,
@@ -96,7 +118,6 @@ def test_rdp_for_exposed_win_vm_as_node_port_svc(
         1. xvfb - Virtual X display server.
         2. xfreerdp - X11 RDP client.
     """
-    # TODO : Supposed to run on latest Windows version (Win19) once RDP issue is fixed - currently testing on Win16.
     rdp_auth_cmd = (
         f"WLOG_PREFIX='[%hr:%mi:%se:%ml] [%mn] - ' xvfb-run --server-args='-screen 0 1024x768x24' "
         f"xfreerdp /cert-ignore /auth-only "


### PR DESCRIPTION
Problems:
- The VM creation flow was outdated and the Windows VM often failed to start.
- The test used an old Windows image (Win16), misaligned with current releases.
- The RDP handshake failed due to server‑side NLA; the FreeRDP client in our environment cannot complete NLA.

High-level solution:
- Use the latest Windows image/template and wait for Windows readiness.
- Configure the VM for RDP use: enable RDP, open firewall, disable NLA.

jira-ticket:
https://issues.redhat.com/browse/CNV-43997

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * RDP tests now run against the latest Windows images instead of a fixed older image.
  * Tests include an automated VM readiness wait and an automated step to enable/configure RDP before exposing VMs.
  * Test parameters (image, size, names, template metadata) are sourced dynamically from current Windows data.
  * Short auth timeout retained; network timeouts adjusted.
  * Removed obsolete quarantine/xfail markers and stale comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->