### PR TITLE
Add client in infrastructure vm_console_proxy, workload_availability

### DIFF
--- a/tests/infrastructure/vm_console_proxy/utils.py
+++ b/tests/infrastructure/vm_console_proxy/utils.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Type
 
 import requests
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.api_service import APIService
 from ocp_resources.resource import Resource
 
@@ -59,15 +60,17 @@ def create_vnc_console_token(
         raise
 
 
-def get_vm_console_proxy_resource(resource_kind: Type, namespace: str | None = None) -> Type:
+def get_vm_console_proxy_resource(resource_kind: Type, client: DynamicClient, namespace: str | None = None) -> Type:
     if namespace:
         vm_console_proxy_resource_object = resource_kind(
             name=VM_CONSOLE_PROXY,
             namespace=namespace,
+            client=client,
         )
     else:
         vm_console_proxy_resource_object = resource_kind(
-            name=f"{TOKEN_API_VERSION}.{TOKEN_ENDPOINT}" if resource_kind == APIService else VM_CONSOLE_PROXY
+            name=f"{TOKEN_API_VERSION}.{TOKEN_ENDPOINT}" if resource_kind == APIService else VM_CONSOLE_PROXY,
+            client=client,
         )
     return vm_console_proxy_resource_object
 

--- a/tests/infrastructure/workload_availability/remediation_fencing/test_nodehealthcheck_default_remediation.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing/test_nodehealthcheck_default_remediation.py
@@ -28,9 +28,10 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def created_nodehealthcheck_snr_object(snr_remediation_template):
+def created_nodehealthcheck_snr_object(admin_client, snr_remediation_template):
     with NodeHealthCheck(
         name="nhc-remediation-snr",
+        client=admin_client,
         min_unhealthy=1,
         selector_match_expressions=SELECTOR_MATCH_EXPRESSIONS,
         unhealthy_conditions=UNHEALTHY_CONDITIONS,
@@ -41,8 +42,8 @@ def created_nodehealthcheck_snr_object(snr_remediation_template):
 
 
 @pytest.fixture(scope="module")
-def snr_remediation_template(checkup_nodehealthcheck_operator_deployment):
-    template = next(SelfNodeRemediationTemplate.get(namespace=REMEDIATION_OPERATOR_NAMESPACE))
+def snr_remediation_template(admin_client, checkup_nodehealthcheck_operator_deployment):
+    template = next(SelfNodeRemediationTemplate.get(namespace=REMEDIATION_OPERATOR_NAMESPACE, dyn_client=admin_client))
     return {
         "apiVersion": template.api_version,
         "name": template.name,

--- a/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
@@ -34,10 +34,11 @@ DV_DICT = {
 
 
 @pytest.fixture()
-def machine_health_check_reboot(worker_machine1):
+def machine_health_check_reboot(admin_client, worker_machine1):
     with MachineHealthCheck(
         name="ha-vm-mhc",
         namespace=worker_machine1.namespace,
+        client=admin_client,
         cluster_name=worker_machine1.cluster_name,
         machineset_name=worker_machine1.machineset_name,
         unhealthy_timeout="60s",


### PR DESCRIPTION
##### Short description:
Add client in infrastructure vm_console_proxy, workload_availability folders

##### What this PR does / why we need it:
The client in resources from the openshift-python-wrapper are planned to be a required field

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to utilize administrative client contexts across VM console proxy, remediation fencing, and machine health check test suites for enhanced resource creation and validation in test fixtures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->