### PR TITLE
net, quarantine: localnet test_ovs_bridge

### DIFF
--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -7,6 +7,7 @@ from tests.network.localnet.liblocalnet import (
     LOCALNET_OVS_BRIDGE_INTERFACE,
     client_server_active_connection,
 )
+from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 
@@ -14,6 +15,10 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")
 @pytest.mark.polarion("CNV-11905")
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: fails in CI due to cluster issue; tracked in CNV-71535",
+    run=False,
+)
 def test_connectivity_over_migration_between_ovs_bridge_localnet_vms(
     localnet_ovs_bridge_server, localnet_ovs_bridge_client
 ):
@@ -24,6 +29,10 @@ def test_connectivity_over_migration_between_ovs_bridge_localnet_vms(
 @pytest.mark.ipv4
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")
 @pytest.mark.polarion("CNV-12006")
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: fails in CI due to cluster issue; tracked in CNV-71535",
+    run=False,
+)
 def test_connectivity_after_interface_state_change_in_ovs_bridge_localnet_vms(
     ovs_bridge_localnet_running_vms_one_with_interface_down,
 ):


### PR DESCRIPTION
The test fails only in CI on a specific cluster. Need to investigate the cluster issue and then return the test back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked specific network connectivity tests as expected failures in CI environments due to a known cluster issue, preventing active test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->