### PR TITLE
[storage][gating] Wait for PVC use_populator annotation and remove quarantine from test_successful_import_image

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -30,7 +30,6 @@ from tests.storage.utils import (
 from utilities import console
 from utilities.constants import (
     OS_FLAVOR_RHEL,
-    QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
@@ -177,15 +176,12 @@ def test_empty_url(namespace, storage_class_name_scope_module):
     ],
     indirect=True,
 )
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}:PVC missing/not found during operation. CNV-73536",
-    run=False,
-)
 def test_successful_import_image(
     dv_from_http_import,
     storage_class_name_scope_module,
     cluster_csi_drivers_names,
 ):
+    dv_from_http_import.pvc.wait()
     assert_use_populator(
         pvc=dv_from_http_import.pvc,
         storage_class=storage_class_name_scope_module,


### PR DESCRIPTION
##### Short description:
Fix PVC race condition in assert_use_populator and remove quarantine marker from test_successful_import_image
(automation issue)

##### More details:
Previously, assert_use_populator could fail intermittently because the use_populator annotation on the PVC might not be present immediately after creation.

This update adds a wait for the use_populator annotation to ensure the test accesses it reliably.
The xfail quarantine marker on test_successful_import_image has been removed since the test is now stable.



##### What this PR does / why we need it:
Resolves intermittent test failures caused by PVC readiness timing issues.

Allows test_successful_import_image to run normally without being quarantined.

##### Which issue(s) this PR fixes:
Fixes race condition / intermittent failure for test_successful_import_image.

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-73536
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
