### PR TITLE
[VIRT] Fix for descheduler psi test

### DIFF
--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -350,3 +350,14 @@ def nodes_taints_before_descheduler_test_run(nodes):
     for node in nodes_taints_before:
         if nodes_taints_after[node] != nodes_taints_before[node]:
             ResourceEditor(patches={node: {"spec": {"taints": nodes_taints_before[node]}}}).update()
+
+
+@pytest.fixture()
+def workers_psi_metric_values(prometheus, workers):
+    workers_names_list = [worker.name for worker in workers]
+    metric_output = prometheus.query_sampler(query="descheduler:combined_utilization_and_pressure:avg1m")
+    return {
+        item["metric"]["instance"]: float(item["value"][1]) * 100
+        for item in metric_output
+        if item["metric"]["instance"] in workers_names_list
+    }

--- a/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
+++ b/tests/virt/node/descheduler/test_descheduler_psi_metrics.py
@@ -57,6 +57,6 @@ class TestDeschedulerLoadAwareRebalancing:
     @pytest.mark.polarion("CNV-12346")
     def test_psi_values_within_threshold(
         self,
-        prometheus,
+        workers_psi_metric_values,
     ):
-        assert_psi_values_within_threshold(prometheus=prometheus)
+        assert_psi_values_within_threshold(psi_values_dict=workers_psi_metric_values)

--- a/tests/virt/node/descheduler/utils.py
+++ b/tests/virt/node/descheduler/utils.py
@@ -282,10 +282,7 @@ def wait_for_overutilized_soft_taint(node, taint_expected, wait_timeout=TIMEOUT_
         raise
 
 
-def assert_psi_values_within_threshold(prometheus):
-    metric_output = prometheus.query_sampler(query="descheduler:combined_utilization_and_pressure:avg1m")
-    psi_values_dict = {item["metric"]["instance"]: float(item["value"][1]) * 100 for item in metric_output}
-
+def assert_psi_values_within_threshold(psi_values_dict):
     # Default deviation threshold is AsymmetricLow, i.e. "average + 10"
     threshold = sum(psi_values_dict.values()) / len(psi_values_dict) + 10
     assert all(percentage < threshold for percentage in psi_values_dict.values()), (


### PR DESCRIPTION
Get PSI metrics for workers only

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for PSI metrics validation by extracting metric data retrieval into a reusable fixture and refactoring assertion utilities for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->