### PR TITLE
Add istio-ca-crl to the allowed list

### DIFF
--- a/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
@@ -29,6 +29,7 @@ ALLOWLIST_STRING_LIST = [
     "hyperconverged-cluster-operator-lock",
     "kubevirt-ipam-controller-webhook-service",
     "istio-ca-root-cert",
+    "istio-ca-crl",
 ]
 PRINT_COMMAND = '{printf "%s%s",sep,$0;sep=","}'
 AWK_COMMAND = f"awk '{PRINT_COMMAND}'"
@@ -136,7 +137,7 @@ def test_relationship_labels_all_cnv_resources(
 
                         else:
                             errors.setdefault(kind, []).append(
-                                f"{name} has missing labels: {labels} and is not managed by olm"
+                                f'{name} has missing labels. Current labels are "{labels}" and is not managed by olm'
                             )
             else:
                 errors.setdefault(kind, []).append(f"{name} resource not found")


### PR DESCRIPTION
##### Short description:
Istio 1.19 includes a new feature Certificate Revocation List (CRL).
As a consequence, a new configMap is appearing on the openshift-cnv namespace called `istio-ca-crl`.
This PR is adding it to the list of allowed elements in the openshfit-cnv.

##### More details:
Follow-up of https://github.com/RedHatQE/openshift-virtualization-tests/pull/1044

##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message clarity for missing labels, now displaying label information in a more readable format.
  * Added support for "istio-ca-crl" label handling in resource validation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->