### PR TITLE
infra, workflows: rename net-utils image

### DIFF
--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     # safe to use pull_request_target because we only run this for trusted collaborators
-    if: contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    if: contains(fromJson('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -34,7 +34,7 @@ jobs:
       - name: Define image tag
         id: image-tag
         run: |
-          IMAGE_NAME="quay.io/openshift-cnv/qe-cnv-tests-net-util-container"
+          IMAGE_NAME="quay.io/openshift-cnv/qe-net-utils"
           TAG="staging"
           echo "IMAGE_TAG=${IMAGE_NAME}:${TAG}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/net-utils-promote.yml
+++ b/.github/workflows/net-utils-promote.yml
@@ -18,7 +18,7 @@ jobs:
 
     # safe to use pull_request_target because we only run this for trusted collaborators
     if: |
-      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association) &&
       github.event.pull_request.merged == true
     steps:
       - name: Install skopeo
@@ -35,7 +35,7 @@ jobs:
 
       - name: Promote manifest (staging -> latest)
         run: |
-          IMAGE_NAME="quay.io/openshift-cnv/qe-cnv-tests-net-util-container"
+          IMAGE_NAME="quay.io/openshift-cnv/qe-net-utils"
           skopeo copy \
             --all \
             docker://${IMAGE_NAME}:staging \


### PR DESCRIPTION
The current name `qe-cnv-tests-net-util-container` looks long and redundant. 
Renaming it to `qe-net-utils` and fixing all necessary places that uses this image.

Also added "CONTRIBUTOR" to the trusted `author_association` list 
(relevant when fork workflow is used).

Once this PR is merged, the image name will be changed all over the repo (PRs order matters).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configurations for build and deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->