### PR TITLE
Add client in infrastructure tekton, numa, vhostmd folders

### DIFF
--- a/tests/infrastructure/numa/conftest.py
+++ b/tests/infrastructure/numa/conftest.py
@@ -53,6 +53,7 @@ def created_vm_cx1_instancetype(
         vm_preference_infer=True,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=DataSource(
+                client=unprivileged_client,
                 name=data_source_name,
                 namespace=golden_images_namespace.name,
             ),

--- a/tests/infrastructure/tekton/test_tekton_custom_ns.py
+++ b/tests/infrastructure/tekton/test_tekton_custom_ns.py
@@ -21,6 +21,7 @@ class TestTektonResources:
     @pytest.mark.polarion("CNV-11254")
     def test_validate_tekton_pipeline_resources(
         self,
+        unprivileged_client,
         custom_pipeline_namespace,
         cnv_tekton_pipelines_resource_matrix__class__,
     ):
@@ -28,11 +29,13 @@ class TestTektonResources:
             tekton_namespace=custom_pipeline_namespace,
             tekton_resource_kind=Pipeline,
             resource_name=cnv_tekton_pipelines_resource_matrix__class__,
+            client=unprivileged_client,
         )
 
     @pytest.mark.polarion("CNV-11252")
     def test_validate_tekton_tasks_resources(
         self,
+        unprivileged_client,
         custom_pipeline_namespace,
         cnv_tekton_tasks_resource_matrix__class__,
     ):
@@ -40,6 +43,7 @@ class TestTektonResources:
             tekton_namespace=custom_pipeline_namespace,
             tekton_resource_kind=Task,
             resource_name=cnv_tekton_tasks_resource_matrix__class__,
+            client=unprivileged_client,
         )
 
 

--- a/tests/infrastructure/tekton/utils.py
+++ b/tests/infrastructure/tekton/utils.py
@@ -59,12 +59,14 @@ def win_iso_download_url_for_pipelineref():
     }
 
 
-def wait_for_tekton_resource_availability(tekton_namespace, tekton_resource_kind, resource_name):
+def wait_for_tekton_resource_availability(tekton_namespace, tekton_resource_kind, resource_name, client):
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_10SEC,
             sleep=TIMEOUT_5SEC,
-            func=lambda: tekton_resource_kind(namespace=tekton_namespace.name, name=resource_name).exists,
+            func=lambda: tekton_resource_kind(
+                namespace=tekton_namespace.name, name=resource_name, client=client
+            ).exists,
         ):
             if sample:
                 return True
@@ -103,11 +105,11 @@ def update_tekton_resources_yaml_file(file_path, replacements):
         file.write(yaml_content)
 
 
-def process_yaml_files(file_paths, replacements, resource_kind, namespace):
+def process_yaml_files(client, file_paths, replacements, resource_kind, namespace):
     resources = []
     for file_path in file_paths:
         update_tekton_resources_yaml_file(file_path=file_path, replacements=replacements)
-        resources.append(resource_kind(yaml_file=file_path, namespace=namespace).create())
+        resources.append(resource_kind(yaml_file=file_path, namespace=namespace, client=client).create())
     return resources
 
 

--- a/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
+++ b/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
@@ -114,19 +114,21 @@ def rhel_container_disk_image(rhel_version, cnv_rhel_container_disk_images_matri
 
 
 @pytest.fixture()
-def preferred_cluster_instance_type():
+def preferred_cluster_instance_type(unprivileged_client):
     instance_type_selector = (
         f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/class=general.purpose, "
         f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/cpu=1, "
         f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/memory in (2Gi, 4Gi)"
     )
-    return next(VirtualMachineClusterInstancetype.get(label_selector=instance_type_selector))
+    return next(
+        VirtualMachineClusterInstancetype.get(client=unprivileged_client, label_selector=instance_type_selector)
+    )
 
 
 @pytest.fixture()
-def preferred_preference_for_rhel_version(rhel_version):
+def preferred_preference_for_rhel_version(rhel_version, unprivileged_client):
     preference_name = re.sub(r"(\D+)(\d+)", r"\1.\2", rhel_version)
-    preference_object = VirtualMachineClusterPreference(name=preference_name)
+    preference_object = VirtualMachineClusterPreference(name=preference_name, client=unprivileged_client)
     if preference_object.exists:
         return preference_object
     raise ResourceNotFoundError(f"VirtualMachineClusterPreference {preference_name} not found")


### PR DESCRIPTION
##### Short description:
Add client in infrastructure tekton, numa, vhostmd folders

##### What this PR does / why we need it:
The client in resources from the openshift-python-wrapper are planned to be a required field

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68529


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to support client parameter propagation across test fixtures and utilities.
  * Enhanced test resource instantiation to properly associate resources with specified client contexts.
  * Improved test configuration in multiple test suites to enable better resource isolation and management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->