### PR TITLE
Fix CodeRabbit smoke test pattern matching

### DIFF
--- a/.github/workflows/smoke-tests-label-from-coderabbit.yml
+++ b/.github/workflows/smoke-tests-label-from-coderabbit.yml
@@ -78,8 +78,8 @@ jobs:
           # These patterns require the text to appear at the start of a line, matching the actual
           # Test Execution Plan format instead of matching when CodeRabbit explains how it works
           HAS_TEST_PLAN=$(grep -qE '^## Test Execution Plan' <<< "$COMMENT_STRIPPED" && echo "true" || echo "false")
-          HAS_RUN_TRUE=$(grep -qE '^- \*\*Run smoke tests: True\*\*' <<< "$COMMENT_STRIPPED" && echo "true" || echo "false")
-          HAS_RUN_FALSE=$(grep -qE '^- \*\*Run smoke tests: False\*\*' <<< "$COMMENT_STRIPPED" && echo "true" || echo "false")
+          HAS_RUN_TRUE=$(grep -qE '^\*\*Run smoke tests: True\*\*' <<< "$COMMENT_STRIPPED" && echo "true" || echo "false")
+          HAS_RUN_FALSE=$(grep -qE '^\*\*Run smoke tests: False\*\*' <<< "$COMMENT_STRIPPED" && echo "true" || echo "false")
 
           FLOW_ADD="false"
           FLOW_REMOVE="false"


### PR DESCRIPTION
The workflow was failing because it expected CodeRabbit to output metadata with bullet point prefixes (e.g., '- **Run smoke tests: True**'), but CodeRabbit actually posts without bullet points (e.g., '**Run smoke tests: True**').

This fix removes the '- ' prefix from the regex patterns while keeping the '^' line anchor to ensure proper line-start matching.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated smoke test detection logic in the CI/CD workflow to improve reliability of test triggering based on inline instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->