### PR TITLE
tests/network/migration: enable early IPv6 validation for migration test

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -21,8 +21,6 @@ from tests.network.utils import get_vlan_index_number, vm_for_brcnv_tests
 from utilities.constants import (
     CLUSTER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
-    IPV4_STR,
-    IPV6_STR,
     ISTIO_SYSTEM_DEFAULT_NS,
     OVS_BRIDGE,
     VIRT_HANDLER,
@@ -36,7 +34,6 @@ from utilities.infra import (
 )
 from utilities.network import (
     get_cluster_cni_type,
-    ip_version_data_from_matrix,
     network_nad,
 )
 from utilities.pytest_utils import exit_pytest_execution
@@ -70,24 +67,6 @@ def virt_handler_pod(admin_client):
 @pytest.fixture(scope="session")
 def dual_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
     return ipv4_supported_cluster and ipv6_supported_cluster
-
-
-@pytest.fixture()
-def fail_if_not_ipv4_supported_cluster_from_mtx(
-    request,
-    ipv4_supported_cluster,
-):
-    if ip_version_data_from_matrix(request=request) == IPV4_STR and not ipv4_supported_cluster:
-        pytest.fail(reason="IPv4 is not supported in this cluster")
-
-
-@pytest.fixture()
-def fail_if_not_ipv6_supported_cluster_from_mtx(
-    request,
-    ipv6_supported_cluster,
-):
-    if ip_version_data_from_matrix(request=request) == IPV6_STR and not ipv6_supported_cluster:
-        pytest.fail(reason="IPv6 is not supported in this cluster")
 
 
 @pytest.fixture()

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -20,6 +20,7 @@ from tests.network.utils import (
 )
 from utilities.constants import (
     IP_FAMILY_POLICY_PREFER_DUAL_STACK,
+    IPV4_STR,
     IPV6_STR,
     LINUX_BRIDGE,
     TIMEOUT_1MIN,
@@ -398,13 +399,29 @@ def test_connectivity_after_migration_and_restart(
     )
 
 
+@pytest.mark.parametrize(
+    "ip_family",
+    [
+        pytest.param(
+            IPV4_STR,
+            marks=[
+                pytest.mark.ipv4,
+            ],
+        ),
+        pytest.param(
+            IPV6_STR,
+            marks=[
+                pytest.mark.ipv6,
+            ],
+        ),
+    ],
+    indirect=False,
+)
 @pytest.mark.polarion("CNV-2061")
 @pytest.mark.s390x
 def test_migration_with_masquerade(
-    ip_stack_version_matrix__module__,
+    ip_family,
     admin_client,
-    fail_if_not_ipv4_supported_cluster_from_mtx,
-    fail_if_not_ipv6_supported_cluster_from_mtx,
     vma,
     vmb,
     running_vma,
@@ -414,7 +431,7 @@ def test_migration_with_masquerade(
     LOGGER.info(f"Testing HTTP service after migration on node {running_vmb.vmi.node.name}")
     http_port_accessible(
         vm=running_vma,
-        server_ip=running_vmb.custom_service.service_ip(ip_family=ip_stack_version_matrix__module__),
+        server_ip=running_vmb.custom_service.service_ip(ip_family=ip_family),
         server_port=running_vmb.custom_service.service_port,
     )
 

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -832,23 +832,6 @@ def get_valid_ip_address(dst_ip, family):
         return
 
 
-def ip_version_data_from_matrix(request):
-    """
-    Check if fixture ip_stack_version_matrix__<scope>__ is used in the flow, to indicate whether
-    it's a dual-stack test or not.
-
-    Args:
-        request (fixtures.SubRequest): Test's parameterized request.
-
-    Returns:
-        str: The IP family (IPv4 or IPv6) if the matrix fixture is used, else None.
-    """
-    ip_stack_matrix_fixture = [fix_name for fix_name in request.fixturenames if "ip_stack_version_matrix__" in fix_name]
-    if not ip_stack_matrix_fixture:
-        return
-    return request.getfixturevalue(ip_stack_matrix_fixture[0])
-
-
 def compose_cloud_init_data_dict(network_data=None, ipv6_network_data=None):
     init_data = {}
     interfaces_data = {"ethernets": {}}


### PR DESCRIPTION
##### Short description:
Enable early IPv6 validation for migration test by switching to explicit ipv4/ipv6 markers.

##### More details:
test_migration_with_masquerade verifies HTTP service connectivity after VM migration across both IPv4 and IPv6. Previously, it used matrix-based parameterization which wasn't detected by the session-level network_sanity check, causing IPv6 tests to waste time on expensive fixture setup before failing.

By switching to explicit parametrization with ipv4/ipv6 markers, the session-level check can now detect IPv6 requirements early and fail fast when the cluster doesn't support IPv6.

##### What this PR does / why we need it:
Ensures IPv6 cluster capability is validated before expensive fixture setup, improving test efficiency and providing faster feedback when running tests on clusters that don't support IPv6.
Removes outdated per-test validation fixtures that are no longer needed since the session-level check handles this validation.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored IPv4/IPv6 test parameterization in network migration tests to use explicit parameters instead of cluster-dependent fixtures.
  * Simplified network test configuration by consolidating IP version handling and removing intermediate utility functions.
  * Updated migration tests to directly specify IP family versions for improved test clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->