### PR TITLE
Upgrade Scale Testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -75,6 +75,9 @@ fcn_exclude_functions =
     QueueListener,
     requests,
     multiprocessing,
+    getrlimit,
+    setrlimit,
+    ceil,
 
 nit_exclude_imports =
     os_params,

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ docs/source/rst
 
 # For local run (debug).
 ocp_resources
+
+# For scale testing
+tests/scale/stress-ng

--- a/conftest.py
+++ b/conftest.py
@@ -287,6 +287,11 @@ def pytest_addoption(parser):
         help="Path to scale test params file, default is tests/scale/scale_params.yaml",
         default="tests/scale/scale_params.yaml",
     )
+    scale_group.addoption(
+        "--scale",
+        help="Enable scale tests",
+        action="store_true",
+    )
 
     # Session group
     session_group.addoption(
@@ -496,6 +501,7 @@ def filter_deprecated_api_tests(items: list[Item], config: Config) -> list[Item]
         or config.getoption("--install")
         or config.getoption("--upgrade")
         or config.getoption("--upgrade_custom")
+        or config.getoption("--scale")
     ):
         discard_tests, items_to_return = remove_tests_from_list(items=items, filter_str="deprecated_api")
         config.hook.pytest_deselected(items=discard_tests)
@@ -506,6 +512,14 @@ def filter_deprecated_api_tests(items: list[Item], config: Config) -> list[Item]
 def filter_sno_only_tests(items: list[Item], config: Config) -> list[Item]:
     if config.getoption("-m") and "sno" not in config.getoption("-m"):
         discard_tests, items_to_return = remove_tests_from_list(items=items, filter_str="single_node_tests")
+        config.hook.pytest_deselected(items=discard_tests)
+        return items_to_return
+    return items
+
+
+def filter_scale_only_tests(items: list[Item], config: Config) -> list[Item]:
+    if not config.getoption("--scale"):
+        discard_tests, items_to_return = remove_tests_from_list(items=items, filter_str="scale")
         config.hook.pytest_deselected(items=discard_tests)
         return items_to_return
     return items
@@ -586,6 +600,7 @@ def pytest_collection_modifyitems(session, config, items):
         config.hook.pytest_deselected(items=discard)
     items[:] = filter_deprecated_api_tests(items=items, config=config)
     items[:] = filter_sno_only_tests(items=items, config=config)
+    items[:] = filter_scale_only_tests(items=items, config=config)
 
 
 def pytest_report_teststatus(report, config):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dependencies = [
   "openshift-python-wrapper>=11.0.93",
   "marshmallow==3.26.1",
   "cachetools>=6.2.2",
+  "openshift-python-scale-utilities>=0.1.1.5",
 ]
 
 [project.optional-dependencies]

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,7 @@ markers =
     node_remediation: Destructive Node Remediation using NodeHealthCheck with SNR
     node_remediation_ipmi_enabled: Destructive NodeHealthCheck with SNR/FAR on IPMI-enabled clusters
     cclm: Cross-cluster live migration tests. Require remote_cluster marker
