### PR TITLE
 infra/tests, net, udn: mandatory client for CUDN

### DIFF
--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -131,7 +131,10 @@ def namespace_cudn(admin_client: DynamicClient) -> Generator[Namespace]:
 
 
 @pytest.fixture(scope="module")
-def cudn_layer2(namespace_cudn: Namespace) -> Generator[libcudn.ClusterUserDefinedNetwork]:
+def cudn_layer2(
+    admin_client: DynamicClient,
+    namespace_cudn: Namespace,
+) -> Generator[libcudn.ClusterUserDefinedNetwork]:
     with libcudn.ClusterUserDefinedNetwork(
         name="l2-network-cudn",
         namespace_selector=LabelSelector(matchLabels=CUDN_BGP_LABEL),
@@ -144,6 +147,7 @@ def cudn_layer2(namespace_cudn: Namespace) -> Generator[libcudn.ClusterUserDefin
             ),
         ),
         label=APP_CUDN_LABEL,
+        client=admin_client,
     ) as cudn:
         cudn.wait_for_status_success()
         yield cudn

--- a/tests/network/libs/cluster_user_defined_network.py
+++ b/tests/network/libs/cluster_user_defined_network.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict, dataclass
 from enum import Enum
 
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.cluster_user_defined_network import ClusterUserDefinedNetwork as Cudn
 
 from tests.network.libs.apimachinery import dict_normalization_for_dataclass
@@ -71,7 +72,12 @@ class ClusterUserDefinedNetwork(Cudn):
     """
 
     def __init__(
-        self, name: str, namespace_selector: LabelSelector, network: Network, label: dict[str, str] | None = None
+        self,
+        name: str,
+        namespace_selector: LabelSelector,
+        network: Network,
+        client: DynamicClient,
+        label: dict[str, str] | None = None,
     ):
         """
         Create and manage ClusterUserDefinedNetwork
@@ -84,12 +90,14 @@ class ClusterUserDefinedNetwork(Cudn):
             namespace_selector (NamespaceSelector): NamespaceSelector Label selector for which namespace network should
                 be available for.
             network (Network): Network is the user-defined-network spec.
