### PR TITLE
Mark new jumbo tests module as special_infra

### DIFF
--- a/tests/network/localnet/test_jumbo_frames.py
+++ b/tests/network/localnet/test_jumbo_frames.py
@@ -6,7 +6,6 @@ from tests.network.localnet.liblocalnet import LOCALNET_OVS_BRIDGE_INTERFACE
 from utilities.network import get_vmi_ip_v4_by_name
 from utilities.virt import vm_console_run_commands
 
-
 pytestmark = [
     pytest.mark.special_infra,
     pytest.mark.jumbo_frame,


### PR DESCRIPTION
Jumbo suppurt is considered as special_infra, and its tests are executed on the dedicated full-capabilities lanes. Not having the special_infra marker on these tests leads to attempting to execute these tests on clusters that don't support jumbo, and fail on sanity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated test categorization by moving per-test markers to a module-level classification, improving organization for specialized test scenarios while preserving existing test behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->