+    threaded: Code requires thread-safe processing
 
     # Cluster markers
     ## Architecture support

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -45,6 +45,7 @@ from utilities.infra import (
 from utilities.virt import VirtualMachineForTests, create_vm_with_nginx_service, running_vm
 
 LOGGER = logging.getLogger(__name__)
+NGINX = "nginx"
 
 
 @pytest.fixture(scope="module")
@@ -277,6 +278,7 @@ def nginx_monitoring_process(
 @pytest.fixture()
 def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
+        name=NGINX,
         namespace=chaos_namespace,
         client=admin_client,
         utility_pods=workers_utility_pods,
@@ -287,6 +289,7 @@ def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, w
 @pytest.fixture()
 def vm_with_nginx_service_and_node_selector(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
+        name=NGINX,
         namespace=chaos_namespace,
         client=admin_client,
         utility_pods=workers_utility_pods,

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -406,3 +406,14 @@ def deleted_pod_by_name_prefix(admin_client, cnv_pod_deletion_test_matrix__class
         namespace=pod_deletion_config["namespace_name"],
         pod_prefix=pod_deletion_config["pod_prefix"],
     )
+
+
+@pytest.fixture(scope="module")
+def multiprocessing_start_method_fork():
+    # Use fork context to avoid pickling issues with nested functions
+    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process
+    # https://github.com/python/cpython/issues/132898
+    original_start_method = multiprocessing.get_start_method()
+    multiprocessing.set_start_method("fork", force=True)
+    yield
+    multiprocessing.set_start_method(original_start_method, force=True)

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -12,7 +12,6 @@ from tests.chaos.utils import (
     create_cluster_monitoring_process,
     create_nginx_monitoring_process,
     create_pod_deleting_process,
-    create_vm_with_nginx_service,
     get_instance_type,
     pod_deleting_process_recover,
     terminate_process,
@@ -43,7 +42,7 @@ from utilities.infra import (
     utility_daemonset_for_custom_tests,
     wait_for_node_status,
 )
-from utilities.virt import VirtualMachineForTests, running_vm
+from utilities.virt import VirtualMachineForTests, create_vm_with_nginx_service, running_vm
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -277,8 +277,8 @@ def nginx_monitoring_process(
 @pytest.fixture()
 def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
-        chaos_namespace=chaos_namespace,
-        admin_client=admin_client,
+        namespace=chaos_namespace,
+        client=admin_client,
         utility_pods=workers_utility_pods,
         node=random.choice(workers),
     )
@@ -287,8 +287,8 @@ def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, w
 @pytest.fixture()
 def vm_with_nginx_service_and_node_selector(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
-        chaos_namespace=chaos_namespace,
-        admin_client=admin_client,
+        namespace=chaos_namespace,
+        client=admin_client,
         utility_pods=workers_utility_pods,
         node=random.choice(workers),
         node_selector_label=HOST_LABEL,

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -27,7 +27,7 @@ from utilities.virt import wait_for_vmi_relocation_and_running
 
 pytestmark = [
     pytest.mark.chaos,
-    pytest.mark.usefixtures("chaos_namespace", "cluster_monitoring_process"),
+    pytest.mark.usefixtures("multiprocessing_start_method_fork", "chaos_namespace", "cluster_monitoring_process"),
 ]
 
 

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -9,7 +9,6 @@ from tests.chaos.constants import STRESS_NG
 from tests.chaos.migration.utils import (
     assert_migration_result_and_cleanup,
 )
-from tests.chaos.utils import verify_vm_service_reachable
 from utilities.constants import (
     PORT_80,
     QUARANTINED,
@@ -23,7 +22,7 @@ from utilities.constants import (
     StorageClassNames,
 )
 from utilities.infra import wait_for_pods_running
-from utilities.virt import wait_for_vmi_relocation_and_running
+from utilities.virt import verify_vm_service_reachable, wait_for_vmi_relocation_and_running
 
 pytestmark = [
     pytest.mark.chaos,

--- a/tests/chaos/snapshot/test_snapshot.py
+++ b/tests/chaos/snapshot/test_snapshot.py
@@ -11,6 +11,7 @@ pytestmark = [
     pytest.mark.gpfs,
     pytest.mark.usefixtures(
         "skip_if_no_storage_class_for_snapshot",
+        "multiprocessing_start_method_fork",
         "chaos_namespace",
         "cluster_monitoring_process",
     ),

--- a/tests/chaos/standard/test_standard.py
+++ b/tests/chaos/standard/test_standard.py
@@ -15,7 +15,9 @@ from utilities.virt import VirtualMachineForTests, running_vm
 
 pytestmark = [
     pytest.mark.chaos,
-    pytest.mark.usefixtures("chaos_namespace", "cluster_monitoring_process", "skip_on_aws_cluster"),
+    pytest.mark.usefixtures(
+        "multiprocessing_start_method_fork", "chaos_namespace", "cluster_monitoring_process", "skip_on_aws_cluster"
+    ),
 ]
 
 

--- a/tests/chaos/utils.py
+++ b/tests/chaos/utils.py
@@ -6,7 +6,6 @@ import random
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from multiprocessing.context import ForkContext
 
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.deployment import Deployment
@@ -44,9 +43,6 @@ from utilities.infra import (
     wait_for_node_status,
 )
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
-
-# Use fork context to avoid pickling issues with nested functions
-_FORK_CONTEXT: ForkContext = multiprocessing.get_context("fork")
 
 LOGGER = logging.getLogger(__name__)
 
@@ -135,7 +131,7 @@ def create_pod_deleting_process(
         except TimeoutExpiredError:
             LOGGER.info("Pod deleting process finished.")
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="pod_delete",
         target=_delete_pods_continuously,
         args=(
@@ -189,7 +185,7 @@ def create_nginx_monitoring_process(
             time.sleep(_sampling_interval)
         LOGGER.info("HTTP querying finished successfully.")
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="nginx_monitoring",
         target=_monitor_nginx_server,
         args=(
@@ -320,7 +316,7 @@ def create_cluster_monitoring_process(
             )
             time.sleep(interval)
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="cluster_monitoring",
         target=_monitor_cluster,
     )

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -30,8 +30,7 @@ from tests.install_upgrade_operators.product_upgrade.utils import (
     wait_for_pods_replacement_by_type,
 )
 from tests.install_upgrade_operators.utils import wait_for_operator_condition
-from tests.upgrade_params import EUS
-from utilities.constants import HCO_CATALOG_SOURCE, HOTFIX_STR, TIMEOUT_10MIN, NamespacesNames
+from utilities.constants import EUS, HCO_CATALOG_SOURCE, HOTFIX_STR, TIMEOUT_10MIN, NamespacesNames
 from utilities.data_collector import (
     get_data_collector_base_directory,
 )

--- a/tests/scale/conftest.py
+++ b/tests/scale/conftest.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import logging
+import math
+import resource
+from copy import deepcopy
+
+import kubernetes
+import pytest
+from ocp_resources.cdi import CDI
+from ocp_resources.kubelet_config import KubeletConfig
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.pod import Pod
+from ocp_resources.resource import get_client
+from ocp_resources.ssp import SSP
+
+from tests.scale.utils import get_user_kubeconfig_context, label_mcps, pause_mcps
+from utilities.constants import TIMEOUT_20MIN, TIMEOUT_30SEC, UNPRIVILEGED_USER
+from utilities.hco import ResourceEditorValidateHCOReconcile, wait_for_hco_conditions
+from utilities.operator import (
+    get_machine_config_pool_by_name,
+    get_machine_config_pools_conditions,
+    get_mcp_updating_transition_times,
+    wait_for_mcp_update_end,
+    wait_for_mcp_update_start,
+)
+from utilities.virt import get_virt_handler_pods
+
+LOGGER = logging.getLogger(__name__)
+
+KUBE_API_QPS = 200
+KUBE_API_BURST = 400
+
+
+@pytest.fixture(scope="module")
+def scale_client_configuration(request):  # skip-unused-code
+    client_configuration = kubernetes.client.Configuration()
+    client_configuration.connection_pool_maxsize = request.param["connection_pool_maxsize"]
+    return client_configuration
+
+
+@pytest.fixture(scope="module")
+def scale_unprivileged_client(
+    scale_client_configuration, skip_unprivileged_client, exported_kubeconfig, unprivileged_client
+):  # skip-unused-code
+    if skip_unprivileged_client:
+        yield
+    else:
+        yield get_client(
+            client_configuration=deepcopy(scale_client_configuration),
+            config_file=exported_kubeconfig,
+            context=get_user_kubeconfig_context(kubeconfig_filename=exported_kubeconfig, username=UNPRIVILEGED_USER),
+        )
+
+
+@pytest.fixture(scope="module")
+def patched_hco_for_scale_testing(
+    admin_client, hco_namespace, hyperconverged_resource_scope_module, cpu_for_migration
+):  # skip-unused-code
+    with ResourceEditorValidateHCOReconcile(
+        patches={
+            hyperconverged_resource_scope_module: {
+                "spec": {
+                    "tuningPolicy": "highBurst",
+                    "defaultCPUModel": cpu_for_migration,
+                },
+            },
+        },
+        list_resource_reconcile=[KubeVirt, CDI, SSP],
+        wait_for_reconcile_post_update=True,
+    ):
+        wait_for_hco_conditions(
+            admin_client=admin_client,
+            hco_namespace=hco_namespace,
+        )
+        yield
+
+
+@pytest.fixture(scope="session")
+def increased_open_file_limit(request):  # skip-unused-code
+    """
+    If you use this fixture and still receive max open files errors
+    then please raise the default limits on your system.
+    The test code is properly raising and lowering limits,
+    closing threads and files, your base limits are just too low.
+    Run to see your current limits: `ulimit -H -n && ulimit -S -n`
+    """
+    nofile_hard_limit = request.param["nofile_hard_limit"]
+    original_limits = resource.getrlimit(resource.RLIMIT_NOFILE)
+    new_limits = (nofile_hard_limit, nofile_hard_limit)
+    if new_limits > original_limits:
+        resource.setrlimit(resource.RLIMIT_NOFILE, new_limits)
+        yield
+        resource.setrlimit(resource.RLIMIT_NOFILE, original_limits)
+    else:
+        LOGGER.info(f"Current open file limits {original_limits} are greater than {new_limits}.")
+        yield
+
+
+@pytest.fixture(scope="module")
+def virt_handler_pods(admin_client, hco_namespace):  # skip-unused-code
+    return get_virt_handler_pods(client=admin_client, namespace=hco_namespace)
+
+
+@pytest.fixture(scope="module")
+def virt_handler_nodes(virt_handler_pods):  # skip-unused-code
+    return [pod.node for pod in virt_handler_pods]
+
+
+@pytest.fixture(scope="module")
+def existing_pod_count(admin_client):  # skip-unused-code
+    return len(list(Pod.get(dyn_client=admin_client)))
+
+
+@pytest.fixture(scope="module")
+def calculated_max_pods_per_virt_node(request, existing_pod_count, virt_handler_nodes):  # skip-unused-code
+    assert virt_handler_nodes, "No virt-handler pods present"
+
+    default_pods_per_node = 250
+    total_pod_count = existing_pod_count + request.param["total_vm_count"]
+    num_virt_handler_nodes = len(virt_handler_nodes)
+
+    max_pods = math.ceil(
+        total_pod_count / (num_virt_handler_nodes - 1) if num_virt_handler_nodes > 1 else total_pod_count
+    )
+    if default_pods_per_node > max_pods:
+        max_pods = default_pods_per_node
+
+    min_existing_max_pods_per_node = min([int(node.instance.status.capacity.pods) for node in virt_handler_nodes])
+    if min_existing_max_pods_per_node > max_pods:
+        max_pods = min_existing_max_pods_per_node
+
+    return max_pods
+
+
+@pytest.fixture(scope="module")
+def created_kubeletconfigs_for_scale(
+    request, calculated_max_pods_per_virt_node, workers, machine_config_pools
+):  # skip-unused-code
+    control_plane_mcp = get_machine_config_pool_by_name(mcp_name="master")
+    worker_mcp = get_machine_config_pool_by_name(mcp_name="worker")
+
+    initial_updating_transition_times = get_mcp_updating_transition_times(
+        mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=machine_config_pools)
+    )
+
+    pause_mcps(paused=True, mcps=machine_config_pools)
+    with KubeletConfig(
+        name="test-custom-control-plane-kubelet-config",
+        auto_sizing_reserved=True,
+        kubelet_config={
+            "nodeStatusMaxImages": -1,
+            "kubeAPIQPS": KUBE_API_QPS,
+            "kubeAPIBurst": KUBE_API_BURST,
+        },
+        machine_config_pool_selector={"matchLabels": {"custom-control-plane-kubelet": "enabled"}},
+    ):
+        with KubeletConfig(
+            name="test-custom-worker-kubelet-config",
+            auto_sizing_reserved=True,
+            kubelet_config={
+                "nodeStatusMaxImages": -1,
+                "kubeAPIQPS": KUBE_API_QPS,
+                "kubeAPIBurst": KUBE_API_BURST,
+                "maxPods": calculated_max_pods_per_virt_node,
+            },
+            machine_config_pool_selector={"matchLabels": {"custom-worker-kubelet": "enabled"}},
+        ):
+            with label_mcps([control_plane_mcp], {"custom-control-plane-kubelet": "enabled"}):
+                with label_mcps([worker_mcp], {"custom-worker-kubelet": "enabled"}):
+                    pause_mcps(paused=False, mcps=machine_config_pools)
+                    wait_for_mcp_update_start(
+                        machine_config_pools_list=machine_config_pools,
+                        initial_transition_times=initial_updating_transition_times,
+                    )
+                    wait_for_mcp_update_end(
+                        machine_config_pools_list=machine_config_pools,
+                        timeout=TIMEOUT_20MIN * len(workers),
+                        sleep=TIMEOUT_30SEC,
+                    )
+
+                    yield
+                    teardown_updating_transition_times = get_mcp_updating_transition_times(
+                        mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=machine_config_pools)
+                    )
+                    pause_mcps(paused=True, mcps=machine_config_pools)
+
+    pause_mcps(paused=False, mcps=machine_config_pools)
+    wait_for_mcp_update_start(
+        machine_config_pools_list=machine_config_pools,
+        initial_transition_times=teardown_updating_transition_times,
+    )
+    wait_for_mcp_update_end(
+        machine_config_pools_list=machine_config_pools,
+        timeout=TIMEOUT_20MIN * len(workers),
+        sleep=TIMEOUT_30SEC,
+    )

--- a/tests/scale/constants.py
+++ b/tests/scale/constants.py
@@ -1,0 +1,35 @@
+import re
+import shlex
+from typing import TypedDict
+
+
+class GuestDataCommandListType(TypedDict):
+    name: str
+    command: str
+    regex: re.Pattern
+
+
+VIRT_HANDLER_API_IDLE_STATE = 0.067
+
+GUEST_DATA_RESULT_SEPARATOR = "|=====|"
+GUEST_DATA_COMMAND_LIST: list[GuestDataCommandListType] = [
+    {"name": "datetime", "command": "date -u -Is", "regex": re.compile(r"^(?P<datetime>.*)$")},
+    {
+        "name": "proc_stat",
+        "command": "cat /proc/stat",
+        "regex": re.compile(r".*\nbtime (?P<btime>[0-9]+)\n.*", re.DOTALL),
+    },
+    {
+        "name": "uptime",
+        "command": "uptime",
+        "regex": re.compile(
+            r"^(?P<current_time>[^ ]+) up (?P<up_for>[^,]+),[ ]+(?P<user_info>[^,]+),[ ]+"
+            r"load average: (?P<load1min>[0-9]+\.[0-9]+), (?P<load5min>[0-9]+\.[0-9]+), (?P<load15min>[0-9]+\.[0-9]+)$"
+        ),
+    },
+]
+GUEST_DATA_COMMANDS = shlex.split(
+    'sh -c "'
+    + f" && echo '{GUEST_DATA_RESULT_SEPARATOR}' && ".join([str(entry["command"]) for entry in GUEST_DATA_COMMAND_LIST])
+    + '"'
+)

--- a/tests/scale/test_upgrade_scale.py
+++ b/tests/scale/test_upgrade_scale.py
@@ -71,10 +71,6 @@ pytestmark = [
     pytest.mark.destructive,
     pytest.mark.threaded,
     pytest.mark.cpu_manager,
-    pytest.mark.upgrade,
-    pytest.mark.ocp_upgrade,
-    pytest.mark.cnv_upgrade,
-    pytest.mark.eus_upgrade,
     pytest.mark.usefixtures(
         "fail_if_no_stress_ng",
         "cache_key_scope_module",
@@ -390,6 +386,10 @@ def test_scale(
     )
 
 
+@pytest.mark.upgrade
+@pytest.mark.ocp_upgrade
+@pytest.mark.cnv_upgrade
+@pytest.mark.eus_upgrade
 @pytest.mark.usefixtures("stress_ng_url_for_cirros")
 @pytest.mark.parametrize(
     "cache_key_scope_class,created_data_source_for_scale,vms_for_upgrade_test",

--- a/tests/scale/test_upgrade_scale.py
+++ b/tests/scale/test_upgrade_scale.py
@@ -245,6 +245,8 @@ def vms_for_upgrade_test(
             for index in range(entry["vm_count"])
         ])
 
+    yield vms
+
 
 @pytest.fixture(scope="module")
 def running_vms_for_upgrade_test(
@@ -309,7 +311,7 @@ def idle_monitored_api_requests(monitor_api_requests_object):
 def running_vms_with_load(running_vms_for_upgrade_test, stopped_nginx_vm):
     commands = "./stress-ng --iomix 1 --cpu 1 --cpu-load 20 --cpu-load-slice 0 --vm 1 --timeout 0 &>/dev/null &"
     threaded_run_vm_ssh_command(vms=running_vms_for_upgrade_test, commands=shlex.split(commands))
-    yield vms_for_upgrade_test
+    yield running_vms_for_upgrade_test
     threaded_run_vm_ssh_command(vms=running_vms_for_upgrade_test, commands=shlex.split("killall -9 stress-ng"))
 
 

--- a/tests/scale/test_upgrade_scale.py
+++ b/tests/scale/test_upgrade_scale.py
@@ -1,0 +1,443 @@
+# test_upgrade_scale
+# Notes
+# - statically linked stress-ng executable must be placed in the tests/scale/
+#   directory prior to running to support use in cirros
+
+import logging
+import os
+import random
+import shlex
+
+import pytest
+from ocp_resources.data_source import DataSource
+from ocp_resources.datavolume import DataVolume
+from ocp_resources.migration_policy import MigrationPolicy
+from ocp_resources.resource import Resource
+from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+from ocp_scale_utilities.monitoring import MonitorResourceAPIServerRequests
+from pyhelper_utils.shell import run_ssh_commands
+
+from tests.scale.constants import GUEST_DATA_COMMANDS, VIRT_HANDLER_API_IDLE_STATE
+from tests.scale.threaded_utils.utils import LocalThreadedScaleResources
+from tests.scale.threaded_utils.virt import (
+    threaded_get_vm_guest_data,
+    threaded_run_vm_ssh_command,
+    threaded_verify_guest_data,
+    threaded_wait_for_accessible_vms,
+    threaded_wait_for_running_vms,
+    threaded_wait_for_scheduled_vms,
+)
+from tests.scale.utils import (
+    capture_func_elapsed,
+)
+from tests.upgrade_params import (
+    IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
+    IUO_UPGRADE_TEST_ORDERING_NODE_ID,
+    SCALE_NODE_ID_PREFIX,
+    SCALE_VM_LOAD_RUNNING_AFTER_UPGRADE_ID,
+)
+from utilities.constants import (
+    CNV_VM_SSH_KEY_PATH,
+    DEPENDENCY_SCOPE_SESSION,
+    OS_FLAVOR_CIRROS,
+    PORT_80,
+    TIMEOUT_5MIN,
+    TIMEOUT_20MIN,
+    TIMEOUT_30MIN,
+    NamespacesNames,
+    StorageClassNames,
+)
+from utilities.infra import create_ns, run_virtctl_command
+from utilities.storage import data_volume_template_with_source_ref_dict
+from utilities.virt import VirtualMachineForTests, create_vm_with_nginx_service, prepare_cloud_init_user_data
+
+LOGGER = logging.getLogger(__name__)
+DEPENDENCIES_NODE_ID_PREFIX = f"{os.path.abspath(__file__)}::TestUpgradeScale"
+CACHE_KEY_PREFIX = "test_upgrade_scale"
+
+TOTAL_VM_COUNT = int(os.environ.get("SCALE_TEST_TOTAL_VM_COUNT", 2))
+CIRROS_IMG_URL = "https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img"
+CIRROS_DV_SIZE = "150Mi"
+
+STRESS_NG_PATH = "tests/scale/stress-ng"
+
+U1_PICO = "u1.pico"
+ALLOW_POST_COPY_MIGRATION_PROFILE_NAME = "allow-post-copy"
+
+pytestmark = [
+    pytest.mark.scale,
+    pytest.mark.destructive,
+    pytest.mark.threaded,
+    pytest.mark.cpu_manager,
+    pytest.mark.upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+    pytest.mark.usefixtures(
+        "fail_if_no_stress_ng",
+        "cache_key_scope_module",
+        "increased_open_file_limit",
+        "scale_client_configuration",
+        "calculated_max_pods_per_virt_node",
+        "patched_hco_for_scale_testing",
+        "created_kubeletconfigs_for_scale",
+    ),
+    pytest.mark.parametrize(
+        "cache_key_scope_module,increased_open_file_limit,scale_client_configuration,calculated_max_pods_per_virt_node",
+        [
+            pytest.param(
+                "test_upgrade_scale",
+                {"nofile_hard_limit": 2**19},
+                {"connection_pool_maxsize": TOTAL_VM_COUNT},
+                {"total_vm_count": TOTAL_VM_COUNT},
+            ),
+        ],
+        indirect=True,
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def fail_if_no_stress_ng():
+    assert os.path.isfile(STRESS_NG_PATH), f"File not found: {STRESS_NG_PATH}"
+
+
+@pytest.fixture(scope="module")
+def upgrade_scale_namespace(admin_client, unprivileged_client):
+    yield from create_ns(
+        name="test-upgrade-scale",
+        admin_client=admin_client,
+        unprivileged_client=unprivileged_client,
+        delete_timeout=TIMEOUT_20MIN,
+    )
+
+
+@pytest.fixture(scope="module")
+def created_pico_instancetype(admin_client):
+    with VirtualMachineClusterInstancetype(
+        name=U1_PICO,
+        client=admin_client,
+        cpu={"guest": 1},
+        memory={"guest": "256Mi"},
+    ) as instancetype:
+        yield instancetype
+
+
+@pytest.fixture(scope="module")
+def created_data_source_for_scale(request, admin_client, created_pico_instancetype):
+    with DataVolume(
+        name=OS_FLAVOR_CIRROS,
+        namespace=request.param["namespace_name"],
+        client=admin_client,
+        source="http",
+        size=CIRROS_DV_SIZE,
+        url=CIRROS_IMG_URL,
+        storage_class=request.param["storage_class"],
+        volume_mode=request.param["volume_mode"],
+        access_modes=request.param["access_modes"],
+    ) as data_volume:
+        data_volume.wait_for_dv_success(timeout=TIMEOUT_20MIN)
+        with DataSource(
+            name=data_volume.name,
+            namespace=data_volume.namespace,
+            client=admin_client,
+            label={
+                f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/default-instancetype": created_pico_instancetype.name,
+                f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/default-preference": OS_FLAVOR_CIRROS,
+            },
+            source={
+                "pvc": {
+                    "name": data_volume.name,
+                    "namespace": data_volume.namespace,
+                },
+            },
+        ) as data_source:
+            yield data_source
+
+
+@pytest.fixture(scope="module")
+def created_post_copy_migration_policy_for_upgrade(admin_client, upgrade_scale_namespace):
+    with MigrationPolicy(
+        name=ALLOW_POST_COPY_MIGRATION_PROFILE_NAME,
+        client=admin_client,
+        allow_post_copy=True,
+        namespace_selector={f"{Resource.ApiGroup.KUBERNETES_IO}/metadata.name": upgrade_scale_namespace.name},
+        vmi_selector={f"{Resource.ApiGroup.KUBEVIRT_IO}/migration-profile": ALLOW_POST_COPY_MIGRATION_PROFILE_NAME},
+    ) as migration_policy:
+        yield migration_policy
+
+
+@pytest.fixture(scope="module")
+def vm_with_nginx_service_scope_module(upgrade_scale_namespace, admin_client, workers_utility_pods, workers):
+    yield from create_vm_with_nginx_service(
+        chaos_namespace=upgrade_scale_namespace,
+        admin_client=admin_client,
+        utility_pods=workers_utility_pods,
+        node=random.choice(workers),
+    )
+
+
+@pytest.fixture(scope="module")
+def stopped_nginx_vm(vm_with_nginx_service_scope_module, stress_ng_url_for_cirros, vms_for_upgrade_test):
+    vm_with_nginx_service_scope_module.stop(wait=True)
+    yield
+
+
+@pytest.fixture(scope="module")
+def stress_ng_url_for_cirros(vm_with_nginx_service_scope_module):
+    run_virtctl_command(
+        command=shlex.split(
+            (
+                f"scp -i '{os.environ[CNV_VM_SSH_KEY_PATH]}' "
+                "--local-ssh-opts='-o StrictHostKeyChecking=no' "
+                f"'{STRESS_NG_PATH}' "
+                f"fedora@vm/{vm_with_nginx_service_scope_module.name}:~/stress-ng"
+            )
+        ),
+        namespace=vm_with_nginx_service_scope_module.namespace,
+    )
+    run_ssh_commands(
+        host=vm_with_nginx_service_scope_module.ssh_exec,
+        commands=shlex.split("sudo cp ~/stress-ng /usr/share/nginx/html/"),
+    )
+    yield f"http://{vm_with_nginx_service_scope_module.custom_service.instance.spec.clusterIPs[0]}:{PORT_80}/stress-ng"
+
+
+@pytest.fixture(scope="module")
+def vms_for_upgrade_test(
+    request,
+    scale_unprivileged_client,
+    upgrade_scale_namespace,
+    prometheus,
+    cache_key_scope_module,
+    created_data_source_for_scale,
+    stress_ng_url_for_cirros,
+    created_post_copy_migration_policy_for_upgrade,
+):
+    vms = []
+    for entry in request.param:
+        vm_instancetype = VirtualMachineClusterInstancetype(name=entry["vm_instancetype"])
+        vm_preference = VirtualMachineClusterPreference(name=entry["vm_preference"])
+        cloud_init_data = None
+        if entry.get("runcmd"):
+            cloud_init_data = prepare_cloud_init_user_data(section="runcmd", data=entry["runcmd"])
+        vms.extend([
+            VirtualMachineForTests(
+                client=scale_unprivileged_client,
+                name=f"vm-scale-load-test-{vm_instancetype.name}-{vm_preference.name}-{index}",
+                namespace=upgrade_scale_namespace.name,
+                run_strategy="Always",
+                data_volume_template=data_volume_template_with_source_ref_dict(
+                    data_source=created_data_source_for_scale
+                ),
+                vm_instance_type=vm_instancetype,
+                vm_preference=vm_preference,
+                os_flavor=entry["os_flavor"],
+                cloud_init_data=cloud_init_data,
+                additional_labels={
+                    f"{Resource.ApiGroup.KUBEVIRT_IO}/migration-profile": ALLOW_POST_COPY_MIGRATION_PROFILE_NAME
+                }
+                if index % 2
+                else None,
+            )
+            for index in range(entry["vm_count"])
+        ])
+    monitor_api_requests = MonitorResourceAPIServerRequests(
+        prometheus=prometheus,
+        resource_class=VirtualMachine,
+        idle_requests_value=VIRT_HANDLER_API_IDLE_STATE * len(vms),
+    )
+
+    monitor_api_requests.wait_for_idle()
+    with LocalThreadedScaleResources(resources=vms, cache_key_prefix=cache_key_scope_module):
+        capture_func_elapsed(
+            cache=request.config.cache,
+            cache_key_prefix=cache_key_scope_module,
+            func=threaded_wait_for_scheduled_vms,
+            vms=vms,
+        )
+        capture_func_elapsed(
+            cache=request.config.cache,
+            cache_key_prefix=cache_key_scope_module,
+            func=threaded_wait_for_running_vms,
+            vms=vms,
+        )
+        capture_func_elapsed(
+            cache=request.config.cache,
+            cache_key_prefix=cache_key_scope_module,
+            func=threaded_wait_for_accessible_vms,
+            vms=vms,
+            timeout=TIMEOUT_30MIN,
+            tcp_timeout=TIMEOUT_5MIN,
+        )
+        capture_func_elapsed(
+            cache=request.config.cache,
+            cache_key_prefix=cache_key_scope_module,
+            func=threaded_run_vm_ssh_command,
+            vms=vms,
+            commands=shlex.split(
+                f"curl -LO {stress_ng_url_for_cirros} && chmod 0755 stress-ng && ./stress-ng --version"
+            ),
+        )
+        yield vms
+    monitor_api_requests.wait_for_idle()
+
+
+@pytest.fixture(scope="module")
+def monitor_api_requests_object(prometheus, vms_for_upgrade_test) -> MonitorResourceAPIServerRequests:
+    return MonitorResourceAPIServerRequests(
+        prometheus=prometheus,
+        resource_class=VirtualMachine,
+        idle_requests_value=VIRT_HANDLER_API_IDLE_STATE * len(vms_for_upgrade_test),
+    )
+
+
+@pytest.fixture()
+def idle_monitored_api_requests(monitor_api_requests_object):
+    monitor_api_requests_object.wait_for_idle()
+
+
+@pytest.fixture(scope="module")
+def running_vms_with_load(vms_for_upgrade_test, stopped_nginx_vm):
+    commands = "./stress-ng --iomix 1 --cpu 1 --cpu-load 20 --cpu-load-slice 0 --vm 1 --timeout 0 &>/dev/null &"
+    threaded_run_vm_ssh_command(vms=vms_for_upgrade_test, commands=shlex.split(commands))
+    yield vms_for_upgrade_test
+    threaded_run_vm_ssh_command(vms=vms_for_upgrade_test, commands=shlex.split("killall -9 stress-ng"))
+
+
+@pytest.fixture()
+def cache_key_scope_func(request):
+    return request.param
+
+
+@pytest.fixture(scope="class")
+def cache_key_scope_class(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def cache_key_scope_module(request):
+    return request.param
+
+
+@pytest.fixture()
+def get_vm_guest_data_scope_func(request, cache_key_scope_func, vms_for_upgrade_test):
+    guest_data = threaded_get_vm_guest_data(vms=vms_for_upgrade_test, commands=GUEST_DATA_COMMANDS)
+    request.config.cache.set(f"{cache_key_scope_func}::get_vm_guest_data_scope_func", guest_data)
+    return guest_data
+
+
+@pytest.fixture(scope="class")
+def get_vm_guest_data_scope_class(request, cache_key_scope_class, vms_for_upgrade_test):
+    guest_data = threaded_get_vm_guest_data(vms=vms_for_upgrade_test, commands=GUEST_DATA_COMMANDS)
+    request.config.cache.set(f"{cache_key_scope_class}::get_vm_guest_data_scope_class", guest_data)
+    return guest_data
+
+
+@pytest.mark.polarion("CNV-12243")
+@pytest.mark.usefixtures("stress_ng_url_for_cirros")
+@pytest.mark.parametrize(
+    "cache_key_scope_func,created_data_source_for_scale,vms_for_upgrade_test",
+    [
+        pytest.param(
+            "test_scale",
+            {
+                "namespace_name": NamespacesNames.OPENSHIFT_VIRTUALIZATION_OS_IMAGES,
+                "storage_class": StorageClassNames.CEPH_RBD_VIRTUALIZATION,
+                "volume_mode": DataVolume.VolumeMode.BLOCK,
+                "access_modes": DataVolume.AccessMode.RWX,
+            },
+            [
+                {
+                    "vm_count": TOTAL_VM_COUNT,
+                    "vm_instancetype": U1_PICO,
+                    "vm_preference": OS_FLAVOR_CIRROS,
+                    "os_flavor": OS_FLAVOR_CIRROS,
+                },
+            ],
+        )
+    ],
+    indirect=True,
+)
+def test_scale(
+    request,
+    running_vms_with_load,
+    cache_key_scope_func,
+    get_vm_guest_data_scope_func,
+    idle_monitored_api_requests,
+):
+    guest_data_list = threaded_get_vm_guest_data(vms=running_vms_with_load, commands=GUEST_DATA_COMMANDS)
+    request.config.cache.set(f"{cache_key_scope_func}::guest_data_list", guest_data_list)
+    threaded_verify_guest_data(before_list=get_vm_guest_data_scope_func, after_list=guest_data_list)
+
+
+@pytest.mark.usefixtures("stress_ng_url_for_cirros")
+@pytest.mark.parametrize(
+    "cache_key_scope_class,created_data_source_for_scale,vms_for_upgrade_test",
+    [
+        pytest.param(
+            "TestUpgradeScale",
+            {
+                "namespace_name": NamespacesNames.OPENSHIFT_VIRTUALIZATION_OS_IMAGES,
+                "storage_class": StorageClassNames.CEPH_RBD_VIRTUALIZATION,
+                "volume_mode": DataVolume.VolumeMode.BLOCK,
+                "access_modes": DataVolume.AccessMode.RWX,
+            },
+            [
+                {
+                    "vm_count": TOTAL_VM_COUNT,
+                    "vm_instancetype": U1_PICO,
+                    "vm_preference": OS_FLAVOR_CIRROS,
+                    "os_flavor": OS_FLAVOR_CIRROS,
+                },
+            ],
+        )
+    ],
+    indirect=True,
+)
+class TestUpgradeScale:
+    """Pre-upgrade tests"""
+
+    @pytest.mark.polarion("CNV-12242")
+    @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
+    @pytest.mark.dependency(name=f"{SCALE_NODE_ID_PREFIX}::test_load_running_before_upgrade")
+    def test_load_running_before_upgrade(
+        self,
+        request,
+        cache_key_scope_class,
+        running_vms_with_load,
+        get_vm_guest_data_scope_class,
+        idle_monitored_api_requests,
+    ):
+        before_upgrade_list = threaded_get_vm_guest_data(vms=running_vms_with_load, commands=GUEST_DATA_COMMANDS)
+        request.config.cache.set(f"{cache_key_scope_class}::before_upgrade_list", before_upgrade_list)
+        threaded_verify_guest_data(before_list=get_vm_guest_data_scope_class, after_list=before_upgrade_list)
+
+    """ Post-upgrade tests """
+
+    @pytest.mark.polarion("CNV-11308")
+    @pytest.mark.order(after=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
+    @pytest.mark.dependency(
+        name=SCALE_VM_LOAD_RUNNING_AFTER_UPGRADE_ID,
+        depends=[
+            IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
+            f"{SCALE_NODE_ID_PREFIX}::test_load_running_before_upgrade",
+        ],
+        scope=DEPENDENCY_SCOPE_SESSION,
+    )
+    def test_load_running_after_upgrade(
+        self,
+        request,
+        cache_key_scope_class,
+        running_vms_with_load,
+        get_vm_guest_data_scope_class,
+        idle_monitored_api_requests,
+    ):
+        after_upgrade_list = threaded_get_vm_guest_data(vms=running_vms_with_load, commands=GUEST_DATA_COMMANDS)
+        request.config.cache.set(f"{cache_key_scope_class}::after_upgrade_list", after_upgrade_list)
+        threaded_verify_guest_data(
+            before_list=get_vm_guest_data_scope_class,
+            after_list=after_upgrade_list,
+        )

--- a/tests/scale/test_upgrade_scale.py
+++ b/tests/scale/test_upgrade_scale.py
@@ -250,7 +250,12 @@ def vms_for_upgrade_test(
 
 @pytest.fixture(scope="module")
 def running_vms_for_upgrade_test(
-    request, prometheus, cache_key_scope_module, stress_ng_url_for_cirros, vms_for_upgrade_test
+    request,
+    admin_client,
+    prometheus,
+    cache_key_scope_module,
+    stress_ng_url_for_cirros,
+    vms_for_upgrade_test,
 ):
     monitor_api_requests = MonitorResourceAPIServerRequests(
         prometheus=prometheus,
@@ -259,7 +264,9 @@ def running_vms_for_upgrade_test(
     )
 
     monitor_api_requests.wait_for_idle()
-    with LocalThreadedScaleResources(resources=vms_for_upgrade_test, cache_key_prefix=cache_key_scope_module):
+    with LocalThreadedScaleResources(
+        resources=vms_for_upgrade_test, cache_key_prefix=cache_key_scope_module, admin_client=admin_client
+    ):
         capture_func_elapsed(
             cache=request.config.cache,
             cache_key_prefix=cache_key_scope_module,

--- a/tests/scale/threaded_utils/utils.py
+++ b/tests/scale/threaded_utils/utils.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import os
 import time
+from typing import Sequence
 
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.resource import Resource
 from ocp_scale_utilities.threaded.scale import ThreadedScaleResources
+from pytest import Cache
 
 from utilities.data_collector import (
     collect_alerts_data,
@@ -14,13 +18,30 @@ from utilities.data_collector import (
 
 
 class LocalThreadedScaleResources(ThreadedScaleResources):  # skip-unused-code
-    def collect_data(self, id: str, start_time: float):  # skip-unused-code
+    def __init__(
+        self,
+        resources: Sequence[Resource],
+        request_resources: Sequence[Resource] | None = None,
+        pytest_cache: Cache | None = None,
+        cache_key_prefix: str | None = None,
+        wait_for_status: str | None = None,
+        admin_client: DynamicClient | None = None,
+    ) -> None:  # skip-unused-code
+        self.admin_client = admin_client
+        super().__init__(
+            resources=resources,
+            request_resources=request_resources,
+            pytest_cache=pytest_cache,
+            cache_key_prefix=cache_key_prefix,
+            wait_for_status=wait_for_status,
+        )
+
+    def collect_data(self, id: str, start_time: float) -> None:  # skip-unused-code
         target_dir = os.path.join(get_data_collector_dir(), "ThreadedScaleResources", id)
 
         collect_alerts_data()
         collect_ocp_must_gather(since_time=int(time.time() - start_time))
-        admin_client = getattr(self, "admin_client", None)
-        if admin_client:
+        if self.admin_client:
             collect_default_cnv_must_gather_with_vm_gather(
-                since_time=int(time.time() - start_time), target_dir=target_dir, admin_client=admin_client
+                since_time=int(time.time() - start_time), target_dir=target_dir, admin_client=self.admin_client
             )

--- a/tests/scale/threaded_utils/utils.py
+++ b/tests/scale/threaded_utils/utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+import time
+
+from ocp_scale_utilities.threaded.scale import ThreadedScaleResources
+
+from utilities.data_collector import (
+    collect_alerts_data,
+    collect_default_cnv_must_gather_with_vm_gather,
+    collect_ocp_must_gather,
+    get_data_collector_dir,
+)
+
+
+class LocalThreadedScaleResources(ThreadedScaleResources):  # skip-unused-code
+    def collect_data(self, id: str, start_time: float):  # skip-unused-code
+        target_dir = os.path.join(get_data_collector_dir(), "ThreadedScaleResources", id)
+
+        collect_alerts_data()
+        collect_ocp_must_gather(since_time=int(time.time() - start_time))
+        collect_default_cnv_must_gather_with_vm_gather(since_time=int(time.time() - start_time), target_dir=target_dir)

--- a/tests/scale/threaded_utils/utils.py
+++ b/tests/scale/threaded_utils/utils.py
@@ -19,4 +19,8 @@ class LocalThreadedScaleResources(ThreadedScaleResources):  # skip-unused-code
 
         collect_alerts_data()
         collect_ocp_must_gather(since_time=int(time.time() - start_time))
-        collect_default_cnv_must_gather_with_vm_gather(since_time=int(time.time() - start_time), target_dir=target_dir)
+        admin_client = getattr(self, "admin_client", None)
+        if admin_client:
+            collect_default_cnv_must_gather_with_vm_gather(
+                since_time=int(time.time() - start_time), target_dir=target_dir, admin_client=admin_client
+            )

--- a/tests/scale/threaded_utils/virt.py
+++ b/tests/scale/threaded_utils/virt.py
@@ -211,7 +211,7 @@ def verify_guest_data(data_before_action: dict, data_after_action: dict) -> None
             if data_before_action[name] >= data_after_action[name]:
                 return_errors.append(
                     "Before datetime is not before after datetime. "
-                    "before: {data_before_action[name]} after: {data_after_action[name]}"
+                    f"before: {data_before_action[name]} after: {data_after_action[name]}"
                 )
         elif name == "btime":
             if data_before_action[name] != data_after_action[name]:

--- a/tests/scale/threaded_utils/virt.py
+++ b/tests/scale/threaded_utils/virt.py
@@ -28,7 +28,7 @@ def threaded_wait_for_accessible_vms(
     sleep: int = TIMEOUT_10SEC,
 ) -> None:  # skip-unused-code
     """
-    Asyncronously wait for accessible VMs
+    Asynchronously wait for accessible VMs
 
     Args:
         vms (list[VirtualMachineForTests]): List of VMs to wait for

--- a/tests/scale/threaded_utils/virt.py
+++ b/tests/scale/threaded_utils/virt.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import logging
+import re
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from ocp_resources.virtual_machine import VirtualMachine
+from pyhelper_utils.shell import run_ssh_commands
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.scale.constants import GUEST_DATA_COMMAND_LIST, GUEST_DATA_RESULT_SEPARATOR
+from utilities.constants import TIMEOUT_1MIN, TIMEOUT_2MIN, TIMEOUT_4MIN, TIMEOUT_8MIN, TIMEOUT_10SEC
+from utilities.virt import (
+    VirtualMachineForTests,
+    wait_for_cloud_init_complete,
+    wait_for_running_vm,
+    wait_for_ssh_connectivity,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def threaded_wait_for_accessible_vms(
+    vms: list[VirtualMachineForTests],
+    timeout: int = TIMEOUT_2MIN,
+    tcp_timeout: int = TIMEOUT_1MIN,
+    sleep: int = TIMEOUT_10SEC,
+) -> list[Any]:  # skip-unused-code
+    assert vms, f"No VMs provided {vms!r}"
+
+    def _wait_for_accessible_vm(_vm: VirtualMachineForTests) -> None:
+        wait_for_ssh_connectivity(vm=_vm, timeout=timeout, tcp_timeout=tcp_timeout, sleep=sleep)
+
+    with ThreadPoolExecutor(max_workers=len(vms)) as executor:
+        return list(executor.map(_wait_for_accessible_vm, vms))
+
+
+def threaded_wait_for_running_vms(
+    vms: list[VirtualMachineForTests],
+    wait_for_interfaces: bool = False,
+    check_ssh_connectivity: bool = False,
+    wait_for_cloud_init: bool = False,
+    wait_until_running_timeout: int = TIMEOUT_8MIN,
+    ssh_timeout: int = TIMEOUT_4MIN,
+    cloud_init_timeout: int = TIMEOUT_8MIN,
+) -> list[Any]:  # skip-unused-code
+    """
+    Asynchronously wait for running VMs
+
+    Args:
+        vms (list): List of VirtualMachines
+        wait_for_cloud_init (bool, optional): Wait for VM cloud-init completion
+
+    Returns:
+        dict: Data related to the running of the async function
+    """
+    assert vms, f"No VMs provided {vms!r}"
+
+    def _wait_running_vm(_vm: VirtualMachineForTests) -> None:
+        try:
+            wait_for_running_vm(
+                vm=_vm,
+                wait_for_interfaces=wait_for_interfaces,
+                check_ssh_connectivity=check_ssh_connectivity,
+                wait_until_running_timeout=wait_until_running_timeout,
+                ssh_timeout=ssh_timeout,
+            )
+        except TimeoutExpiredError:
+            LOGGER.error(f"VM: {_vm.name} Status: {_vm.instance.status}")
+            raise
+
+        if wait_for_cloud_init:
+            wait_for_cloud_init_complete(vm=_vm, timeout=cloud_init_timeout)
+
+    with ThreadPoolExecutor(max_workers=len(vms)) as executor:
+        return list(executor.map(_wait_running_vm, vms))
+
+
+def threaded_wait_for_scheduled_vms(
+    vms: list[VirtualMachine], wait_timeout=TIMEOUT_8MIN
+) -> list[Any]:  # skip-unused-code
+    """
+    Asynchronously wait for scheduled VMs
+
+    Args:
+        vms (list): List of VirtualMachines
+
+    Returns:
+        dict: Data related to the running of the async function
+    """
+    assert vms, f"No VMs provided {vms!r}"
+
+    def _wait_for_scheduled_vm(_vm: VirtualMachine) -> None:
+        def _get_virt_launcher_instance():
+            virt_launcher_pod = _vm.vmi.virt_launcher_pod
+            if virt_launcher_pod:
+                return virt_launcher_pod.exists
+
+        sampler = TimeoutSampler(
+            wait_timeout=wait_timeout,
+            sleep=1,
+            func=_get_virt_launcher_instance,
+        )
+        try:
+            sample = None
+            for sample in sampler:
+                if sample and sample.spec.nodeName:
+                    break
+        except TimeoutExpiredError:
+            LOGGER.error(f"VM: {_vm.name} Status: {_vm.instance.status} virt-launcher: {sample}")
+
+            raise
+
+    with ThreadPoolExecutor(max_workers=len(vms)) as executor:
+        return list(executor.map(_wait_for_scheduled_vm, vms))
+
+
+def threaded_run_vm_ssh_command(
+    vms: list[VirtualMachineForTests], commands: list[str], tcp_timeout=TIMEOUT_8MIN
+) -> list:  # skip-unused-code
+    assert vms, f"No VMs provided {vms!r}"
+
+    def _run_ssh_commands(_vm: VirtualMachineForTests) -> list:
+        return run_ssh_commands(
+            host=_vm.ssh_exec,
+            commands=commands,
+            tcp_timeout=tcp_timeout,
+        )
+
+    with ThreadPoolExecutor(max_workers=len(vms)) as executor:
+        return list(executor.map(_run_ssh_commands, vms))
+
+
+def threaded_get_vm_guest_data(vms: list[VirtualMachineForTests], commands: list[str]) -> list[Any]:  # skip-unused-code
+    assert vms, f"No VMs provided {vms!r}"
+    result = threaded_run_vm_ssh_command(vms=vms, commands=commands)
+    all_guest_data = []
+    for idx, entry in enumerate(result):
+        vm = vms[idx]
+        command_call_result_list = entry[0].strip().split(GUEST_DATA_RESULT_SEPARATOR)
+
+        entry_data = {}
+        for cmd_idx, call_result in enumerate(command_call_result_list):
+            command_call_info = GUEST_DATA_COMMAND_LIST[cmd_idx]
+            regex: re.Pattern = command_call_info["regex"]
+            data_match = regex.match(string=call_result.strip())
+            if data_match:
+                entry_data.update(data_match.groupdict())
+            else:
+                raise ValueError(
+                    f"VM {vm.namespace} {vm.name}: Regex does not match call result: {regex.pattern!r} {call_result!r}"
+                )
+
+        all_guest_data.append(entry_data)
+
+    return all_guest_data
+
+
+def verify_guest_data(before: dict, after: dict) -> None:  # skip-unused-code
+    return_errors = []
+
+    if not (before and after and before != after):
+        raise ValueError(f"invalid input: before:{before!r} after:{after!r}")
+
+    for name in before:
+        if name == "datetime":
+            if before[name] >= after[name]:
+                return_errors.append(
+                    f"Before datetime is not before after datetime. before: {before[name]} after: {after[name]}"
+                )
+        elif name == "btime":
+            if before[name] != after[name]:
+                return_errors.append(f"Boot times do not match. before: {before[name]} after: {after[name]}")
+
+    assert not return_errors, return_errors
+
+
+def threaded_verify_guest_data(before_list: list[dict], after_list: list[dict]) -> list[Any]:  # skip-unused-code
+    before_list_length = len(before_list)
+    assert before_list and after_list and before_list_length == len(after_list), (
+        "Guest data lists must be provided and be of equal length"
+    )
+    with ThreadPoolExecutor(max_workers=before_list_length) as executor:
+        return list(executor.map(verify_guest_data, before_list, after_list))

--- a/tests/scale/utils.py
+++ b/tests/scale/utils.py
@@ -11,6 +11,19 @@ from ocp_resources.resource import ResourceEditor
 
 
 def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:  # skip-unused-code
+    """
+    In order to modify the kubeconfig client configuration with additional args,
+    the context that is required for a specific user must be specified when calling get_client()
+
+    eg:
+        client_configuration = kubernetes.client.Configuration()
+        client_configuration.connection_pool_maxsize = request.param["connection_pool_maxsize"]
+        get_client(
+            client_configuration=deepcopy(client_configuration),
+            config_file=exported_kubeconfig,
+            context=get_user_kubeconfig_context(kubeconfig_filename=exported_kubeconfig, username=UNPRIVILEGED_USER),
+        )
+    """
     with open(kubeconfig_filename, "r") as file:
         kubeconfig_content = yaml.safe_load(file)
 

--- a/tests/scale/utils.py
+++ b/tests/scale/utils.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Generator
+
+import pytest
+import yaml
+from ocp_resources.machine_config_pool import MachineConfigPool
+from ocp_resources.resource import ResourceEditor
+
+
+def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:  # skip-unused-code
+    with open(kubeconfig_filename, "r") as file:
+        kubeconfig_content = yaml.safe_load(file)
+
+    all_contexts = kubeconfig_content["contexts"]
+    current_context = kubeconfig_content["current-context"]
+    current_cluster = next(
+        (entry["context"]["cluster"] for entry in all_contexts if entry["name"] == current_context),
+        None,
+    )
+    assert current_cluster, f"No context found named {current_context!r}"
+
+    user_context = None
+    for entry in all_contexts:
+        context = entry["context"]
+        if context["cluster"] == current_cluster and context["user"] == f"{username}/{current_cluster}":
+            user_context = entry["name"]
+            break
+
+    assert user_context, "No context found for user"
+    return user_context
+
+
+def pause_mcps(paused: bool, mcps: list[MachineConfigPool]) -> None:  # skip-unused-code
+    ResourceEditor(patches={mcp: {"spec": {"paused": paused}} for mcp in mcps}).update()
+
+
+@contextmanager
+def label_mcps(mcps: list[MachineConfigPool], labels: dict) -> Generator[list[MachineConfigPool]]:  # skip-unused-code
+    updates = [ResourceEditor({mcp: {"metadata": {"labels": labels}}}) for mcp in mcps]
+
+    for update in updates:
+        update.update(backup_resources=True)
+    yield mcps
+    for update in updates:
+        update.restore()
+
+
+def capture_func_elapsed(
+    cache: pytest.Cache, cache_key_prefix: str, func: Callable, **kwargs: Any
+) -> Any:  # skip-unused-code
+    """
+    Capture the start/stop/elapsed of arbitrary functions
+    """
+    start_time = time.time()
+    return_value = func(**kwargs)
+    stop_time = time.time()
+    cache.set(f"{cache_key_prefix}-start", start_time)
+    cache.set(f"{cache_key_prefix}-stop", stop_time)
+    cache.set(f"{cache_key_prefix}-elapsed", stop_time - start_time)
+    return return_value

--- a/tests/scale/utils.py
+++ b/tests/scale/utils.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import time
-from contextlib import contextmanager
-from typing import Any, Callable, Generator
+from contextlib import ExitStack, contextmanager
+from typing import Any, Callable, Generator, Sequence
 
 import pytest
 import yaml
 from ocp_resources.machine_config_pool import MachineConfigPool
-from ocp_resources.resource import ResourceEditor
+from ocp_resources.resource import Resource, ResourceEditor
+
+from utilities.operator import (
+    get_machine_config_pools_conditions,
+    get_mcp_updating_transition_times,
+    wait_for_mcp_update_end,
+    wait_for_mcp_update_start,
+)
 
 
 def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:  # skip-unused-code
@@ -46,21 +53,6 @@ def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:
     return user_context
 
 
-def pause_mcps(paused: bool, mcps: list[MachineConfigPool]) -> None:  # skip-unused-code
-    ResourceEditor(patches={mcp: {"spec": {"paused": paused}} for mcp in mcps}).update()
-
-
-@contextmanager
-def label_mcps(mcps: list[MachineConfigPool], labels: dict) -> Generator[list[MachineConfigPool]]:  # skip-unused-code
-    updates = [ResourceEditor({mcp: {"metadata": {"labels": labels}}}) for mcp in mcps]
-
-    for update in updates:
-        update.update(backup_resources=True)
-    yield mcps
-    for update in updates:
-        update.restore()
-
-
 def capture_func_elapsed(
     cache: pytest.Cache, cache_key_prefix: str, func: Callable, **kwargs: Any
 ) -> Any:  # skip-unused-code
@@ -74,3 +66,92 @@ def capture_func_elapsed(
     cache.set(f"{cache_key_prefix}-stop", stop_time)
     cache.set(f"{cache_key_prefix}-elapsed", stop_time - start_time)
     return return_value
+
+
+class MachineConfigPoolConfiguration(ExitStack):
+    def __init__(
+        self,
+        resources: Sequence[Resource],
+        mcp_labels: dict[MachineConfigPool, dict[str, str]],
+        timeout: int,
+        sleep: int,
+    ) -> None:
+        """
+        Control the machine config pool rollout process for changes,
+        such as KubeletConfigs, that affect the cluster behavior
+
+        Args:
+            resources (Sequence[Resource]): Resources to create while MCP is paused
+            mcp_labels (dict[MachineConfigPool, dict]): Labels to be applied to machine config pools while paused
+            timeout (int): Timeout for wait_for_mcp_update_end
+            sleep (int): Sleep for wait_for_mcp_update_end
+
+        Example:
+            with MachineConfigPoolConfiguration(
+                resources=[KubeletConfig(...)],
+                mcp_labels={worker_machine_config_pool: {"label": "value"}},
+                timeout=TIMEOUT_20MIN * len(workers)
+                sleep=TIMEOUT_30SEC
+            ):
+                yield  # Use cluster with new configuration
+        """
+        super().__init__()
+        self.resources = resources
+        self.mcp_labels = mcp_labels
+        self.timeout = timeout
+        self.sleep = sleep
+
+        self.machine_config_pools = mcp_labels.keys()
+        self.mcp_updates = [
+            ResourceEditor({mcp: {"metadata": {"labels": labels}}}) for mcp, labels in self.mcp_labels.items()
+        ]
+
+    @contextmanager
+    def _cleanup_on_error(self, stack_exit) -> Generator[None, Any, None]:
+        with ExitStack() as stack:
+            stack.push(exit=stack_exit)
+            yield
+            stack.pop_all()
+
+    def __enter__(self) -> MachineConfigPoolConfiguration:
+        initial_updating_transition_times = get_mcp_updating_transition_times(
+            mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=self.machine_config_pools)
+        )
+        with self._cleanup_on_error(stack_exit=super().__exit__):
+            with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in self.machine_config_pools}):
+                for resource in self.resources:
+                    self.enter_context(cm=resource)
+                for mcp_update in self.mcp_updates:
+                    mcp_update.update(backup_resources=True)
+
+        wait_for_mcp_update_start(
+            machine_config_pools_list=self.machine_config_pools,
+            initial_transition_times=initial_updating_transition_times,
+        )
+        wait_for_mcp_update_end(
+            machine_config_pools_list=self.machine_config_pools,
+            timeout=self.timeout,
+            sleep=self.sleep,
+        )
+        return self
+
+    def __exit__(self, *exc_arguments: Any) -> Any:
+        teardown_updating_transition_times = get_mcp_updating_transition_times(
+            mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=self.machine_config_pools)
+        )
+        with self._cleanup_on_error(stack_exit=super().__exit__):
+            with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in self.machine_config_pools}):
+                for mcp_update in self.mcp_updates:
+                    mcp_update.restore()
+                for resource in self.resources:
+                    resource.clean_up()
+
+        wait_for_mcp_update_start(
+            machine_config_pools_list=self.machine_config_pools,
+            initial_transition_times=teardown_updating_transition_times,
+        )
+        wait_for_mcp_update_end(
+            machine_config_pools_list=self.machine_config_pools,
+            timeout=self.timeout,
+            sleep=self.sleep,
+        )

--- a/tests/upgrade_params.py
+++ b/tests/upgrade_params.py
@@ -27,3 +27,5 @@ SNAPSHOT_RESTORE_CREATE_AFTER_UPGRADE = f"{STORAGE_NODE_ID_PREFIX}::test_vm_snap
 HOTPLUG_VM_AFTER_UPGRADE_NODE_ID = f"{STORAGE_NODE_ID_PREFIX}::test_vm_with_hotplug_after_upgrade"
 SNAPSHOT_RESTORE_CHECK_AFTER_UPGRADE_ID = f"{STORAGE_NODE_ID_PREFIX}::test_vm_snapshot_restore_check_after_upgrade"
 CDI_SCRATCH_PRESERVE_NODE_ID = f"{STORAGE_NODE_ID_PREFIX}::test_cdiconfig_scratch_preserved_after_upgrade"
+SCALE_NODE_ID_PREFIX = "tests/scale/test_upgrade_scale.py::TestUpgradeScale"
+SCALE_VM_LOAD_RUNNING_AFTER_UPGRADE_ID = f"{SCALE_NODE_ID_PREFIX}::test_load_running_after_upgrade"

--- a/tests/upgrade_params.py
+++ b/tests/upgrade_params.py
@@ -1,7 +1,8 @@
 from pytest_testconfig import config as py_config
 
+from utilities.constants import EUS
+
 UPGRADE_PACKAGE_NAME = "tests/install_upgrade_operators/product_upgrade"
-EUS = "eus"
 
 if py_config["upgraded_product"] == EUS:
     upgrade_class = "TestEUSToEUSUpgrade"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -394,6 +394,7 @@ DV_DISK = "dv-disk"
 
 # Upgrade tests configuration
 DEPENDENCY_SCOPE_SESSION = "session"
+EUS = "eus"
 
 # hco spec
 ENABLE_COMMON_BOOT_IMAGE_IMPORT = "enableCommonBootImageImport"

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -235,8 +235,10 @@ def consecutive_checks_for_mcp_condition(mcp_sampler, machine_config_pools_list)
         raise
 
 
-def wait_for_mcp_update_end(machine_config_pools_list):
-    wait_for_mcp_updated_condition_true(machine_config_pools_list=machine_config_pools_list)
+def wait_for_mcp_update_end(machine_config_pools_list, timeout=TIMEOUT_75MIN, sleep=TIMEOUT_5SEC):
+    wait_for_mcp_updated_condition_true(
+        machine_config_pools_list=machine_config_pools_list, timeout=timeout, sleep=sleep
+    )
     wait_for_mcp_ready_machine_count(machine_config_pools_list=machine_config_pools_list)
 
 

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -54,6 +54,9 @@ from utilities.operator import (  # noqa: E402
     wait_for_package_manifest_to_exist,
 )
 
+TIMEOUT_75MIN = 4500
+TIMEOUT_5SEC = 5
+
 # ============================================================================
 # SIMPLE FUNCTIONS (8 tests)
 # ============================================================================
@@ -1077,8 +1080,44 @@ class TestWaitForMcpUpdateEnd:
 
         wait_for_mcp_update_end([mock_mcp])
 
-        mock_wait_updated.assert_called_once_with(machine_config_pools_list=[mock_mcp])
+        mock_wait_updated.assert_called_once_with(
+            machine_config_pools_list=[mock_mcp],
+            timeout=TIMEOUT_75MIN,
+            sleep=TIMEOUT_5SEC,
+        )
         mock_wait_ready.assert_called_once_with(machine_config_pools_list=[mock_mcp])
+
+    @patch("utilities.operator.wait_for_mcp_ready_machine_count")
+    @patch("utilities.operator.wait_for_mcp_updated_condition_true")
+    def test_wait_for_update_end_custom_args(self, mock_wait_updated, mock_wait_ready):
+        """Test waiting for MCP update to end with custom timeout and sleep"""
+        mock_mcp = MagicMock()
+        custom_timeout = 100
+        custom_sleep = 1
+
+        wait_for_mcp_update_end([mock_mcp], timeout=custom_timeout, sleep=custom_sleep)
+
+        mock_wait_updated.assert_called_once_with(
+            machine_config_pools_list=[mock_mcp],
+            timeout=custom_timeout,
+            sleep=custom_sleep,
+        )
+        mock_wait_ready.assert_called_once_with(machine_config_pools_list=[mock_mcp])
+
+    @patch("utilities.operator.wait_for_mcp_ready_machine_count")
+    @patch("utilities.operator.wait_for_mcp_updated_condition_true")
+    def test_wait_for_update_end_partial_args(self, mock_wait_updated, mock_wait_ready):
+        """Test waiting for MCP update to end with only custom timeout"""
+        mock_mcp = MagicMock()
+        custom_timeout = 500
+
+        wait_for_mcp_update_end([mock_mcp], timeout=custom_timeout)
+
+        mock_wait_updated.assert_called_once_with(
+            machine_config_pools_list=[mock_mcp],
+            timeout=custom_timeout,
+            sleep=TIMEOUT_5SEC,
+        )
 
 
 class TestWaitForMcpUpdateStart:

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -1118,6 +1118,7 @@ class TestWaitForMcpUpdateEnd:
             timeout=custom_timeout,
             sleep=TIMEOUT_5SEC,
         )
+        mock_wait_ready.assert_called_once_with(machine_config_pools_list=[mock_mcp])
 
 
 class TestWaitForMcpUpdateStart:

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1535,13 +1535,13 @@ class ServiceForVirtualMachineForTests(Service):
 
 
 def wait_for_ssh_connectivity(
-    vm: VirtualMachineForTests, timeout: int = TIMEOUT_2MIN, tcp_timeout: int = TIMEOUT_1MIN
+    vm: VirtualMachineForTests, timeout: int = TIMEOUT_2MIN, tcp_timeout: int = TIMEOUT_1MIN, sleep: int = TIMEOUT_5SEC
 ) -> None:
     LOGGER.info(f"Wait for {vm.name} SSH connectivity.")
 
     for sample in TimeoutSampler(
         wait_timeout=timeout,
-        sleep=5,
+        sleep=sleep,
         func=vm.ssh_exec.run_command,
         command=["exit"],
         tcp_timeout=tcp_timeout,

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http
 import io
 import ipaddress
 import json
@@ -61,11 +62,13 @@ from utilities.constants import (
     IP_FAMILY_POLICY_PREFER_DUAL_STACK,
     LINUX_AMD_64,
     LINUX_STR,
+    MIGRATION_POLICY_VM_LABEL,
     OS_FLAVOR_ALPINE,
     OS_FLAVOR_CIRROS,
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
     OS_PROC_NAME,
+    PORT_80,
     ROOTDISK,
     SSH_PORT_22,
     TCP_TIMEOUT_30SEC,
@@ -2761,3 +2764,48 @@ def wait_for_virt_handler_pods_network_updated(
         )
         raise
     return False
+
+
+def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, node, node_selector_label=None):
+    name = "nginx"
+    with VirtualMachineForTests(
+        namespace=chaos_namespace.name,
+        name=name,
+        body=fedora_vm_body(name=name),
+        client=admin_client,
+        node_selector_labels=node_selector_label,
+        additional_labels=MIGRATION_POLICY_VM_LABEL,
+    ) as vm:
+        running_vm(vm=vm, check_ssh_connectivity=False)
+        vm.custom_service_enable(service_name=name, port=PORT_80, service_type=Service.Type.CLUSTER_IP)
+        verify_vm_service_reachable(
+            utility_pods=utility_pods,
+            node=node,
+            url=f"{vm.custom_service.instance.spec.clusterIPs[0]}:{PORT_80}",
+        )
+        LOGGER.info(f"VMI Host Node:{vm.vmi.node.name}")
+        yield vm
+
+
+def verify_vm_service_reachable(utility_pods, node, url):
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_2MIN,
+            sleep=TIMEOUT_5SEC,
+            func=is_http_ok,
+            utility_pods=utility_pods,
+            node=node,
+            url=url,
+        ):
+            if sample:
+                break
+    except TimeoutExpiredError:
+        LOGGER.error(f"Service at {url} is not reachable")
+        raise
+
+
+def is_http_ok(utility_pods, node, url):
+    http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
+        command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
+    )
+    return int(http_result) == http.HTTPStatus.OK

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from json import JSONDecodeError
 from subprocess import run
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional
 
 import bitmath
 import jinja2
@@ -2767,13 +2767,13 @@ def wait_for_virt_handler_pods_network_updated(
 
 
 def create_vm_with_nginx_service(
+    name: str,
     namespace: Namespace,
     client: DynamicClient,
     utility_pods: list[Pod],
     node: Node,
-    node_selector_label: Optional[dict] = None,
-):
-    name = "nginx"
+    node_selector_label: dict | None = None,
+) -> Generator[VirtualMachine]:
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
@@ -2793,7 +2793,7 @@ def create_vm_with_nginx_service(
         yield vm
 
 
-def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
+def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str) -> None:
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
@@ -2810,7 +2810,7 @@ def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
         raise
 
 
-def is_http_ok(utility_pods: list[Pod], node: Node, url: str):
+def is_http_ok(utility_pods: list[Pod], node: Node, url: str) -> bool:
     http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
         command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
     )

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2766,13 +2766,19 @@ def wait_for_virt_handler_pods_network_updated(
     return False
 
 
-def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, node, node_selector_label=None):
+def create_vm_with_nginx_service(
+    namespace: Namespace,
+    client: DynamicClient,
+    utility_pods: list[Pod],
+    node: Node,
+    node_selector_label: Optional[dict] = None,
+):
     name = "nginx"
     with VirtualMachineForTests(
-        namespace=chaos_namespace.name,
+        namespace=namespace.name,
         name=name,
         body=fedora_vm_body(name=name),
-        client=admin_client,
+        client=client,
         node_selector_labels=node_selector_label,
         additional_labels=MIGRATION_POLICY_VM_LABEL,
     ) as vm:
@@ -2787,7 +2793,7 @@ def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, no
         yield vm
 
 
-def verify_vm_service_reachable(utility_pods, node, url):
+def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
@@ -2804,7 +2810,7 @@ def verify_vm_service_reachable(utility_pods, node, url):
         raise
 
 
-def is_http_ok(utility_pods, node, url):
+def is_http_ok(utility_pods: list[Pod], node: Node, url: str):
     http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
         command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -1055,6 +1055,22 @@ wheels = [
 ]
 
 [[package]]
+name = "openshift-python-scale-utilities"
+version = "0.1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openshift-python-utilities" },
+    { name = "openshift-python-wrapper" },
+    { name = "pytest" },
+    { name = "pytest-order" },
+    { name = "python-simple-logger" },
+    { name = "timeout-sampler" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/ce/b665316eea3b5c8f622953cf28ef5d009fe54fabe760e149bb4b49be387f/openshift_python_scale_utilities-0.1.1.5-py3-none-any.whl", hash = "sha256:b85acac5441d38f0cd56b642f4dd23eb85a900d7a806fa6869e3845ec7a70f85", size = 11872, upload-time = "2025-12-04T19:05:30.831Z" },
+]
+
+[[package]]
 name = "openshift-python-utilities"
 version = "6.0.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1130,6 +1146,7 @@ dependencies = [
     { name = "kubernetes" },
     { name = "marshmallow" },
     { name = "netaddr" },
+    { name = "openshift-python-scale-utilities" },
     { name = "openshift-python-utilities" },
     { name = "openshift-python-wrapper" },
     { name = "openstacksdk" },
@@ -1195,6 +1212,7 @@ requires-dist = [
     { name = "kubernetes", specifier = ">=34.1.0" },
     { name = "marshmallow", specifier = "==3.26.1" },
     { name = "netaddr", specifier = ">=1.3.0" },
+    { name = "openshift-python-scale-utilities", specifier = ">=0.1.1.5" },
     { name = "openshift-python-utilities", specifier = ">=6.0.0" },
     { name = "openshift-python-wrapper", specifier = ">=11.0.93" },
     { name = "openstacksdk", specifier = ">=4.1.0" },


### PR DESCRIPTION
- create vms w/ load

Part of a dependency path for scale upgrade testing
Rebased on #3108 

Depends on:
#3149 - Alter chaos multiprocessing start method
#3029 - Move Chaos utils
#3103 - Move EUS Constant
#3105 - Add scale utils.py
#3107 - Add scale conftest.py
#3108 - Add scale threaded utils

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end upgrade-scale test suite and threaded scale utilities for parallel VM orchestration, guest-data collection/validation, and stress-ng workload support.

* **Dependencies**
  * Added runtime dependency: openshift-python-scale-utilities (>=0.1.1.5).

* **Tests**
  * New pytest marker and --scale option, numerous scale/chaos fixtures, multiprocessing start-method fixture, and many new/updated scale test modules.

* **Chores**
  * Updated ignore list to exclude scale test artifacts; added new constants and test utilities to support scale workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->