### PR TITLE
Fix audit log timeout: increase to 3 minutes for large files

### DIFF
--- a/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
+++ b/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
@@ -56,6 +56,7 @@ def pod_security_violations_apis_calls(audit_logs, hco_namespace):
     return failed_api_calls
 
 
+@pytest.mark.tier3
 @pytest.mark.polarion("CNV-9115")
 def test_cnv_pod_security_violation_audit_logs(pod_security_violations_apis_calls):
     LOGGER.info("Test pod security violations API calls:")

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -57,6 +57,8 @@ from utilities.constants import (
     PROMETHEUS_K8S,
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
+    TIMEOUT_3MIN,
+    TIMEOUT_4MIN,
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_6MIN,
@@ -837,9 +839,9 @@ def generate_openshift_pull_secret_file(client: DynamicClient = None) -> str:
 
 
 @retry(
-    wait_timeout=TIMEOUT_30SEC,
+    wait_timeout=TIMEOUT_4MIN,
     sleep=TIMEOUT_10SEC,
-    exceptions_dict={RuntimeError: [], subprocess.TimeoutExpired: []},
+    exceptions_dict={RuntimeError: []},
 )
 def get_node_audit_log_entries(log, node, log_entry):
     # Patterns to match errors that should trigger a retry
@@ -855,7 +857,7 @@ def get_node_audit_log_entries(log, node, log_entry):
         shell=True,
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=TIMEOUT_3MIN,
     )
     lines = result.stdout.splitlines()
     has_errors = any(error_patterns.search(line) for line in lines)


### PR DESCRIPTION
##### Short description:
Audit log files can be very large (~100MB when close to rotation) on CI clusters and take significant time to transfer over the network and process with grep. Testing showed that some files take 60-110 seconds to complete, causing
timeouts with the previous 30-90 second limits.

This change makes the test duration to potentially increase to ~20-30 minutes on busy CI clusters but eliminates timeout failures. Therefore, the tests are moved to tier3 on this PR.

##### More details:
PR #3043 added `timeout=10` to subprocess.run() for audit log reads but 10 seconds is insufficient for large audit logs in busy clusters.

Changes:
- Increase subprocess timeout from 10s to 180s (3 minutes)
- Increase retry wait_timeout from 30s to 240s (4 minutes)
- Add TIMEOUT_4MIN to imports in utilities/infra.py

With these timeouts, all audit log files process successfully:
- Rotated files with 404: ~2s
- Active audit.log: ~8-40s
- Large rotated files: ~60-110s

##### What this PR does / why we need it:
Analysis of audit.log on CI cluster showed ~34k events per file for
OpenShift clusters with CNV, resulting in ~50-100MB files that require
extended timeouts to process without false failures.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-74779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced node audit log retrieval stability by increasing timeout limits, reducing timeout-related failures during log collection operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->