### PR TITLE
Fix get_node_audit_log_entries: add subprocess timeout to enable retry mechanism

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -839,7 +839,7 @@ def generate_openshift_pull_secret_file(client: DynamicClient = None) -> str:
 @retry(
     wait_timeout=TIMEOUT_30SEC,
     sleep=TIMEOUT_10SEC,
-    exceptions_dict={RuntimeError: []},
+    exceptions_dict={RuntimeError: [], subprocess.TimeoutExpired: []},
 )
 def get_node_audit_log_entries(log, node, log_entry):
     # Patterns to match errors that should trigger a retry
@@ -850,9 +850,14 @@ def get_node_audit_log_entries(log, node, log_entry):
     ]
     error_patterns = re.compile("|".join(f"({pattern})" for pattern in error_patterns_list))
 
-    lines = subprocess.getoutput(
-        f"{OC_ADM_LOGS_COMMAND} {node} {AUDIT_LOGS_PATH}/{log} | grep {shlex.quote(log_entry)}"
-    ).splitlines()
+    result = subprocess.run(
+        f"{OC_ADM_LOGS_COMMAND} {node} {AUDIT_LOGS_PATH}/{log} | grep {shlex.quote(log_entry)}",
+        shell=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    lines = result.stdout.splitlines()
     has_errors = any(error_patterns.search(line) for line in lines)
     if has_errors:
         if any(line.strip().startswith("404 page not found") for line in lines):


### PR DESCRIPTION
##### Short description:
The `get_node_audit_log_entries` function uses `subprocess.getoutput()` which blocks indefinitely when the oc command hangs, consuming the entire 30-second `@retry` timeout before returning. This prevents the retry mechanism from working when transient network errors occur (e.g., HTTP/2 GOAWAY).

##### More details:
This follows the same pattern as previous fixes in PR #2750 (CNV-72975) and PR #2368 (CNV-70167) for test_deprecated_apis_in_audit_logs.

##### What this PR does / why we need it:
- Replace subprocess.getoutput() with subprocess.run(timeout=10)
- Add subprocess.TimeoutExpired to `@retry` exceptions_dict
- 10-second timeout per attempt allows 2 retries within 30s total timeout

##### Which issue(s) this PR fixes:
Root cause analysis showed subprocess hung for ~99 seconds waiting for HTTP/2 GOAWAY response, exhausting the retry timeout. With this fix, each attempt times out after 10s, allowing retries to handle transient failures.

##### Special notes for reviewer:

##### jira-ticket:
[CNV-74779](https://issues.redhat.com/browse/CNV-74779)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened timeout handling for audit log operations with improved error management, preventing potential service hangs and ensuring predictable completion.
  * Enhanced command execution to safely handle timeout scenarios and reliably capture output without data loss.

* **Chores**
  * Optimized internal execution mechanisms for improved reliability and safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->