### PR TITLE
infra: rename net-utils image + Dockerfile refactoring

### DIFF
--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Define image tag
         id: image-tag
         run: |
-          IMAGE_NAME="quay.io/openshift-cnv/qe-cnv-tests-net-util-container"
+          IMAGE_NAME="quay.io/openshift-cnv/qe-net-utils"
           TAG="staging"
           echo "IMAGE_TAG=${IMAGE_NAME}:${TAG}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/net-utils-promote.yml
+++ b/.github/workflows/net-utils-promote.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Promote manifest (staging -> latest)
         run: |
-          IMAGE_NAME="quay.io/openshift-cnv/qe-cnv-tests-net-util-container"
+          IMAGE_NAME="quay.io/openshift-cnv/qe-net-utils"
           skopeo copy \
             --all \
             docker://${IMAGE_NAME}:staging \

--- a/containers/utility/Dockerfile
+++ b/containers/utility/Dockerfile
@@ -1,9 +1,30 @@
 FROM quay.io/centos/centos:stream9
 ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "s390x" ] ; then \
-      yum install yum-utils -y ; \
-      yum-config-manager --add-repo='https://buildlogs.centos.org/centos/9-stream/nfv/s390x/openvswitch-2' ; \
+
+RUN set -eux; \
+    if [ "$TARGETARCH" = "s390x" ]; then \
+        yum install -y yum-utils && \
+        yum-config-manager --add-repo "https://buildlogs.centos.org/centos/9-stream/nfv/s390x/openvswitch-2"; \
     else \
-      yum install epel-release centos-release-nfv-openvswitch -y ; \
-    fi ; \
-    yum update -y && yum install iproute tcpdump qemu-img NetworkManager xfreerdp xauth xorg-x11-server-Xvfb which nftables stress-ng nmap -y && yum install --nogpgcheck openvswitch3.1 -y && yum clean all
+        yum install -y epel-release centos-release-nfv-openvswitch; \
+    fi; \
+    yum -y update && \
+    yum install -y \
+        NetworkManager \
+        centos-release-nfv-openvswitch \
+        epel-release \
+        iperf3 \
+        iproute \
+        nftables \
+        nmap \
+        openvswitch3.1 --nogpgcheck \
+        procps-ng \
+        qemu-img \
+        stress-ng \
+        tcpdump \
+        which \
+        xauth \
+        xfreerdp \
+        xorg-x11-server-Xvfb && \
+    yum clean all && \
+    rm -rf /var/cache/yum

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -619,7 +619,7 @@ BASE_EXCEPTIONS_DICT: dict[type[Exception], list[str]] = {
 }
 
 # Container images
-NET_UTIL_CONTAINER_IMAGE = "quay.io/openshift-cnv/qe-cnv-tests-net-util-container:centos-stream-9"
+NET_UTIL_CONTAINER_IMAGE = "quay.io/openshift-cnv/qe-net-utils:latest"
 
 
 OC_ADM_LOGS_COMMAND = "oc adm node-logs"

--- a/utilities/manifests/utility-daemonset.yaml
+++ b/utilities/manifests/utility-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             - /bin/bash
             - -c
             - echo ok > /tmp/healthy && sleep INF
-          image: quay.io/openshift-cnv/qe-cnv-tests-net-util-container:centos-stream-9
+          image: quay.io/openshift-cnv/qe-net-utils:latest
           imagePullPolicy: IfNotPresent
           name: utility
           readinessProbe:


### PR DESCRIPTION
1) The current name `qe-cnv-tests-net-util-container` looks long and redundant. 
Renaming it to `qe-net-utils` and fixing all necessary places that uses this image.

2) refactoring for Dockerfile for better readability and maintainability. 
Also adding `iperf3` tool to the image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized container image naming across build workflows and configurations
  * Enhanced container build process with expanded package dependencies and improved architecture-specific handling to ensure consistent, reliable environments across supported platforms

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->