### PR TITLE
 net, migration: Split test_migration_with_masquerade

### DIFF
--- a/docs/RUNNING_TESTS.md
+++ b/docs/RUNNING_TESTS.md
@@ -99,11 +99,7 @@ To run tests with an admin client only, pass `--tc=no_unprivileged_client:True` 
 ### Running tests using matrix fixtures
 
 Matrix fixtures can be added in global_config.py.
-You can run a test using a subset of a simple matrix (i.e flat list), example:
-
-```bash
---tc=ip_stack_version_matrix:ipv4
-```
+You can run a test using a subset of a simple matrix (i.e flat list).
 
 To run a test using a subset of a complex matrix (e.g list of dicts), you'll also need to add
 the following to `openshift-virtualization-tests/conftest.py`

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -22,8 +22,6 @@ from utilities.constants import (
     CNV_PROMETHEUS_RULES,
     HCO_CATALOG_SOURCE,
     HPP_CAPABILITIES,
-    IPV4_STR,
-    IPV6_STR,
     LINUX_BRIDGE,
     MONITORING_METRICS,
     OS_FLAVOR_FEDORA,
@@ -191,10 +189,6 @@ data_import_cron_matrix = [
     {"rhel10": {"instance_type": U1_MEDIUM_STR, "preference": RHEL10_PREFERENCE}},
 ]
 
-ip_stack_version_matrix = [
-    IPV4_STR,
-    IPV6_STR,
-]
 cnv_pod_matrix = ALL_CNV_PODS
 cnv_crd_matrix = ALL_CNV_CRDS
 cnv_crypto_policy_matrix = [TLS_OLD_POLICY, TLS_CUSTOM_POLICY]

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -21,8 +21,6 @@ from tests.network.utils import get_vlan_index_number, vm_for_brcnv_tests
 from utilities.constants import (
     CLUSTER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
-    IPV4_STR,
-    IPV6_STR,
     ISTIO_SYSTEM_DEFAULT_NS,
     OVS_BRIDGE,
     VIRT_HANDLER,
@@ -36,7 +34,6 @@ from utilities.infra import (
 )
 from utilities.network import (
     get_cluster_cni_type,
-    ip_version_data_from_matrix,
     network_nad,
 )
 from utilities.pytest_utils import exit_pytest_execution
@@ -70,24 +67,6 @@ def virt_handler_pod(admin_client):
 @pytest.fixture(scope="session")
 def dual_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
     return ipv4_supported_cluster and ipv6_supported_cluster
-
-
-@pytest.fixture()
-def fail_if_not_ipv4_supported_cluster_from_mtx(
-    request,
-    ipv4_supported_cluster,
-):
-    if ip_version_data_from_matrix(request=request) == IPV4_STR and not ipv4_supported_cluster:
-        pytest.fail(reason="IPv4 is not supported in this cluster")
-
-
-@pytest.fixture()
-def fail_if_not_ipv6_supported_cluster_from_mtx(
-    request,
-    ipv6_supported_cluster,
-):
-    if ip_version_data_from_matrix(request=request) == IPV6_STR and not ipv6_supported_cluster:
-        pytest.fail(reason="IPv6 is not supported in this cluster")
 
 
 @pytest.fixture()

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -399,23 +399,23 @@ def test_connectivity_after_migration_and_restart(
     )
 
 
-@pytest.mark.polarion("CNV-2061")
 @pytest.mark.s390x
+@pytest.mark.usefixtures("http_service", "migrated_vmb_and_wait_for_success")
+@pytest.mark.parametrize(
+    "ip_family",
+    [
+        pytest.param("ipv4", marks=[pytest.mark.ipv4, pytest.mark.polarion("CNV-12508")]),
+        pytest.param("ipv6", marks=[pytest.mark.ipv6, pytest.mark.polarion("CNV-12509")]),
+    ],
+)
 def test_migration_with_masquerade(
-    ip_stack_version_matrix__module__,
-    admin_client,
-    fail_if_not_ipv4_supported_cluster_from_mtx,
-    fail_if_not_ipv6_supported_cluster_from_mtx,
-    vma,
-    vmb,
     running_vma,
     running_vmb,
-    migrated_vmb_and_wait_for_success,
+    ip_family,
 ):
-    LOGGER.info(f"Testing HTTP service after migration on node {running_vmb.vmi.node.name}")
     http_port_accessible(
         vm=running_vma,
-        server_ip=running_vmb.custom_service.service_ip(ip_family=ip_stack_version_matrix__module__),
+        server_ip=running_vmb.custom_service.service_ip(ip_family=ip_family),
         server_port=running_vmb.custom_service.service_port,
     )
 

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -786,23 +786,6 @@ def get_valid_ip_address(dst_ip, family):
         return
 
 
-def ip_version_data_from_matrix(request):
-    """
-    Check if fixture ip_stack_version_matrix__<scope>__ is used in the flow, to indicate whether
-    it's a dual-stack test or not.
-
-    Args:
-        request (fixtures.SubRequest): Test's parameterized request.
-
-    Returns:
-        str: The IP family (IPv4 or IPv6) if the matrix fixture is used, else None.
-    """
-    ip_stack_matrix_fixture = [fix_name for fix_name in request.fixturenames if "ip_stack_version_matrix__" in fix_name]
-    if not ip_stack_matrix_fixture:
-        return
-    return request.getfixturevalue(ip_stack_matrix_fixture[0])
-
-
 def compose_cloud_init_data_dict(network_data=None, ipv6_network_data=None):
     init_data = {}
     interfaces_data = {"ethernets": {}}


### PR DESCRIPTION
`test_migration_with_masquerade` test is collected to run twice: once with `ip_family="ipv4"` and again with `ip_family="ipv6"`.
On IPv6 single-stack lane it fails when it runs with `ip_family="ipv4"`: `failed on setup with "Failed: IPv4 is not supported in this cluster"`

This test must be split with parametrize to ensure it runs with both ip families on dual-stack clusters and with IPv6 only on IPv6 single-stack clusters.


##### jira-ticket: https://issues.redhat.com/browse/CNV-74436
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Parameterized the masquerade migration test for IPv4 and IPv6; it now uses an ip-family parameter and relies on streamlined fixtures for network resolution and migration preconditions.
* **Docs**
  * Expanded test-running guidance with detailed matrix fixtures usage, customization examples, and improved tooling/Jenkins instructions.
* **Chores**
  * Removed legacy matrix-derived IP-version helpers, related gating fixtures, and constants to simplify IP-family handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->