### PR TITLE
tests, net, ssp: Add client arg to create_custom_template_from_url

### DIFF
--- a/tests/infrastructure/sap/test_sap_hana_vm.py
+++ b/tests/infrastructure/sap/test_sap_hana_vm.py
@@ -474,7 +474,7 @@ def sap_hana_template_labels():
 
 
 @pytest.fixture(scope="module")
-def sap_hana_template(tmpdir_factory):
+def sap_hana_template(admin_client, tmpdir_factory):
     template_name = "sap_hana_template"
     template_dir = tmpdir_factory.mktemp(template_name)
     with create_custom_template_from_url(
@@ -482,6 +482,7 @@ def sap_hana_template(tmpdir_factory):
         template_name=f"{template_name}.yaml",
         template_dir=template_dir,
         namespace=NamespacesNames.OPENSHIFT,
+        client=admin_client,
     ) as template:
         yield template
 

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -248,13 +248,14 @@ def sriov_vm_migrate(index_number, unprivileged_client, namespace, sriov_network
 
 
 @pytest.fixture(scope="class")
-def dpdk_template(namespace, tmpdir_factory):
+def dpdk_template(admin_client, namespace, tmpdir_factory):
     template_dir = tmpdir_factory.mktemp("dpdk_template")
     with create_custom_template_from_url(
         url=f"{CNV_SUPPLEMENTAL_TEMPLATES_URL}/testpmd/resource-specs/sriov-vm1-template.yaml",
         template_name="dpdk_vm_template.yaml",
         template_dir=template_dir,
         namespace=namespace.name,
+        client=admin_client,
     ) as template:
         yield template
 

--- a/utilities/ssp.py
+++ b/utilities/ssp.py
@@ -150,7 +150,7 @@ def wait_for_condition_message_value(resource, expected_message):
 
 
 @contextmanager
-def create_custom_template_from_url(url, template_name, template_dir, namespace):
+def create_custom_template_from_url(url, template_name, template_dir, namespace, client):
     template_filepath = os.path.join(template_dir, template_name)
     urllib.request.urlretrieve(
         url=url,
@@ -159,6 +159,7 @@ def create_custom_template_from_url(url, template_name, template_dir, namespace)
     with Template(
         yaml_file=template_filepath,
         namespace=namespace,
+        client=client,
     ) as template:
         yield template
 

--- a/utilities/unittests/test_ssp.py
+++ b/utilities/unittests/test_ssp.py
@@ -347,19 +347,25 @@ class TestCreateCustomTemplateFromUrl:
         mock_template_class.return_value.__exit__ = MagicMock(return_value=None)
 
         mock_namespace = MagicMock()
+        mock_client = MagicMock()
 
         with create_custom_template_from_url(
             url="https://example.com/template.yaml",
             template_name="custom-template",
             template_dir="/tmp",
             namespace=mock_namespace,
+            client=mock_client,
         ) as template:
             assert template == mock_template
 
         mock_urlretrieve.assert_called_once_with(
             url="https://example.com/template.yaml", filename="/tmp/custom-template"
         )
-        mock_template_class.assert_called_once()
+        mock_template_class.assert_called_once_with(
+            yaml_file="/tmp/custom-template",
+            namespace=mock_namespace,
+            client=mock_client,
+        )
 
 
 class TestGuestAgentVersionParser:


### PR DESCRIPTION
##### Short description:
Make create_custom_template_from_url take a mandatory DynamicClient and update all call sites to pass an admin_client explicitly (no implicit default clients).


##### What this PR does / why we need it:
As of its next releas, openshift-python-wrapper will enforce passing `client` when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources  should be updated to pass `client` arg.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test fixtures to accept and propagate an admin client parameter through template creation workflow. Modified fixture signatures and test expectations to support client parameter usage in template initialization functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->