### PR TITLE
quarantine label: add support for cherry-picked PRs

### DIFF
--- a/.github/workflows/pr-title-labeler.yml
+++ b/.github/workflows/pr-title-labeler.yml
@@ -1,17 +1,19 @@
 # PR Title Labeler - Automatically adds/removes 'quarantine' label based on PR title
 #
 # Summary:
-# ┌──────────────────┬─────────────────────────┬───────────────┬──────────────────────┐
-# │ Event            │ Title                   │ Current Label │ Action               │
-# ├──────────────────┼─────────────────────────┼───────────────┼──────────────────────┤
-# │ PR opened        │ "Quarantine: test"      │ None          │ ✅ Add label         │
-# │ PR opened        │ "Quarantine: test"      │ Already has   │ ✅ No-op (safe)      │
-# │ Title edited     │ "Fix" → "Quarantine: x" │ None          │ ✅ Add label         │
-# │ Title edited     │ "Quarantine: x" → "Fix" │ Has label     │ ✅ Remove label      │
-# │ PR reopened      │ "Quarantine: test"      │ None          │ ✅ Add label         │
-# │ PR opened        │ "Fix test"              │ None          │ ✅ No action         │
-# │ New commit       │ Any                     │ Any           │ ⏭️  Does NOT run     │
-# └──────────────────┴─────────────────────────┴───────────────┴──────────────────────┘
+# ┌──────────────────┬────────────────────────────────────────┬───────────────┬──────────────────────┐
+# │ Event            │ Title                                  │ Current Label │ Action               │
+# ├──────────────────┼────────────────────────────────────────┼───────────────┼──────────────────────┤
+# │ PR opened        │ "Quarantine: test"                     │ None          │ ✅ Add label         │
+# │ PR opened        │ "CherryPicked: [cnv-4.20] Quarantine:" │ None          │ ✅ Add label         │
+# │ PR opened        │ "Quarantine: test"                     │ Already has   │ ✅ No-op (safe)      │
+# │ Title edited     │ "Fix" → "Quarantine: x"                │ None          │ ✅ Add label         │
+# │ Title edited     │ "Quarantine: x" → "Fix"                │ Has label     │ ✅ Remove label      │
+# │ PR reopened      │ "Quarantine: test"                     │ None          │ ✅ Add label         │
+# │ PR opened        │ "CherryPicked: [cnv-4.20] Fix test"    │ None          │ ✅ No action         │
+# │ PR opened        │ "Fix test"                             │ None          │ ✅ No action         │
+# │ New commit       │ Any                                    │ Any           │ ⏭️  Does NOT run     │
+# └──────────────────┴────────────────────────────────────────┴───────────────┴──────────────────────┘
 #
 
 name: "PR Title Labeler"
@@ -28,17 +30,25 @@ jobs:
   label-quarantine:
     runs-on: ubuntu-latest
     steps:
-      - name: Add quarantine label for PRs starting with "Quarantine:"
+      - name: 'Add quarantine label for PRs starting with "Quarantine:" or "CherryPicked: [cnv-X.Y] Quarantine:"'
         uses: actions/github-script@v7
         with:
           script: |
-            const title = context.payload.pull_request.title.toLowerCase();
+            const originalTitle = context.payload.pull_request.title;
             const prNumber = context.payload.pull_request.number;
 
-            console.log(`Processing PR #${prNumber}: "${context.payload.pull_request.title}"`);
+            console.log(`Processing PR #${prNumber}: "${originalTitle}"`);
 
             try {
-              // Check if title starts with "quarantine:" (case-insensitive)
+              // Strip "CherryPicked: [cnv-X.Y]" prefix if present (case-insensitive)
+              // Regex matches: CherryPicked: [cnv-4.20] or CherryPicked: [cnv-4.xy] etc.
+              let title = originalTitle.replace(/^CherryPicked:\s*\[cnv-\d+\.\d+\]\s*/i, '').toLowerCase();
+
+              if (title !== originalTitle.toLowerCase()) {
+                console.log(`Stripped cherry-pick prefix, effective title: "${title}"`);
+              }
+
+              // Check if effective title starts with "quarantine:" (case-insensitive)
               if (title.startsWith('quarantine:')) {
                 console.log(`Title starts with "quarantine:", adding label`);
 


### PR DESCRIPTION
##### Short description:
auto cherry-picked PR have a "CherryPicked: [cnv-x.y]" prefix, add quaratnine label if title starts with "CherryPicked: [cnv-x.y] quaratnine:"

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

Generated using Claude AI

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated PR workflow to recognize and handle additional title patterns for improved label management processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->