### PR TITLE
 regression: Tier2: test_print_response_body_on_error_upload_virtctl

### DIFF
--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -492,6 +492,7 @@ def test_disk_image_after_upload_virtctl(
     indirect=True,
 )
 @pytest.mark.s390x
+@pytest.mark.jira("CNV-73405", run=False)
 def test_print_response_body_on_error_upload_virtctl(
     namespace, download_specified_image, storage_class_name_scope_module
 ):


### PR DESCRIPTION
##### Short description:
add regression/jira bug marker for  test_print_response_body_on_error_upload_virtctl due to unexpected 401 error instead of PVC size assertion failure (CNV-73329)




Jira: https://issues.redhat.com/browse/CNV-73405
