### PR TITLE
net, stability: Add ipv4 mark to rdp tests

### DIFF
--- a/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
+++ b/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
@@ -19,6 +19,8 @@ from utilities.virt import VirtualMachineForTests, vm_instance_from_template, wa
 LOGGER = logging.getLogger(__name__)
 TCP_TIMEOUT_SEC = 60
 
+pytestmark = [pytest.mark.ipv4]
+
 
 @pytest.fixture(scope="module")
 def rdp_vm(


### PR DESCRIPTION
RDP tests were recently fixed and run in dual-stack lane. These tests are designed to perform ssh using ipv4 only - because of that the test fails in the single-stack ipv6 lane.
This test does not need to be covered in the single-stack ipv6 lane.

An IPv4 mark is added so that these tests are not collected on the single stack IPv6 lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an IPv4 marker to the RDP exposure test module to adjust test selection.

Note: Internal testing configuration only—no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->