### PR TITLE
[virt] drop explicit access/volume mode from dv template

### DIFF
--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -333,7 +333,8 @@ def golden_image_data_source_for_test_scope_module(request, admin_client, golden
 @pytest.fixture(scope="module")
 def golden_image_data_volume_template_for_test_scope_module(request, golden_image_data_source_for_test_scope_module):
     return get_data_volume_template_dict_with_default_storage_class(
-        data_source=golden_image_data_source_for_test_scope_module, params=getattr(request, "param", {})
+        data_source=golden_image_data_source_for_test_scope_module,
+        storage_class=getattr(request, "param", {}).get("storage_class"),
     )
 
 
@@ -347,7 +348,8 @@ def golden_image_data_source_for_test_scope_class(request, admin_client, golden_
 @pytest.fixture(scope="class")
 def golden_image_data_volume_template_for_test_scope_class(request, golden_image_data_source_for_test_scope_class):
     return get_data_volume_template_dict_with_default_storage_class(
-        data_source=golden_image_data_source_for_test_scope_class, params=getattr(request, "param", {})
+        data_source=golden_image_data_source_for_test_scope_class,
+        storage_class=getattr(request, "param", {}).get("storage_class"),
     )
 
 
@@ -363,7 +365,8 @@ def golden_image_data_volume_template_for_test_scope_function(
     request, golden_image_data_source_for_test_scope_function
 ):
     return get_data_volume_template_dict_with_default_storage_class(
-        data_source=golden_image_data_source_for_test_scope_function, params=getattr(request, "param", {})
+        data_source=golden_image_data_source_for_test_scope_function,
+        storage_class=getattr(request, "param", {}).get("storage_class"),
     )
 
 

--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -1,5 +1,4 @@
 import pytest
-from ocp_resources.datavolume import DataVolume
 
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS
 from utilities.constants import StorageClassNames
@@ -31,13 +30,7 @@ def vm_with_common_cpu_model_scope_function(
     [
         pytest.param(
             {"os_dict": FEDORA_LATEST},
-            {
-                "storage_class": {
-                    "name": StorageClassNames.CEPHFS,
-                    "volume_mode": DataVolume.VolumeMode.FILE,
-                    "access_mode": DataVolume.AccessMode.RWX,
-                },
-            },
+            {"storage_class": StorageClassNames.CEPHFS},
             {"vm_name": "cephfs-vm", "template_labels": FEDORA_LATEST_LABELS},
             marks=pytest.mark.polarion("CNV-11303"),
         )

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -529,26 +529,20 @@ def get_or_create_golden_image_data_source(
 
 
 def get_data_volume_template_dict_with_default_storage_class(
-    data_source: DataSource, params: dict[str, Any] | None = None
+    data_source: DataSource, storage_class: str | None = None
 ) -> dict[str, dict]:
     """
     Generates a dataVolumeTemplate dict with the py_config based storage class.
 
     Args:
         data_source (DataSource): The data source object used to create the data volume template.
-        params (dict[str, Any], optional): dict of request.param passed to pytest fixture.
+        storage_class (str, optional): Storage class name.
 
     Returns:
         dict[str, dict]: A dict representing the dataVolumeTemplate to be used in VM spec.
     """
     data_volume_template = data_volume_template_with_source_ref_dict(data_source=data_source)
-    if params and (storage_class_params := params.get("storage_class")):
-        data_volume_template["spec"]["storage"]["storageClassName"] = storage_class_params["name"]
-        data_volume_template["spec"]["storage"]["accessModes"] = [storage_class_params["access_mode"]]
-        data_volume_template["spec"]["storage"]["volumeMode"] = storage_class_params["volume_mode"]
-    else:
-        data_volume_template["spec"]["storage"]["storageClassName"] = py_config["default_storage_class"]
-
+    data_volume_template["spec"]["storage"]["storageClassName"] = storage_class or py_config["default_storage_class"]
     return data_volume_template
 
 


### PR DESCRIPTION
##### Short description:
Don't set access/volume mode explicitly if using default storage (not passing any params)

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified test infrastructure for data volume templates by switching to a single storage-class value instead of nested configuration objects.
  * Updated fixtures and test cases to pass the storage class directly, and adjusted parameterization to use the simplified storage-class format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->