### PR TITLE
  [VIRT] Replace cluster-wide CPU config with per-VM CPU for selected tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
 import utilities.hco
-from tests.utils import download_and_extract_tar, update_cluster_cpu_model
+from tests.utils import download_and_extract_tar
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.cluster import cache_admin_client
@@ -203,7 +203,6 @@ from utilities.virt import (
     running_vm,
     start_and_fetch_processid_on_linux_vm,
     vm_instance_from_template,
-    wait_for_kv_stabilize,
     wait_for_windows_vm,
 )
 
@@ -2526,74 +2525,6 @@ def is_aws_cluster(admin_client):
 def skip_on_aws_cluster(is_aws_cluster):
     if is_aws_cluster:
         pytest.skip("This test is skipped on an AWS cluster")
-
-
-@pytest.fixture()
-def cluster_cpu_model_scope_function(
-    admin_client,
-    hco_namespace,
-    hyperconverged_resource_scope_function,
-    cluster_common_node_cpu,
-):
-    with update_cluster_cpu_model(
-        admin_client=admin_client,
-        hco_namespace=hco_namespace,
-        hco_resource=hyperconverged_resource_scope_function,
-        cpu_model=cluster_common_node_cpu,
-    ):
-        yield
-    wait_for_kv_stabilize(admin_client=admin_client, hco_namespace=hco_namespace)
-
-
-@pytest.fixture(scope="module")
-def cluster_cpu_model_scope_module(
-    admin_client,
-    hco_namespace,
-    hyperconverged_resource_scope_module,
-    cluster_common_node_cpu,
-):
-    with update_cluster_cpu_model(
-        admin_client=admin_client,
-        hco_namespace=hco_namespace,
-        hco_resource=hyperconverged_resource_scope_module,
-        cpu_model=cluster_common_node_cpu,
-    ):
-        yield
-    wait_for_kv_stabilize(admin_client=admin_client, hco_namespace=hco_namespace)
-
-
-@pytest.fixture(scope="class")
-def cluster_cpu_model_scope_class(
-    admin_client,
-    hco_namespace,
-    hyperconverged_resource_scope_class,
-    cluster_common_node_cpu,
-):
-    with update_cluster_cpu_model(
-        admin_client=admin_client,
-        hco_namespace=hco_namespace,
-        hco_resource=hyperconverged_resource_scope_class,
-        cpu_model=cluster_common_node_cpu,
-    ):
-        yield
-    wait_for_kv_stabilize(admin_client=admin_client, hco_namespace=hco_namespace)
-
-
-@pytest.fixture(scope="class")
-def cluster_modern_cpu_model_scope_class(
-    admin_client,
-    hco_namespace,
-    hyperconverged_resource_scope_class,
-    cluster_common_modern_node_cpu,
-):
-    with update_cluster_cpu_model(
-        admin_client=admin_client,
-        hco_namespace=hco_namespace,
-        hco_resource=hyperconverged_resource_scope_class,
-        cpu_model=cluster_common_modern_node_cpu,
-    ):
-        yield
-    wait_for_kv_stabilize(admin_client=admin_client, hco_namespace=hco_namespace)
 
 
 @pytest.fixture(scope="module")

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -31,7 +31,6 @@ LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestCommonTemplatesCentos"
 
 
-@pytest.mark.usefixtures("cluster_cpu_model_scope_class")
 class TestCommonTemplatesCentos:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")
     @pytest.mark.polarion("CNV-5337")

