### PR TITLE
net, bond: Fix Bond NNCP teardown

### DIFF
--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -7,11 +7,14 @@ from collections import OrderedDict
 import pytest
 
 from libs.net.vmspec import lookup_iface_status_ip
+from tests.network.libs.bondnodenetworkconfigurationpolicy import (
+    BondNodeNetworkConfigurationPolicy,
+    create_bond_desired_state,
+)
 from tests.network.libs.ip import random_ipv4_address
 from tests.network.utils import assert_no_ping
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
-    BondNodeNetworkConfigurationPolicy,
     assert_ping_successful,
     cloud_init_network_data,
     network_device,
@@ -44,14 +47,19 @@ def jumbo_frame_bond1_worker_1(
     """
     Create BOND if setup support BOND
     """
+    desired_state = create_bond_desired_state(
+        bond_name=BOND_NAME,
+        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        mtu=cluster_hardware_mtu,
+    )
     with BondNodeNetworkConfigurationPolicy(
         client=admin_client,
         name=f"jumbo-frame-bond{next(index_number)}-nncp",
         bond_name=BOND_NAME,
-        bond_ports=nodes_available_nics[worker_node1.name][-2:],
+        desired_state=desired_state,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
-        mtu=cluster_hardware_mtu,
     ) as bond:
+        bond.wait_for_status_success()
         yield bond
 
 
@@ -66,14 +74,19 @@ def jumbo_frame_bond1_worker_2(
     """
     Create BOND if setup support BOND
     """
+    desired_state = create_bond_desired_state(
+        bond_name=BOND_NAME,
+        bond_ports=nodes_available_nics[worker_node2.name][-2:],
+        mtu=cluster_hardware_mtu,
+    )
     with BondNodeNetworkConfigurationPolicy(
         client=admin_client,
         name=f"jumbo-frame-bond{next(index_number)}-nncp",
         bond_name=BOND_NAME,
-        bond_ports=nodes_available_nics[worker_node2.name][-2:],
+        desired_state=desired_state,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
-        mtu=cluster_hardware_mtu,
     ) as bond:
+        bond.wait_for_status_success()
         yield bond
 
 

--- a/tests/network/libs/bondnodenetworkconfigurationpolicy.py
+++ b/tests/network/libs/bondnodenetworkconfigurationpolicy.py
@@ -1,0 +1,177 @@
+from dataclasses import dataclass
+from typing import Any
+
+from kubernetes.dynamic import DynamicClient
+from timeout_sampler import retry
+
+from tests.network.libs.nodenetworkconfigurationpolicy import (
+    DesiredState,
+    Interface,
+    IPv4,
+    IPv6,
+    NodeNetworkConfigurationPolicy,
+)
+from utilities.constants import ACTIVE_BACKUP
+from utilities.network import BOND
+
+LINK_AGGREGATION_ATTR = "link_aggregation"
+
+
+@dataclass
+class LinkAggregationOptions:
+    miimon: str
+    primary: str | None = None
+
+
+@dataclass
+class LinkAggregation:
+    mode: str
+    port: list[str]
+    options: LinkAggregationOptions
+
+
+@dataclass
+class BondInterface:
+    name: str
+    type: str
+    state: str
+    link_aggregation: LinkAggregation
+    mtu: int | None = None
+    ipv4: IPv4 | None = None
+    ipv6: IPv6 | None = None
+
+
+def create_bond_desired_state(
+    bond_name: str,
+    bond_ports: list[str],
+    mode: str = ACTIVE_BACKUP,
+    mtu: int | None = None,
+    primary_bond_port: str | None = None,
+    ipv4_enable: bool = False,
+    ipv4_dhcp: bool = False,
+    ipv6_enable: bool = False,
+    bond_options: dict | None = None,
+) -> DesiredState:
+    """Creates a DesiredState for bond interface configuration.
+
+    Args:
+        bond_name: Name of the bond interface.
+        bond_ports: List of port names to aggregate.
+        mode: Bond mode. Defaults to ACTIVE_BACKUP.
+        mtu: MTU for the bond and port interfaces.
+        primary_bond_port: Primary port for active-backup mode.
+        ipv4_enable: Enable IPv4 on the bond.
+        ipv4_dhcp: Enable IPv4 DHCP on the bond.
+        ipv6_enable: Enable IPv6 on the bond.
+        bond_options: Additional bond options.
+
+    Returns:
+        DesiredState: The desired state configuration for the bond.
+    """
+    options_dict = {"miimon": "120"}
+    if bond_options:
+        options_dict.update(bond_options)
+    if mode == ACTIVE_BACKUP and primary_bond_port is not None:
+        options_dict["primary"] = primary_bond_port
+
+    link_aggregation = LinkAggregation(
+        mode=mode,
+        port=bond_ports,
+        options=LinkAggregationOptions(
+            miimon=options_dict["miimon"],
+            primary=options_dict.get("primary"),
+        ),
+    )
+
+    bond_interface = BondInterface(
+        name=bond_name,
+        type=BOND,
+        state=NodeNetworkConfigurationPolicy.Interface.State.UP,
+        link_aggregation=link_aggregation,
+        mtu=mtu,
+        ipv4=IPv4(enabled=ipv4_enable, dhcp=ipv4_dhcp) if ipv4_enable or ipv4_dhcp else None,
+        ipv6=IPv6(enabled=ipv6_enable) if ipv6_enable else None,
+    )
+
+    port_interfaces = [
+        Interface(
+            name=port,
+            type="ethernet",
+            state=NodeNetworkConfigurationPolicy.Interface.State.UP,
+            mtu=mtu,
+        )
+        for port in bond_ports
+    ]
+
+    return DesiredState(interfaces=[bond_interface] + port_interfaces)  # type: ignore[arg-type]
+
+
+class BondNodeNetworkConfigurationPolicy(NodeNetworkConfigurationPolicy):
+    """
+    NodeNetworkConfigurationPolicy for bond interface configuration.
+    """
+
+    def __init__(
+        self,
+        client: DynamicClient,
+        name: str,
+        bond_name: str,
+        desired_state: DesiredState,
+        node_selector: dict[str, str] | None = None,
+        bond_ports: list[str] | None = None,
+        mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Create and manage Bond NodeNetworkConfigurationPolicy
+
+        Args:
+            client: Dynamic client used to interact with the cluster.
+            name: Name of the NodeNetworkConfigurationPolicy object.
+            bond_name: Name of the bond interface.
+            desired_state: Desired policy configuration for the bond.
+            node_selector: Node selector to apply the policy to.
+            bond_ports: Bond ports (extracted from desired_state if not provided).
+            mode: Bond mode (extracted from desired_state if not provided).
+            **kwargs: Additional arguments passed to the parent class.
+        """
+        self.bond_name = bond_name
+        self.bond_ports = bond_ports if bond_ports is not None else self._extract_bond_ports(desired_state, bond_name)
+        self.mode = mode if mode is not None else self._extract_bond_mode(desired_state, bond_name)
+
+        super().__init__(
+            client=client,
+            name=name,
+            desired_state=desired_state,
+            node_selector=node_selector,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _extract_bond_ports(desired_state: DesiredState, bond_name: str) -> list[str]:
+        for iface in desired_state.interfaces or []:
+            if iface.name == bond_name and hasattr(iface, LINK_AGGREGATION_ATTR):
+                return iface.link_aggregation.port  # type: ignore[attr-defined]
+        return []
+
+    @staticmethod
+    def _extract_bond_mode(desired_state: DesiredState, bond_name: str) -> str:
+        for iface in desired_state.interfaces or []:
+            if iface.name == bond_name and hasattr(iface, LINK_AGGREGATION_ATTR):
+                return iface.link_aggregation.mode  # type: ignore[attr-defined]
+        return ""
+
+    @retry(wait_timeout=300, sleep=5)
+    def _wait_for_nncp_status_update(self, initial_transition_time: str) -> bool:
+        for condition in self.instance.get("status", {}).get("conditions", []):
+            if (
+                condition.get("type") == self.Conditions.Type.AVAILABLE
+                and condition.get("reason") == self.Conditions.Reason.SUCCESSFULLY_CONFIGURED
+            ):
+                current_ifaces = self.instance.get("status", {}).get("currentState", {}).get("interfaces", [])
+                bond_iface = next(
+                    (current_iface for current_iface in current_ifaces if current_iface["name"] == self.bond_name), None
+                )
+                if not bond_iface or bond_iface.get("state") == self.Interface.State.ABSENT:
+                    return True
+        return False

--- a/tests/network/libs/nodenetworkconfigurationpolicy.py
+++ b/tests/network/libs/nodenetworkconfigurationpolicy.py
@@ -114,6 +114,7 @@ class NodeNetworkConfigurationPolicy(Nncp):
         name: str,
         desired_state: DesiredState,
         node_selector: dict[str, str] | None = None,
+        **kwargs: Any,
     ):
         """
         Create and manage NodeNetworkConfigurationPolicy
@@ -124,6 +125,7 @@ class NodeNetworkConfigurationPolicy(Nncp):
             node_selector (dict, optional): A node selector that specifies the nodes to apply the node network
                 configuration policy to.
             client: Dynamic client used to interact with the cluster.
+            **kwargs: Additional arguments passed to the parent class.
         """
         self._desired_state = desired_state
         super().__init__(
@@ -132,6 +134,7 @@ class NodeNetworkConfigurationPolicy(Nncp):
             desired_state=asdict(desired_state, dict_factory=dict_normalization_for_dataclass),
             node_selector=node_selector,
             wait_for_resource=True,
+            **kwargs,
         )
 
     @property


### PR DESCRIPTION
Problem:
Default NodeNetworkConfigurationPolicy ocp resource teardown is not compatible with the teardown of Bond NNCP.
Bond NNCP status transitions to `Available` very quickly which makes the dependency on parent's NNCP class
timestamp check incorrect. This causing to reach the 60-second timeout without proper teardown.
As a result, the NICs previously used in the bond remain marked as in use, causing an incomplete cleanup and preventing the cluster from being reused in subsequent test session.

Fix:
Override the `_wait_for_nncp_status_update` to ensure proper teardown after bond tests and add retry decorator with more time for teardown.

##### jira-ticket: https://issues.redhat.com/browse/CNV-75615
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized bond configuration logic into a dedicated test library and consolidated bond configuration representation.
* **Tests**
  * Updated test fixtures to use the new bond configuration helper and to wait for policy status before proceeding, improving test reliability.
* **Chores**
  * Removed legacy bond entry from the previous utilities surface and propagated flexible constructor arguments for policy helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->