### PR TITLE
Add client in infrastructure numa folder and create_custom_template_from_url

### DIFF
--- a/tests/infrastructure/numa/conftest.py
+++ b/tests/infrastructure/numa/conftest.py
@@ -55,6 +55,7 @@ def created_vm_cx1_instancetype(
             data_source=DataSource(
                 name=data_source_name,
                 namespace=golden_images_namespace.name,
+                client=unprivileged_client,
             ),
             storage_class=[*storage_class_matrix__module__][0],
         ),

--- a/tests/infrastructure/sap/test_sap_hana_vm.py
+++ b/tests/infrastructure/sap/test_sap_hana_vm.py
@@ -474,10 +474,11 @@ def sap_hana_template_labels():
 
 
 @pytest.fixture(scope="module")
-def sap_hana_template(tmpdir_factory):
+def sap_hana_template(admin_client, tmpdir_factory):
     template_name = "sap_hana_template"
     template_dir = tmpdir_factory.mktemp(template_name)
     with create_custom_template_from_url(
+        client=admin_client,
         url=f"{CNV_SUPPLEMENTAL_TEMPLATES_URL}/saphana/rhel8.saphana.yaml",
         template_name=f"{template_name}.yaml",
         template_dir=template_dir,

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -248,9 +248,10 @@ def sriov_vm_migrate(index_number, unprivileged_client, namespace, sriov_network
 
 
 @pytest.fixture(scope="class")
-def dpdk_template(namespace, tmpdir_factory):
+def dpdk_template(admin_client, namespace, tmpdir_factory):
     template_dir = tmpdir_factory.mktemp("dpdk_template")
     with create_custom_template_from_url(
+        client=admin_client,
         url=f"{CNV_SUPPLEMENTAL_TEMPLATES_URL}/testpmd/resource-specs/sriov-vm1-template.yaml",
         template_name="dpdk_vm_template.yaml",
         template_dir=template_dir,

--- a/utilities/ssp.py
+++ b/utilities/ssp.py
@@ -150,13 +150,14 @@ def wait_for_condition_message_value(resource, expected_message):
 
 
 @contextmanager
-def create_custom_template_from_url(url, template_name, template_dir, namespace):
+def create_custom_template_from_url(client, url, template_name, template_dir, namespace):
     template_filepath = os.path.join(template_dir, template_name)
     urllib.request.urlretrieve(
         url=url,
         filename=template_filepath,
     )
     with Template(
+        client=client,
         yaml_file=template_filepath,
         namespace=namespace,
     ) as template:

--- a/utilities/unittests/test_ssp.py
+++ b/utilities/unittests/test_ssp.py
@@ -342,6 +342,7 @@ class TestCreateCustomTemplateFromUrl:
     @patch("utilities.ssp.Template")
     def test_create_custom_template_from_url_success(self, mock_template_class, mock_urlretrieve):
         """Test successful creation of custom template from URL"""
+        mock_admin_client = MagicMock()
         mock_template = MagicMock()
         mock_template_class.return_value.__enter__ = MagicMock(return_value=mock_template)
         mock_template_class.return_value.__exit__ = MagicMock(return_value=None)
@@ -349,6 +350,7 @@ class TestCreateCustomTemplateFromUrl:
         mock_namespace = MagicMock()
 
         with create_custom_template_from_url(
+            client=mock_admin_client,
             url="https://example.com/template.yaml",
             template_name="custom-template",
             template_dir="/tmp",


### PR DESCRIPTION
##### Short description:
Add client to wrapper resources in infrastructure/numa and  `create_custom_template_from_url`

##### What this PR does / why we need it:
The `client` in resources from the openshift-python-wrapper are planned to be a `required` field

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to pass client authentication context when creating custom templates.

* **Chores**
  * Updated utility function for template creation to accept and propagate client parameter for improved authorization handling across template operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->