### PR TITLE
 infra/tests, net, nad: mandatory client for NAD

### DIFF
--- a/libs/net/netattachdef.py
+++ b/libs/net/netattachdef.py
@@ -120,8 +120,8 @@ class NetworkAttachmentDefinition(NamespacedResource):
         name: str,
         namespace: str,
         config: NetConfig,
+        client: DynamicClient,
         resource_name: str | None = None,
-        client: DynamicClient | None = None,
     ):
         """
         Create and manage NetworkAttachmentDefinition
@@ -132,7 +132,7 @@ class NetworkAttachmentDefinition(NamespacedResource):
             config (NetConfig): Configuration body, as defined by the CNI spec.
             resource_name (str): Optional resource name marking
                 (set on the object annotations).
-            client: (DynamicClient): Optional DynamicClient to use.
+            client (DynamicClient): Dynamic client used to interact with the cluster.
         """
         super().__init__(
             name=name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1695,12 +1695,13 @@ def bridge_on_one_node(worker_node1):
 
 
 @pytest.fixture(scope="session")
-def upgrade_bridge_marker_nad(bridge_on_one_node, kmp_enabled_namespace, worker_node1):
+def upgrade_bridge_marker_nad(admin_client, bridge_on_one_node, kmp_enabled_namespace, worker_node1):
     with network_nad(
         nad_type=LINUX_BRIDGE,
         nad_name=bridge_on_one_node.bridge_name,
         interface_name=bridge_on_one_node.bridge_name,
         namespace=kmp_enabled_namespace,
+        client=admin_client,
     ) as nad:
         wait_for_node_marked_by_bridge(bridge_nad=nad, node=worker_node1)
         yield nad
@@ -1751,12 +1752,13 @@ def running_vm_upgrade_b(
 
 
 @pytest.fixture(scope="session")
-def upgrade_br1test_nad(upgrade_namespace_scope_session, upgrade_bridge_on_all_nodes):
+def upgrade_br1test_nad(admin_client, upgrade_namespace_scope_session, upgrade_bridge_on_all_nodes):
     with network_nad(
         nad_type=LINUX_BRIDGE,
         nad_name=upgrade_bridge_on_all_nodes.bridge_name,
         interface_name=upgrade_bridge_on_all_nodes.bridge_name,
         namespace=upgrade_namespace_scope_session,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/infrastructure/sap/test_sap_hana_vm.py
+++ b/tests/infrastructure/sap/test_sap_hana_vm.py
@@ -340,7 +340,7 @@ def sriov_network_node_policy(admin_client, sriov_namespace):
 
 
 @pytest.fixture(scope="class")
-def sriov_nads(namespace, sriov_network_node_policy, sriov_namespace):
+def sriov_nads(admin_client, namespace, sriov_network_node_policy, sriov_namespace):
     nads_list = []
     for idx in range(REQUIRED_NUMBER_OF_NETWORKS):
         with network_nad(
@@ -351,6 +351,7 @@ def sriov_nads(namespace, sriov_network_node_policy, sriov_namespace):
             sriov_network_namespace=namespace.name,
             macspoofchk="off",
             teardown=False,
+            client=admin_client,
         ) as nad:
             nads_list.append(nad)
     yield nads_list

--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -149,12 +149,13 @@ def kubevirt_crd_by_type(cnv_crd_matrix__function__, kubevirt_crd_resources, kub
 
 
 @pytest.fixture(scope="package")
-def must_gather_nad(must_gather_bridge, node_gather_unprivileged_namespace, worker_node1):
+def must_gather_nad(admin_client, must_gather_bridge, node_gather_unprivileged_namespace, worker_node1):
     with network_nad(
         nad_type=must_gather_bridge.bridge_type,
         nad_name=must_gather_bridge.bridge_name,
         interface_name=must_gather_bridge.bridge_name,
         namespace=node_gather_unprivileged_namespace,
+        client=admin_client,
     ) as must_gather_nad:
         wait_for_node_marked_by_bridge(bridge_nad=must_gather_nad, node=worker_node1)
         yield must_gather_nad

--- a/tests/network/bond/test_bond_modes.py
+++ b/tests/network/bond/test_bond_modes.py
@@ -83,12 +83,13 @@ def matrix_bond_modes_bond(
 
 
 @pytest.fixture()
-def bond_modes_nad(bridge_device_matrix__function__, namespace, matrix_bond_modes_bond):
+def bond_modes_nad(admin_client, bridge_device_matrix__function__, namespace, matrix_bond_modes_bond):
     with network_nad(
         namespace=namespace,
         nad_type=bridge_device_matrix__function__,
         nad_name=f"bond-nad-{matrix_bond_modes_bond.bond_name}",
         interface_name=f"br{matrix_bond_modes_bond.bond_name}",
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -26,12 +26,13 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.fixture(scope="class")
-def ovs_linux_br1bond_nad(bridge_device_matrix__class__, namespace):
+def ovs_linux_br1bond_nad(admin_client, bridge_device_matrix__class__, namespace):
     with network_nad(
         namespace=namespace,
         nad_type=bridge_device_matrix__class__,
         nad_name="br1bond-nad",
         interface_name="br1bond",
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -145,6 +145,7 @@ def vlan_index_number(vlans_list):
 
 @pytest.fixture(scope="module")
 def brcnv_ovs_nad_vlan_1(
+    admin_client,
     hyperconverged_ovs_annotations_enabled_scope_session,
     namespace,
     vlan_index_number,
@@ -156,6 +157,7 @@ def brcnv_ovs_nad_vlan_1(
         nad_name=f"{BRCNV}-{vlan_tag}",
         interface_name=BRCNV,
         vlan=vlan_tag,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/connectivity/conftest.py
+++ b/tests/network/connectivity/conftest.py
@@ -99,6 +99,7 @@ def nncp_ovs_bridge_device_worker_2_destination(
 
 @pytest.fixture(scope="class")
 def nad_linux_bridge(
+    admin_client,
     namespace,
     nncp_linux_bridge_device_worker_1_source,
     nncp_linux_bridge_device_worker_2_destination,
@@ -109,12 +110,14 @@ def nad_linux_bridge(
         nad_type=LINUX_BRIDGE,
         nad_name=f"linux-{bridge_device_name}-nad",
         interface_name=bridge_device_name,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def nad_ovs_bridge(
+    admin_client,
     namespace,
     nncp_ovs_bridge_device_worker_1_source,
     nncp_ovs_bridge_device_worker_2_destination,
@@ -125,12 +128,14 @@ def nad_ovs_bridge(
         nad_type=OVS_BRIDGE,
         nad_name=f"ovs-{bridge_device_name}-nad",
         interface_name=bridge_device_name,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def nad_linux_bridge_vlan_1(
+    admin_client,
     namespace,
     nncp_linux_bridge_device_worker_1_source,
     nncp_linux_bridge_device_worker_2_destination,
@@ -143,12 +148,14 @@ def nad_linux_bridge_vlan_1(
         nad_name=f"linux-{bridge_device_name}-vlan{vlan_id_1}-nad",
         interface_name=bridge_device_name,
         vlan=vlan_id_1,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def nad_ovs_bridge_vlan_1(
+    admin_client,
     namespace,
     nncp_ovs_bridge_device_worker_1_source,
     nncp_ovs_bridge_device_worker_2_destination,
@@ -161,12 +168,14 @@ def nad_ovs_bridge_vlan_1(
         nad_name=f"ovs-{bridge_device_name}-vlan{vlan_id_1}-nad",
         interface_name=bridge_device_name,
         vlan=vlan_id_1,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def nad_linux_bridge_vlan_2(
+    admin_client,
     namespace,
     nncp_linux_bridge_device_worker_1_source,
     nncp_linux_bridge_device_worker_2_destination,
@@ -179,12 +188,14 @@ def nad_linux_bridge_vlan_2(
         nad_name=f"linux-{bridge_device_name}-vlan{vlan_id_2}-nad",
         interface_name=bridge_device_name,
         vlan=vlan_id_2,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def nad_ovs_bridge_vlan_2(
+    admin_client,
     namespace,
     nncp_ovs_bridge_device_worker_1_source,
     nncp_ovs_bridge_device_worker_2_destination,
@@ -197,12 +208,14 @@ def nad_ovs_bridge_vlan_2(
         nad_name=f"ovs-{bridge_device_name}-vlan{vlan_id_2}-nad",
         interface_name=bridge_device_name,
         vlan=vlan_id_2,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def nad_linux_bridge_vlan_3(
+    admin_client,
     namespace,
     nncp_linux_bridge_device_worker_1_source,
     nncp_linux_bridge_device_worker_2_destination,
@@ -215,12 +228,14 @@ def nad_linux_bridge_vlan_3(
         nad_name=f"linux-{bridge_device_name}-vlan{vlan_id_3}-nad",
         interface_name=bridge_device_name,
         vlan=vlan_id_3,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def nad_ovs_bridge_vlan_3(
+    admin_client,
     namespace,
     nncp_ovs_bridge_device_worker_1_source,
     nncp_ovs_bridge_device_worker_2_destination,
@@ -233,6 +248,7 @@ def nad_ovs_bridge_vlan_3(
         nad_name=f"ovs-{bridge_device_name}-vlan{vlan_id_3}-nad",
         interface_name=bridge_device_name,
         vlan=vlan_id_3,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/dry_run/test_dry_run_kubemacpool.py
+++ b/tests/network/dry_run/test_dry_run_kubemacpool.py
@@ -43,12 +43,13 @@ def bridge_on_all_nodes():
 
 
 @pytest.fixture()
-def linux_bridge_network_nad(namespace, bridge_on_all_nodes):
+def linux_bridge_network_nad(admin_client, namespace, bridge_on_all_nodes):
     with network_nad(
         nad_type=bridge_on_all_nodes.bridge_type,
         nad_name=f"{bridge_on_all_nodes.bridge_name}-nad",
         interface_name=bridge_on_all_nodes.bridge_name,
         namespace=namespace,
+        client=admin_client,
     ) as dry_run_nad:
         yield dry_run_nad
 

--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -82,19 +82,20 @@ def flat_overlay_second_namespace(admin_client, unprivileged_client):
 
 
 @pytest.fixture(scope="class")
-def flat_overlay_vma_vmb_nad(namespace):
+def flat_overlay_vma_vmb_nad(admin_client, namespace):
     with network_nad(
         nad_type=FLAT_OVERLAY_STR,
         network_name=FLAT_OVERLAY_VMA_VMB_NETWORK_NAME,
         nad_name=FLAT_OVERLAY_VMA_VMB_NAD_NAME,
         namespace=namespace,
         topology=LAYER2,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
-def flat_overlay_vmc_vmd_nad(namespace):
+def flat_overlay_vmc_vmd_nad(admin_client, namespace):
     nad_for_vms = "vmc-vmd"
     with network_nad(
         nad_type=FLAT_OVERLAY_STR,
@@ -102,24 +103,26 @@ def flat_overlay_vmc_vmd_nad(namespace):
         nad_name=f"{FLAT_L2_BASIC_NAD_NAME}-{nad_for_vms}",
         namespace=namespace,
         topology=LAYER2,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
-def flat_overlay_vme_nad(flat_overlay_second_namespace):
+def flat_overlay_vme_nad(admin_client, flat_overlay_second_namespace):
     with network_nad(
         nad_type=FLAT_OVERLAY_STR,
         network_name=FLAT_OVERLAY_VMA_VMB_NETWORK_NAME,
         nad_name=FLAT_OVERLAY_VMA_VMB_NAD_NAME,
         namespace=flat_overlay_second_namespace,
         topology=LAYER2,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
-def flat_overlay_jumbo_frame_nad(namespace, cluster_hardware_mtu):
+def flat_overlay_jumbo_frame_nad(admin_client, namespace, cluster_hardware_mtu):
     with network_nad(
         nad_type=FLAT_OVERLAY_STR,
         network_name=f"{FLAT_L2_BASIC_NETWORK_NAME}-jumbo",
@@ -127,6 +130,7 @@ def flat_overlay_jumbo_frame_nad(namespace, cluster_hardware_mtu):
         namespace=namespace,
         mtu=cluster_hardware_mtu,
         topology=LAYER2,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -38,29 +38,32 @@ def _get_name(suffix):
 
 
 @pytest.fixture()
-def bridge_marker_bridge_network(namespace):
+def bridge_marker_bridge_network(admin_client, namespace):
     with network_nad(
         nad_type=LINUX_BRIDGE,
         nad_name=BRIDGEMARKER1,
         interface_name=BRIDGEMARKER1,
         namespace=namespace,
+        client=admin_client,
     ) as attachdef:
         yield attachdef
 
 
 @pytest.fixture()
-def bridge_networks(namespace):
+def bridge_networks(admin_client, namespace):
     with network_nad(
         nad_type=LINUX_BRIDGE,
         nad_name=BRIDGEMARKER2,
         interface_name=BRIDGEMARKER2,
         namespace=namespace,
+        client=admin_client,
     ) as bridgemarker2_nad:
         with network_nad(
             nad_type=LINUX_BRIDGE,
             nad_name=BRIDGEMARKER3,
             interface_name=BRIDGEMARKER3,
             namespace=namespace,
+            client=admin_client,
         ) as bridgemarker3_nad:
             yield bridgemarker2_nad, bridgemarker3_nad
 

--- a/tests/network/general/test_cnv_tuning_regression.py
+++ b/tests/network/general/test_cnv_tuning_regression.py
@@ -8,13 +8,14 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 
 @pytest.fixture()
-def linux_bridge_nad(namespace):
+def linux_bridge_nad(admin_client, namespace):
     with network_nad(
         namespace=namespace,
         nad_type=LINUX_BRIDGE,
         nad_name="br1-nad",
         interface_name="br1bridge",
         tuning=True,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/jumbo_frame/conftest.py
+++ b/tests/network/jumbo_frame/conftest.py
@@ -109,12 +109,13 @@ def running_vme_jumbo_primary_interface_and_secondary_interface(
 
 
 @pytest.fixture()
-def secondary_linux_bridge_nad(namespace, linux_bridge_interface):
+def secondary_linux_bridge_nad(admin_client, namespace, linux_bridge_interface):
     with network_nad(
         namespace=namespace,
         nad_type=linux_bridge_interface.bridge_type,
         nad_name=f"{linux_bridge_interface.name}-nad",
         interface_name=linux_bridge_interface.bridge_name,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -115,6 +115,7 @@ def jumbo_frame_bridge_on_bond_worker_2(
 
 @pytest.fixture(scope="class")
 def br1bond_nad(
+    admin_client,
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     namespace,
@@ -127,6 +128,7 @@ def br1bond_nad(
         nad_name=f"{BRIDGE_NAME}-bond-nad",
         interface_name=jumbo_frame_bridge_on_bond_worker_1.bridge_name,
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -72,6 +72,7 @@ def jumbo_frame_bridge_device_worker_2(
 
 @pytest.fixture(scope="class")
 def br1test_bridge_nad(
+    admin_client,
     cluster_hardware_mtu,
     bridge_device_matrix__class__,
     namespace,
@@ -85,6 +86,7 @@ def br1test_bridge_nad(
         nad_name=f"{jumbo_frame_bridge_device_name}-nad",
         interface_name=jumbo_frame_bridge_device_name,
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -51,6 +51,7 @@ def kubemacpool_bridge_device_worker_2(
 
 @pytest.fixture(scope="module")
 def manual_mac_nad(
+    admin_client,
     namespace,
     kubemacpool_bridge_device_worker_1,
     kubemacpool_bridge_device_worker_2,
@@ -61,12 +62,14 @@ def manual_mac_nad(
         nad_name=f"{kubemacpool_bridge_device_name}-manual-mac-nad",
         interface_name=kubemacpool_bridge_device_name,
         namespace=namespace,
+        client=admin_client,
     ) as manual_mac_nad:
         yield manual_mac_nad
 
 
 @pytest.fixture(scope="module")
 def automatic_mac_nad(
+    admin_client,
     namespace,
     kubemacpool_bridge_device_worker_1,
     kubemacpool_bridge_device_worker_2,
@@ -77,12 +80,14 @@ def automatic_mac_nad(
         nad_name=f"{kubemacpool_bridge_device_name}-automatic-mac-nad",
         interface_name=kubemacpool_bridge_device_name,
         namespace=namespace,
+        client=admin_client,
     ) as automatic_mac_nad:
         yield automatic_mac_nad
 
 
 @pytest.fixture(scope="module")
 def manual_mac_out_of_pool_nad(
+    admin_client,
     namespace,
     kubemacpool_bridge_device_worker_1,
     kubemacpool_bridge_device_worker_2,
@@ -93,12 +98,14 @@ def manual_mac_out_of_pool_nad(
         nad_name=f"{kubemacpool_bridge_device_name}-manual-out-pool-mac-nad",
         interface_name=kubemacpool_bridge_device_name,
         namespace=namespace,
+        client=admin_client,
     ) as manual_mac_out_pool_nad:
         yield manual_mac_out_pool_nad
 
 
 @pytest.fixture(scope="module")
 def automatic_mac_tuning_net_nad(
+    admin_client,
     namespace,
     kubemacpool_bridge_device_worker_1,
     kubemacpool_bridge_device_worker_2,
@@ -109,12 +116,14 @@ def automatic_mac_tuning_net_nad(
         nad_name=f"{kubemacpool_bridge_device_name}-automatic-mac-tun-net-nad",
         interface_name=kubemacpool_bridge_device_name,
         namespace=namespace,
+        client=admin_client,
     ) as automatic_mac_tuning_net_nad:
         yield automatic_mac_tuning_net_nad
 
 
 @pytest.fixture(scope="class")
 def disabled_ns_nad(
+    admin_client,
     disabled_ns,
     kubemacpool_bridge_device_worker_1,
     kubemacpool_bridge_device_worker_2,
@@ -125,12 +134,14 @@ def disabled_ns_nad(
         nad_name=f"{kubemacpool_bridge_device_name}-{disabled_ns.name}-nad",
         interface_name=kubemacpool_bridge_device_name,
         namespace=disabled_ns,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def enabled_ns_nad(
+    admin_client,
     kmp_enabled_ns,
     kubemacpool_bridge_device_worker_1,
     kubemacpool_bridge_device_worker_2,
@@ -141,12 +152,14 @@ def enabled_ns_nad(
         nad_name=f"{kubemacpool_bridge_device_name}-{kmp_enabled_ns.name}-nad",
         interface_name=kubemacpool_bridge_device_name,
         namespace=kmp_enabled_ns,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def no_label_ns_nad(
+    admin_client,
     no_label_ns,
     kubemacpool_bridge_device_worker_1,
     kubemacpool_bridge_device_worker_2,
@@ -157,6 +170,7 @@ def no_label_ns_nad(
         nad_name=f"{kubemacpool_bridge_device_name}-{no_label_ns.name}-nad",
         interface_name=kubemacpool_bridge_device_name,
         namespace=no_label_ns,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -87,6 +87,7 @@ def l2_bridge_device_worker_2(
 
 @pytest.fixture(scope="class")
 def dhcp_nad(
+    admin_client,
     bridge_device_matrix__class__,
     namespace,
     l2_bridge_device_worker_1,
@@ -101,12 +102,14 @@ def dhcp_nad(
         nad_name=f"{l2_bridge_device_name}-dhcp-broadcast-nad-vlan-{vlan_tag}",
         interface_name=l2_bridge_device_name,
         vlan=vlan_tag,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def custom_eth_type_llpd_nad(
+    admin_client,
     bridge_device_matrix__class__,
     namespace,
     l2_bridge_device_worker_1,
@@ -118,12 +121,14 @@ def custom_eth_type_llpd_nad(
         nad_type=bridge_device_matrix__class__,
         nad_name=f"{l2_bridge_device_name}-custom-eth-type-icmp-nad",
         interface_name=l2_bridge_device_name,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def mpls_nad(
+    admin_client,
     bridge_device_matrix__class__,
     namespace,
     l2_bridge_device_worker_1,
@@ -135,12 +140,14 @@ def mpls_nad(
         nad_type=bridge_device_matrix__class__,
         nad_name=f"{l2_bridge_device_name}-mpls-nad",
         interface_name=l2_bridge_device_name,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="class")
 def dot1q_nad(
+    admin_client,
     bridge_device_matrix__class__,
     namespace,
     l2_bridge_device_worker_1,
@@ -152,6 +159,7 @@ def dot1q_nad(
         nad_type=bridge_device_matrix__class__,
         nad_name=f"{l2_bridge_device_name}-dot1q-nad",
         interface_name=l2_bridge_device_name,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -55,6 +55,7 @@ def bridge_interface_for_hot_plug(hosts_common_available_ports):
 
 @pytest.fixture(scope="module")
 def network_attachment_definition_for_hot_plug(
+    admin_client,
     namespace,
     bridge_interface_for_hot_plug,
 ):
@@ -63,6 +64,7 @@ def network_attachment_definition_for_hot_plug(
         namespace=namespace.name,
         name=f"{bridge_name}-nad",
         config=netattachdef.NetConfig(bridge_name, [netattachdef.CNIPluginBridgeConfig(bridge=bridge_name)]),
+        client=admin_client,
     ) as nad:
         yield nad
 
@@ -185,6 +187,7 @@ def bridge_jumbo_interface_for_hot_plug(hosts_common_available_ports, cluster_ha
 
 @pytest.fixture()
 def network_attachment_definition_for_jumbo_hot_plug(
+    admin_client,
     namespace,
     bridge_jumbo_interface_for_hot_plug,
     cluster_hardware_mtu,
@@ -202,6 +205,7 @@ def network_attachment_definition_for_jumbo_hot_plug(
                 )
             ],
         ),
+        client=admin_client,
     ) as nad:
         yield nad
 
@@ -255,6 +259,7 @@ def hot_plugged_interface_from_flat_overlay_network(
 
 @pytest.fixture()
 def flat_overlay_network_attachment_definition_for_hot_plug(
+    admin_client,
     namespace,
 ):
     with network_nad(
@@ -263,6 +268,7 @@ def flat_overlay_network_attachment_definition_for_hot_plug(
         nad_name=f"{FLAT_OVERLAY_STR}-nad",
         network_name=f"{FLAT_OVERLAY_STR}-network",
         topology=FLAT_OVERLAY_STR,
+        client=admin_client,
     ) as nad:
         yield nad
 
@@ -419,13 +425,14 @@ def vm2_with_hot_plugged_sriov_interface(
 
 
 @pytest.fixture(scope="module")
-def sriov_network_for_hot_plug(sriov_node_policy, namespace, sriov_namespace):
+def sriov_network_for_hot_plug(admin_client, sriov_node_policy, namespace, sriov_namespace):
     with network_nad(
         nad_type=SRIOV,
         nad_name="sriov-hot-plug-test-network",
         sriov_resource_name=sriov_node_policy.resource_name,
         namespace=sriov_namespace,
         sriov_network_namespace=namespace.name,
+        client=admin_client,
     ) as sriov_network:
         yield sriov_network
 

--- a/tests/network/l2_bridge/test_ovs_bridge.py
+++ b/tests/network/l2_bridge/test_ovs_bridge.py
@@ -29,18 +29,20 @@ def ovs_bridge_on_worker1(worker_node1_pod_executor):
 
 
 @pytest.fixture()
-def ovs_bridge_nad(namespace, ovs_bridge_on_worker1):
+def ovs_bridge_nad(admin_client, namespace, ovs_bridge_on_worker1):
     with network_nad(
         namespace=namespace,
         nad_type=OVS_BRIDGE,
         nad_name="ovs-test-nad",
         interface_name=ovs_bridge_on_worker1,
+        client=admin_client,
     ) as nad:
         yield nad
 
 
 @pytest.fixture(scope="module")
 def brcnv_ovs_nad_vlan_2(
+    admin_client,
     namespace,
     vlan_index_number,
 ):
@@ -51,6 +53,7 @@ def brcnv_ovs_nad_vlan_2(
         nad_name=f"{BRCNV}-{vlan_tag}",
         interface_name=BRCNV,
         vlan=vlan_tag,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/macspoof/conftest.py
+++ b/tests/network/macspoof/conftest.py
@@ -83,6 +83,7 @@ def linux_bridge_device_worker_2(nodes_available_nics, worker_node2):
 
 @pytest.fixture(scope="class")
 def linux_macspoof_nad(
+    admin_client,
     namespace,
     linux_bridge_device_worker_1,
     linux_bridge_device_worker_2,
@@ -93,6 +94,7 @@ def linux_macspoof_nad(
         nad_name=linux_bridge_device_worker_1.bridge_name,
         interface_name=linux_bridge_device_worker_1.iface["name"],
         macspoofchk=True,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -94,12 +94,13 @@ def bridge_worker_2(
 
 
 @pytest.fixture(scope="module")
-def br1test_nad(namespace, bridge_worker_1, bridge_worker_2):
+def br1test_nad(admin_client, namespace, bridge_worker_1, bridge_worker_2):
     with network_nad(
         nad_type=bridge_worker_1.bridge_type,
         nad_name="network-migration-nad",
         interface_name=bridge_worker_1.bridge_name,
         namespace=namespace,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -71,6 +71,7 @@ def nmstate_linux_bridge_device_worker_2(nodes_available_nics, worker_node2):
 
 @pytest.fixture(scope="class")
 def nmstate_linux_nad(
+    admin_client,
     namespace,
     nmstate_linux_bridge_device_worker_1,
     nmstate_linux_bridge_device_worker_2,
@@ -80,6 +81,7 @@ def nmstate_linux_nad(
         nad_type=nmstate_linux_bridge_device_worker_1.bridge_type,
         nad_name="nmstate-br1test-nad",
         interface_name=nmstate_linux_bridge_device_worker_1.bridge_name,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -87,11 +87,12 @@ def sriov_vm(
 
 
 @pytest.fixture(scope="module")
-def sriov_network(sriov_node_policy, namespace, sriov_namespace):
+def sriov_network(admin_client, sriov_node_policy, namespace, sriov_namespace):
     """
     Create a SR-IOV network linked to SR-IOV policy.
     """
     with network_nad(
+        client=admin_client,
         nad_type=SRIOV,
         nad_name="sriov-test-network",
         sriov_resource_name=sriov_node_policy.resource_name,
@@ -102,7 +103,7 @@ def sriov_network(sriov_node_policy, namespace, sriov_namespace):
 
 
 @pytest.fixture(scope="class")
-def sriov_network_vlan(sriov_node_policy, namespace, sriov_namespace, vlan_index_number):
+def sriov_network_vlan(admin_client, sriov_node_policy, namespace, sriov_namespace, vlan_index_number):
     """
     Create a SR-IOV VLAN network linked to SR-IOV policy.
     """
@@ -113,6 +114,7 @@ def sriov_network_vlan(sriov_node_policy, namespace, sriov_namespace, vlan_index
         namespace=sriov_namespace,
         sriov_network_namespace=namespace.name,
         vlan=next(vlan_index_number),
+        client=admin_client,
     ) as sriov_network:
         yield sriov_network
 

--- a/tests/network/upgrade/conftest.py
+++ b/tests/network/upgrade/conftest.py
@@ -17,6 +17,7 @@ NAD_MAC_SPOOF_NAME = "brspoofupgrade"
 
 @pytest.fixture(scope="session")
 def upgrade_linux_macspoof_nad(
+    admin_client,
     upgrade_namespace_scope_session,
 ):
     with network_nad(
@@ -26,6 +27,7 @@ def upgrade_linux_macspoof_nad(
         interface_name=NAD_MAC_SPOOF_NAME,
         macspoofchk=True,
         add_resource_name=False,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -56,12 +56,13 @@ def bridge_on_node():
 
 
 @pytest.fixture()
-def linux_nad(namespace, bridge_on_node):
+def linux_nad(admin_client, namespace, bridge_on_node):
     with network_nad(
         namespace=namespace,
         nad_type=LINUX_BRIDGE,
         nad_name=f"{BRIDGE_NAME}-nad",
         interface_name=bridge_on_node.bridge_name,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -121,12 +121,13 @@ def windows_custom_bridge():
 
 
 @pytest.fixture(scope="class")
-def windows_custom_bridge_nad(windows_custom_bridge, namespace):
+def windows_custom_bridge_nad(admin_client, windows_custom_bridge, namespace):
     with network_nad(
         namespace=namespace,
         nad_type=windows_custom_bridge.bridge_type,
         nad_name="br1-win-custom-nad",
         interface_name=(windows_custom_bridge.bridge_name),
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/virt/node/high_performance_vm/test_numa.py
+++ b/tests/virt/node/high_performance_vm/test_numa.py
@@ -35,12 +35,13 @@ def fail_if_no_numa(schedulable_nodes, workers_utility_pods):
 
 
 @pytest.fixture(scope="module")
-def sriov_net(sriov_node_policy, namespace):
+def sriov_net(admin_client, sriov_node_policy, namespace):
     with SriovNetwork(
         name="numa-sriov-test-net",
         namespace=sriov_node_policy.namespace,
         resource_name=sriov_node_policy.resource_name,
         network_namespace=namespace.name,
+        client=admin_client,
     ) as net:
         yield net
 

--- a/tests/virt/node/migration_and_maintenance/test_dedicated_live_migration_network.py
+++ b/tests/virt/node/migration_and_maintenance/test_dedicated_live_migration_network.py
@@ -48,11 +48,12 @@ def migration_interface(hosts_common_available_ports):
 
 
 @pytest.fixture(scope="module")
-def dedicated_network_nad(migration_interface, hco_namespace):
+def dedicated_network_nad(admin_client, migration_interface, hco_namespace):
     with MACVLANNetworkAttachmentDefinition(
         name="migration-nad",
         namespace=hco_namespace.name,
         master=migration_interface,
+        client=admin_client,
     ) as nad:
         yield nad
 

--- a/tests/virt/node/migration_and_maintenance/utils.py
+++ b/tests/virt/node/migration_and_maintenance/utils.py
@@ -23,7 +23,7 @@ class MACVLANNetworkAttachmentDefinition(NetworkAttachmentDefinition):
         name,
         namespace,
         master,
-        client=None,
+        client,
         teardown=True,
     ):
         super().__init__(name=name, namespace=namespace, client=client, teardown=teardown)

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -523,6 +523,7 @@ def network_nad(
     nad_type,
     nad_name,
     namespace,
+    client,
     interface_name=None,
     tuning=None,
     vlan=None,
@@ -541,6 +542,7 @@ def network_nad(
         "namespace": namespace.name,
         "teardown": teardown,
         "vlan": vlan,
+        "client": client,
     }
     if nad_type == LINUX_BRIDGE:
         kwargs["cni_type"] = py_config["linux_bridge_cni"]


### PR DESCRIPTION
##### Short description:
This change makes the client mandatory for all NAD-related resources. Updated fixtures so that all calls to openshift-python-wrapper NAD resources explicitly pass a client.

While NADs are namespaced CRDs, OpenShift's default "admin" role only grants permissions for standard Kubernetes resources (pods, services, configmaps, etc.) and does not include permissions for any custom resources, even within a user's own namespace. Because network configuration can affect cluster-wide networking, NAD creation requires privileged clients by default.


##### What this PR does / why we need it:
As of its next releas, openshift-python-wrapper will enforce passing `client` when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources  should be updated to pass `client` arg.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Network attachment client is now required, enforcing explicit admin authentication when creating network attachments.

* **Tests**
  * Many test fixtures and utilities updated to accept and forward an admin client so test network attachments are created with authenticated admin context.
  * Some fixtures add explicit cleanup steps after use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->