### PR TITLE
fix: architecture suffix for the fedora-container-image artifact

### DIFF
--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -51,12 +51,12 @@ jobs:
         run: |
           mkdir -p artifacts
           podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image.tar"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
       - name: Upload container image artifact
         uses: actions/upload-artifact@v6
         with:
-          name: fedora-container-image
-          path: artifacts/fedora-image.tar
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
           retention-days: 5
           compression-level: 0


### PR DESCRIPTION
This change introduces a suffix to the built artifact to facilitate multi-architecture image testing. Without this modification, a race condition occurs when the jobs for s390x and x86_64 run in parallel.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build artifacts and upload paths now include CPU architecture identifiers, making produced files and storage paths architecture-specific.
  * Artifact names and build/upload messages updated to indicate the CPU architecture.
  * No changes to runtime behavior, control flow, or public interfaces; functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->