### PR TITLE
WIP: infra/tests, net, sriov: Add client arg

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1064,13 +1064,14 @@ def sriov_ifaces(sriov_nodes_states, workers_utility_pods):
 
 
 @pytest.fixture(scope="session")
-def sriov_node_policy(sriov_unused_ifaces, sriov_nodes_states, workers_utility_pods, sriov_namespace):
+def sriov_node_policy(admin_client, sriov_unused_ifaces, sriov_nodes_states, workers_utility_pods, sriov_namespace):
     yield from create_sriov_node_policy(
         nncp_name="test-sriov-policy",
         namespace=sriov_namespace.name,
         sriov_iface=sriov_unused_ifaces[0],
         sriov_nodes_states=sriov_nodes_states,
         sriov_resource_name="sriov_net",
+        client=admin_client,
     )
 
 

--- a/tests/infrastructure/sap/test_sap_hana_vm.py
+++ b/tests/infrastructure/sap/test_sap_hana_vm.py
@@ -340,10 +340,11 @@ def sriov_network_node_policy(admin_client, sriov_namespace):
 
 
 @pytest.fixture(scope="class")
-def sriov_nads(namespace, sriov_network_node_policy, sriov_namespace):
+def sriov_nads(admin_client, namespace, sriov_network_node_policy, sriov_namespace):
     nads_list = []
     for idx in range(REQUIRED_NUMBER_OF_NETWORKS):
         with network_nad(
+            client=admin_client,
             nad_type=SRIOV,
             nad_name=f"sriov-net-{idx + 1}",
             sriov_resource_name=sriov_network_node_policy[idx].instance.spec.resourceName,

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -419,8 +419,9 @@ def vm2_with_hot_plugged_sriov_interface(
 
 
 @pytest.fixture(scope="module")
-def sriov_network_for_hot_plug(sriov_node_policy, namespace, sriov_namespace):
+def sriov_network_for_hot_plug(admin_client, sriov_node_policy, namespace, sriov_namespace):
     with network_nad(
+        client=admin_client,
         nad_type=SRIOV,
         nad_name="sriov-hot-plug-test-network",
         sriov_resource_name=sriov_node_policy.resource_name,

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -87,11 +87,12 @@ def sriov_vm(
 
 
 @pytest.fixture(scope="module")
-def sriov_network(sriov_node_policy, namespace, sriov_namespace):
+def sriov_network(admin_client, sriov_node_policy, namespace, sriov_namespace):
     """
     Create a SR-IOV network linked to SR-IOV policy.
     """
     with network_nad(
+        client=admin_client,
         nad_type=SRIOV,
         nad_name="sriov-test-network",
         sriov_resource_name=sriov_node_policy.resource_name,
@@ -102,11 +103,12 @@ def sriov_network(sriov_node_policy, namespace, sriov_namespace):
 
 
 @pytest.fixture(scope="class")
-def sriov_network_vlan(sriov_node_policy, namespace, sriov_namespace, vlan_index_number):
+def sriov_network_vlan(admin_client, sriov_node_policy, namespace, sriov_namespace, vlan_index_number):
     """
     Create a SR-IOV VLAN network linked to SR-IOV policy.
     """
     with network_nad(
+        client=admin_client,
         nad_type=SRIOV,
         nad_name="sriov-test-network-vlan",
         sriov_resource_name=sriov_node_policy.resource_name,

--- a/tests/virt/node/high_performance_vm/test_numa.py
+++ b/tests/virt/node/high_performance_vm/test_numa.py
@@ -35,9 +35,10 @@ def fail_if_no_numa(schedulable_nodes, workers_utility_pods):
 
 
 @pytest.fixture(scope="module")
-def sriov_net(sriov_node_policy, namespace):
+def sriov_net(admin_client, sriov_node_policy, namespace):
     with SriovNetwork(
         name="numa-sriov-test-net",
+        client=admin_client,
         namespace=sriov_node_policy.namespace,
         resource_name=sriov_node_policy.resource_name,
         network_namespace=namespace.name,

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -92,6 +92,7 @@ class BridgeNodeNetworkConfigurationPolicy(NodeNetworkConfigurationPolicy):
             bridge_name (str): Bridge name.
             bridge_type (str): Bridge type (Linux Bridge, OVS)
             stp_config (bool): Spanning Tree enabled/disabled.
+            client (DynamicClient): DynamicClient to use.
             ports (list): The bridge's port(s).
             mtu (int): MTU size
             ipv4_dhcp: determines if ipv4_dhcp should be used
@@ -549,6 +550,7 @@ def network_nad(
         "teardown": teardown,
         "vlan": vlan,
     }
+    # TODO: Client should be mandatory. Remove this check once all tests are updated, and add client to kwargs.
     if client is not None:
         kwargs["client"] = client
     if nad_type == LINUX_BRIDGE:


### PR DESCRIPTION
##### Short description:
This change prepares making the client mandatory for all SR-IOV-related resources.
Updated fixtures so that all calls to openshift-python-wrapper SR-IOV resources explicitly pass a client.

##### More details:

##### What this PR does / why we need it:
The current PR adds an optional client parameter in the infra (SR-IOV-related helpers) and passes the appropriate client from the fixtures. After the entire code base is updated so that all resource creations pass a client, a follow-up PR will make the client argument mandatory.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tests and networking utilities now accept and propagate an explicit admin client for SR-IOV and bridge network setup.
  * Admin client is used when creating network resources and policies, improving permission handling and reliability of infrastructure-related test setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->