### PR TITLE
Move chaos utils

### DIFF
--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -45,6 +45,7 @@ from utilities.infra import (
 from utilities.virt import VirtualMachineForTests, create_vm_with_nginx_service, running_vm
 
 LOGGER = logging.getLogger(__name__)
+NGINX = "nginx"
 
 
 @pytest.fixture(scope="module")
@@ -277,6 +278,7 @@ def nginx_monitoring_process(
 @pytest.fixture()
 def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
+        name=NGINX,
         namespace=chaos_namespace,
         client=admin_client,
         utility_pods=workers_utility_pods,
@@ -287,6 +289,7 @@ def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, w
 @pytest.fixture()
 def vm_with_nginx_service_and_node_selector(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
+        name=NGINX,
         namespace=chaos_namespace,
         client=admin_client,
         utility_pods=workers_utility_pods,

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -12,7 +12,6 @@ from tests.chaos.utils import (
     create_cluster_monitoring_process,
     create_nginx_monitoring_process,
     create_pod_deleting_process,
-    create_vm_with_nginx_service,
     get_instance_type,
     pod_deleting_process_recover,
     terminate_process,
@@ -43,7 +42,7 @@ from utilities.infra import (
     utility_daemonset_for_custom_tests,
     wait_for_node_status,
 )
-from utilities.virt import VirtualMachineForTests, running_vm
+from utilities.virt import VirtualMachineForTests, create_vm_with_nginx_service, running_vm
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -277,8 +277,8 @@ def nginx_monitoring_process(
 @pytest.fixture()
 def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
-        chaos_namespace=chaos_namespace,
-        admin_client=admin_client,
+        namespace=chaos_namespace,
+        client=admin_client,
         utility_pods=workers_utility_pods,
         node=random.choice(workers),
     )
@@ -287,8 +287,8 @@ def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, w
 @pytest.fixture()
 def vm_with_nginx_service_and_node_selector(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
-        chaos_namespace=chaos_namespace,
-        admin_client=admin_client,
+        namespace=chaos_namespace,
+        client=admin_client,
         utility_pods=workers_utility_pods,
         node=random.choice(workers),
         node_selector_label=HOST_LABEL,

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -9,7 +9,6 @@ from tests.chaos.constants import STRESS_NG
 from tests.chaos.migration.utils import (
     assert_migration_result_and_cleanup,
 )
-from tests.chaos.utils import verify_vm_service_reachable
 from utilities.constants import (
     PORT_80,
     QUARANTINED,
@@ -23,7 +22,7 @@ from utilities.constants import (
     StorageClassNames,
 )
 from utilities.infra import wait_for_pods_running
-from utilities.virt import wait_for_vmi_relocation_and_running
+from utilities.virt import verify_vm_service_reachable, wait_for_vmi_relocation_and_running
 
 pytestmark = [
     pytest.mark.chaos,

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2768,13 +2768,19 @@ def wait_for_virt_handler_pods_network_updated(
     return False
 
 
-def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, node, node_selector_label=None):
+def create_vm_with_nginx_service(
+    namespace: Namespace,
+    client: DynamicClient,
+    utility_pods: list[Pod],
+    node: Node,
+    node_selector_label: Optional[dict] = None,
+):
     name = "nginx"
     with VirtualMachineForTests(
-        namespace=chaos_namespace.name,
+        namespace=namespace.name,
         name=name,
         body=fedora_vm_body(name=name),
-        client=admin_client,
+        client=client,
         node_selector_labels=node_selector_label,
         additional_labels=MIGRATION_POLICY_VM_LABEL,
     ) as vm:
@@ -2789,7 +2795,7 @@ def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, no
         yield vm
 
 
-def verify_vm_service_reachable(utility_pods, node, url):
+def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
@@ -2806,7 +2812,7 @@ def verify_vm_service_reachable(utility_pods, node, url):
         raise
 
 
-def is_http_ok(utility_pods, node, url):
+def is_http_ok(utility_pods: list[Pod], node: Node, url: str):
     http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
         command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
     )

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from json import JSONDecodeError
 from subprocess import run
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional
 
 import bitmath
 import jinja2
@@ -2769,13 +2769,13 @@ def wait_for_virt_handler_pods_network_updated(
 
 
 def create_vm_with_nginx_service(
+    name: str,
     namespace: Namespace,
     client: DynamicClient,
     utility_pods: list[Pod],
     node: Node,
-    node_selector_label: Optional[dict] = None,
-):
-    name = "nginx"
+    node_selector_label: dict | None = None,
+) -> Generator[VirtualMachine]:
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
@@ -2795,7 +2795,7 @@ def create_vm_with_nginx_service(
         yield vm
 
 
-def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
+def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str) -> None:
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
@@ -2812,7 +2812,7 @@ def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
         raise
 
 
-def is_http_ok(utility_pods: list[Pod], node: Node, url: str):
+def is_http_ok(utility_pods: list[Pod], node: Node, url: str) -> bool:
     http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
         command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
     )

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http
 import io
 import ipaddress
 import json
@@ -61,11 +62,13 @@ from utilities.constants import (
     IP_FAMILY_POLICY_PREFER_DUAL_STACK,
     LINUX_AMD_64,
     LINUX_STR,
+    MIGRATION_POLICY_VM_LABEL,
     OS_FLAVOR_ALPINE,
     OS_FLAVOR_CIRROS,
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
     OS_PROC_NAME,
+    PORT_80,
     ROOTDISK,
     SSH_PORT_22,
     TCP_TIMEOUT_30SEC,
@@ -2763,3 +2766,48 @@ def wait_for_virt_handler_pods_network_updated(
         )
         raise
     return False
+
+
+def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, node, node_selector_label=None):
+    name = "nginx"
+    with VirtualMachineForTests(
+        namespace=chaos_namespace.name,
+        name=name,
+        body=fedora_vm_body(name=name),
+        client=admin_client,
+        node_selector_labels=node_selector_label,
+        additional_labels=MIGRATION_POLICY_VM_LABEL,
+    ) as vm:
+        running_vm(vm=vm, check_ssh_connectivity=False)
+        vm.custom_service_enable(service_name=name, port=PORT_80, service_type=Service.Type.CLUSTER_IP)
+        verify_vm_service_reachable(
+            utility_pods=utility_pods,
+            node=node,
+            url=f"{vm.custom_service.instance.spec.clusterIPs[0]}:{PORT_80}",
+        )
+        LOGGER.info(f"VMI Host Node:{vm.vmi.node.name}")
+        yield vm
+
+
+def verify_vm_service_reachable(utility_pods, node, url):
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_2MIN,
+            sleep=TIMEOUT_5SEC,
+            func=is_http_ok,
+            utility_pods=utility_pods,
+            node=node,
+            url=url,
+        ):
+            if sample:
+                break
+    except TimeoutExpiredError:
+        LOGGER.error(f"Service at {url} is not reachable")
+        raise
+
+
+def is_http_ok(utility_pods, node, url):
+    http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
+        command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
+    )
+    return int(http_result) == http.HTTPStatus.OK


### PR DESCRIPTION
Move chaos utils for use in other modules
- create_vm_with_nginx_service
- verify_vm_service_reachable
- is_http_ok

Part of a dependency path for scale testing #3031

Depends on #3149 

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized test utilities and virtual machine fixtures to improve code maintainability and reduce duplication across test infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->