### PR TITLE
Remove dev-preview branch from test_channels_in_manifest

### DIFF
--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -5,7 +5,7 @@ pytestmark = [pytest.mark.sno, pytest.mark.s390x]
 
 @pytest.mark.polarion("CNV-7169")
 def test_channels_in_manifest(kubevirt_package_manifest_channels):
-    expected_channels = {"stable", "dev-preview"}
+    expected_channels = {"stable", "candidate"}
     missing_channels = expected_channels - {channel.name for channel in kubevirt_package_manifest_channels}
     assert not missing_channels, f"Missing channels: {missing_channels}"
 


### PR DESCRIPTION
##### Short description:

Due to the removal of dev-preview channel performed on task:

https://issues.redhat.com/browse/CNV-71454

This commit is updating the test to reflect that change. It is also adding the candidate channel which should be present on the manifest.

##### More details:
N/A
##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated subscription channel validation tests to align with current channel expectations (ensuring the test suite checks for the revised set of release channels). This keeps automated checks in sync with the product's published channel configuration and reduces false test failures due to outdated channel assumptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->