### PR TITLE
Manual cherry-pick 4.20: net: Remove fixed IPv4 addresses (#2449)

### DIFF
--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -8,6 +8,7 @@ import pytest
 
 import utilities.network
 from tests.network.libs import cloudinit as netcloud
+from tests.network.libs.ip import random_ipv4_address
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
     BondNodeNetworkConfigurationPolicy,
@@ -127,7 +128,9 @@ def ovs_linux_bond_bridge_attached_vma(
     name = "bond-vma"
     networks = OrderedDict()
     networks[ovs_linux_br1bond_nad.name] = ovs_linux_br1bond_nad.name
-    netdata = netcloud.NetworkData(ethernets={"eth1": netcloud.EthernetDevice(addresses=["10.200.3.1/24"])})
+    netdata = netcloud.NetworkData(
+        ethernets={"eth1": netcloud.EthernetDevice(addresses=[f"{random_ipv4_address(net_seed=0, host_address=1)}/24"])}
+    )
 
     with VirtualMachineForTests(
         namespace=namespace.name,
@@ -154,7 +157,9 @@ def ovs_linux_bond_bridge_attached_vmb(
     name = "bond-vmb"
     networks = OrderedDict()
     networks[ovs_linux_br1bond_nad.name] = ovs_linux_br1bond_nad.name
-    network_data_data = {"ethernets": {"eth1": {"addresses": ["10.200.3.2/24"]}}}
+    network_data_data = {
+        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
+    }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(

--- a/tests/network/general/test_cnv_tuning_regression.py
+++ b/tests/network/general/test_cnv_tuning_regression.py
@@ -1,5 +1,6 @@
 import pytest
 
+from tests.network.libs.ip import random_ipv4_address
 from utilities.constants import LINUX_BRIDGE
 from utilities.infra import get_node_selector_dict
 from utilities.network import compose_cloud_init_data_dict, network_device, network_nad
@@ -33,7 +34,9 @@ def linux_bridge_device(worker_node1, linux_bridge_nad):
 def cnv_tuning_vm(unprivileged_client, worker_node1, linux_bridge_nad, linux_bridge_device):
     name = "tuning-vma"
     networks = {"net1": linux_bridge_nad.name}
-    network_data_data = {"ethernets": {"eth1": {"addresses": ["10.200.0.1/24"]}}}
+    network_data_data = {
+        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
+    }
 
     with VirtualMachineForTests(
         namespace=linux_bridge_nad.namespace,

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import pytest
 
+from tests.network.libs.ip import random_ipv4_address
 from tests.network.utils import assert_no_ping
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
@@ -141,7 +142,9 @@ def bond_bridge_attached_vma(
     name = "bond-vma"
     networks = OrderedDict()
     networks[br1bond_nad.name] = br1bond_nad.name
-    network_data_data = {"ethernets": {"eth1": {"addresses": ["10.200.1.1/24"]}}}
+    network_data_data = {
+        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
+    }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(
@@ -169,7 +172,9 @@ def bond_bridge_attached_vmb(
     name = "bond-vmb"
     networks = OrderedDict()
     networks[br1bond_nad.name] = br1bond_nad.name
-    network_data_data = {"ethernets": {"eth1": {"addresses": ["10.200.1.2/24"]}}}
+    network_data_data = {
+        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
+    }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import pytest
 
+from tests.network.libs.ip import random_ipv4_address
 from tests.network.utils import assert_no_ping
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
@@ -93,7 +94,9 @@ def bridge_attached_vma(worker_node1, namespace, unprivileged_client, br1test_br
     name = "vma"
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
-    network_data_data = {"ethernets": {"eth1": {"addresses": ["10.200.0.1/24"]}}}
+    network_data_data = {
+        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
+    }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(
@@ -116,7 +119,9 @@ def bridge_attached_vmb(worker_node2, namespace, unprivileged_client, br1test_br
     name = "vmb"
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
-    network_data_data = {"ethernets": {"eth1": {"addresses": ["10.200.0.2/24"]}}}
+    network_data_data = {
+        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
+    }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(

--- a/tests/network/jumbo_frame/utils.py
+++ b/tests/network/jumbo_frame/utils.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 
+from tests.network.libs.ip import random_ipv4_address
 from utilities.network import compose_cloud_init_data_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
@@ -31,7 +32,7 @@ def create_vm_for_jumbo_test(
 def cloud_init_data_for_secondary_traffic(index):
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"10.200.0.{index}/24"]},
+            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=index)}/24"]},
         }
     }
 

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -10,6 +10,7 @@ from libs.net.traffic_generator import Client, Server
 from libs.net.vmspec import lookup_iface_status
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cluster_user_defined_network as libcudn
+from tests.network.libs.ip import random_ipv4_address
 from tests.network.localnet.liblocalnet import (
     LINK_STATE_DOWN,
     LOCALNET_BR_EX_NETWORK,
@@ -95,7 +96,7 @@ def cudn_localnet(
 
 @pytest.fixture(scope="module")
 def ipv4_localnet_address_pool() -> Generator[str]:
-    return (f"10.0.0.{host_value}/24" for host_value in range(1, 254))
+    return (f"{random_ipv4_address(net_seed=0, host_address=host_value)}/24" for host_value in range(1, 254))
 
 
 @pytest.fixture(scope="module")

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -12,6 +12,7 @@ from ocp_resources.template import Template
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutSampler
 
+from tests.network.libs.ip import random_ipv4_address
 from utilities.constants import (
     CNV_SUPPLEMENTAL_TEMPLATES_URL,
     MTU_9000,
@@ -148,7 +149,7 @@ def sriov_vm1(index_number, sriov_workers_node1, namespace, unprivileged_client,
         name="sriov-vm1",
         namespace=namespace,
         worker=sriov_workers_node1,
-        ip_config="10.200.1.1/24",
+        ip_config=f"{random_ipv4_address(net_seed=0, host_address=1)}/24",
         sriov_network=sriov_network,
     )
 
@@ -161,7 +162,7 @@ def sriov_vm2(index_number, unprivileged_client, sriov_workers_node2, namespace,
         name="sriov-vm2",
         namespace=namespace,
         worker=sriov_workers_node2,
-        ip_config="10.200.1.2/24",
+        ip_config=f"{random_ipv4_address(net_seed=0, host_address=2)}/24",
         sriov_network=sriov_network,
     )
 
@@ -180,7 +181,7 @@ def sriov_vm3(
         name="sriov-vm3",
         namespace=namespace,
         worker=sriov_workers_node1,
-        ip_config="10.200.3.1/24",
+        ip_config=f"{random_ipv4_address(net_seed=1, host_address=1)}/24",
         sriov_network=sriov_network_vlan,
     )
 
@@ -199,7 +200,7 @@ def sriov_vm4(
         name="sriov-vm4",
         namespace=namespace,
         worker=sriov_workers_node2,
-        ip_config="10.200.3.2/24",
+        ip_config=f"{random_ipv4_address(net_seed=1, host_address=2)}/24",
         sriov_network=sriov_network_vlan,
     )
 
@@ -265,7 +266,7 @@ def sriov_vm_migrate(index_number, unprivileged_client, namespace, sriov_network
         unprivileged_client=unprivileged_client,
         name="sriov-vm-migrate",
         namespace=namespace,
-        ip_config="10.200.1.3/24",
+        ip_config=f"{random_ipv4_address(net_seed=0, host_address=3)}/24",
         sriov_network=sriov_network,
     )
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -7,6 +7,7 @@ from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 from libs.net.traffic_generator import Client, Server, is_tcp_connection
 from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm import affinity
+from tests.network.libs.ip import random_ipv4_address
 from tests.network.libs.vm_factory import udn_vm
 from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
 from utilities.infra import create_ns
@@ -31,7 +32,7 @@ def namespaced_layer2_user_defined_network(udn_namespace):
         name="layer2-udn",
         namespace=udn_namespace.name,
         role="Primary",
-        subnets=["10.10.0.0/24"],
+        subnets=[f"{random_ipv4_address(net_seed=0, host_address=0)}/24"],
         ipam={"lifecycle": "Persistent"},
     ) as udn:
         udn.wait_for_condition(


### PR DESCRIPTION
Manual cherry-pick 4.20: https://github.com/RedHatQE/openshift-virtualization-tests/pull/2449

cmd log:

```
git cherry-pick 3c10183673d900b801e1af68b1403129971a8388
Auto-merging tests/network/localnet/conftest.py
Auto-merging tests/network/user_defined_network/test_user_defined_network.py
[remove_hardcoded_ip_prefix-cnv-4.20 c4dd577]  net: Remove fixed IPv4 addresses (#2449)
 Author: Asia Zhivov Khromov <azhivovk@redhat.com>
 Date: Thu Nov 6 13:30:49 2025 +0200
 8 files changed, 37 insertions(+), 15 deletions(-)
```