### PR TITLE
Add missing stress-ng, iotop tools for fedora 43 

### DIFF
--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -34,6 +34,9 @@ def vm_with_fio(
 
 @pytest.fixture()
 def running_fio_in_vm(vm_with_fio):
+    LOGGER.info("Installing fio and iotop tools")
+    run_ssh_commands(host=vm_with_fio.ssh_exec, commands=shlex.split("sudo dnf install -y iotop fio"))
+
     # Random write/read -  create a 1G file, and perform 4KB reads and writes using a 75%/25%
     LOGGER.info("Running fio in VM")
     fio_cmd = shlex.split(

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -184,6 +184,7 @@ def start_stress_on_vm(vm, stress_command):
         verify_wsl2_guest_works(vm=vm)
         command = f"wsl nohup bash -c '{stress_command}'"
     else:
+        run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("sudo dnf install -y stress-ng"))
         command = stress_command
     run_ssh_commands(
         host=vm.ssh_exec,


### PR DESCRIPTION
##### Short description:

Fedora 43 images missing stress-ng and iotop tools for load during migration causing test failures.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  https://issues.redhat.com/browse/CNV-73089
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Actions PR labeling workflow for automated quarantine marking.
  * Enhanced test error reporting with improved logging and pod diagnostics.

* **Updates**
  * Migrated Fedora support from version 41 to 43.
  * Updated dependency constraints: openshift-python-wrapper (~=4.20.0) and added cachetools (>=6.2.1).
  * Updated Docker image tag to cnv-4.20.

* **Tests**
  * Enhanced quarantine marking for unstable tests with traceable error codes.
  * Removed several network and storage test modules; consolidated validation logic.
  * Improved fixture dependencies and error handling paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->