### PR TITLE
[gating][storage] Fix snapshot readiness wait logic in DataImportCron tests and restore gating marker test_data_import_cron_garbage_collection

### DIFF
--- a/tests/storage/test_data_import_cron.py
+++ b/tests/storage/test_data_import_cron.py
@@ -206,6 +206,7 @@ def second_object_cleanup(
     resource_class(namespace=namespace.name, name=second_object_name).clean_up()
 
 
+@pytest.mark.gating
 @pytest.mark.polarion("CNV-7602")
 @pytest.mark.s390x
 def test_data_import_cron_garbage_collection(

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1013,6 +1013,7 @@ def wait_for_volume_snapshot_ready_to_use(namespace, name):
     ready_to_use_status = "readyToUse"
     LOGGER.info(f"Wait for VolumeSnapshot '{name}' in '{namespace}' to be '{ready_to_use_status}'")
     volume_snapshot = VolumeSnapshot(namespace=namespace, name=name)
+    volume_snapshot.wait()
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_5MIN,
@@ -1020,6 +1021,7 @@ def wait_for_volume_snapshot_ready_to_use(namespace, name):
             func=lambda: volume_snapshot.instance.get("status", {}).get(ready_to_use_status) is True,
         ):
             if sample:
+                LOGGER.info(f"VolumeSnapshot '{name}' in namespace '{namespace}' reached '{ready_to_use_status}'")
                 return volume_snapshot
     except TimeoutExpiredError:
         fail_msg = f"failed to reach {ready_to_use_status} status" if volume_snapshot.exists else "failed to create"


### PR DESCRIPTION
Fix DataImportCron test failures by properly waiting for VolumeSnapshot readiness using volume_snapshot.wait().
also  return gating marker to test_data_import_cron_garbage_collection test


##### Short description:
DataImportCron tests were failing intermittently because the tests attempted to check VolumeSnapshot.readyToUse before the VolumeSnapshot resource actually existed.
This caused NotFoundError exceptions inside a TimeoutSampler, immediately failing instead of retrying.

gating test failing due to this ::test_data_import_cron_garbage_collection




##### More details:
volume_snapshot.wait() already handles:

waiting for the VolumeSnapshot to be created

waiting for it to become readyToUse=True

retrying on NotFound errors

##### What this PR does / why we need it:

minates the race condition between DataVolume completion and VolumeSnapshot creation.

Ensures proper dependency order: DataVolume → VolumeSnapshot.

Simplifies waiting logic by relying on volume_snapshot.wait() 

Resolves intermittent test failures caused by NotFoundError.

#####Evidence from cluster outputs:

DataVolume importing (28s-39s) - NO new VolumeSnapshot exists
test-data-import-cron rhel8-947541648d7f ImportInProgress 56.20%→99.38%
test-data-import-cron rhel8-752e28b38ddc true (old snapshot)

data import cron trigger

*here is where the code fails) he is looking for VS test-data-import-cron rhel8-947541648d7f but he didnt find it
because the dv import is not finished

DataVolume completes (42s) - NEW VolumeSnapshot appears immediately
test-data-import-cron rhel8-947541648d7f Succeeded
test-data-import-cron rhel8-947541648d7f true (new snapshot appears)

##### Which issue(s) this PR fixes:

failed on setup with "ocp_resources.utils.TimeoutExpiredError: Timed Out: 300 Function: utilities.storage..lambda: ready_to_use_status.volume_snapshot.instance.get Last exception: TimeoutExpiredError: Timed Out: 10 Function: ocp_resources.resource._instance Last exception: NotFoundError: 404 Reason: Not Found HTTP response headers: HTTPHeaderDict({'Audit-Id': '0e5e11dc-0117-45b3-88dd-2fba45913c12', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': 'fe96e2ca-91ff-4a85-bf1d-bb59abcaa930', 'X-Kubernetes-Pf-Prioritylevel-Uid': '7bcbdcef-aabb-4204-b6f5-1da13f0745ee', 'Date': 'Tue, 21 Oct 2025 20:19:19 GMT', 'Content-Length': '284'}) HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"volumesnapshots.snapshot.storage.k8s.io \"rhel8-947541648d7f\" not found","reason":"NotFound","details":{"name":"rhel8-947541648d7f","group":"snapshot.storage.k8s.io","kind":"volumesnapshots"},"code":404}\n' Original traceback: File "/cnv-tests/.venv/lib/python3.12/site-packages/kubernetes/dynamic/client.py", line 55, in inner resp = func(self, *args, **kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/cnv-tests/.venv/lib/python3.12/site-packages/kubernetes/dynamic/client.py", line 270, in request api_response = self.client.call_api( ^^^^^^^^^^^^^^^^^^^^^ File "/cnv-tests/.venv/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 348, in call_api return self.__call_api(resource_path, method, ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/cnv-tests/.venv/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 180, in __call_api response_data = self.request( ^^^^^^^^^^^^^ File "/cnv-tests/.venv/lib/python3.12/site-packages/kubernetes/client/api_client.py", line 373, in request return self.rest_client.GET(url, ^^^^^^^^^^^^^^^^^^^^^^^^^ File "/cnv-tests/.venv/lib/python3.12/site-packages/kubernetes/client/rest.py", line 241, in GET return self.request("GET", url, ^^^^^^^^^^^^^^^^^^^^^^^^ File "/cnv-tests/.venv/lib/python3.12/site-packages/kubernetes/client/rest.py", line 235, in request raise ApiException(http_resp=r)"

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-72441
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Volume snapshot flow now waits explicitly for readiness and emits success and timeout logs to improve reliability and diagnostics.

* **Tests**
  * A storage-related test was marked with a gating marker to refine test discovery and selection for targeted runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->