### PR TITLE
utilities/tests, net: Add mandatory client arg

### DIFF
--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -346,10 +346,11 @@ def kmp_down(cnao_down, kmp_deployment):
 
 
 @pytest.fixture()
-def cnao_down(cnao_deployment):
+def cnao_down(admin_client, cnao_deployment):
     with ResourceEditorValidateHCOReconcile(
         patches={cnao_deployment: {"spec": {"replicas": 0}}},
         list_resource_reconcile=[NetworkAddonsConfig],
+        admin_client=admin_client,
     ):
         cnao_deployment.wait_for_replicas(deployed=False)
         yield

--- a/tests/network/ovs_optin/test_ovs_optin.py
+++ b/tests/network/ovs_optin/test_ovs_optin.py
@@ -26,24 +26,28 @@ def wait_for_ovs_removed(admin_client, ovs_daemonset, network_addons_config):
 
 @pytest.fixture()
 def hyperconverged_ovs_annotations_disabled(
+    admin_client,
     hyperconverged_resource_scope_function,
     hyperconverged_ovs_annotations_enabled_scope_session,
 ):
     with ResourceEditorValidateHCOReconcile(
         patches={hyperconverged_resource_scope_function: {"metadata": {"annotations": {DEPLOY_OVS: "false"}}}},
         list_resource_reconcile=[NetworkAddonsConfig],
+        admin_client=admin_client,
     ):
         yield
 
 
 @pytest.fixture()
 def hyperconverged_ovs_annotations_removed(
+    admin_client,
     hyperconverged_resource_scope_function,
     hyperconverged_ovs_annotations_enabled_scope_session,
 ):
     with ResourceEditorValidateHCOReconcile(
         patches={hyperconverged_resource_scope_function: {"metadata": {"annotations": {DEPLOY_OVS: None}}}},
         list_resource_reconcile=[NetworkAddonsConfig],
+        admin_client=admin_client,
     ):
         yield
 

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -156,7 +156,8 @@ class BridgeNodeNetworkConfigurationPolicy(NodeNetworkConfigurationPolicy):
                 nns = NodeNetworkState(
                     name=utilities.infra.get_node_selector_name(node_selector=self.node_selector)
                     if self.node_selector
-                    else self.nodes[0].name
+                    else self.nodes[0].name,
+                    client=self.client,
                 )
                 port_name = port["name"]
                 if self._does_port_match_type(nns=nns, port_name=port_name, port_type=BOND):
@@ -283,7 +284,7 @@ class OvsBridgeNodeNetworkConfigurationPolicy(BridgeNodeNetworkConfigurationPoli
                     port_name = iface["bridge"]["port"][0]["name"]
 
                     if self.mtu:
-                        nns = NodeNetworkState(name=self._nns_node.name)
+                        nns = NodeNetworkState(name=self._nns_node.name, client=self.client)
                         if BridgeNodeNetworkConfigurationPolicy._does_port_match_type(
                             nns=nns, port_name=port_name, port_type=BOND
                         ):
@@ -315,7 +316,8 @@ class OvsBridgeNodeNetworkConfigurationPolicy(BridgeNodeNetworkConfigurationPoli
                                 raise ValueError("node_selector is required for set_port_mac")
 
                             nns = NodeNetworkState(
-                                name=utilities.infra.get_node_selector_name(node_selector=self.node_selector)
+                                name=utilities.infra.get_node_selector_name(node_selector=self.node_selector),
+                                client=self.client,
                             )
                             port_mac = [iface["mac-address"] for iface in nns.interfaces if iface["name"] == port_name]
                             ovs_iface["mac-address"] = port_mac[0]
@@ -1024,6 +1026,7 @@ def enable_hyperconverged_ovs_annotations(
         patches={hyperconverged_resource: {"metadata": {"annotations": {DEPLOY_OVS: "true"}}}},
         list_resource_reconcile=[NetworkAddonsConfig],
         wait_for_reconcile_post_update=True,
+        admin_client=admin_client,
     ):
         wait_for_ovs_status(network_addons_config=network_addons_config, status=True)
         ovs_daemonset = wait_for_ovs_daemonset_resource(admin_client=admin_client, hco_namespace=hco_namespace)


### PR DESCRIPTION
This change makes the client mandatory for all network-related resource instantiations. Updated utilities and test fixtures so that all calls to openshift-python-wrapper resources explicitly pass a client parameter.

As of its next release, openshift-python-wrapper will enforce passing client when working with cluster resources.
openshift-virtualization-tests must align with this change. All calls in the code to openshift-python-wrapper resources should be updated to pass client arg.

Add explicit client parameter to NodeNetworkState and ResourceEditorValidateHCOReconcile instantiations in network tests.

https://issues.redhat.com/browse/CNV-72392

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to support improved client context handling.

* **Refactor**
  * Enhanced internal network configuration utilities for better client context propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->