### PR TITLE
Manual cherry-pick 4.20: net, sriov: Remove redundant sriov policy and fixtures (#2809)

### DIFF
--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -21,9 +21,7 @@ from utilities.constants import (
 )
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
-    SriovIfaceNotFound,
     cloud_init_network_data,
-    create_sriov_node_policy,
     network_nad,
     sriov_network_dict,
 )
@@ -87,28 +85,6 @@ def sriov_vm(
         yield vm
 
 
-@pytest.fixture(scope="session")
-def sriov_iface_with_vlan(sriov_unused_ifaces, vlan_base_iface):
-    for interface in sriov_unused_ifaces:
-        if interface["name"] == vlan_base_iface:
-            return interface
-    raise SriovIfaceNotFound(
-        f"No sriov interface with vlan found. vlan base iface is {vlan_base_iface}, "
-        f"sriov ifaces is {sriov_unused_ifaces}"
-    )
-
-
-@pytest.fixture(scope="session")
-def sriov_with_vlan_node_policy(sriov_nodes_states, sriov_iface_with_vlan, sriov_namespace):
-    yield from create_sriov_node_policy(
-        nncp_name="test-sriov-on-vlan-policy",
-        namespace=sriov_namespace.name,
-        sriov_iface=sriov_iface_with_vlan,
-        sriov_nodes_states=sriov_nodes_states,
-        sriov_resource_name="sriov_net_with_vlan",
-    )
-
-
 @pytest.fixture(scope="module")
 def sriov_network(sriov_node_policy, namespace, sriov_namespace):
     """
@@ -125,14 +101,14 @@ def sriov_network(sriov_node_policy, namespace, sriov_namespace):
 
 
 @pytest.fixture(scope="class")
-def sriov_network_vlan(sriov_with_vlan_node_policy, namespace, sriov_namespace, vlan_index_number):
+def sriov_network_vlan(sriov_node_policy, namespace, sriov_namespace, vlan_index_number):
     """
     Create a SR-IOV VLAN network linked to SR-IOV policy.
     """
     with network_nad(
         nad_type=SRIOV,
         nad_name="sriov-test-network-vlan",
-        sriov_resource_name=sriov_with_vlan_node_policy.resource_name,
+        sriov_resource_name=sriov_node_policy.resource_name,
         namespace=sriov_namespace,
         sriov_network_namespace=namespace.name,
         vlan=next(vlan_index_number),


### PR DESCRIPTION
Manual cherry-pick 4.20: https://github.com/RedHatQE/openshift-virtualization-tests/pull/2809

cmd log:

```
git cherry-pick 5e5167d68719b3f692e5dc90a74ff1324448bc81 -m 1
Auto-merging tests/network/sriov/conftest.py
[fix_sriov_policy_and_remove_fixtures-cnv-4.20 7643304] net, sriov: Remove redundant sriov policy and fixtures (#2809)
 Author: Ruth Netser <rnetser@redhat.com>
 Date: Thu Nov 27 11:29:07 2025 +0200
 1 file changed, 2 insertions(+), 26 deletions(-)
```