--- a/tests/virt/cluster/common_templates/conftest.py
+++ b/tests/virt/cluster/common_templates/conftest.py
@@ -33,6 +33,7 @@ def matrix_centos_os_vm_from_template(
     namespace,
     centos_os_matrix__class__,
     matrix_centos_os_golden_image_data_source,
+    cpu_for_migration,
 ):
     return matrix_os_vm_from_template(
         unprivileged_client=unprivileged_client,
@@ -42,6 +43,7 @@ def matrix_centos_os_vm_from_template(
         data_volume_template=get_data_volume_template_dict_with_default_storage_class(
             data_source=matrix_centos_os_golden_image_data_source
         ),
+        cpu_model=cpu_for_migration,
     )
 
 
@@ -60,6 +62,7 @@ def matrix_fedora_os_vm_from_template(
     namespace,
     fedora_os_matrix__class__,
     matrix_fedora_os_golden_image_data_source,
+    cpu_for_migration,
 ):
     return matrix_os_vm_from_template(
         request=request,
@@ -70,6 +73,7 @@ def matrix_fedora_os_vm_from_template(
         data_volume_template=get_data_volume_template_dict_with_default_storage_class(
             data_source=matrix_fedora_os_golden_image_data_source
         ),
+        cpu_model=cpu_for_migration,
     )
 
 
@@ -87,6 +91,7 @@ def matrix_rhel_os_vm_from_template(
     namespace,
     rhel_os_matrix__class__,
     matrix_rhel_os_golden_image_data_source,
+    cpu_for_migration,
 ):
     return matrix_os_vm_from_template(
         unprivileged_client=unprivileged_client,
@@ -96,6 +101,7 @@ def matrix_rhel_os_vm_from_template(
         data_volume_template=get_data_volume_template_dict_with_default_storage_class(
             data_source=matrix_rhel_os_golden_image_data_source
         ),
+        cpu_model=cpu_for_migration,
     )
 
 
@@ -113,6 +119,7 @@ def matrix_windows_os_vm_from_template(
     namespace,
     windows_os_matrix__class__,
     matrix_windows_os_golden_image_data_source,
+    modern_cpu_for_migration,
 ):
     return matrix_os_vm_from_template(
         unprivileged_client=unprivileged_client,
@@ -122,6 +129,7 @@ def matrix_windows_os_vm_from_template(
         data_volume_template=get_data_volume_template_dict_with_default_storage_class(
             data_source=matrix_windows_os_golden_image_data_source
         ),
+        cpu_model=modern_cpu_for_migration,
     )
 
 

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -78,7 +78,6 @@ HYPERV_DICT = {
     [({"vm_dict": HYPERV_DICT})],
     indirect=True,
 )
-@pytest.mark.usefixtures("cluster_cpu_model_scope_class")
 class TestCommonTemplatesFedora:
     @pytest.mark.sno
     @pytest.mark.ibm_bare_metal

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -39,7 +39,6 @@ LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestCommonTemplatesRhel"
 
 
-@pytest.mark.usefixtures("cluster_cpu_model_scope_class")
 class TestCommonTemplatesRhel:
     @pytest.mark.arm64
     @pytest.mark.sno

--- a/tests/virt/cluster/common_templates/utils.py
+++ b/tests/virt/cluster/common_templates/utils.py
@@ -518,6 +518,7 @@ def matrix_os_vm_from_template(
     namespace: Namespace,
     data_source_object: DataSource,
     os_matrix: dict[str, dict],
+    cpu_model: str | None = None,
     request: Optional[FixtureRequest] = None,
     data_volume_template: Optional[dict[str, dict]] = None,
 ) -> VirtualMachineForTestsFromTemplate:
@@ -532,6 +533,7 @@ def matrix_os_vm_from_template(
         labels=Template.generate_template_labels(**os_matrix[os_matrix_key]["template_labels"]),
         data_volume_template=data_volume_template,
         vm_dict=param_dict.get("vm_dict"),
+        cpu_model=cpu_model,
     )
 
 

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -32,7 +32,6 @@ LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestCommonTemplatesWindows"
 
 
-@pytest.mark.usefixtures("cluster_cpu_model_scope_class")
 class TestCommonTemplatesWindows:
     @pytest.mark.sno
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -119,7 +119,6 @@ def test_evictionstrategy_in_kubevirt(sno_cluster, kubevirt_config_scope_module)
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("cluster_cpu_model_scope_class")
 class TestEvictionStrategy:
     @pytest.mark.polarion("CNV-10087")
     def test_hco_evictionstrategy_livemigrate_vm_no_evictionstrategy(

--- a/tests/virt/cluster/vm_lifecycle/conftest.py
+++ b/tests/virt/cluster/vm_lifecycle/conftest.py
@@ -10,12 +10,13 @@ default_run_strategy = VirtualMachine.RunStrategy.MANUAL
 
 
 @contextmanager
-def container_disk_vm(namespace, unprivileged_client, data_volume_template=None):
+def container_disk_vm(namespace, unprivileged_client, cpu_model=None, data_volume_template=None):
     """lifecycle_vm is used to call this fixture and data_volume_vm; data_source is not needed in this use cases"""
     name = "fedora-vm-lifecycle"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
+        cpu_model=cpu_model,
         client=unprivileged_client,
         body=fedora_vm_body(name=name),
         run_strategy=default_run_strategy,
@@ -24,10 +25,11 @@ def container_disk_vm(namespace, unprivileged_client, data_volume_template=None)
 
 
 @contextmanager
-def data_volume_vm(unprivileged_client, namespace, data_volume_template):
+def data_volume_vm(unprivileged_client, namespace, data_volume_template, cpu_model=None):
     with VirtualMachineForTests(
         name="rhel-vm-lifecycle",
         namespace=namespace.name,
+        cpu_model=cpu_model,
         client=unprivileged_client,
         memory_requests=Images.Rhel.DEFAULT_MEMORY_SIZE,
         run_strategy=default_run_strategy,
@@ -38,7 +40,7 @@ def data_volume_vm(unprivileged_client, namespace, data_volume_template):
 
 @pytest.fixture(scope="class")
 def lifecycle_vm(
-    cluster_cpu_model_scope_module,
+    cpu_for_migration,
     unprivileged_client,
     namespace,
     vm_volumes_matrix__class__,
@@ -53,5 +55,6 @@ def lifecycle_vm(
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_module,
+        cpu_model=cpu_for_migration,
     ) as vm:
         yield vm

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -365,12 +365,14 @@ def vm_for_test_from_template_scope_class(
     unprivileged_client,
     namespace,
     golden_image_data_volume_template_for_test_scope_class,
+    modern_cpu_for_migration,
 ):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
+        vm_cpu_model=modern_cpu_for_migration,
     ) as vm:
         yield vm
 

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -35,13 +35,14 @@ RHEL_8_10_TEMPLATE_LABELS = {
 
 
 @pytest.fixture(scope="class")
-def vm_for_machine_type_test(request, cluster_cpu_model_scope_class, unprivileged_client, namespace):
+def vm_for_machine_type_test(request, cpu_for_migration, unprivileged_client, namespace):
     name = f"vm-{request.param['vm_name']}-machine-type"
 
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
+        cpu_model=cpu_for_migration,
         client=unprivileged_client,
         machine_type=request.param.get("machine_type"),
     ) as vm:

--- a/tests/virt/node/migration_and_maintenance/test_dedicated_live_migration_network.py
+++ b/tests/virt/node/migration_and_maintenance/test_dedicated_live_migration_network.py
@@ -102,14 +102,13 @@ def dedicated_migration_network_hco_config(
 
 @pytest.fixture(scope="class")
 def migration_vm_1(
-    namespace,
-    unprivileged_client,
-    golden_image_data_volume_template_for_test_scope_class,
+    namespace, unprivileged_client, golden_image_data_volume_template_for_test_scope_class, cpu_for_migration
 ):
     with VirtualMachineForTestsFromTemplate(
         name="migration-vm-1",
         labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
         namespace=namespace.name,
+        cpu_model=cpu_for_migration,
         client=unprivileged_client,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:
@@ -139,11 +138,13 @@ def migration_vm_2(
     unprivileged_client,
     golden_image_data_volume_template_for_test_scope_class,
     tainted_all_nodes_but_one,
+    cpu_for_migration,
 ):
     with VirtualMachineForTestsFromTemplate(
         name="migration-vm-2",
         labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
         namespace=namespace.name,
+        cpu_model=cpu_for_migration,
         client=unprivileged_client,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:
@@ -186,7 +187,6 @@ class TestDedicatedLiveMigrationNetwork:
     @pytest.mark.polarion("CNV-7877")
     def test_migrate_vm_via_dedicated_network(
         self,
-        cluster_cpu_model_scope_module,
         workers_utility_pods,
         migration_interface,
         virt_handler_pods_with_migration_network,

--- a/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
+++ b/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
@@ -62,11 +62,12 @@ def node_filter(pod, schedulable_nodes):
 
 
 @pytest.fixture()
-def vm_container_disk_fedora(cluster_cpu_model_scope_module, namespace, unprivileged_client):
+def vm_container_disk_fedora(cpu_for_migration, namespace, unprivileged_client):
     name = f"vm-nodemaintenance-{random.randrange(99999)}"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
+        cpu_model=cpu_for_migration,
         body=fedora_vm_body(name=name),
         client=unprivileged_client,
     ) as vm:
@@ -121,7 +122,6 @@ def test_node_drain_using_console_fedora(
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("cluster_cpu_model_scope_class")
 @pytest.mark.ibm_bare_metal
 class TestNodeMaintenanceRHEL:
     @pytest.mark.polarion("CNV-2292")
@@ -166,7 +166,6 @@ class TestNodeMaintenanceRHEL:
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("cluster_modern_cpu_model_scope_class")
 @pytest.mark.ibm_bare_metal
 class TestNodeCordonAndDrain:
     @pytest.mark.polarion("CNV-2048")

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture()
 def vm_with_fio(
     request,
-    cluster_cpu_model_scope_function,
+    cpu_for_migration,
     unprivileged_client,
     namespace,
     golden_image_data_volume_template_for_test_scope_class,
@@ -24,6 +24,7 @@ def vm_with_fio(
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
+        vm_cpu_model=cpu_for_migration,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm_with_fio:

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -13,7 +13,6 @@ from utilities.virt import (
 @pytest.fixture()
 def unscheduled_node_vm(
     request,
-    cluster_cpu_model_scope_function,
     worker_node1,
     unprivileged_client,
     namespace,

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -75,7 +75,7 @@ def hco_csv_win_virtio_image(csv_scope_session):
 
 @pytest.fixture(scope="class")
 def vm_with_guest_tools(
-    cluster_modern_cpu_model_scope_class,
+    modern_cpu_for_migration,
     namespace,
     unprivileged_client,
     golden_image_data_volume_template_for_test_scope_class,
@@ -93,6 +93,7 @@ def vm_with_guest_tools(
         os_flavor=OS_FLAVOR_WINDOWS,
         disk_type=None,
         virtio_image=virtio_win_image,
+        cpu_model=modern_cpu_for_migration,
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -144,12 +144,13 @@ def ksm_deactivated_on_node(worker_node1, workers_utility_pods):
 
 
 @pytest.fixture(scope="class")
-def vms_for_ksm_test(namespace):
+def vms_for_ksm_test(namespace, cpu_for_migration):
     # We need several VMs for sharing memory
     vms_list = create_vms(
         name_prefix="ksm-test-vm",
         namespace_name=namespace.name,
         node_selector_labels=KERNEL_SAMEPAGE_MERGING_TEST_LABEL,
+        cpu_model=cpu_for_migration,
     )
     for vm in vms_list:
         running_vm(vm=vm)
@@ -170,7 +171,6 @@ def pages_to_scan_initial_value(worker_node1, workers_utility_pods):
 @pytest.mark.usefixtures(
     "ksm_enabled_in_hco",
     "ksm_label_added_to_worker1",
-    "cluster_cpu_model_scope_class",
     "vms_for_ksm_test",
     "ksm_override_annotation_added_to_worker1",
 )


### PR DESCRIPTION
Replace cluster-scoped CPU configuration with direct per-VM CPU parameter in common template tests and migration tests. This optimization eliminates expensive cluster-wide CPU changes (avoiding HCO reconcilation).

Windows / RHEL - use modern CPU 
CentOS / Fedora - use regular cpu_for_migration fixture. 

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed class-level CPU-model fixtures so CPU model is no longer applied automatically to entire test classes.
  * Added optional CPU-model parameters to many VM fixtures and helpers to enable per-test CPU model selection and propagation.
  * Adjusted fixtures to yield and perform VM cleanup where applicable.

* **Chores**
  * Removed legacy CPU-model update/wait helpers and related imports, simplifying test wiring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->