### PR TITLE
tests, net, service-mesh: fix test_outside_mesh_traffic_blocked scenario

### DIFF
--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -36,9 +36,9 @@ from tests.network.utils import (
     ServiceMeshDeployments,
     ServiceMeshDeploymentService,
 )
-from utilities.constants import PORT_80, TIMEOUT_4MIN, TIMEOUT_10SEC
+from utilities.constants import OS_FLAVOR_FEDORA, PORT_80, TIMEOUT_4MIN, TIMEOUT_10SEC
 from utilities.infra import add_scc_to_service_account, create_ns, label_project, unique_name
-from utilities.virt import vm_console_run_commands
+from utilities.virt import VirtualMachineForTests, fedora_vm_body, vm_console_run_commands
 
 LOGGER = logging.getLogger(__name__)
 
@@ -257,10 +257,12 @@ def outside_mesh_vm_fedora_with_service_mesh_annotation(
     ns_outside_of_service_mesh,
 ):
     vm_name = "out-service-mesh-vm"
-    with FedoraVirtualMachineForServiceMesh(
+    with VirtualMachineForTests(
         client=admin_client,
         name=vm_name,
         namespace=ns_outside_of_service_mesh.name,
+        os_flavor=OS_FLAVOR_FEDORA,
+        body=fedora_vm_body(name=vm_name),
     ) as vm:
         vm.custom_service_enable(
             service_name=vm_name,

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -93,6 +93,8 @@ class TestSMPeerAuthentication:
         peer_authentication_service_mesh_deployment,
         httpbin_service_service_mesh,
     ):
+        # Test Authentication Policy - The service (httpbin) shouldn't be reached from a VM that's outside the mesh
+        # The VM is in a namespace without istio-injection label and without sidecar injection annotation
         # We must specify the full service DNS name since the VM is outside the mesh in a different namespace
         # Format: http://<service_name>.<service_namespace>.svc.cluster.local
         result = run_console_command(


### PR DESCRIPTION
The blocking scenario is failing (traffic is not blocked) since the outside-mesh NS is not labeled with "istio-injection": "enabled", but the VM running in it is created with the annotation "sidecar.istio.io/inject": "true". Having a VM created with this annotation, even if it is created in a NS without the istio-injection label, will inject the istio sidecar to the virt-launcher pod of the VM, thereby connecting it to the mesh.

Created the outside-mesh VM without the annotation "sidecar.istio.io/inject": "true", so that it is indeed created outside the mesh.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test configuration for service mesh testing with improved OS-specific setup.
  * Added documentation comments to clarify service mesh test behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->