### PR TITLE
Add conformance marker to test_rhel_os.py

### DIFF
--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -30,6 +30,7 @@ pytestmark = [pytest.mark.post_upgrade]
 TESTS_MODULE_IDENTIFIER = "TestCommonInstancetypeRhel"
 
 
+@pytest.mark.conformance
 @pytest.mark.arm64
 @pytest.mark.s390x
 @pytest.mark.smoke
@@ -153,6 +154,7 @@ class TestVMMigrationAndState:
         )
 
 
+@pytest.mark.conformance
 @pytest.mark.arm64
 @pytest.mark.smoke
 @pytest.mark.gating


### PR DESCRIPTION
##### Short description:
Add conformance marker to test_rhel_os.py

##### More details:
Adding RHEL basic tests using data sources to the conformance tests used by `https://github.com/openshift-cnv/ocp-virt-validation-checkup/` 

##### What this PR does / why we need it:
Add extra coverage for https://github.com/openshift-cnv/ocp-virt-validation-checkup/ 

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68864


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance annotations to VM creation and deletion test classes for improved test organization and tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->