### PR TITLE
Modify validate_vnic_info function to support s390x

### DIFF
--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -653,8 +653,8 @@ def validate_vnic_info(prometheus: Prometheus, vnic_info_to_compare: dict[str, s
     sample = None
     try:
         for sample in samples:
-            if sample and sample.get("data") and sample.get("data").get("result"):
-                vnic_info_metric_result = sample.get("data").get("result")[0].get("metric")
+            if sample and (result := sample.get("data", {}).get("result")):
+                vnic_info_metric_result = result[0].get("metric")
                 break
     except TimeoutExpiredError:
         LOGGER.error(f"Metric value of: {metric_name} is: {sample}, should not be empty.")


### PR DESCRIPTION
##### Short description:
In s390x the test using this function is flaky right now because it doesn't get always the value from the metric in the first call, added sampler for it so it will be more robust and support s390x.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-75605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Metric validation now uses a polling-and-retry approach (up to ~5 minutes, checking every ~30 seconds) to handle eventual consistency instead of a single synchronous query.
  * On timeout, the last observed sample is captured and surfaced to aid debugging; existing mismatch comparison logic remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->