### PR TITLE
[DONT REVIEW] Temp fix for running s390x Infra gating tests from Jenkins

### DIFF
--- a/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
+++ b/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
@@ -15,8 +15,7 @@ CLOCK_TIMEZONE = "America/New_York"
 CLOCK_UTC_OFFSET = 600
 CLOCK_TIMER = {
     "hpet": {"present": False},
-    "hyperv": {"present": True},
-    "kvm": {"present": True},
+    "hyperv": {"present": False},
     "pit": {"present": True, "tickPolicy": "delay"},
     "rtc": {"present": True, "tickPolicy": "catchup", "track": "guest"},
 }


### PR DESCRIPTION
To avoid failure test_start_vm_with_instance_type_and_preference[common_instance_type_param_dict0-common_vm_preference_param_dict0] – tests.infrastructure.instance_types.test_vm_with_instance_and_pref.TestVmWithInstanceTypeAndPref

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
