### PR TITLE
sanity-check: Fail if cluster is already tainted

### DIFF
--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -141,6 +141,7 @@ def updated_cr_with_custom_crypto_policy(
     indirect=["updated_cr_with_custom_crypto_policy"],
 )
 def test_update_specific_component_crypto_policy(
+    validate_cluster_not_tainted,
     resources_dict,
     updated_cr_with_custom_crypto_policy,
 ):

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
@@ -39,6 +39,7 @@ def json_patched_cdi(admin_client, hco_namespace, prometheus, hyperconverged_res
 
 
 @pytest.mark.usefixtures(
+    "validate_cluster_not_tainted",
     "kubevirt_all_unsafe_modification_metrics_before_test",
     "kubevirt_alerts_before_test",
     "cdi_feature_gates_scope_class",

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
@@ -45,6 +45,7 @@ def json_patched_cnao(
 
 
 @pytest.mark.usefixtures(
+    "validate_cluster_not_tainted",
     "kubevirt_all_unsafe_modification_metrics_before_test",
     "kubevirt_alerts_before_test",
     "json_patched_cnao",

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
@@ -38,6 +38,7 @@ def json_patched_kubevirt(admin_client, hco_namespace, prometheus, hyperconverge
 
 
 @pytest.mark.usefixtures(
+    "validate_cluster_not_tainted",
     "kubevirt_all_unsafe_modification_metrics_before_test",
     "kubevirt_alerts_before_test",
     "json_patched_kubevirt",

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
@@ -72,6 +72,7 @@ def multiple_json_patched(admin_client, hco_namespace, prometheus, hyperconverge
 
 
 @pytest.mark.usefixtures(
+    "validate_cluster_not_tainted",
     "kubevirt_all_unsafe_modification_metrics_before_test",
     "kubevirt_alerts_before_test",
     "cdi_feature_gates_scope_class",

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -41,6 +41,7 @@ def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_res
 
 
 @pytest.mark.usefixtures(
+    "validate_cluster_not_tainted",
     "kubevirt_all_unsafe_modification_metrics_before_test",
     "kubevirt_alerts_before_test",
     "json_patched_ssp",


### PR DESCRIPTION
##### Short description:

Crypto policy and JSON patch tests fail systematically in teardown when the cluster has pre-existing jsonpatch annotations on HyperConverged CR that were not created by the tests themselves.

Furthermore, testing a cluster with unsupported configuration should not be valid for CI.

This PR is adding a sanity-check for this.

##### More details:

Tests assume clean cluster state but do not validate it before execution. When cluster has pre-existing jsonpatch annotations (from previous tests, manual changes, or incomplete cleanup), the cluster is already in TaintedConfiguration status.

##### What this PR does / why we need it:

includes a session-scoped fixture that will ensure that the HCO is not tainted before running the tests and, if that is not the case, it will fail fast.

##### Which issue(s) this PR fixes:
Observed on CI, tests failing with below reason:
```
        AssertionError: assert not [TaintedConfiguration condition]
        lastTransitionTime: 2025-11-14T06:13:05Z
        message: Unsupported feature was activated via an HCO annotation
        reason: UnsupportedFeatureAnnotation
        status: True
        type: TaintedConfiguration
```

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-72688


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Introduced cluster taint state validation that runs before test execution
* Applied validation to multiple test suites to verify cluster health and prevent tainted states from interfering with test operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->