### PR TITLE
tests, net, service-mesh: Add client arg

### DIFF
--- a/tests/network/utils.py
+++ b/tests/network/utils.py
@@ -32,10 +32,11 @@ SERVICE_MESH_INJECT_ANNOTATION = "sidecar.istio.io/inject"
 
 
 class ServiceMeshDeploymentService(Service):
-    def __init__(self, app_name, namespace, port, port_name=None):
+    def __init__(self, app_name, namespace, port, client, port_name=None):
         super().__init__(
             name=app_name,
             namespace=namespace,
+            client=client,
         )
         self.port = port
         self.app_name = app_name
@@ -85,6 +86,7 @@ class ServiceMeshDeployments(Deployment):
         namespace,
         version,
         image,
+        client,
         replicas=1,
         command=None,
         strategy=None,
@@ -106,7 +108,7 @@ class ServiceMeshDeployments(Deployment):
             },
         }
 
-        super().__init__(name=self.name, namespace=namespace, template=template, selector=selector)
+        super().__init__(name=self.name, namespace=namespace, template=template, selector=selector, client=client)
         self.version = version
         self.replicas = replicas
         self.image = image


### PR DESCRIPTION
##### Short description:
Updated class instance and fixtures - all calls to openshift-python-wrapper resource should be updated to pass client.


##### What this PR does / why we need it:
As of its next releas, openshift-python-wrapper will enforce passing `client` when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources  should be updated to pass `client` arg.

All other resources in the service mesh tests already use `unprivileged_client` (deployments, services, service accounts, VMs), and the Istio resources should follow the same pattern.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test infrastructure and service-mesh fixtures now accept an additional client parameter and propagate it to underlying resources, improving flexibility for unprivileged-client testing and making service-mesh test setup more configurable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->