### PR TITLE
WIP:  net, sriov: Refactor wait_for_ready_sriov_nodes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1079,14 +1079,15 @@ def sriov_node_policy(
     workers_utility_pods,
     sriov_namespace,
 ):
-    yield from create_sriov_node_policy(
+    with create_sriov_node_policy(
         nncp_name="test-sriov-policy",
         namespace=sriov_namespace.name,
         sriov_iface=sriov_unused_ifaces[0],
         sriov_nodes_states=sriov_nodes_states,
         sriov_resource_name="sriov_net",
-        client=admin_client,
-    )
+        admin_client=admin_client,
+    ) as sriov_node_policy:
+        yield sriov_node_policy
 
 
 @pytest.fixture(scope="session")

--- a/tests/network/libs/sriovnetworknode.py
+++ b/tests/network/libs/sriovnetworknode.py
@@ -1,0 +1,154 @@
+import logging
+
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.node import Node
+from ocp_resources.sriov_network_node_policy import SriovNetworkNodePolicy
+from ocp_resources.sriov_network_node_state import SriovNetworkNodeState
+from timeout_sampler import TimeoutExpiredError, retry
+
+from utilities.exceptions import ResourceMismatch
+
+LOGGER = logging.getLogger(__name__)
+
+
+def wait_for_ready_sriov_nodes(
+    snns_list: list[SriovNetworkNodeState],
+    client: DynamicClient,
+    policy: SriovNetworkNodePolicy | None = None,
+    nic_selector: dict[str, list[str]] | None = None,
+) -> None:
+    """
+    Wait for SR-IOV nodes to be ready and verify interface configuration.
+
+    Usage:
+    1. Policy creation: Waits for SUCCEEDED status and verifies config matches policy.
+    2. Policy teardown: Verifies VFs are removed from specified interfaces.
+
+    Args:
+        snns_list: List of SriovNetworkNodeState objects.
+        client: client for Node access.
+        policy: SriovNetworkNodePolicy for verification. None during teardown.
+        nic_selector: NIC selector dict with pfNames/rootDevices for teardown verification.
+
+    Raises:
+        TimeoutExpiredError: If sync status doesn't reach SUCCEEDED or verification times out.
+    """
+    for sriov_node_network_state in snns_list:
+        try:
+            _check_sriov_node_ready_and_configured(
+                sriov_node_network_state=sriov_node_network_state,
+                policy=policy,
+                client=client,
+                nic_selector=nic_selector,
+            )
+        except TimeoutExpiredError:
+            current_status = sriov_node_network_state.instance.status.syncStatus
+            if current_status == SriovNetworkNodePolicy.Status.SUCCEEDED:
+                LOGGER.error(
+                    f"Timeout waiting for SR-IOV configuration to match policy on node {sriov_node_network_state.name}"
+                )
+            else:
+                LOGGER.error(
+                    f"Timeout waiting for node {sriov_node_network_state.name} "
+                    f"SriovNetworkNodeState to reach SUCCEEDED status. "
+                    f"Current status: {current_status}"
+                )
+            raise
+
+
+@retry(wait_timeout=1000, sleep=5, exceptions_dict={ResourceMismatch: []})
+def _check_sriov_node_ready_and_configured(
+    sriov_node_network_state: SriovNetworkNodeState,
+    client: DynamicClient,
+    nic_selector: dict[str, list[str]],
+    policy: SriovNetworkNodePolicy | None = None,
+) -> bool:
+    if sriov_node_network_state.instance.status.syncStatus != SriovNetworkNodePolicy.Status.SUCCEEDED:
+        return False
+
+    if policy:
+        _verify_sriov_setup_config(
+            sriov_node_network_state=sriov_node_network_state,
+            client=client,
+            policy=policy,
+        )
+    else:
+        _verify_sriov_teardown_config(
+            sriov_node_network_state=sriov_node_network_state,
+            nic_selector=nic_selector,
+        )
+
+    return True
+
+
+def _verify_sriov_setup_config(
+    sriov_node_network_state: SriovNetworkNodeState,
+    client: DynamicClient,
+    policy: SriovNetworkNodePolicy,
+) -> None:
+    node = Node(client=client, name=sriov_node_network_state.name)
+
+    if not _node_matches_policy_selector(node=node, policy=policy):
+        LOGGER.info(f"Skipping verification for node {node.name} - does not match policy {policy.name} nodeSelector")
+        return
+
+    policy_spec = policy.instance.spec
+    pf_names = policy_spec.nicSelector.get("pfNames", [])
+    root_devices = policy_spec.nicSelector.get("rootDevices", [])
+    expected_num_vfs = policy_spec.numVfs
+    expected_mtu = policy_spec.get("mtu")
+
+    matching_interfaces = []
+    for iface in sriov_node_network_state.instance.status.interfaces:
+        if iface.name in pf_names or iface.pciAddress in root_devices:
+            matching_interfaces.append(iface)
+
+    if not matching_interfaces:
+        raise ResourceMismatch(
+            f"Node {sriov_node_network_state.name} matches policy {policy.name} nodeSelector "
+            f"but has no interfaces matching pfNames={pf_names}, rootDevices={root_devices})."
+        )
+
+    for iface in matching_interfaces:
+        if iface.numVfs != expected_num_vfs:
+            raise ResourceMismatch(
+                f"SR-IOV interface {iface.name} on node {sriov_node_network_state.name}: "
+                f"numVfs mismatch - got {iface.numVfs}, expected {expected_num_vfs}"
+            )
+
+        if expected_mtu:
+            iface_mtu = getattr(iface, "mtu", None)
+            if iface_mtu and iface_mtu != expected_mtu:
+                raise ResourceMismatch(
+                    f"SR-IOV interface {iface.name} on node {sriov_node_network_state.name}: "
+                    f"MTU mismatch - got {iface_mtu}, expected {expected_mtu}"
+                )
+
+        LOGGER.info(f"Interface {iface.name} configuration verified successfully")
+
+
+def _verify_sriov_teardown_config(
+    sriov_node_network_state: SriovNetworkNodeState,
+    nic_selector: dict[str, list[str]],
+) -> None:
+    pf_names = nic_selector.get("pfNames", [])
+    root_devices = nic_selector.get("rootDevices", [])
+
+    for iface in sriov_node_network_state.instance.status.interfaces:
+        if iface.name in pf_names or iface.pciAddress in root_devices:
+            if iface.numVfs:
+                raise ResourceMismatch(
+                    f"SR-IOV interface {iface.name} on node {sriov_node_network_state.name} still has "
+                    f"numVfs={iface.numVfs} after policy deletion. Expected numVfs=0 or None"
+                )
+            LOGGER.info(f"Interface {iface.name} teardown verified successfully")
+
+
+def _node_matches_policy_selector(node: Node, policy: SriovNetworkNodePolicy) -> bool:
+    node_labels = node.instance.metadata.labels
+    for key, value in policy.instance.spec.nodeSelector.items():
+        if (node_value := node_labels.get(key)) != value:
+            LOGGER.info(f"Node {node.name} does not match nodeSelector: {key}={value} (node has {key}={node_value})")
+            return False
+
+    return True


### PR DESCRIPTION
Problem:
SriovNetworkNodeState sometimes does not change to InProgress after sriov configuration and stays in Succeeded state. This could lead to errors in setup and teardown of each node and declaration of the error might take 1000 seconds (~17 minutes).

Fix:
Waiting for SNNS status to be updated according to the test's SriovNetworkNodePolicy instead of waiting for state to change to InProgress.

##### jira-ticket: https://issues.redhat.com/browse/CNV-20564
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced SR‑IOV node readiness checks with policy-aware verification, stricter interface and MTU validation, and explicit teardown detection.
  * Test fixture now uses a context manager and accepts an administrative client to support policy-driven flows.

* **Refactor**
  * Centralized readiness verification into a shared helper and removed duplicate logic.
  * Converted policy creation to a context manager and propagated NIC selector handling to centralized checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->