### PR TITLE
[4.19] Refactor fg tests cnv 4.19

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -22,7 +22,7 @@ RESOURCE_TYPE_STR = "resource_type"
 RESOURCE_NAME_STR = "resource_name"
 RESOURCE_NAMESPACE_STR = "resource_namespace"
 KEY_NAME_STR = "key_name"
-EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = [
+EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
     "CPUManager",
     "Snapshot",
     "HotplugVolumes",
@@ -34,8 +34,12 @@ EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = [
     "InstancetypeReferencePolicy",
     "WithHostModelCPU",
     "HypervStrictCheck",
-]
-EXPECTED_CDI_HARDCODED_FEATUREGATES = ["DataVolumeClaimAdoption", "HonorWaitForFirstConsumer", "WebhookPvcRendering"]
+}
+EXPECTED_CDI_HARDCODED_FEATUREGATES = {
+    "DataVolumeClaimAdoption",
+    "HonorWaitForFirstConsumer",
+    "WebhookPvcRendering",
+}
 HCO_DEFAULT_FEATUREGATES = {
     DEPLOY_KUBE_SECONDARY_DNS: FG_DISABLED,
     DISABLE_MDEV_CONFIGURATION: FG_DISABLED,

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -82,8 +82,7 @@ def test_default_featuregates_by_resource(
     expected,
     resource_object_value_by_key,
 ):
+    if isinstance(resource_object_value_by_key, list):
+        resource_object_value_by_key = set(resource_object_value_by_key)
     error_message = f"Expected featuregates: {expected}, actual: {resource_object_value_by_key}"
-    if isinstance(expected, list):
-        assert sorted(expected) == sorted(resource_object_value_by_key), error_message
-    else:
-        assert expected == resource_object_value_by_key, error_message
+    assert expected == resource_object_value_by_key, error_message

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -59,7 +59,9 @@ class TestHardcodedFeatureGates:
         key_name,
     ):
         actual_value = get_resource_key_value(resource=updated_resource, key_name=key_name)
-        assert sorted(actual_value) == sorted(expected_value), (
+        if isinstance(actual_value, list):
+            actual_value = set(actual_value)
+        assert actual_value == expected_value, (
             f"For {updated_resource.name}, actual featuregates:"
             f" {actual_value} does not match expected "
             f"featuregates: {expected_value}"


### PR DESCRIPTION
##### Short description:
cherry pick for 4.19, replacing sorted list comparisons in feature gate tests with set comparisons, and updating consts to match

##### More details:

##### What this PR does / why we need it:
cherry pick for 4.19, comparing sorted lists rather than comparing sets is bad practice

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/3033 already merged to main

##### jira-ticket:
https://issues.redhat.com/browse/CNV-72349
