### PR TITLE
tests, net, kmp: Add client arg

### DIFF
--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -265,7 +265,7 @@ def restarted_vmi_b(vm_b):
 
 
 @pytest.fixture(scope="class")
-def disabled_ns_vm(unprivileged_client, disabled_ns, disabled_ns_nad, mac_pool):
+def disabled_ns_vm(admin_client, disabled_ns, disabled_ns_nad, mac_pool):
     networks = {disabled_ns_nad.name: disabled_ns_nad.name}
     name = f"{disabled_ns.name}-vm"
     with VirtualMachineForTests(
@@ -274,7 +274,7 @@ def disabled_ns_vm(unprivileged_client, disabled_ns, disabled_ns_nad, mac_pool):
         networks=networks,
         interfaces=networks.keys(),
         body=fedora_vm_body(name=name),
-        client=unprivileged_client,
+        client=admin_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
         vm.start(wait=True)
@@ -284,7 +284,7 @@ def disabled_ns_vm(unprivileged_client, disabled_ns, disabled_ns_nad, mac_pool):
 
 
 @pytest.fixture(scope="class")
-def enabled_ns_vm(unprivileged_client, kmp_enabled_ns, enabled_ns_nad, mac_pool):
+def enabled_ns_vm(admin_client, kmp_enabled_ns, enabled_ns_nad, mac_pool):
     networks = {enabled_ns_nad.name: enabled_ns_nad.name}
     name = f"{kmp_enabled_ns.name}-vm"
     with VirtualMachineForTests(
@@ -293,7 +293,7 @@ def enabled_ns_vm(unprivileged_client, kmp_enabled_ns, enabled_ns_nad, mac_pool)
         networks=networks,
         interfaces=networks.keys(),
         body=fedora_vm_body(name=name),
-        client=unprivileged_client,
+        client=admin_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
         vm.start(wait=True)
@@ -303,7 +303,7 @@ def enabled_ns_vm(unprivileged_client, kmp_enabled_ns, enabled_ns_nad, mac_pool)
 
 
 @pytest.fixture(scope="class")
-def no_label_ns_vm(unprivileged_client, no_label_ns, no_label_ns_nad, mac_pool):
+def no_label_ns_vm(admin_client, no_label_ns, no_label_ns_nad, mac_pool):
     networks = {no_label_ns_nad.name: no_label_ns_nad.name}
     name = f"{no_label_ns.name}-vm"
     with VirtualMachineForTests(
@@ -312,7 +312,7 @@ def no_label_ns_vm(unprivileged_client, no_label_ns, no_label_ns_nad, mac_pool):
         networks=networks,
         interfaces=networks.keys(),
         body=fedora_vm_body(name=name),
-        client=unprivileged_client,
+        client=admin_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
         vm.start(wait=True)


### PR DESCRIPTION
##### Short description:
Updated VM fixtures - all calls to openshift-python-wrapper resource should be updated to pass client.


##### What this PR does / why we need it:
As of its next release, openshift-python-wrapper will enforce passing client when working with cluster resources.
openshift-virtualization-tests must align with this change.
All calls in the code to openshift-python-wrapper resources should be updated to pass client arg.

Since the KMP NS is created with an admin_client the VMs must be created with the same client - VMs under a namespace that is not created by a project admin require admin privileges.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixtures updated to exercise VMs with elevated/admin access to cover additional scenarios.
  * VMs are started and waited on during setup so tests hit running state deterministically.
  * Added explicit teardown to remove allocated MACs, preventing leftover network state.
  * Improves lifecycle validation and overall reliability across network MAC pool configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->