### PR TITLE
fix: allow build.sh to run multiple times

### DIFF
--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -15,7 +15,7 @@ trap cleanup EXIT
 [ -z "${FEDORA_VERSION}" ] && echo "Set the env variable FEDORA_VERSION" && exit 1
 [ -z "${CPU_ARCH}" ] && echo "Set the env variable CPU_ARCH" && exit 1
 
-BUILD_DIR="fedora_build"
+BUILD_DIR="fedora_build_${CPU_ARCH}"
 CLOUD_INIT_ISO="cidata.iso"
 NAME="fedora${FEDORA_VERSION}"
 FEDORA_CONTAINER_IMAGE="localhost/fedora:${FEDORA_VERSION}-${CPU_ARCH}"
@@ -96,6 +96,9 @@ if [ $CPU_ARCH = "arm64" ]; then
 else
     virsh undefine "${NAME}"
 fi
+
+# Ensures the 'fedora' pool is destroyed to prevent hanging on subsequent executions
+virsh pool-destroy fedora
 
 rm -f "${CLOUD_INIT_ISO}"
 


### PR DESCRIPTION
This change enables the script to be executed multiple times without requiring a reboot. Previously, the virtual machine was undefined, but the pool remained intact. When run a second time, no error was thrown; however, the virsh-sysprep command experienced a timeout.

Additionally, the BUILD_DIR variable now includes an architecture suffix. This enhancement eliminates the need to delete any folders or residual data when building for different architectures.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build directory naming now appends the CPU architecture suffix, improving clarity and compatibility across different systems.
  * Cleanup process enhanced to explicitly remove lingering storage pools after virtual machine removal, preventing hangs and ensuring subsequent runs proceed reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->