### PR TITLE
Add tox `verify-bugs-are-open-gh` to add this check as a check run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -101,7 +101,7 @@ setenv =
 deps =
     python-utility-scripts
 commands =
-    pyutils-jira --url https://issues.redhat.com --token "{env:JIRA_TOKEN}" --target-versions "vfuture,4.22.0,4.22.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
+    pyutils-jira --url https://issues.redhat.com --target-versions "vfuture,4.22.0,4.22.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
 
 #Unused code
 [testenv:unused-code]


### PR DESCRIPTION
##### Short description:

To allow open bugs check to be a GH check run, integrated with https://github.com/myk-org/github-webhook-server/pull/961 - `tox` was updated with an explicit command

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new test environment to extend automated bug verification to a GitHub-specific workflow while preserving the existing verification flow.
  * Included a temporary TODO note indicating the new workflow is under validation and may be removed after checks complete.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->