### PR TITLE
 infra/tests, net, nncp: require explicit client for NNCP

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -961,7 +961,11 @@ def started_windows_vm(
 
 
 @pytest.fixture(scope="session")
-def worker_nodes_ipv4_false_secondary_nics(nodes_available_nics, schedulable_nodes):
+def worker_nodes_ipv4_false_secondary_nics(
+    admin_client,
+    nodes_available_nics,
+    schedulable_nodes,
+):
     """
     Function removes ipv4 from secondary nics.
     """
@@ -969,6 +973,7 @@ def worker_nodes_ipv4_false_secondary_nics(nodes_available_nics, schedulable_nod
         worker_nics = nodes_available_nics[worker_node.name]
         with EthernetNetworkConfigurationPolicy(
             name=f"disable-ipv4-{name_prefix(worker_node.name)}",
+            client=admin_client,
             node_selector=get_node_selector_dict(node_selector=worker_node.hostname),
             interfaces_name=worker_nics,
         ):
@@ -1066,13 +1071,20 @@ def sriov_ifaces(sriov_nodes_states, workers_utility_pods):
 
 
 @pytest.fixture(scope="session")
-def sriov_node_policy(sriov_unused_ifaces, sriov_nodes_states, workers_utility_pods, sriov_namespace):
+def sriov_node_policy(
+    admin_client,
+    sriov_unused_ifaces,
+    sriov_nodes_states,
+    workers_utility_pods,
+    sriov_namespace,
+):
     yield from create_sriov_node_policy(
         nncp_name="test-sriov-policy",
         namespace=sriov_namespace.name,
         sriov_iface=sriov_unused_ifaces[0],
         sriov_nodes_states=sriov_nodes_states,
         sriov_resource_name="sriov_net",
+        client=admin_client,
     )
 
 
@@ -1671,6 +1683,7 @@ def term_handler_scope_session():
 
 @pytest.fixture(scope="session")
 def upgrade_bridge_on_all_nodes(
+    admin_client,
     label_schedulable_nodes,
     hosts_common_available_ports,
 ):
@@ -1680,17 +1693,19 @@ def upgrade_bridge_on_all_nodes(
         interface_name="br1upgrade",
         node_selector_labels=NODE_TYPE_WORKER_LABEL,
         ports=[hosts_common_available_ports[0]],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="session")
-def bridge_on_one_node(worker_node1):
+def bridge_on_one_node(admin_client, worker_node1):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="upgrade-br-marker",
         interface_name="upg-br-mark",
         node_selector=get_node_selector_dict(node_selector=worker_node1.name),
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -162,12 +162,13 @@ def must_gather_nad(admin_client, must_gather_bridge, node_gather_unprivileged_n
 
 
 @pytest.fixture(scope="package")
-def must_gather_bridge(worker_node1):
+def must_gather_bridge(admin_client, worker_node1):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="must-gather-br",
         interface_name="mg-br1",
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -45,8 +45,13 @@ IPERF3_SERVER_PORT: Final[int] = 2354
 
 
 @pytest.fixture(scope="session")
-def vlan_nncp(vlan_base_iface: str, worker_node1: Node) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
+def vlan_nncp(
+    admin_client: DynamicClient,
+    vlan_base_iface: str,
+    worker_node1: Node,
+) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
     with libnncp.NodeNetworkConfigurationPolicy(
+        client=admin_client,
         name="test-vlan-nncp",
         desired_state=libnncp.DesiredState(
             interfaces=[

--- a/tests/network/bond/test_bond_modes.py
+++ b/tests/network/bond/test_bond_modes.py
@@ -63,6 +63,7 @@ def create_vm(namespace, nad, node_selector, unprivileged_client):
 
 @pytest.fixture()
 def matrix_bond_modes_bond(
+    admin_client,
     index_number,
     link_aggregation_mode_no_connectivity_matrix__function__,
     nodes_available_nics,
@@ -75,6 +76,7 @@ def matrix_bond_modes_bond(
     with BondNodeNetworkConfigurationPolicy(
         name=f"matrix-bond{bond_index}-nncp",
         bond_name=f"mtx-bond{bond_index}",
+        client=admin_client,
         bond_ports=nodes_available_nics[worker_node1.name][-2:],
         mode=link_aggregation_mode_no_connectivity_matrix__function__,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -96,6 +98,7 @@ def bond_modes_nad(admin_client, bridge_device_matrix__function__, namespace, ma
 
 @pytest.fixture()
 def matrix_bond_modes_bridge(
+    admin_client,
     bridge_device_matrix__function__,
     worker_node1,
     bond_modes_nad,
@@ -110,6 +113,7 @@ def matrix_bond_modes_bridge(
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         interface_name=bond_modes_nad.bridge_name,
         ports=[matrix_bond_modes_bond.bond_name],
+        client=admin_client,
     ) as br:
         yield br
 
@@ -133,6 +137,7 @@ def bond_modes_vm(
 
 @pytest.fixture()
 def bridge_on_bond_fail_over_mac(
+    admin_client,
     bridge_device_matrix__function__,
     worker_node1,
     bond_modes_nad,
@@ -147,14 +152,16 @@ def bridge_on_bond_fail_over_mac(
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         interface_name=bond_modes_nad.bridge_name,
         ports=[active_backup_bond_with_fail_over_mac.bond_name],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture()
-def active_backup_bond_with_fail_over_mac(index_number, worker_node1, nodes_available_nics):
+def active_backup_bond_with_fail_over_mac(admin_client, index_number, worker_node1, nodes_available_nics):
     bond_index = next(index_number)
     with BondNodeNetworkConfigurationPolicy(
+        client=admin_client,
         name=f"active-bond{bond_index}-nncp",
         bond_name=f"act-bond{bond_index}",
         bond_ports=nodes_available_nics[worker_node1.name][-2:],
@@ -184,9 +191,10 @@ def vm_with_fail_over_mac_bond(
 
 
 @pytest.fixture()
-def bond_resource(index_number, nodes_available_nics, worker_node1):
+def bond_resource(admin_client, index_number, nodes_available_nics, worker_node1):
     bond_idx = next(index_number)
     with BondNodeNetworkConfigurationPolicy(
+        client=admin_client,
         name=f"bond-with-port{bond_idx}nncp",
         bond_name=f"bond-w-port{bond_idx}",
         bond_ports=nodes_available_nics[worker_node1.name][-2:],
@@ -211,6 +219,7 @@ def test_vm_started(bond_modes_vm):
 @pytest.mark.polarion("CNV-6583")
 @pytest.mark.s390x
 def test_active_backup_bond_with_fail_over_mac(
+    admin_client,
     index_number,
     worker_node1,
     nodes_available_nics,
@@ -220,6 +229,7 @@ def test_active_backup_bond_with_fail_over_mac(
     with BondNodeNetworkConfigurationPolicy(
         name=f"test-active-bond{bond_index}-nncp",
         bond_name=f"test-act-bond{bond_index}",
+        client=admin_client,
         bond_ports=nodes_available_nics[worker_node1.name][-2:],
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         options={"fail_over_mac": "active"},

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -39,6 +39,7 @@ def ovs_linux_br1bond_nad(admin_client, bridge_device_matrix__class__, namespace
 
 @pytest.fixture(scope="class")
 def ovs_linux_bond1_worker_1(
+    admin_client,
     index_number,
     worker_node1,
     nodes_available_nics,
@@ -48,6 +49,7 @@ def ovs_linux_bond1_worker_1(
     """
     bond_idx = next(index_number)
     with BondNodeNetworkConfigurationPolicy(
+        client=admin_client,
         name=f"bond{bond_idx}nncp-worker-1",
         bond_name=f"bond{bond_idx}",
         bond_ports=nodes_available_nics[worker_node1.name][-2:],
@@ -58,6 +60,7 @@ def ovs_linux_bond1_worker_1(
 
 @pytest.fixture(scope="class")
 def ovs_linux_bond1_worker_2(
+    admin_client,
     index_number,
     worker_node2,
     nodes_available_nics,
@@ -70,6 +73,7 @@ def ovs_linux_bond1_worker_2(
     with (
         BondNodeNetworkConfigurationPolicy(
             name=f"bond{bond_idx}nncp-worker-2",
+            client=admin_client,
             bond_name=ovs_linux_bond1_worker_1.bond_name,  # Use the same BOND name for each test.
             bond_ports=nodes_available_nics[worker_node2.name][-2:],
             node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
@@ -80,6 +84,7 @@ def ovs_linux_bond1_worker_2(
 
 @pytest.fixture(scope="class")
 def ovs_linux_bridge_on_bond_worker_1(
+    admin_client,
     bridge_device_matrix__class__,
     worker_node1,
     ovs_linux_br1bond_nad,
@@ -94,12 +99,14 @@ def ovs_linux_bridge_on_bond_worker_1(
         interface_name=ovs_linux_br1bond_nad.bridge_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[ovs_linux_bond1_worker_1.bond_name],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="class")
 def ovs_linux_bridge_on_bond_worker_2(
+    admin_client,
     bridge_device_matrix__class__,
     worker_node2,
     ovs_linux_br1bond_nad,
@@ -114,6 +121,7 @@ def ovs_linux_bridge_on_bond_worker_2(
         interface_name=ovs_linux_br1bond_nad.bridge_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[ovs_linux_bond1_worker_2.bond_name],
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/connectivity/conftest.py
+++ b/tests/network/connectivity/conftest.py
@@ -35,6 +35,7 @@ def fail_if_not_ipv6_supported_cluster(ipv6_supported_cluster):
 
 @pytest.fixture(scope="class")
 def nncp_linux_bridge_device_worker_1_source(
+    admin_client,
     nodes_available_nics,
     worker_node1,
     bridge_device_name,
@@ -45,12 +46,14 @@ def nncp_linux_bridge_device_worker_1_source(
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="class")
 def nncp_ovs_bridge_device_worker_1_source(
+    admin_client,
     nodes_available_nics,
     worker_node1,
     bridge_device_name,
@@ -61,12 +64,14 @@ def nncp_ovs_bridge_device_worker_1_source(
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="class")
 def nncp_linux_bridge_device_worker_2_destination(
+    admin_client,
     nodes_available_nics,
     worker_node2,
     bridge_device_name,
@@ -77,12 +82,14 @@ def nncp_linux_bridge_device_worker_2_destination(
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="class")
 def nncp_ovs_bridge_device_worker_2_destination(
+    admin_client,
     nodes_available_nics,
     worker_node2,
     bridge_device_name,
@@ -93,6 +100,7 @@ def nncp_ovs_bridge_device_worker_2_destination(
         interface_name=bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/dry_run/test_dry_run_kubemacpool.py
+++ b/tests/network/dry_run/test_dry_run_kubemacpool.py
@@ -32,12 +32,13 @@ def create_dry_run_vm(name, namespace, networks, unprivileged_client, macs=None)
 
 
 @pytest.fixture()
-def bridge_on_all_nodes():
+def bridge_on_all_nodes(admin_client):
     bridge_name = "br-dry-run-test"
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"{bridge_name}-nncp",
         interface_name=bridge_name,
+        client=admin_client,
     ) as dev:
         yield dev
 

--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -104,28 +104,31 @@ def multi_bridge_attached_vmi(namespace, bridge_networks, unprivileged_client):
 
 
 @pytest.fixture()
-def bridge_device_on_all_nodes():
+def bridge_device_on_all_nodes(admin_client):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="bridge-marker1",
         interface_name=BRIDGEMARKER1,
+        client=admin_client,
     ) as dev:
         yield dev
 
 
 @pytest.fixture()
-def non_homogenous_bridges(worker_node1, worker_node2):
+def non_homogenous_bridges(admin_client, worker_node1, worker_node2):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="bridge-marker2",
         interface_name=BRIDGEMARKER2,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
+        client=admin_client,
     ) as bridgemarker2_ncp:
         with network_device(
             interface_type=LINUX_BRIDGE,
             nncp_name="bridge-marker3",
             interface_name=BRIDGEMARKER3,
             node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
+            client=admin_client,
         ) as bridgemarker3_ncp:
             yield bridgemarker2_ncp, bridgemarker3_ncp
 

--- a/tests/network/general/test_cnv_tuning_regression.py
+++ b/tests/network/general/test_cnv_tuning_regression.py
@@ -21,12 +21,13 @@ def linux_bridge_nad(admin_client, namespace):
 
 
 @pytest.fixture()
-def linux_bridge_device(worker_node1, linux_bridge_nad):
+def linux_bridge_device(admin_client, worker_node1, linux_bridge_nad):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="cnv-tuning-nncp",
         interface_name=linux_bridge_nad.bridge_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
+        client=admin_client,
     ) as dev:
         yield dev
 

--- a/tests/network/jumbo_frame/conftest.py
+++ b/tests/network/jumbo_frame/conftest.py
@@ -121,13 +121,14 @@ def secondary_linux_bridge_nad(admin_client, namespace, linux_bridge_interface):
 
 
 @pytest.fixture(scope="module")
-def linux_bridge_interface(hosts_common_available_ports):
+def linux_bridge_interface(admin_client, hosts_common_available_ports):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="sec-br",
         interface_name="sec-br",
         ports=[hosts_common_available_ports[-1]],
         node_selector_labels={WORKER_NODE_LABEL_KEY: ""},
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -35,6 +35,7 @@ pytestmark = [
 
 @pytest.fixture(scope="class")
 def jumbo_frame_bond1_worker_1(
+    admin_client,
     cluster_hardware_mtu,
     index_number,
     worker_node1,
@@ -44,6 +45,7 @@ def jumbo_frame_bond1_worker_1(
     Create BOND if setup support BOND
     """
     with BondNodeNetworkConfigurationPolicy(
+        client=admin_client,
         name=f"jumbo-frame-bond{next(index_number)}-nncp",
         bond_name=BOND_NAME,
         bond_ports=nodes_available_nics[worker_node1.name][-2:],
@@ -55,6 +57,7 @@ def jumbo_frame_bond1_worker_1(
 
 @pytest.fixture(scope="class")
 def jumbo_frame_bond1_worker_2(
+    admin_client,
     cluster_hardware_mtu,
     index_number,
     worker_node2,
@@ -64,6 +67,7 @@ def jumbo_frame_bond1_worker_2(
     Create BOND if setup support BOND
     """
     with BondNodeNetworkConfigurationPolicy(
+        client=admin_client,
         name=f"jumbo-frame-bond{next(index_number)}-nncp",
         bond_name=BOND_NAME,
         bond_ports=nodes_available_nics[worker_node2.name][-2:],
@@ -75,6 +79,7 @@ def jumbo_frame_bond1_worker_2(
 
 @pytest.fixture(scope="class")
 def jumbo_frame_bridge_on_bond_worker_1(
+    admin_client,
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     jumbo_frame_bond1_worker_1,
@@ -89,12 +94,14 @@ def jumbo_frame_bridge_on_bond_worker_1(
         node_selector=jumbo_frame_bond1_worker_1.node_selector,
         ports=[jumbo_frame_bond1_worker_1.bond_name],
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="class")
 def jumbo_frame_bridge_on_bond_worker_2(
+    admin_client,
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     jumbo_frame_bond1_worker_2,
@@ -109,6 +116,7 @@ def jumbo_frame_bridge_on_bond_worker_2(
         node_selector=jumbo_frame_bond1_worker_2.node_selector,
         ports=[jumbo_frame_bond1_worker_2.bond_name],
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -34,6 +34,7 @@ def jumbo_frame_bridge_device_name(index_number):
 
 @pytest.fixture(scope="class")
 def jumbo_frame_bridge_device_worker_1(
+    admin_client,
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     worker_node1,
@@ -47,12 +48,14 @@ def jumbo_frame_bridge_device_worker_1(
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.name][-1]],
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="class")
 def jumbo_frame_bridge_device_worker_2(
+    admin_client,
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     worker_node2,
@@ -66,6 +69,7 @@ def jumbo_frame_bridge_device_worker_2(
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.name][-1]],
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -19,6 +19,7 @@ def kubemacpool_bridge_device_name(index_number):
 
 @pytest.fixture(scope="module")
 def kubemacpool_bridge_device_worker_1(
+    admin_client,
     worker_node1,
     kubemacpool_bridge_device_name,
     nodes_available_nics,
@@ -29,12 +30,14 @@ def kubemacpool_bridge_device_worker_1(
         interface_name=kubemacpool_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.name][-1]],
+        client=admin_client,
     ) as dev:
         yield dev
 
 
 @pytest.fixture(scope="module")
 def kubemacpool_bridge_device_worker_2(
+    admin_client,
     worker_node2,
     kubemacpool_bridge_device_name,
     nodes_available_nics,
@@ -45,6 +48,7 @@ def kubemacpool_bridge_device_worker_2(
         interface_name=kubemacpool_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.name][-1]],
+        client=admin_client,
     ) as dev:
         yield dev
 

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -53,6 +53,7 @@ def l2_bridge_device_name(index_number):
 
 @pytest.fixture(scope="class")
 def l2_bridge_device_worker_1(
+    admin_client,
     bridge_device_matrix__class__,
     nodes_available_nics,
     worker_node1,
@@ -64,12 +65,14 @@ def l2_bridge_device_worker_1(
         interface_name=l2_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="class")
 def l2_bridge_device_worker_2(
+    admin_client,
     bridge_device_matrix__class__,
     nodes_available_nics,
     worker_node2,
@@ -81,6 +84,7 @@ def l2_bridge_device_worker_2(
         interface_name=l2_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -46,10 +46,11 @@ def running_vm_for_nic_hot_plug(namespace, unprivileged_client):
 
 
 @pytest.fixture(scope="module")
-def bridge_interface_for_hot_plug(hosts_common_available_ports):
+def bridge_interface_for_hot_plug(admin_client, hosts_common_available_ports):
     yield from create_bridge_interface_for_hot_plug(
         bridge_name=f"{HOT_PLUG_STR}-br",
         bridge_port=hosts_common_available_ports[-1],
+        client=admin_client,
     )
 
 
@@ -176,12 +177,13 @@ def running_vm_for_jumbo_nic_hot_plug(namespace, unprivileged_client):
 
 
 @pytest.fixture()
-def bridge_jumbo_interface_for_hot_plug(hosts_common_available_ports, cluster_hardware_mtu):
+def bridge_jumbo_interface_for_hot_plug(admin_client, hosts_common_available_ports, cluster_hardware_mtu):
     yield from create_bridge_interface_for_hot_plug(
         bridge_name=f"{HOT_PLUG_STR}-jumbo",
         # hosts_common_available_ports[-1] is already used for another tests bridge.
         bridge_port=hosts_common_available_ports[-2],
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     )
 
 

--- a/tests/network/l2_bridge/utils.py
+++ b/tests/network/l2_bridge/utils.py
@@ -171,6 +171,7 @@ def update_hot_plug_config_in_vm(vm, interfaces, networks=None):
 def create_bridge_interface_for_hot_plug(
     bridge_name,
     bridge_port,
+    client,
     mtu=None,
 ):
     with network_device(
@@ -182,6 +183,7 @@ def create_bridge_interface_for_hot_plug(
         ipv4_dhcp=True,
         node_selector_labels=NODE_TYPE_WORKER_LABEL,
         mtu=mtu,
+        client=client,
     ) as br:
         yield br
 

--- a/tests/network/libs/nodenetworkconfigurationpolicy.py
+++ b/tests/network/libs/nodenetworkconfigurationpolicy.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.exceptions import NNCPConfigurationFailed
 from ocp_resources.node_network_configuration_policy_latest import NodeNetworkConfigurationPolicy as Nncp
 from ocp_resources.resource import Resource, ResourceEditor
@@ -109,6 +110,7 @@ class NodeNetworkConfigurationPolicy(Nncp):
 
     def __init__(
         self,
+        client: DynamicClient,
         name: str,
         desired_state: DesiredState,
         node_selector: dict[str, str] | None = None,
@@ -121,10 +123,12 @@ class NodeNetworkConfigurationPolicy(Nncp):
             desired_state (DesiredState): Desired policy configuration - interface creation, modification or removal.
             node_selector (dict, optional): A node selector that specifies the nodes to apply the node network
                 configuration policy to.
+            client: Dynamic client used to interact with the cluster.
         """
         self._desired_state = desired_state
         super().__init__(
             name=name,
+            client=client,
             desired_state=asdict(desired_state, dict_factory=dict_normalization_for_dataclass),
             node_selector=node_selector,
             wait_for_resource=True,

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -41,7 +41,7 @@ PRIMARY_INTERFACE_NAME = "eth0"
 
 
 @pytest.fixture(scope="module")
-def nncp_localnet() -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
+def nncp_localnet(admin_client: DynamicClient) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
     desired_state = libnncp.DesiredState(
         ovn=libnncp.OVN([
             libnncp.BridgeMappings(
@@ -53,6 +53,7 @@ def nncp_localnet() -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
     )
 
     with libnncp.NodeNetworkConfigurationPolicy(
+        client=admin_client,
         name="test-localnet-nncp",
         desired_state=desired_state,
         node_selector={WORKER_NODE_LABEL_KEY: ""},
@@ -359,18 +360,26 @@ def migrated_localnet_vm(
 
 @pytest.fixture(scope="module")
 def nncp_localnet_on_secondary_node_nic(
+    admin_client: DynamicClient,
     hosts_common_available_ports: list[str],
 ) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
-    with create_nncp_localnet_on_secondary_node_nic(node_nic_name=(hosts_common_available_ports[-1])) as nncp:
+    with create_nncp_localnet_on_secondary_node_nic(
+        node_nic_name=(hosts_common_available_ports[-1]),
+        client=admin_client,
+    ) as nncp:
         yield nncp
 
 
 @pytest.fixture(scope="module")
 def nncp_localnet_on_secondary_node_nic_with_jumbo_frame(
-    hosts_common_available_ports: list[str], cluster_hardware_mtu: int
+    admin_client: DynamicClient,
+    hosts_common_available_ports: list[str],
+    cluster_hardware_mtu: int,
 ) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
     with create_nncp_localnet_on_secondary_node_nic(
-        node_nic_name=(hosts_common_available_ports[-1]), mtu=cluster_hardware_mtu
+        node_nic_name=(hosts_common_available_ports[-1]),
+        client=admin_client,
+        mtu=cluster_hardware_mtu,
     ) as nncp:
         yield nncp
 

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -224,6 +224,7 @@ def client_server_active_connection(
 @contextlib.contextmanager
 def create_nncp_localnet_on_secondary_node_nic(
     node_nic_name: str,
+    client: DynamicClient,
     mtu: int | None = None,
 ) -> Generator[libnncp.NodeNetworkConfigurationPolicy, None, None]:
     """Create NNCP to configure an OVS bridge on a secondary NIC across all worker nodes.
@@ -234,6 +235,7 @@ def create_nncp_localnet_on_secondary_node_nic(
 
     Args:
         node_nic_name: Name of the available NIC on all nodes.
+        client: Dynamic client used to create and manage the NNCP resource.
         mtu: Optional MTU to configure on the physical NIC.
 
     Yields:
@@ -282,6 +284,7 @@ def create_nncp_localnet_on_secondary_node_nic(
         ]),
     )
     with libnncp.NodeNetworkConfigurationPolicy(
+        client=client,
         name=bridge_name,
         desired_state=desired_state,
         node_selector={WORKER_NODE_LABEL_KEY: ""},

--- a/tests/network/macspoof/conftest.py
+++ b/tests/network/macspoof/conftest.py
@@ -58,25 +58,27 @@ def set_vm_interface_network_mac(vm, mac):
 
 
 @pytest.fixture(scope="class")
-def linux_bridge_device_worker_1(nodes_available_nics, worker_node1):
+def linux_bridge_device_worker_1(admin_client, nodes_available_nics, worker_node1):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"bridge-{name_prefix(worker_node1.hostname)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.hostname][-1]],
+        client=admin_client,
     ) as br_dev:
         yield br_dev
 
 
 @pytest.fixture(scope="class")
-def linux_bridge_device_worker_2(nodes_available_nics, worker_node2):
+def linux_bridge_device_worker_2(admin_client, nodes_available_nics, worker_node2):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"bridge-{name_prefix(worker_node2.hostname)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.hostname][-1]],
+        client=admin_client,
     ) as br_dev:
         yield br_dev
 

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -64,6 +64,7 @@ def http_port_accessible(vm, server_ip, server_port):
 
 @pytest.fixture(scope="module")
 def bridge_worker_1(
+    admin_client,
     worker_node1,
     nodes_available_nics,
 ):
@@ -73,12 +74,14 @@ def bridge_worker_1(
         interface_name="migration-br",
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 
 
 @pytest.fixture(scope="module")
 def bridge_worker_2(
+    admin_client,
     worker_node2,
     nodes_available_nics,
     bridge_worker_1,
@@ -89,6 +92,7 @@ def bridge_worker_2(
         interface_name=bridge_worker_1.bridge_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.name][-1]],
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/network/nmstate/conftest.py
+++ b/tests/network/nmstate/conftest.py
@@ -71,6 +71,7 @@ def running_nmstate_vmb(nmstate_vmb):
 
 @pytest.fixture(scope="module")
 def bridge_on_management_ifaces_node1(
+    admin_client,
     worker_nodes_management_iface_stats,
     worker_node1,
     workers_utility_pods,
@@ -86,6 +87,7 @@ def bridge_on_management_ifaces_node1(
         ports=[management_iface],
         ipv4_enable=True,
         ipv4_dhcp=True,
+        client=admin_client,
     ) as br_dev:
         # Wait for bridge to get management IP
         wait_for_address_on_iface(worker_pod=worker_pod, iface_name=br_dev.bridge_name)
@@ -97,6 +99,7 @@ def bridge_on_management_ifaces_node1(
 
 @pytest.fixture(scope="module")
 def bridge_on_management_ifaces_node2(
+    admin_client,
     workers_utility_pods,
     worker_nodes_management_iface_stats,
     worker_node2,
@@ -112,6 +115,7 @@ def bridge_on_management_ifaces_node2(
         ports=[management_iface],
         ipv4_enable=True,
         ipv4_dhcp=True,
+        client=admin_client,
     ) as br_dev:
         # Wait for bridge to get management IP
         wait_for_address_on_iface(worker_pod=worker_pod, iface_name=br_dev.bridge_name)

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -46,25 +46,27 @@ def restart_nmstate_handler(admin_client, nmstate_ds, nmstate_namespace):
 
 
 @pytest.fixture(scope="class")
-def nmstate_linux_bridge_device_worker_1(nodes_available_nics, worker_node1):
+def nmstate_linux_bridge_device_worker_1(admin_client, nodes_available_nics, worker_node1):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"restart-nmstate-{name_prefix(worker_node1.name)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         ports=[nodes_available_nics[worker_node1.name][-1]],
+        client=admin_client,
     ) as br_dev:
         yield br_dev
 
 
 @pytest.fixture(scope="class")
-def nmstate_linux_bridge_device_worker_2(nodes_available_nics, worker_node2):
+def nmstate_linux_bridge_device_worker_2(admin_client, nodes_available_nics, worker_node2):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=f"restart-nmstate-{name_prefix(worker_node2.name)}",
         interface_name=BRIDGE_NAME,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         ports=[nodes_available_nics[worker_node2.name][-1]],
+        client=admin_client,
     ) as br_dev:
         yield br_dev
 

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -46,11 +46,12 @@ def skip_non_shared_storage(storage_class_name_scope_function):
 
 
 @pytest.fixture()
-def bridge_on_node():
+def bridge_on_node(admin_client):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=BRIDGE_NAME,
         interface_name=BRIDGE_NAME,
+        client=admin_client,
     ) as br:
         yield br
 

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -111,11 +111,12 @@ def initialize_and_format_windows_drive(vm, disk_number, partition_number, drive
 
 
 @pytest.fixture(scope="class")
-def windows_custom_bridge():
+def windows_custom_bridge(admin_client):
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name="br1-win-custom-nnc",
         interface_name="br1-win-custom",
+        client=admin_client,
     ) as br:
         yield br
 


### PR DESCRIPTION
##### Short description:
Make NNCP-related classes take a mandatory DynamicClient and update all NNCP-related fixtures to pass an admin_client explicitly (no implicit default clients).

NNCPs are cluster-wide resources, that affect cluster nodes. For this reason project admins cannot apply them and they must be applied by cluster admin (privileged clients).

##### What this PR does / why we need it:
As of its next releas, openshift-python-wrapper will enforce passing `client` when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources  should be updated to pass `client` arg.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Many test fixtures across networking, storage, and virtualization now accept and use an admin-level client so bridge, bond, VLAN and related setups run with authenticated/admin context.
* **Chores**
  * Network helpers and policy constructors updated to accept and consistently forward an admin client, enabling admin-authenticated network operations in tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->