### PR TITLE
[VIRT] Move virt-only fixtures closer to their usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,6 @@ from utilities.artifactory import get_artifactory_header, get_http_image_url, ge
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.constants import (
     AAQ_NAMESPACE_LABEL,
-    AMD,
     ARM_64,
     ARQ_QUOTA_HARD_SPEC,
     AUDIT_LOGS_PATH,
@@ -90,7 +89,6 @@ from utilities.constants import (
     HCO_SUBSCRIPTION,
     HOTFIX_STR,
     INSTANCE_TYPE_STR,
-    INTEL,
     KMP_ENABLED_LABEL,
     KMP_VM_ASSIGNMENT_LABEL,
     KUBECONFIG,
@@ -105,15 +103,12 @@ from utilities.constants import (
     OVS_BRIDGE,
     POD_SECURITY_NAMESPACE_LABELS,
     PREFERENCE_STR,
-    RHEL9_PREFERENCE,
     RHEL9_STR,
-    RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
     RHSM_SECRET_NAME,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
     TIMEOUT_5MIN,
-    U1_SMALL,
     UNPRIVILEGED_PASSWORD,
     UNPRIVILEGED_USER,
     UTILITY,
@@ -196,9 +191,7 @@ from utilities.storage import (
     verify_boot_sources_reimported,
 )
 from utilities.virt import (
-    VirtualMachineForCloning,
     VirtualMachineForTests,
-    create_vm_cloning_job,
     fedora_vm_body,
     get_all_virt_pods_with_running_status,
     get_base_templates_list,
@@ -208,7 +201,6 @@ from utilities.virt import (
     kubernetes_taint_exists,
     running_vm,
     start_and_fetch_processid_on_linux_vm,
-    target_vm_from_cloning_job,
     vm_instance_from_template,
     wait_for_kv_stabilize,
     wait_for_windows_vm,
@@ -742,11 +734,6 @@ def workers_type(workers_utility_pods, installing_cnv):
     return virtual
 
 
-@pytest.fixture(scope="session")
-def is_psi_cluster():
-    return Infrastructure(name="cluster").instance.status.platform == "OpenStack"
-
-
 @pytest.fixture()
 def data_volume_multi_storage_scope_function(
     request,
@@ -1095,16 +1082,6 @@ def skip_access_mode_rwo_scope_function(storage_class_matrix__function__):
 @pytest.fixture(scope="class")
 def skip_access_mode_rwo_scope_class(storage_class_matrix__class__):
     _skip_access_mode_rwo(storage_class_matrix=storage_class_matrix__class__)
-
-
-@pytest.fixture(scope="session")
-def nodes_cpu_vendor(schedulable_nodes):
-    if schedulable_nodes[0].labels.get(f"cpu-vendor.node.kubevirt.io/{AMD}"):
-        return AMD
-    elif schedulable_nodes[0].labels.get(f"cpu-vendor.node.kubevirt.io/{INTEL}"):
-        return INTEL
-    else:
-        return None
 
 
 @pytest.fixture(scope="session")
@@ -2341,11 +2318,6 @@ def migration_policy_with_bandwidth_scope_class():
 
 
 @pytest.fixture(scope="session")
-def gpu_nodes(nodes):
-    return get_nodes_with_label(nodes=nodes, label="nvidia.com/gpu.present")
-
-
-@pytest.fixture(scope="session")
 def worker_machine1(worker_node1):
     machine = Machine(
         name=worker_node1.machine_name,
@@ -2395,21 +2367,6 @@ def vm_for_test(request, namespace, unprivileged_client):
         name=vm_name,
         body=fedora_vm_body(name=vm_name),
         namespace=namespace.name,
-    ) as vm:
-        running_vm(vm=vm)
-        yield vm
-
-
-@pytest.fixture(scope="class")
-def rhel_vm_with_instancetype_and_preference_for_cloning(namespace, unprivileged_client):
-    with VirtualMachineForCloning(
-        name=RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
-        image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
-        namespace=namespace.name,
-        client=unprivileged_client,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
-        vm_preference=VirtualMachineClusterPreference(name=RHEL9_PREFERENCE),
-        os_flavor=OS_FLAVOR_RHEL,
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -2466,25 +2423,6 @@ def hyperconverged_status_templates_scope_class(
     hyperconverged_resource_scope_class,
 ):
     return hyperconverged_resource_scope_class.instance.status.dataImportCronTemplates
-
-
-@pytest.fixture()
-def cloning_job_scope_function(request, unprivileged_client, namespace):
-    with create_vm_cloning_job(
-        name=f"clone-job-{request.param['source_name']}",
-        client=unprivileged_client,
-        namespace=namespace.name,
-        source_name=request.param["source_name"],
-        label_filters=request.param.get("label_filters"),
-        annotation_filters=request.param.get("annotation_filters"),
-    ) as vmc:
-        yield vmc
-
-
-@pytest.fixture()
-def target_vm_scope_function(unprivileged_client, cloning_job_scope_function):
-    with target_vm_from_cloning_job(client=unprivileged_client, cloning_job=cloning_job_scope_function) as target_vm:
-        yield target_vm
 
 
 @pytest.fixture(scope="module")
@@ -2621,18 +2559,6 @@ def vm_for_migration_test(request, namespace, unprivileged_client, cpu_for_migra
 @pytest.fixture(scope="class")
 def ssp_resource_scope_class(admin_client, hco_namespace):
     return get_ssp_resource(admin_client=admin_client, namespace=hco_namespace)
-
-
-@pytest.fixture(scope="session")
-def skip_test_if_no_odf_cephfs_sc(cluster_storage_classes_names):
-    """
-    Skip test if no odf cephfs storage class available
-    """
-    if StorageClassNames.CEPHFS not in cluster_storage_classes_names:
-        pytest.skip(
-            f"Skipping test, {StorageClassNames.CEPHFS} storage class is not deployed,"
-            f"deployed storage classes: {cluster_storage_classes_names}"
-        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/virt/cluster/vm_cloning/conftest.py
+++ b/tests/virt/cluster/vm_cloning/conftest.py
@@ -1,6 +1,25 @@
 import pytest
+from ocp_resources.virtual_machine_cluster_instancetype import (
+    VirtualMachineClusterInstancetype,
+)
+from ocp_resources.virtual_machine_cluster_preference import (
+    VirtualMachineClusterPreference,
+)
 
-from utilities.virt import VirtualMachineForCloning, fedora_vm_body, running_vm
+from utilities.constants import (
+    OS_FLAVOR_RHEL,
+    RHEL9_PREFERENCE,
+    RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
+    U1_SMALL,
+    Images,
+)
+from utilities.virt import (
+    VirtualMachineForCloning,
+    create_vm_cloning_job,
+    fedora_vm_body,
+    running_vm,
+    target_vm_from_cloning_job,
+)
 
 
 @pytest.fixture(scope="class")
@@ -18,3 +37,35 @@ def fedora_vm_for_cloning(request, unprivileged_client, namespace, cpu_for_migra
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)
         yield vm
+
+
+@pytest.fixture(scope="class")
+def rhel_vm_with_instancetype_and_preference_for_cloning(namespace, unprivileged_client):
+    with VirtualMachineForCloning(
+        name=RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
+        image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
+        namespace=namespace.name,
+        client=unprivileged_client,
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
+        vm_preference=VirtualMachineClusterPreference(name=RHEL9_PREFERENCE),
+        os_flavor=OS_FLAVOR_RHEL,
+    ) as vm:
+        running_vm(vm=vm)
+        yield vm
+
+
+@pytest.fixture()
+def cloning_job_scope_function(request, unprivileged_client, namespace):
+    yield from create_vm_cloning_job(
+        name=f"clone-job-{request.param['source_name']}",
+        client=unprivileged_client,
+        namespace=namespace.name,
+        source_name=request.param["source_name"],
+        label_filters=request.param.get("label_filters"),
+        annotation_filters=request.param.get("annotation_filters"),
+    )
+
+
+@pytest.fixture()
+def target_vm_scope_function(unprivileged_client, cloning_job_scope_function):
+    yield from target_vm_from_cloning_job(client=unprivileged_client, cloning_job=cloning_job_scope_function)

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from bitmath import parse_string_unsafe
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.deployment import Deployment
+from ocp_resources.infrastructure import Infrastructure
 from ocp_resources.performance_profile import PerformanceProfile
 from ocp_resources.storage_profile import StorageProfile
 from pytest_testconfig import py_config
@@ -30,7 +31,7 @@ from tests.virt.utils import (
 )
 from utilities.constants import AMD, INTEL, TIMEOUT_1MIN, TIMEOUT_5SEC, NamespacesNames
 from utilities.exceptions import UnsupportedGPUDeviceError
-from utilities.infra import ExecCommandOnPod, label_nodes
+from utilities.infra import ExecCommandOnPod, get_nodes_with_label, label_nodes
 from utilities.pytest_utils import exit_pytest_execution
 from utilities.virt import get_nodes_gpu_info, vm_instance_from_template
 
@@ -42,7 +43,6 @@ def virt_special_infra_sanity(
     request,
     admin_client,
     junitxml_plugin,
-    is_psi_cluster,
     schedulable_nodes,
     gpu_nodes,
     nodes_with_supported_gpus,
@@ -54,9 +54,9 @@ def virt_special_infra_sanity(
 ):
     """Performs verification that cluster has all required capabilities based on collected tests."""
 
-    def _verify_not_psi_cluster(_is_psi_cluster):
+    def _verify_not_psi_cluster():
         LOGGER.info("Verifying tests run on BM cluster")
-        if _is_psi_cluster:
+        if Infrastructure(name="cluster").instance.status.platform == "OpenStack":
             failed_verifications_list.append("Cluster should be BM and not PSI")
 
     def _verify_cpumanager_workers(_schedulable_nodes):
@@ -143,7 +143,7 @@ def virt_special_infra_sanity(
     if not request.session.config.getoption(skip_virt_sanity_check):
         LOGGER.info("Verifying that cluster has all required capabilities for special_infra marked tests")
         if any(item.get_closest_marker("high_resource_vm") for item in request.session.items):
-            _verify_not_psi_cluster(_is_psi_cluster=is_psi_cluster)
+            _verify_not_psi_cluster()
             _verify_hw_virtualization(
                 _schedulable_nodes=schedulable_nodes, _nodes_cpu_virt_extension=nodes_cpu_virt_extension
             )
@@ -389,3 +389,18 @@ def vm_for_test_from_template_scope_class(
 @pytest.fixture(scope="class")
 def hco_memory_overcommit_increased(hyperconverged_resource_scope_class):
     yield from update_hco_memory_overcommit(hco=hyperconverged_resource_scope_class, percentage=200)
+
+
+@pytest.fixture(scope="session")
+def gpu_nodes(nodes):
+    return get_nodes_with_label(nodes=nodes, label="nvidia.com/gpu.present")
+
+
+@pytest.fixture(scope="session")
+def nodes_cpu_vendor(schedulable_nodes):
+    if schedulable_nodes[0].labels.get(f"cpu-vendor.node.kubevirt.io/{AMD}"):
+        return AMD
+    elif schedulable_nodes[0].labels.get(f"cpu-vendor.node.kubevirt.io/{INTEL}"):
+        return INTEL
+    else:
+        return None

--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -23,6 +23,18 @@ def vm_with_common_cpu_model_scope_function(
         yield vm_from_template
 
 
+@pytest.fixture(scope="session")
+def xfail_if_no_odf_cephfs_sc(cluster_storage_classes_names):
+    """
+    Skip test if no odf cephfs storage class available
+    """
+    if StorageClassNames.CEPHFS not in cluster_storage_classes_names:
+        pytest.xfail(
+            f"Cannot execute test, {StorageClassNames.CEPHFS} storage class is not deployed,"
+            f"deployed storage classes: {cluster_storage_classes_names}"
+        )
+
+
 @pytest.mark.parametrize(
     "golden_image_data_source_for_test_scope_function,"
     "golden_image_data_volume_template_for_test_scope_function,"
@@ -37,7 +49,5 @@ def vm_with_common_cpu_model_scope_function(
     ],
     indirect=True,
 )
-def test_vm_with_odf_cephfs_storage_class_migrates(
-    skip_test_if_no_odf_cephfs_sc, vm_with_common_cpu_model_scope_function
-):
+def test_vm_with_odf_cephfs_storage_class_migrates(xfail_if_no_odf_cephfs_sc, vm_with_common_cpu_model_scope_function):
     migrate_vm_and_verify(vm=vm_with_common_cpu_model_scope_function)


### PR DESCRIPTION
This PR Moves virt-only fixtures closer to their usage from the main tests/conftest.py to tests/virt/conftest.py for better organization and proximity to their usage.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: 

https://issues.redhat.com/browse/CNV-72171


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added RHEL VM cloning scenarios, a target-VM test scope, GPU discovery and CPU-vendor detection fixtures, and a session-level xfail for missing ODF CephFS.
* **Chores**
  * Removed deprecated test utilities and several public test hooks to reduce the public test surface.
* **Refactor**
  * Streamlined fixture signatures and simplified psi-cluster detection logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->