### PR TITLE
tests, net: mandatory client for OCP wrapper instantiations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -583,6 +583,7 @@ def node_physical_nics(workers_utility_pods):
 
 @pytest.fixture(scope="session")
 def nodes_active_nics(
+    admin_client,
     workers,
     workers_utility_pods,
     node_physical_nics,
@@ -606,7 +607,7 @@ def nodes_active_nics(
     nodes_nics = {}
     for node in workers:
         nodes_nics[node.name] = {"available": [], "occupied": []}
-        nns = NodeNetworkState(name=node.name)
+        nns = NodeNetworkState(name=node.name, client=admin_client)
 
         for node_iface in nns.interfaces:
             iface_name = node_iface["name"]
@@ -1015,8 +1016,8 @@ def worker_node3(schedulable_nodes):
 
 
 @pytest.fixture(scope="session")
-def sriov_namespace():
-    return Namespace(name=py_config["sriov_namespace"])
+def sriov_namespace(admin_client):
+    return Namespace(name=py_config["sriov_namespace"], client=admin_client)
 
 
 @pytest.fixture(scope="session")
@@ -1076,9 +1077,11 @@ def sriov_node_policy(sriov_unused_ifaces, sriov_nodes_states, workers_utility_p
 
 
 @pytest.fixture(scope="session")
-def mac_pool(hco_namespace):
+def mac_pool(admin_client, hco_namespace):
     return MacPool(
-        kmp_range=ConfigMap(namespace=hco_namespace.name, name=KUBEMACPOOL_MAC_RANGE_CONFIG).instance["data"]
+        kmp_range=ConfigMap(
+            namespace=hco_namespace.name, name=KUBEMACPOOL_MAC_RANGE_CONFIG, client=admin_client
+        ).instance["data"]
     )
 
 
@@ -2223,8 +2226,8 @@ def disabled_default_sources_in_operatorhub_scope_module(admin_client, installin
 
 
 @pytest.fixture(scope="module")
-def kmp_deployment(hco_namespace):
-    return Deployment(namespace=hco_namespace.name, name=KUBEMACPOOL_MAC_CONTROLLER_MANAGER)
+def kmp_deployment(admin_client, hco_namespace):
+    return Deployment(namespace=hco_namespace.name, name=KUBEMACPOOL_MAC_CONTROLLER_MANAGER, client=admin_client)
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -178,8 +178,8 @@ def brcnv_vma_with_vlan_1(
 
 
 @pytest.fixture(scope="session")
-def cluster_network_mtu():
-    network_resource = Network(name=CLUSTER)
+def cluster_network_mtu(admin_client):
+    network_resource = Network(name=CLUSTER, client=admin_client)
     if not network_resource.exists:
         raise ResourceNotFoundError(f"{CLUSTER} Network resource not found.")
 
@@ -213,8 +213,10 @@ def ovn_kubernetes_cluster(admin_client):
 
 
 @pytest.fixture(scope="session")
-def network_operator():
-    return Network(name=CLUSTER, api_group=Network.ApiGroup.OPERATOR_OPENSHIFT_IO, ensure_exists=True)
+def network_operator(admin_client):
+    return Network(
+        name=CLUSTER, api_group=Network.ApiGroup.OPERATOR_OPENSHIFT_IO, ensure_exists=True, client=admin_client
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -266,7 +268,7 @@ def network_sanity(
         if any(test.get_closest_marker("dpdk") for test in collected_tests):
             LOGGER.info("Verifying if the cluster supports running DPDK tests...")
             dpdk_performance_profile_name = "dpdk"
-            if not PerformanceProfile(name=dpdk_performance_profile_name).exists:
+            if not PerformanceProfile(name=dpdk_performance_profile_name, client=admin_client).exists:
                 failure_msgs.append(
                     f"DPDK is not configured, the {PerformanceProfile.kind}/{dpdk_performance_profile_name} "
                     "does not exist"
@@ -302,7 +304,7 @@ def network_sanity(
     def _verify_sriov():
         if any(test.get_closest_marker("sriov") for test in collected_tests):
             LOGGER.info("Verifying if the cluster supports running SRIOV tests...")
-            if not Namespace(name=py_config["sriov_namespace"]).exists:
+            if not Namespace(name=py_config["sriov_namespace"], client=admin_client).exists:
                 failure_msgs.append(
                     f"SRIOV operator is not installed, the '{py_config['sriov_namespace']}' namespace does not exist"
                 )

--- a/tests/network/general/test_ip_family_services.py
+++ b/tests/network/general/test_ip_family_services.py
@@ -73,7 +73,7 @@ def default_ip_family_policy_service(running_vm_for_exposure):
 @pytest.fixture()
 def virtctl_expose_service(
     request,
-    admin_client,
+    unprivileged_client,
     running_vm_for_exposure,
     dual_stack_cluster,
 ):
@@ -91,6 +91,7 @@ def virtctl_expose_service(
     svc = get_service(
         name=svc_name,
         namespace=running_vm_for_exposure.namespace,
+        client=unprivileged_client,
     )
     yield svc
     svc.clean_up()

--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -251,7 +251,7 @@ def restarted_vmi_b(vm_b):
 
 
 @pytest.fixture(scope="class")
-def disabled_ns_vm(disabled_ns, disabled_ns_nad, mac_pool):
+def disabled_ns_vm(unprivileged_client, disabled_ns, disabled_ns_nad, mac_pool):
     networks = {disabled_ns_nad.name: disabled_ns_nad.name}
     name = f"{disabled_ns.name}-vm"
     with VirtualMachineForTests(
@@ -260,6 +260,7 @@ def disabled_ns_vm(disabled_ns, disabled_ns_nad, mac_pool):
         networks=networks,
         interfaces=networks.keys(),
         body=fedora_vm_body(name=name),
+        client=unprivileged_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
         vm.start(wait=True)
@@ -269,7 +270,7 @@ def disabled_ns_vm(disabled_ns, disabled_ns_nad, mac_pool):
 
 
 @pytest.fixture(scope="class")
-def enabled_ns_vm(kmp_enabled_ns, enabled_ns_nad, mac_pool):
+def enabled_ns_vm(unprivileged_client, kmp_enabled_ns, enabled_ns_nad, mac_pool):
     networks = {enabled_ns_nad.name: enabled_ns_nad.name}
     name = f"{kmp_enabled_ns.name}-vm"
     with VirtualMachineForTests(
@@ -278,6 +279,7 @@ def enabled_ns_vm(kmp_enabled_ns, enabled_ns_nad, mac_pool):
         networks=networks,
         interfaces=networks.keys(),
         body=fedora_vm_body(name=name),
+        client=unprivileged_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
         vm.start(wait=True)
@@ -287,7 +289,7 @@ def enabled_ns_vm(kmp_enabled_ns, enabled_ns_nad, mac_pool):
 
 
 @pytest.fixture(scope="class")
-def no_label_ns_vm(no_label_ns, no_label_ns_nad, mac_pool):
+def no_label_ns_vm(unprivileged_client, no_label_ns, no_label_ns_nad, mac_pool):
     networks = {no_label_ns_nad.name: no_label_ns_nad.name}
     name = f"{no_label_ns.name}-vm"
     with VirtualMachineForTests(
@@ -296,6 +298,7 @@ def no_label_ns_vm(no_label_ns, no_label_ns_nad, mac_pool):
         networks=networks,
         interfaces=networks.keys(),
         body=fedora_vm_body(name=name),
+        client=unprivileged_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
         vm.start(wait=True)

--- a/tests/network/kubemacpool/test_kubemacpool.py
+++ b/tests/network/kubemacpool/test_kubemacpool.py
@@ -128,7 +128,7 @@ class TestNegatives:
 @pytest.mark.polarion("CNV-4405")
 @pytest.mark.single_nic
 @pytest.mark.s390x
-def test_kmp_down(namespace, kmp_down):
+def test_kmp_down(unprivileged_client, namespace, kmp_down):
     with pytest.raises(ApiException):
-        with VirtualMachineForTests(name="kmp-down-vm", namespace=namespace.name):
+        with VirtualMachineForTests(name="kmp-down-vm", namespace=namespace.name, client=unprivileged_client):
             return

--- a/tests/network/upgrade/utils.py
+++ b/tests/network/upgrade/utils.py
@@ -27,9 +27,9 @@ def assert_nmstate_bridge_creation(bridge):
     sampler = TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=TIMEOUT_5SEC,
-        func=lambda: NodeNetworkState(name=get_node_selector_name(node_selector=bridge.node_selector)).get_interface(
-            name=bridge_name
-        ),
+        func=lambda: NodeNetworkState(
+            name=get_node_selector_name(node_selector=bridge.node_selector), client=bridge.client
+        ).get_interface(name=bridge_name),
     )
     try:
         for sample in sampler:

--- a/tests/network/utils.py
+++ b/tests/network/utils.py
@@ -183,7 +183,7 @@ def wait_for_address_on_iface(worker_pod, iface_name):
     samples = TimeoutSampler(
         wait_timeout=TIMEOUT_2MIN,
         sleep=1,
-        func=NodeNetworkState(worker_pod.node.name).ipv4,
+        func=NodeNetworkState(name=worker_pod.node.name, client=worker_pod.client).ipv4,
         iface=iface_name,
     )
     try:
@@ -323,8 +323,8 @@ def basic_expose_command(
     )
 
 
-def get_service(name, namespace):
-    service = Service(name=name, namespace=namespace)
+def get_service(name, namespace, client):
+    service = Service(name=name, namespace=namespace, client=client)
     if service.exists:
         return service
 


### PR DESCRIPTION
##### Short description:
Updated all OCP wrapper class instantiations across the network segment with the relevant client parameter.


##### What this PR does / why we need it:
As of its next releas, openshift-python-wrapper will enforce passing `client` when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources  should be updated to pass `client` arg.

The choice between admin_client and unprivileged_client follows a clear principle based on the type of resource being accessed and the test scenario being validated: 
admin_client is used for cluster-level infrastructure and operator-managed resources that require cluster-admin privileges.
unprivileged_client is used for user-created resources and scenarios that simulate real user workflows. Using unprivileged_client follows the principle of using the least privilege user possible.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized client usage in test fixtures and helpers, switching several fixtures and tests to use explicit admin or unprivileged clients and updating service lookup behavior (now raises when missing).

* **Refactor**
  * Test infrastructure updated to support admin and unprivileged client contexts broadly, improving consistency and isolation for network and VM-related tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->