### PR TITLE
Fix filter_metric_by_component to return 0 when metric not found

### DIFF
--- a/tests/install_upgrade_operators/json_patch/utils.py
+++ b/tests/install_upgrade_operators/json_patch/utils.py
@@ -60,11 +60,14 @@ def get_metrics_value_with_annotation(prometheus, query_string, component_name):
     return int(metric_results[0]["value"][1]) if metric_results else 0
 
 
-def filter_metric_by_component(metrics, metric_name, component_name):
+def filter_metric_by_component(metrics: list[dict], metric_name: str, component_name: str) -> int:
     annotation_name = get_annotation_name_for_component(component_name=component_name)
     for metric in metrics:
         if metric["metric"]["annotation_name"] == annotation_name and metric["metric"]["__name__"] == metric_name:
             return int(metric["value"][1])
+    raise ValueError(
+        f"Metric '{metric_name}' not found for component '{component_name}' with annotation '{annotation_name}'"
+    )
 
 
 def wait_for_metrics_value_update(prometheus, component_name, query_string, previous_value):


### PR DESCRIPTION
##### Short description:
The filter_metric_by_component() function was returning None implicitly when no metric matched the component name, causing a TypeError when wait_for_metrics_value_update() attempted to compute previous_value + 1.

This fix adds an explicit 'return 0' statement to handle the case when no matching metric exists, making the function consistent with get_metrics_value_with_annotation() which already handles this correctly.

##### More details:
Root cause: Line 67 returned a value inside the loop, but there was no return statement after the loop for the case when no metric is found.

##### What this PR does / why we need it:
Fixes all 5 JSON patch metrics tests:
- test_cdi_json_patch_metrics
- test_cnao_json_patch_metrics
- test_kubevirt_json_patch_metrics
- test_multiple_json_patch_metrics
- test_ssp_json_patch_metrics

##### Which issue(s) this PR fixes:
Seen on CI: 
```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-74940


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated metric filtering utility to raise a clear error when no matching metric is found instead of returning null, ensuring predictable failure behavior and making missing-metric issues easier to detect during runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->