### PR TITLE
 Quarantine: - Migration tests that fails due to Migmigration waiting for succeeded

### DIFF
--- a/tests/storage/storage_migration/test_mtc_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_mtc_storage_class_migration.py
@@ -16,7 +16,7 @@ from tests.storage.storage_migration.utils import (
     verify_vm_storage_class_updated,
     verify_vms_boot_time_after_storage_migration,
 )
-from utilities.constants import TIMEOUT_60MIN
+from utilities.constants import QUARANTINED, TIMEOUT_60MIN
 from utilities.virt import migrate_vm_and_verify
 
 TESTS_CLASS_NAME_A_TO_B = "TestStorageClassMigrationAtoB"
@@ -168,6 +168,10 @@ class TestStorageClassMigrationWithVolumeHotplug:
         ],
         indirect=True,
     )
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: MigMigration resource reports Failed for VMs with RWO storage; MIG-1770",
+        run=False,
+    )
     def test_vm_storage_class_migration_with_hotplugged_volume(
         self,
         source_storage_class,
@@ -235,6 +239,10 @@ class TestStorageClassMigrationWithVolumeHotplug:
 class TestStorageClassMigrationWindowsWithVTPM:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_WINDOWS}::test_vm_storage_class_migration_windows_vm_with_vtpm")
     @pytest.mark.polarion("CNV-11499")
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: MigMigration resource reports Failed for VMs with RWO storage; MIG-1770",
+        run=False,
+    )
     def test_vm_storage_class_migration_windows_vm_with_vtpm(
         self,
         source_storage_class,


### PR DESCRIPTION

##### Short description:

Quarantine tests:
test_vm_storage_class_migration_windows_vm_with_vtpm
test_vm_storage_class_migration_with_hotplugged_volume
due to a Timeout waiting for succeeded MigMigration.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-73329
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked specific storage migration test scenarios as quarantined (expected failures) due to known MigMigration resource failures affecting migrations of VMs using RWO storage (MIG-1770), avoiding unnecessary test runs for these known issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->