### PR TITLE
net, stability: Add IPv4 mark to KMP tests

### DIFF
--- a/tests/network/kubemacpool/test_kubemacpool.py
+++ b/tests/network/kubemacpool/test_kubemacpool.py
@@ -6,6 +6,8 @@ from utilities.virt import VirtualMachineForTests
 
 from . import utils as kmp_utils
 
+pytestmark = [pytest.mark.ipv4]
+
 
 @pytest.mark.s390x
 class TestKMPConnectivity:


### PR DESCRIPTION
KMP tests focus on validating MAC addresses and are designed to run with IPv4 address configurations. Because of this, running them on a single stack IPv6 environment does not add value.
An IPv4 mark is added so that these tests are not collected on the single stack IPv6 lane.

##### jira-ticket: https://issues.redhat.com/browse/CNV-74434
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test collection configuration for IPv4-specific test scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->