+            client (DynamicClient): Dynamic client used to interact with the cluster.
             label (dict[str, str]): Optional labels to apply to the ClusterUserDefinedNetwork.
         """
         super().__init__(
             name=name,
             namespace_selector=asdict(namespace_selector, dict_factory=dict_normalization_for_dataclass),
             network=asdict(network, dict_factory=dict_normalization_for_dataclass),
+            client=client,
             label=label,
         )
 

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -88,6 +88,7 @@ def vlan_id(vlan_index_number: Generator[int]) -> int:
 
 @pytest.fixture(scope="module")
 def cudn_localnet(
+    admin_client: DynamicClient,
     vlan_id: int,
     namespace_localnet_1: Namespace,
     namespace_localnet_2: Namespace,
@@ -97,6 +98,7 @@ def cudn_localnet(
         match_labels=LOCALNET_TEST_LABEL,
         vlan_id=vlan_id,
         physical_network_name=LOCALNET_BR_EX_NETWORK,
+        client=admin_client,
     ) as cudn:
         cudn.wait_for_status_success()
         yield cudn
@@ -104,12 +106,14 @@ def cudn_localnet(
 
 @pytest.fixture(scope="module")
 def cudn_localnet_no_vlan(
+    admin_client: DynamicClient,
     namespace_localnet_1: Namespace,
 ) -> Generator[libcudn.ClusterUserDefinedNetwork]:
     with localnet_cudn(
         name=LOCALNET_BR_EX_NETWORK_NO_VLAN,
         match_labels=LOCALNET_TEST_LABEL,
         physical_network_name=LOCALNET_BR_EX_NETWORK,
+        client=admin_client,
     ) as cudn:
         cudn.wait_for_status_success()
         yield cudn
@@ -209,6 +213,7 @@ def localnet_client(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualM
 
 @pytest.fixture(scope="module")
 def cudn_localnet_ovs_bridge(
+    admin_client: DynamicClient,
     vlan_id: int,
     namespace_localnet_1: Namespace,
 ) -> Generator[libcudn.ClusterUserDefinedNetwork]:
@@ -217,6 +222,7 @@ def cudn_localnet_ovs_bridge(
         match_labels=LOCALNET_TEST_LABEL,
         vlan_id=vlan_id,
         physical_network_name=LOCALNET_OVS_BRIDGE_NETWORK,
+        client=admin_client,
     ) as cudn:
         cudn.wait_for_status_success()
         yield cudn
@@ -371,6 +377,7 @@ def nncp_localnet_on_secondary_node_nic_with_jumbo_frame(
 
 @pytest.fixture(scope="module")
 def cudn_localnet_ovs_bridge_jumbo_frame(
+    admin_client: DynamicClient,
     vlan_id: int,
     cluster_hardware_mtu: int,
     namespace_localnet_1: Namespace,
@@ -381,6 +388,7 @@ def cudn_localnet_ovs_bridge_jumbo_frame(
         vlan_id=vlan_id,
         physical_network_name=LOCALNET_OVS_BRIDGE_NETWORK,
         mtu=cluster_hardware_mtu,
+        client=admin_client,
     ) as cudn:
         cudn.wait_for_status_success()
         yield cudn

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -136,6 +136,7 @@ def localnet_cudn(
     name: str,
     match_labels: dict[str, str],
     physical_network_name: str,
+    client: DynamicClient,
     vlan_id: int | None = None,
     mtu: int | None = None,
 ) -> libcudn.ClusterUserDefinedNetwork:
@@ -152,6 +153,7 @@ def localnet_cudn(
         name (str): The name of the CUDN resource.
         match_labels (dict[str, str]): Labels for namespace selection.
         physical_network_name (str): The name of the physical network to associate with the localnet configuration.
+        client (DynamicClient): Dynamic client for resource creation.
         vlan_id (int|None): The VLAN ID to configure for the network. If None, no VLAN is configured.
         mtu (int): Optional customized MTU of the network.
 
@@ -174,7 +176,10 @@ def localnet_cudn(
     network = libcudn.Network(topology=libcudn.Network.Topology.LOCALNET.value, localnet=localnet)
 
     return libcudn.ClusterUserDefinedNetwork(
-        name=name, namespace_selector=LabelSelector(matchLabels=match_labels), network=network
+        name=name,
+        namespace_selector=LabelSelector(matchLabels=match_labels),
+        network=network,
+        client=client,
     )
 
 
@@ -218,7 +223,8 @@ def client_server_active_connection(
 
 @contextlib.contextmanager
 def create_nncp_localnet_on_secondary_node_nic(
-    node_nic_name: str, mtu: int | None = None
+    node_nic_name: str,
+    mtu: int | None = None,
 ) -> Generator[libnncp.NodeNetworkConfigurationPolicy, None, None]:
     """Create NNCP to configure an OVS bridge on a secondary NIC across all worker nodes.
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -28,13 +28,14 @@ def udn_namespace(admin_client):
 
 
 @pytest.fixture(scope="module")
-def namespaced_layer2_user_defined_network(udn_namespace):
+def namespaced_layer2_user_defined_network(admin_client, udn_namespace):
     with Layer2UserDefinedNetwork(
         name="layer2-udn",
         namespace=udn_namespace.name,
         role="Primary",
         subnets=[f"{random_ipv4_address(net_seed=0, host_address=0)}/24"],
         ipam={"lifecycle": "Persistent"},
+        client=admin_client,
     ) as udn:
         udn.wait_for_condition(
             condition="NetworkAllocationSucceeded",


### PR DESCRIPTION
##### Short description:
This change makes the client mandatory for all CUDN-related resources. Updated fixtures so that all calls to openshift-python-wrapper CUDN resources explicitly pass a client.


##### What this PR does / why we need it:
As of its next releas, openshift-python-wrapper will enforce passing `client` when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources  should be updated to pass `client` arg.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Network test fixtures (BGP, localnet, user-defined network) updated to accept and propagate an admin client across helpers.
  * Test utilities and network resource helpers now accept and forward a client parameter, and several fixtures now yield managed resources for improved lifecycle handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->