### PR TITLE
Add Scale conftest.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -75,6 +75,9 @@ fcn_exclude_functions =
     QueueListener,
     requests,
     multiprocessing,
+    getrlimit,
+    setrlimit,
+    ceil,
 
 nit_exclude_imports =
     os_params,

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -45,6 +45,7 @@ from utilities.infra import (
 from utilities.virt import VirtualMachineForTests, create_vm_with_nginx_service, running_vm
 
 LOGGER = logging.getLogger(__name__)
+NGINX = "nginx"
 
 
 @pytest.fixture(scope="module")
@@ -277,6 +278,7 @@ def nginx_monitoring_process(
 @pytest.fixture()
 def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
+        name=NGINX,
         namespace=chaos_namespace,
         client=admin_client,
         utility_pods=workers_utility_pods,
@@ -287,6 +289,7 @@ def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, w
 @pytest.fixture()
 def vm_with_nginx_service_and_node_selector(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
+        name=NGINX,
         namespace=chaos_namespace,
         client=admin_client,
         utility_pods=workers_utility_pods,

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -406,3 +406,14 @@ def deleted_pod_by_name_prefix(admin_client, cnv_pod_deletion_test_matrix__class
         namespace=pod_deletion_config["namespace_name"],
         pod_prefix=pod_deletion_config["pod_prefix"],
     )
+
+
+@pytest.fixture(scope="module")
+def multiprocessing_start_method_fork():
+    # Use fork context to avoid pickling issues with nested functions
+    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process
+    # https://github.com/python/cpython/issues/132898
+    original_start_method = multiprocessing.get_start_method()
+    multiprocessing.set_start_method("fork", force=True)
+    yield
+    multiprocessing.set_start_method(original_start_method, force=True)

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -12,7 +12,6 @@ from tests.chaos.utils import (
     create_cluster_monitoring_process,
     create_nginx_monitoring_process,
     create_pod_deleting_process,
-    create_vm_with_nginx_service,
     get_instance_type,
     pod_deleting_process_recover,
     terminate_process,
@@ -43,7 +42,7 @@ from utilities.infra import (
     utility_daemonset_for_custom_tests,
     wait_for_node_status,
 )
-from utilities.virt import VirtualMachineForTests, running_vm
+from utilities.virt import VirtualMachineForTests, create_vm_with_nginx_service, running_vm
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -277,8 +277,8 @@ def nginx_monitoring_process(
 @pytest.fixture()
 def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
-        chaos_namespace=chaos_namespace,
-        admin_client=admin_client,
+        namespace=chaos_namespace,
+        client=admin_client,
         utility_pods=workers_utility_pods,
         node=random.choice(workers),
     )
@@ -287,8 +287,8 @@ def vm_with_nginx_service(chaos_namespace, admin_client, workers_utility_pods, w
 @pytest.fixture()
 def vm_with_nginx_service_and_node_selector(chaos_namespace, admin_client, workers_utility_pods, workers):
     yield from create_vm_with_nginx_service(
-        chaos_namespace=chaos_namespace,
-        admin_client=admin_client,
+        namespace=chaos_namespace,
+        client=admin_client,
         utility_pods=workers_utility_pods,
         node=random.choice(workers),
         node_selector_label=HOST_LABEL,

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -27,7 +27,7 @@ from utilities.virt import wait_for_vmi_relocation_and_running
 
 pytestmark = [
     pytest.mark.chaos,
-    pytest.mark.usefixtures("chaos_namespace", "cluster_monitoring_process"),
+    pytest.mark.usefixtures("multiprocessing_start_method_fork", "chaos_namespace", "cluster_monitoring_process"),
 ]
 
 

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -9,7 +9,6 @@ from tests.chaos.constants import STRESS_NG
 from tests.chaos.migration.utils import (
     assert_migration_result_and_cleanup,
 )
-from tests.chaos.utils import verify_vm_service_reachable
 from utilities.constants import (
     PORT_80,
     QUARANTINED,
@@ -23,7 +22,7 @@ from utilities.constants import (
     StorageClassNames,
 )
 from utilities.infra import wait_for_pods_running
-from utilities.virt import wait_for_vmi_relocation_and_running
+from utilities.virt import verify_vm_service_reachable, wait_for_vmi_relocation_and_running
 
 pytestmark = [
     pytest.mark.chaos,

--- a/tests/chaos/snapshot/test_snapshot.py
+++ b/tests/chaos/snapshot/test_snapshot.py
@@ -11,6 +11,7 @@ pytestmark = [
     pytest.mark.gpfs,
     pytest.mark.usefixtures(
         "skip_if_no_storage_class_for_snapshot",
+        "multiprocessing_start_method_fork",
         "chaos_namespace",
         "cluster_monitoring_process",
     ),

--- a/tests/chaos/standard/test_standard.py
+++ b/tests/chaos/standard/test_standard.py
@@ -15,7 +15,9 @@ from utilities.virt import VirtualMachineForTests, running_vm
 
 pytestmark = [
     pytest.mark.chaos,
-    pytest.mark.usefixtures("chaos_namespace", "cluster_monitoring_process", "skip_on_aws_cluster"),
+    pytest.mark.usefixtures(
+        "multiprocessing_start_method_fork", "chaos_namespace", "cluster_monitoring_process", "skip_on_aws_cluster"
+    ),
 ]
 
 

--- a/tests/chaos/utils.py
+++ b/tests/chaos/utils.py
@@ -6,7 +6,6 @@ import random
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from multiprocessing.context import ForkContext
 
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.deployment import Deployment
@@ -44,9 +43,6 @@ from utilities.infra import (
     wait_for_node_status,
 )
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
-
-# Use fork context to avoid pickling issues with nested functions
-_FORK_CONTEXT: ForkContext = multiprocessing.get_context("fork")
 
 LOGGER = logging.getLogger(__name__)
 
@@ -135,7 +131,7 @@ def create_pod_deleting_process(
         except TimeoutExpiredError:
             LOGGER.info("Pod deleting process finished.")
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="pod_delete",
         target=_delete_pods_continuously,
         args=(
@@ -189,7 +185,7 @@ def create_nginx_monitoring_process(
             time.sleep(_sampling_interval)
         LOGGER.info("HTTP querying finished successfully.")
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="nginx_monitoring",
         target=_monitor_nginx_server,
         args=(
@@ -320,7 +316,7 @@ def create_cluster_monitoring_process(
             )
             time.sleep(interval)
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="cluster_monitoring",
         target=_monitor_cluster,
     )

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -30,8 +30,7 @@ from tests.install_upgrade_operators.product_upgrade.utils import (
     wait_for_pods_replacement_by_type,
 )
 from tests.install_upgrade_operators.utils import wait_for_operator_condition
-from tests.upgrade_params import EUS
-from utilities.constants import HCO_CATALOG_SOURCE, HOTFIX_STR, TIMEOUT_10MIN, NamespacesNames
+from utilities.constants import EUS, HCO_CATALOG_SOURCE, HOTFIX_STR, TIMEOUT_10MIN, NamespacesNames
 from utilities.data_collector import (
     get_data_collector_base_directory,
 )

--- a/tests/scale/conftest.py
+++ b/tests/scale/conftest.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import logging
+import math
+import resource
+from copy import deepcopy
+
+import kubernetes
+import pytest
+from ocp_resources.cdi import CDI
+from ocp_resources.kubelet_config import KubeletConfig
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.pod import Pod
+from ocp_resources.resource import get_client
+from ocp_resources.ssp import SSP
+
+from tests.scale.utils import get_user_kubeconfig_context, label_mcps, pause_mcps
+from utilities.constants import TIMEOUT_20MIN, TIMEOUT_30SEC, UNPRIVILEGED_USER
+from utilities.hco import ResourceEditorValidateHCOReconcile, wait_for_hco_conditions
+from utilities.operator import (
+    get_machine_config_pool_by_name,
+    get_machine_config_pools_conditions,
+    get_mcp_updating_transition_times,
+    wait_for_mcp_update_end,
+    wait_for_mcp_update_start,
+)
+from utilities.virt import get_virt_handler_pods
+
+LOGGER = logging.getLogger(__name__)
+
+KUBE_API_QPS = 200
+KUBE_API_BURST = 400
+
+
+@pytest.fixture(scope="module")
+def scale_client_configuration(request):  # skip-unused-code
+    client_configuration = kubernetes.client.Configuration()
+    client_configuration.connection_pool_maxsize = request.param["connection_pool_maxsize"]
+    return client_configuration
+
+
+@pytest.fixture(scope="module")
+def scale_unprivileged_client(
+    scale_client_configuration, skip_unprivileged_client, exported_kubeconfig, unprivileged_client
+):  # skip-unused-code
+    if skip_unprivileged_client:
+        yield
+    else:
+        yield get_client(
+            client_configuration=deepcopy(scale_client_configuration),
+            config_file=exported_kubeconfig,
+            context=get_user_kubeconfig_context(kubeconfig_filename=exported_kubeconfig, username=UNPRIVILEGED_USER),
+        )
+
+
+@pytest.fixture(scope="module")
+def patched_hco_for_scale_testing(
+    admin_client, hco_namespace, hyperconverged_resource_scope_module, cpu_for_migration
+):  # skip-unused-code
+    with ResourceEditorValidateHCOReconcile(
+        patches={
+            hyperconverged_resource_scope_module: {
+                "spec": {
+                    "tuningPolicy": "highBurst",
+                    "defaultCPUModel": cpu_for_migration,
+                },
+            },
+        },
+        list_resource_reconcile=[KubeVirt, CDI, SSP],
+        wait_for_reconcile_post_update=True,
+    ):
+        wait_for_hco_conditions(
+            admin_client=admin_client,
+            hco_namespace=hco_namespace,
+        )
+        yield
+
+
+@pytest.fixture(scope="session")
+def increased_open_file_limit(request):  # skip-unused-code
+    """
+    If you use this fixture and still receive max open files errors
+    then please raise the default limits on your system.
+    The test code is properly raising and lowering limits,
+    closing threads and files, your base limits are just too low.
+    Run to see your current limits: `ulimit -H -n && ulimit -S -n`
+    """
+    nofile_hard_limit = request.param["nofile_hard_limit"]
+    original_limits = resource.getrlimit(resource.RLIMIT_NOFILE)
+    new_limits = (nofile_hard_limit, nofile_hard_limit)
+    if new_limits > original_limits:
+        resource.setrlimit(resource.RLIMIT_NOFILE, new_limits)
+        yield
+        resource.setrlimit(resource.RLIMIT_NOFILE, original_limits)
+    else:
+        LOGGER.info(f"Current open file limits {original_limits} are greater than {new_limits}.")
+        yield
+
+
+@pytest.fixture(scope="module")
+def virt_handler_pods(admin_client, hco_namespace):  # skip-unused-code
+    return get_virt_handler_pods(client=admin_client, namespace=hco_namespace)
+
+
+@pytest.fixture(scope="module")
+def virt_handler_nodes(virt_handler_pods):  # skip-unused-code
+    return [pod.node for pod in virt_handler_pods]
+
+
+@pytest.fixture(scope="module")
+def existing_pod_count(admin_client):  # skip-unused-code
+    return len(list(Pod.get(dyn_client=admin_client)))
+
+
+@pytest.fixture(scope="module")
+def calculated_max_pods_per_virt_node(request, existing_pod_count, virt_handler_nodes):  # skip-unused-code
+    assert virt_handler_nodes, "No virt-handler pods present"
+
+    default_pods_per_node = 250
+    total_pod_count = existing_pod_count + request.param["total_vm_count"]
+    num_virt_handler_nodes = len(virt_handler_nodes)
+
+    max_pods = math.ceil(
+        total_pod_count / (num_virt_handler_nodes - 1) if num_virt_handler_nodes > 1 else total_pod_count
+    )
+    if default_pods_per_node > max_pods:
+        max_pods = default_pods_per_node
+
+    min_existing_max_pods_per_node = min([int(node.instance.status.capacity.pods) for node in virt_handler_nodes])
+    if min_existing_max_pods_per_node > max_pods:
+        max_pods = min_existing_max_pods_per_node
+
+    return max_pods
+
+
+@pytest.fixture(scope="module")
+def created_kubeletconfigs_for_scale(
+    request, calculated_max_pods_per_virt_node, workers, machine_config_pools
+):  # skip-unused-code
+    control_plane_mcp = get_machine_config_pool_by_name(mcp_name="master")
+    worker_mcp = get_machine_config_pool_by_name(mcp_name="worker")
+
+    initial_updating_transition_times = get_mcp_updating_transition_times(
+        mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=machine_config_pools)
+    )
+
+    pause_mcps(paused=True, mcps=machine_config_pools)
+    with KubeletConfig(
+        name="test-custom-control-plane-kubelet-config",
+        auto_sizing_reserved=True,
+        kubelet_config={
+            "nodeStatusMaxImages": -1,
+            "kubeAPIQPS": KUBE_API_QPS,
+            "kubeAPIBurst": KUBE_API_BURST,
+        },
+        machine_config_pool_selector={"matchLabels": {"custom-control-plane-kubelet": "enabled"}},
+    ):
+        with KubeletConfig(
+            name="test-custom-worker-kubelet-config",
+            auto_sizing_reserved=True,
+            kubelet_config={
+                "nodeStatusMaxImages": -1,
+                "kubeAPIQPS": KUBE_API_QPS,
+                "kubeAPIBurst": KUBE_API_BURST,
+                "maxPods": calculated_max_pods_per_virt_node,
+            },
+            machine_config_pool_selector={"matchLabels": {"custom-worker-kubelet": "enabled"}},
+        ):
+            with label_mcps([control_plane_mcp], {"custom-control-plane-kubelet": "enabled"}):
+                with label_mcps([worker_mcp], {"custom-worker-kubelet": "enabled"}):
+                    pause_mcps(paused=False, mcps=machine_config_pools)
+                    wait_for_mcp_update_start(
+                        machine_config_pools_list=machine_config_pools,
+                        initial_transition_times=initial_updating_transition_times,
+                    )
+                    wait_for_mcp_update_end(
+                        machine_config_pools_list=machine_config_pools,
+                        timeout=TIMEOUT_20MIN * len(workers),
+                        sleep=TIMEOUT_30SEC,
+                    )
+
+                    yield
+                    teardown_updating_transition_times = get_mcp_updating_transition_times(
+                        mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=machine_config_pools)
+                    )
+                    pause_mcps(paused=True, mcps=machine_config_pools)
+
+    pause_mcps(paused=False, mcps=machine_config_pools)
+    wait_for_mcp_update_start(
+        machine_config_pools_list=machine_config_pools,
+        initial_transition_times=teardown_updating_transition_times,
+    )
+    wait_for_mcp_update_end(
+        machine_config_pools_list=machine_config_pools,
+        timeout=TIMEOUT_20MIN * len(workers),
+        sleep=TIMEOUT_30SEC,
+    )

--- a/tests/scale/utils.py
+++ b/tests/scale/utils.py
@@ -11,6 +11,19 @@ from ocp_resources.resource import ResourceEditor
 
 
 def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:  # skip-unused-code
+    """
+    In order to modify the kubeconfig client configuration with additional args,
+    the context that is required for a specific user must be specified when calling get_client()
+
+    eg:
+        client_configuration = kubernetes.client.Configuration()
+        client_configuration.connection_pool_maxsize = request.param["connection_pool_maxsize"]
+        get_client(
+            client_configuration=deepcopy(client_configuration),
+            config_file=exported_kubeconfig,
+            context=get_user_kubeconfig_context(kubeconfig_filename=exported_kubeconfig, username=UNPRIVILEGED_USER),
+        )
+    """
     with open(kubeconfig_filename, "r") as file:
         kubeconfig_content = yaml.safe_load(file)
 

--- a/tests/scale/utils.py
+++ b/tests/scale/utils.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Generator
+
+import pytest
+import yaml
+from ocp_resources.machine_config_pool import MachineConfigPool
+from ocp_resources.resource import ResourceEditor
+
+
+def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:  # skip-unused-code
+    with open(kubeconfig_filename, "r") as file:
+        kubeconfig_content = yaml.safe_load(file)
+
+    all_contexts = kubeconfig_content["contexts"]
+    current_context = kubeconfig_content["current-context"]
+    current_cluster = next(
+        (entry["context"]["cluster"] for entry in all_contexts if entry["name"] == current_context),
+        None,
+    )
+    assert current_cluster, f"No context found named {current_context!r}"
+
+    user_context = None
+    for entry in all_contexts:
+        context = entry["context"]
+        if context["cluster"] == current_cluster and context["user"] == f"{username}/{current_cluster}":
+            user_context = entry["name"]
+            break
+
+    assert user_context, "No context found for user"
+    return user_context
+
+
+def pause_mcps(paused: bool, mcps: list[MachineConfigPool]) -> None:  # skip-unused-code
+    ResourceEditor(patches={mcp: {"spec": {"paused": paused}} for mcp in mcps}).update()
+
+
+@contextmanager
+def label_mcps(mcps: list[MachineConfigPool], labels: dict) -> Generator[list[MachineConfigPool]]:  # skip-unused-code
+    updates = [ResourceEditor({mcp: {"metadata": {"labels": labels}}}) for mcp in mcps]
+
+    for update in updates:
+        update.update(backup_resources=True)
+    yield mcps
+    for update in updates:
+        update.restore()
+
+
+def capture_func_elapsed(
+    cache: pytest.Cache, cache_key_prefix: str, func: Callable, **kwargs: Any
+) -> Any:  # skip-unused-code
+    """
+    Capture the start/stop/elapsed of arbitrary functions
+    """
+    start_time = time.time()
+    return_value = func(**kwargs)
+    stop_time = time.time()
+    cache.set(f"{cache_key_prefix}-start", start_time)
+    cache.set(f"{cache_key_prefix}-stop", stop_time)
+    cache.set(f"{cache_key_prefix}-elapsed", stop_time - start_time)
+    return return_value

--- a/tests/scale/utils.py
+++ b/tests/scale/utils.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import time
-from contextlib import contextmanager
-from typing import Any, Callable, Generator
+from contextlib import ExitStack, contextmanager
+from typing import Any, Callable, Generator, Sequence
 
 import pytest
 import yaml
 from ocp_resources.machine_config_pool import MachineConfigPool
-from ocp_resources.resource import ResourceEditor
+from ocp_resources.resource import Resource, ResourceEditor
+
+from utilities.operator import (
+    get_machine_config_pools_conditions,
+    get_mcp_updating_transition_times,
+    wait_for_mcp_update_end,
+    wait_for_mcp_update_start,
+)
 
 
 def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:  # skip-unused-code
@@ -46,21 +53,6 @@ def get_user_kubeconfig_context(kubeconfig_filename: str, username: str) -> str:
     return user_context
 
 
-def pause_mcps(paused: bool, mcps: list[MachineConfigPool]) -> None:  # skip-unused-code
-    ResourceEditor(patches={mcp: {"spec": {"paused": paused}} for mcp in mcps}).update()
-
-
-@contextmanager
-def label_mcps(mcps: list[MachineConfigPool], labels: dict) -> Generator[list[MachineConfigPool]]:  # skip-unused-code
-    updates = [ResourceEditor({mcp: {"metadata": {"labels": labels}}}) for mcp in mcps]
-
-    for update in updates:
-        update.update(backup_resources=True)
-    yield mcps
-    for update in updates:
-        update.restore()
-
-
 def capture_func_elapsed(
     cache: pytest.Cache, cache_key_prefix: str, func: Callable, **kwargs: Any
 ) -> Any:  # skip-unused-code
@@ -74,3 +66,92 @@ def capture_func_elapsed(
     cache.set(f"{cache_key_prefix}-stop", stop_time)
     cache.set(f"{cache_key_prefix}-elapsed", stop_time - start_time)
     return return_value
+
+
+class MachineConfigPoolConfiguration(ExitStack):
+    def __init__(
+        self,
+        resources: Sequence[Resource],
+        mcp_labels: dict[MachineConfigPool, dict[str, str]],
+        timeout: int,
+        sleep: int,
+    ) -> None:
+        """
+        Control the machine config pool rollout process for changes,
+        such as KubeletConfigs, that affect the cluster behavior
+
+        Args:
+            resources (Sequence[Resource]): Resources to create while MCP is paused
+            mcp_labels (dict[MachineConfigPool, dict]): Labels to be applied to machine config pools while paused
+            timeout (int): Timeout for wait_for_mcp_update_end
+            sleep (int): Sleep for wait_for_mcp_update_end
+
+        Example:
+            with MachineConfigPoolConfiguration(
+                resources=[KubeletConfig(...)],
+                mcp_labels={worker_machine_config_pool: {"label": "value"}},
+                timeout=TIMEOUT_20MIN * len(workers)
+                sleep=TIMEOUT_30SEC
+            ):
+                yield  # Use cluster with new configuration
+        """
+        super().__init__()
+        self.resources = resources
+        self.mcp_labels = mcp_labels
+        self.timeout = timeout
+        self.sleep = sleep
+
+        self.machine_config_pools = mcp_labels.keys()
+        self.mcp_updates = [
+            ResourceEditor({mcp: {"metadata": {"labels": labels}}}) for mcp, labels in self.mcp_labels.items()
+        ]
+
+    @contextmanager
+    def _cleanup_on_error(self, stack_exit) -> Generator[None, Any, None]:
+        with ExitStack() as stack:
+            stack.push(exit=stack_exit)
+            yield
+            stack.pop_all()
+
+    def __enter__(self) -> MachineConfigPoolConfiguration:
+        initial_updating_transition_times = get_mcp_updating_transition_times(
+            mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=self.machine_config_pools)
+        )
+        with self._cleanup_on_error(stack_exit=super().__exit__):
+            with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in self.machine_config_pools}):
+                for resource in self.resources:
+                    self.enter_context(cm=resource)
+                for mcp_update in self.mcp_updates:
+                    mcp_update.update(backup_resources=True)
+
+        wait_for_mcp_update_start(
+            machine_config_pools_list=self.machine_config_pools,
+            initial_transition_times=initial_updating_transition_times,
+        )
+        wait_for_mcp_update_end(
+            machine_config_pools_list=self.machine_config_pools,
+            timeout=self.timeout,
+            sleep=self.sleep,
+        )
+        return self
+
+    def __exit__(self, *exc_arguments: Any) -> Any:
+        teardown_updating_transition_times = get_mcp_updating_transition_times(
+            mcp_conditions=get_machine_config_pools_conditions(machine_config_pools=self.machine_config_pools)
+        )
+        with self._cleanup_on_error(stack_exit=super().__exit__):
+            with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in self.machine_config_pools}):
+                for mcp_update in self.mcp_updates:
+                    mcp_update.restore()
+                for resource in self.resources:
+                    resource.clean_up()
+
+        wait_for_mcp_update_start(
+            machine_config_pools_list=self.machine_config_pools,
+            initial_transition_times=teardown_updating_transition_times,
+        )
+        wait_for_mcp_update_end(
+            machine_config_pools_list=self.machine_config_pools,
+            timeout=self.timeout,
+            sleep=self.sleep,
+        )

--- a/tests/upgrade_params.py
+++ b/tests/upgrade_params.py
@@ -1,7 +1,8 @@
 from pytest_testconfig import config as py_config
 
+from utilities.constants import EUS
+
 UPGRADE_PACKAGE_NAME = "tests/install_upgrade_operators/product_upgrade"
-EUS = "eus"
 
 if py_config["upgraded_product"] == EUS:
     upgrade_class = "TestEUSToEUSUpgrade"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -394,6 +394,7 @@ DV_DISK = "dv-disk"
 
 # Upgrade tests configuration
 DEPENDENCY_SCOPE_SESSION = "session"
+EUS = "eus"
 
 # hco spec
 ENABLE_COMMON_BOOT_IMAGE_IMPORT = "enableCommonBootImageImport"

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -235,8 +235,10 @@ def consecutive_checks_for_mcp_condition(mcp_sampler, machine_config_pools_list)
         raise
 
 
-def wait_for_mcp_update_end(machine_config_pools_list):
-    wait_for_mcp_updated_condition_true(machine_config_pools_list=machine_config_pools_list)
+def wait_for_mcp_update_end(machine_config_pools_list, timeout=TIMEOUT_75MIN, sleep=TIMEOUT_5SEC):
+    wait_for_mcp_updated_condition_true(
+        machine_config_pools_list=machine_config_pools_list, timeout=timeout, sleep=sleep
+    )
     wait_for_mcp_ready_machine_count(machine_config_pools_list=machine_config_pools_list)
 
 

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -54,6 +54,9 @@ from utilities.operator import (  # noqa: E402
     wait_for_package_manifest_to_exist,
 )
 
+TIMEOUT_75MIN = 4500
+TIMEOUT_5SEC = 5
+
 # ============================================================================
 # SIMPLE FUNCTIONS (8 tests)
 # ============================================================================
@@ -1077,8 +1080,44 @@ class TestWaitForMcpUpdateEnd:
 
         wait_for_mcp_update_end([mock_mcp])
 
-        mock_wait_updated.assert_called_once_with(machine_config_pools_list=[mock_mcp])
+        mock_wait_updated.assert_called_once_with(
+            machine_config_pools_list=[mock_mcp],
+            timeout=TIMEOUT_75MIN,
+            sleep=TIMEOUT_5SEC,
+        )
         mock_wait_ready.assert_called_once_with(machine_config_pools_list=[mock_mcp])
+
+    @patch("utilities.operator.wait_for_mcp_ready_machine_count")
+    @patch("utilities.operator.wait_for_mcp_updated_condition_true")
+    def test_wait_for_update_end_custom_args(self, mock_wait_updated, mock_wait_ready):
+        """Test waiting for MCP update to end with custom timeout and sleep"""
+        mock_mcp = MagicMock()
+        custom_timeout = 100
+        custom_sleep = 1
+
+        wait_for_mcp_update_end([mock_mcp], timeout=custom_timeout, sleep=custom_sleep)
+
+        mock_wait_updated.assert_called_once_with(
+            machine_config_pools_list=[mock_mcp],
+            timeout=custom_timeout,
+            sleep=custom_sleep,
+        )
+        mock_wait_ready.assert_called_once_with(machine_config_pools_list=[mock_mcp])
+
+    @patch("utilities.operator.wait_for_mcp_ready_machine_count")
+    @patch("utilities.operator.wait_for_mcp_updated_condition_true")
+    def test_wait_for_update_end_partial_args(self, mock_wait_updated, mock_wait_ready):
+        """Test waiting for MCP update to end with only custom timeout"""
+        mock_mcp = MagicMock()
+        custom_timeout = 500
+
+        wait_for_mcp_update_end([mock_mcp], timeout=custom_timeout)
+
+        mock_wait_updated.assert_called_once_with(
+            machine_config_pools_list=[mock_mcp],
+            timeout=custom_timeout,
+            sleep=TIMEOUT_5SEC,
+        )
 
 
 class TestWaitForMcpUpdateStart:

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -1118,6 +1118,7 @@ class TestWaitForMcpUpdateEnd:
             timeout=custom_timeout,
             sleep=TIMEOUT_5SEC,
         )
+        mock_wait_ready.assert_called_once_with(machine_config_pools_list=[mock_mcp])
 
 
 class TestWaitForMcpUpdateStart:

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http
 import io
 import ipaddress
 import json
@@ -61,11 +62,13 @@ from utilities.constants import (
     IP_FAMILY_POLICY_PREFER_DUAL_STACK,
     LINUX_AMD_64,
     LINUX_STR,
+    MIGRATION_POLICY_VM_LABEL,
     OS_FLAVOR_ALPINE,
     OS_FLAVOR_CIRROS,
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
     OS_PROC_NAME,
+    PORT_80,
     ROOTDISK,
     SSH_PORT_22,
     TCP_TIMEOUT_30SEC,
@@ -2761,3 +2764,48 @@ def wait_for_virt_handler_pods_network_updated(
         )
         raise
     return False
+
+
+def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, node, node_selector_label=None):
+    name = "nginx"
+    with VirtualMachineForTests(
+        namespace=chaos_namespace.name,
+        name=name,
+        body=fedora_vm_body(name=name),
+        client=admin_client,
+        node_selector_labels=node_selector_label,
+        additional_labels=MIGRATION_POLICY_VM_LABEL,
+    ) as vm:
+        running_vm(vm=vm, check_ssh_connectivity=False)
+        vm.custom_service_enable(service_name=name, port=PORT_80, service_type=Service.Type.CLUSTER_IP)
+        verify_vm_service_reachable(
+            utility_pods=utility_pods,
+            node=node,
+            url=f"{vm.custom_service.instance.spec.clusterIPs[0]}:{PORT_80}",
+        )
+        LOGGER.info(f"VMI Host Node:{vm.vmi.node.name}")
+        yield vm
+
+
+def verify_vm_service_reachable(utility_pods, node, url):
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_2MIN,
+            sleep=TIMEOUT_5SEC,
+            func=is_http_ok,
+            utility_pods=utility_pods,
+            node=node,
+            url=url,
+        ):
+            if sample:
+                break
+    except TimeoutExpiredError:
+        LOGGER.error(f"Service at {url} is not reachable")
+        raise
+
+
+def is_http_ok(utility_pods, node, url):
+    http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
+        command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
+    )
+    return int(http_result) == http.HTTPStatus.OK

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from json import JSONDecodeError
 from subprocess import run
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional
 
 import bitmath
 import jinja2
@@ -2767,13 +2767,13 @@ def wait_for_virt_handler_pods_network_updated(
 
 
 def create_vm_with_nginx_service(
+    name: str,
     namespace: Namespace,
     client: DynamicClient,
     utility_pods: list[Pod],
     node: Node,
-    node_selector_label: Optional[dict] = None,
-):
-    name = "nginx"
+    node_selector_label: dict | None = None,
+) -> Generator[VirtualMachine]:
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
@@ -2793,7 +2793,7 @@ def create_vm_with_nginx_service(
         yield vm
 
 
-def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
+def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str) -> None:
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
@@ -2810,7 +2810,7 @@ def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
         raise
 
 
-def is_http_ok(utility_pods: list[Pod], node: Node, url: str):
+def is_http_ok(utility_pods: list[Pod], node: Node, url: str) -> bool:
     http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
         command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
     )

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2766,13 +2766,19 @@ def wait_for_virt_handler_pods_network_updated(
     return False
 
 
-def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, node, node_selector_label=None):
+def create_vm_with_nginx_service(
+    namespace: Namespace,
+    client: DynamicClient,
+    utility_pods: list[Pod],
+    node: Node,
+    node_selector_label: Optional[dict] = None,
+):
     name = "nginx"
     with VirtualMachineForTests(
-        namespace=chaos_namespace.name,
+        namespace=namespace.name,
         name=name,
         body=fedora_vm_body(name=name),
-        client=admin_client,
+        client=client,
         node_selector_labels=node_selector_label,
         additional_labels=MIGRATION_POLICY_VM_LABEL,
     ) as vm:
@@ -2787,7 +2793,7 @@ def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, no
         yield vm
 
 
-def verify_vm_service_reachable(utility_pods, node, url):
+def verify_vm_service_reachable(utility_pods: list[Pod], node: Node, url: str):
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
@@ -2804,7 +2810,7 @@ def verify_vm_service_reachable(utility_pods, node, url):
         raise
 
 
-def is_http_ok(utility_pods, node, url):
+def is_http_ok(utility_pods: list[Pod], node: Node, url: str):
     http_result = utilities.infra.ExecCommandOnPod(utility_pods=utility_pods, node=node).exec(
         command=f"curl -s --connect-timeout {TIMEOUT_10SEC} -w '%{{http_code}}' {url}  -o /dev/null"
     )


### PR DESCRIPTION
Add `tests/scale/conftest.py`

Part of a dependency path for scale upgrade testing #3031
Rebased on #3105 

Depends on:
#3029 - Move Chaos utils
#3103 - Move EUS Constant
#3105 - Add scale utils.py

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scale testing infrastructure and fixtures for large-cluster scenarios.
  * Added HTTP-based VM service reachability helpers for test validation.
  * Added a test fixture to enforce a fork-based multiprocessing start method during tests.

* **Refactor**
  * Consolidated and reorganized test utilities into shared modules with clearer APIs.
  * Made MCP update waiting configurable with timeout/sleep options.

* **Chores**
  * Updated linter configuration and centralized constants (added EUS).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->