### PR TITLE
 tests, net, multi_network_policy: Add client arg

### DIFF
--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -43,11 +43,11 @@ SPECIFIC_HOST_MASK = "32"
 
 
 @pytest.fixture(scope="module")
-def enable_multi_network_policy_usage(network_operator):
+def enable_multi_network_policy_usage(admin_client, network_operator):
     with ResourceEditor(patches={network_operator: {"spec": {"useMultiNetworkPolicy": True}}}):
-        wait_for_multi_network_policy_resources(deploy_mnp_crd=True)
+        wait_for_multi_network_policy_resources(admin_client=admin_client, deploy_mnp_crd=True)
         yield
-    wait_for_multi_network_policy_resources(deploy_mnp_crd=False)
+    wait_for_multi_network_policy_resources(admin_client=admin_client, deploy_mnp_crd=False)
 
 
 @pytest.fixture(scope="module")
@@ -284,6 +284,7 @@ def vmd_flat_overlay_ip_address(vmd_flat_overlay, flat_overlay_vmc_vmd_nad):
 
 @pytest.fixture()
 def vma_egress_multi_network_policy(
+    admin_client,
     flat_overlay_vma_vmb_nad,
     vmb_flat_overlay_ip_address,
     vma_domain_label,
@@ -298,12 +299,14 @@ def vma_egress_multi_network_policy(
             ip_address=f"{vmb_flat_overlay_ip_address}/{SPECIFIC_HOST_MASK}",
         ),
         pod_selector={"matchLabels": vma_domain_label},
+        client=admin_client,
     ) as mnp:
         yield mnp
 
 
 @pytest.fixture()
 def vmb_ingress_multi_network_policy(
+    admin_client,
     flat_overlay_vma_vmb_nad,
     vmb_domain_label,
 ):
@@ -316,12 +319,14 @@ def vmb_ingress_multi_network_policy(
         ingress=create_ip_block(
             ip_address=f"{random_ipv4_address(net_seed=0, host_address=123)}/{SPECIFIC_HOST_MASK}",
         ),
+        client=admin_client,
     ) as mnp:
         yield mnp
 
 
 @pytest.fixture()
 def vmc_ingress_multi_network_policy(
+    admin_client,
     flat_overlay_vmc_vmd_nad,
     vmc_domain_label,
     vmd_ingress_ip_block,
@@ -333,6 +338,7 @@ def vmc_ingress_multi_network_policy(
         network_name=flat_overlay_vmc_vmd_nad.name,
         policy_types=["Ingress"],
         ingress=vmd_ingress_ip_block,
+        client=admin_client,
     ) as mnp:
         yield mnp
 

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -66,10 +66,12 @@ def create_ip_block(ip_address, ingress=True):
     return [{network_direction: [{"ipBlock": {"cidr": ip_address}}]}]
 
 
-def wait_for_multi_network_policy_resources(deploy_mnp_crd=False):
+def wait_for_multi_network_policy_resources(admin_client, deploy_mnp_crd=False):
     sample = None
     consecutive_check = 0
-    mnp_crd = CustomResourceDefinition(name=f"multi-networkpolicies.{NamespacedResource.ApiGroup.K8S_CNI_CNCF_IO}")
+    mnp_crd = CustomResourceDefinition(
+        name=f"multi-networkpolicies.{NamespacedResource.ApiGroup.K8S_CNI_CNCF_IO}", client=admin_client
+    )
     try:
         sampler = TimeoutSampler(
             wait_timeout=TIMEOUT_3MIN,


### PR DESCRIPTION
##### Short description:
Updated class instance and fixtures - all calls to openshift-python-wrapper resource should be updated to pass client.


##### What this PR does / why we need it:
As of its next releas, openshift-python-wrapper will enforce passing `client` when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources  should be updated to pass `client` arg.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Network policy tests updated to accept and propagate an administrator client across fixtures and helpers.
  * Test helpers now require an explicit admin client when waiting for multi-network policy resources, improving clarity and ensuring policies are validated with the correct credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->