### PR TITLE
remove explicit return_code from exit_pytest_execution for unittests

### DIFF
--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -975,7 +975,7 @@ class TestExitPytestExecution:
         mock_get_dir.return_value = "/tmp/test"
         message = "Sanity test failure"
 
-        exit_pytest_execution(message, return_code=99)
+        exit_pytest_execution(message)
 
         mock_collect.assert_called_once_with(
             since_time=300,
@@ -996,7 +996,7 @@ class TestExitPytestExecution:
         mock_collect.side_effect = Exception("Must-gather failed")
         message = "Sanity test failure"
 
-        exit_pytest_execution(message, return_code=99)
+        exit_pytest_execution(message)
 
         # Should log warning but still exit
         mock_logger.warning.assert_called_once()
@@ -1031,7 +1031,7 @@ class TestExitPytestExecution:
         filename = "error.log"
         mock_junitxml = MagicMock()
 
-        exit_pytest_execution(message, return_code=99, filename=filename, junitxml_property=mock_junitxml)
+        exit_pytest_execution(message, filename=filename, junitxml_property=mock_junitxml)
 
         # All components should be called
         mock_collect.assert_called_once_with(


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test exit handling patterns to use standardized failure code management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->