### PR TITLE
Storage: use unique DV name in data_volume_template_with_source_ref_dict

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -567,7 +567,7 @@ def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
     source_dict = data_source.source.instance.to_dict()
     source_spec_dict = source_dict["spec"]
     dv = DataVolume(
-        name=data_source.name,
+        name=utilities.infra.unique_name(name=data_source.name),
         namespace=data_source.namespace,
         size=source_spec_dict.get("resources", {}).get("requests", {}).get("storage")
         or source_dict.get("status", {}).get("restoreSize"),


### PR DESCRIPTION
##### Short description:
VMs in one namespace must use unique DV names. 

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal data volume naming mechanism for better uniqueness and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->