### PR TITLE
[gating][main] return gating marker test_unprivileged_user_clone_dv_same_namespace_positive

### DIFF
--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -32,6 +32,7 @@ pytestmark = pytest.mark.usefixtures("fail_when_no_unprivileged_client_available
 
 
 @pytest.mark.sno
+@pytest.mark.gating
 @pytest.mark.parametrize(
     "namespace, data_volume_multi_storage_scope_module, permissions_datavolume_source, "
     "dv_cloned_by_unprivileged_user_in_the_same_namespace",


### PR DESCRIPTION
##### Short description:
following 
https://github.com/RedHatQE/openshift-python-wrapper/pull/2572
https://github.com/RedHatQE/openshift-python-wrapper/pull/2581
we are now returning test:: test_unprivileged_user_clone_dv_same_namespace_positive  to gating 




##### More details:
test_unprivileged_user_clone_dv_same_namespace_positive was part of gating and gating marker was removed 

previouslly test test_unprivileged_user_clone_dv_same_namespace_positive  was failing  due to protocol exception
that have been adressed in 
https://github.com/RedHatQE/openshift-python-wrapper/pull/2581

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-72360
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a pytest marker to gate a namespace-cloning test alongside the existing marker, improving test selection and execution control for namespace cloning validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->