### PR TITLE
Alter chaos multiprocessing start method

### DIFF
--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -406,3 +406,14 @@ def deleted_pod_by_name_prefix(admin_client, cnv_pod_deletion_test_matrix__class
         namespace=pod_deletion_config["namespace_name"],
         pod_prefix=pod_deletion_config["pod_prefix"],
     )
+
+
+@pytest.fixture(scope="module")
+def multiprocessing_start_method_fork():
+    # Use fork context to avoid pickling issues with nested functions
+    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process
+    # https://github.com/python/cpython/issues/132898
+    original_start_method = multiprocessing.get_start_method()
+    multiprocessing.set_start_method("fork", force=True)
+    yield
+    multiprocessing.set_start_method(original_start_method, force=True)

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -27,7 +27,7 @@ from utilities.virt import wait_for_vmi_relocation_and_running
 
 pytestmark = [
     pytest.mark.chaos,
-    pytest.mark.usefixtures("chaos_namespace", "cluster_monitoring_process"),
+    pytest.mark.usefixtures("multiprocessing_start_method_fork", "chaos_namespace", "cluster_monitoring_process"),
 ]
 
 

--- a/tests/chaos/snapshot/test_snapshot.py
+++ b/tests/chaos/snapshot/test_snapshot.py
@@ -11,6 +11,7 @@ pytestmark = [
     pytest.mark.gpfs,
     pytest.mark.usefixtures(
         "skip_if_no_storage_class_for_snapshot",
+        "multiprocessing_start_method_fork",
         "chaos_namespace",
         "cluster_monitoring_process",
     ),

--- a/tests/chaos/standard/test_standard.py
+++ b/tests/chaos/standard/test_standard.py
@@ -15,7 +15,9 @@ from utilities.virt import VirtualMachineForTests, running_vm
 
 pytestmark = [
     pytest.mark.chaos,
-    pytest.mark.usefixtures("chaos_namespace", "cluster_monitoring_process", "skip_on_aws_cluster"),
+    pytest.mark.usefixtures(
+        "multiprocessing_start_method_fork", "chaos_namespace", "cluster_monitoring_process", "skip_on_aws_cluster"
+    ),
 ]
 
 

--- a/tests/chaos/utils.py
+++ b/tests/chaos/utils.py
@@ -6,7 +6,6 @@ import random
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from multiprocessing.context import ForkContext
 
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.deployment import Deployment
@@ -44,9 +43,6 @@ from utilities.infra import (
     wait_for_node_status,
 )
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
-
-# Use fork context to avoid pickling issues with nested functions
-_FORK_CONTEXT: ForkContext = multiprocessing.get_context("fork")
 
 LOGGER = logging.getLogger(__name__)
 
@@ -135,7 +131,7 @@ def create_pod_deleting_process(
         except TimeoutExpiredError:
             LOGGER.info("Pod deleting process finished.")
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="pod_delete",
         target=_delete_pods_continuously,
         args=(
@@ -189,7 +185,7 @@ def create_nginx_monitoring_process(
             time.sleep(_sampling_interval)
         LOGGER.info("HTTP querying finished successfully.")
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="nginx_monitoring",
         target=_monitor_nginx_server,
         args=(
@@ -320,7 +316,7 @@ def create_cluster_monitoring_process(
             )
             time.sleep(interval)
 
-    return _FORK_CONTEXT.Process(
+    return multiprocessing.Process(
         name="cluster_monitoring",
         target=_monitor_cluster,
     )


### PR DESCRIPTION
The previous fix of using get_context(method) is no longer working. To remedy this, switching to a fixture that sets the multiprocessing start method instead.
https://github.com/python/cpython/issues/132898
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new fixture to chaos test suites to enforce a fork-based multiprocessing start method during test runs.
  * Enabled this fixture across migration, snapshot, and standard test modules to standardize behavior.
  * Updated test utilities to use the standard multiprocessing process construction for more consistent, more reliable test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->