### PR TITLE
 net, stability: Refactor dual_stack_network_data

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -96,17 +96,21 @@ def worker_node1_pod_executor(workers_utility_pods, worker_node1):
 
 
 @pytest.fixture(scope="module")
-def dual_stack_network_data(ipv6_supported_cluster):
+def ipv6_primary_interface_cloud_init_data(
+    ipv4_supported_cluster: bool, ipv6_supported_cluster: bool
+) -> dict[str, dict] | None:
     if ipv6_supported_cluster:
         return {
             "ethernets": {
                 "eth0": {
-                    "dhcp4": True,
                     "addresses": ["fd10:0:2::2/120"],
                     "gateway6": "fd10:0:2::1",
+                    "dhcp4": ipv4_supported_cluster,
+                    "dhcp6": False,
                 },
             },
         }
+    return None
 
 
 @pytest.fixture(scope="session")

--- a/tests/network/connectivity/conftest.py
+++ b/tests/network/connectivity/conftest.py
@@ -269,7 +269,7 @@ def vm_linux_bridge_attached_vma_source(
     nad_linux_bridge,
     nad_linux_bridge_vlan_1,
     nad_linux_bridge_vlan_2,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
 ):
     network_names = [
         nad_linux_bridge.name,
@@ -282,7 +282,7 @@ def vm_linux_bridge_attached_vma_source(
         end_ip_octet=1,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         network_names=network_names,
-        dual_stack_network_data=dual_stack_network_data,
+        ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
         client=unprivileged_client,
         namespace=namespace,
     )
@@ -296,7 +296,7 @@ def vm_ovs_bridge_attached_vma_source(
     nad_ovs_bridge,
     nad_ovs_bridge_vlan_1,
     nad_ovs_bridge_vlan_2,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
 ):
     network_names = [
         nad_ovs_bridge.name,
@@ -309,7 +309,7 @@ def vm_ovs_bridge_attached_vma_source(
         end_ip_octet=1,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         network_names=network_names,
-        dual_stack_network_data=dual_stack_network_data,
+        ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
         client=unprivileged_client,
         namespace=namespace,
     )
@@ -323,7 +323,7 @@ def vm_linux_bridge_attached_vmb_destination(
     nad_linux_bridge,
     nad_linux_bridge_vlan_1,
     nad_linux_bridge_vlan_3,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
 ):
     network_names = [
         nad_linux_bridge.name,
@@ -336,7 +336,7 @@ def vm_linux_bridge_attached_vmb_destination(
         end_ip_octet=2,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         network_names=network_names,
-        dual_stack_network_data=dual_stack_network_data,
+        ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
         client=unprivileged_client,
         namespace=namespace,
     )
@@ -350,7 +350,7 @@ def vm_ovs_bridge_attached_vmb_destination(
     nad_ovs_bridge,
     nad_ovs_bridge_vlan_1,
     nad_ovs_bridge_vlan_3,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
 ):
     network_names = [
         nad_ovs_bridge.name,
@@ -363,7 +363,7 @@ def vm_ovs_bridge_attached_vmb_destination(
         end_ip_octet=2,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         network_names=network_names,
-        dual_stack_network_data=dual_stack_network_data,
+        ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
         client=unprivileged_client,
         namespace=namespace,
     )

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -72,8 +72,8 @@ def pod_net_running_vmb(pod_net_vmb):
 
 
 @pytest.fixture(scope="module")
-def cloud_init_ipv6_network_data(dual_stack_network_data):
-    return compose_cloud_init_data_dict(ipv6_network_data=dual_stack_network_data)
+def cloud_init_ipv6_network_data(ipv6_primary_interface_cloud_init_data):
+    return compose_cloud_init_data_dict(ipv6_network_data=ipv6_primary_interface_cloud_init_data)
 
 
 @pytest.mark.parametrize(

--- a/tests/network/connectivity/utils.py
+++ b/tests/network/connectivity/utils.py
@@ -14,7 +14,7 @@ def create_running_vm(
     end_ip_octet,
     node_selector,
     network_names,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
     client,
     namespace,
 ):
@@ -37,7 +37,7 @@ def create_running_vm(
                     for i in range(0, 3)
                 }
             },
-            ipv6_network_data=dual_stack_network_data,
+            ipv6_network_data=ipv6_primary_interface_cloud_init_data,
         ),
         client=client,
     ) as vm:

--- a/tests/network/general/test_ip_family_services.py
+++ b/tests/network/general/test_ip_family_services.py
@@ -35,10 +35,10 @@ def running_vm_for_exposure(
     worker_node1,
     namespace,
     unprivileged_client,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
 ):
     vm_name = "exposed-vm"
-    cloud_init_data = compose_cloud_init_data_dict(ipv6_network_data=dual_stack_network_data)
+    cloud_init_data = compose_cloud_init_data_dict(ipv6_network_data=ipv6_primary_interface_cloud_init_data)
 
     with VirtualMachineForTests(
         namespace=namespace.name,

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -114,7 +114,7 @@ def vma(
     namespace,
     unprivileged_client,
     cpu_for_migration,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
     br1test_nad,
 ):
     name = "vma"
@@ -124,8 +124,9 @@ def vma(
     }
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,
-        ipv6_network_data=dual_stack_network_data,
+        ipv6_network_data=ipv6_primary_interface_cloud_init_data,
     )
+
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
@@ -145,7 +146,7 @@ def vmb(
     namespace,
     unprivileged_client,
     cpu_for_migration,
-    dual_stack_network_data,
+    ipv6_primary_interface_cloud_init_data,
     br1test_nad,
 ):
     name = "vmb"
@@ -155,7 +156,7 @@ def vmb(
     }
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,
-        ipv6_network_data=dual_stack_network_data,
+        ipv6_network_data=ipv6_primary_interface_cloud_init_data,
     )
 
     with VirtualMachineForTests(


### PR DESCRIPTION
Problem:
Some tests from single-stack IPv6 lane fail for `no ssh session` when pinging from guest VM to other guest VM over pod network.
This error happens because the guest is missing masquerade IPv6 address on the primary interface.
On single stack IPv6 clusters, by default, the primary interface of guest is not configured with a masquerade IPv6 address - it must be configured manually in cloud-init.
The existing cloud-init configuration is conflicting as it assigns static address for `gateway6` while the default for `dhcp6` is True - this is breaking the assignment of IPv6 address on the primary interface of guest and ssh is failing.

Fix:
Fix the conflicting configuration for primary interface when using IPv6 cluster by refactoring the fixture `dual_stack_network_data` since this configuration must be used both on dual-stack clusters and single-stack IPv6 clusters.


##### jira-ticket: https://issues.redhat.com/browse/CNV-72381
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Test network fixtures renamed to clarify IPv6-primary interface behavior and adjusted DHCP settings when IPv4 is absent.
  * Test helpers and VM setup updated to use the new fixture shape and parameters across connectivity, migration, and general network tests.
  * Default test service IP-family behavior clarified to prefer IPv6 where applicable; no user-facing behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->