### PR TITLE
[virt] drop jira from machinetype tests

### DIFF
--- a/tests/virt/node/conftest.py
+++ b/tests/virt/node/conftest.py
@@ -140,9 +140,3 @@ def migration_policy_with_allow_auto_converge(namespace):
         allow_auto_converge=True,
     ):
         yield
-
-
-@pytest.fixture(scope="session")
-def xfail_if_jira_75031_is_open():
-    if is_jira_open(jira_id="CNV-75031"):
-        pytest.xfail(reason="Machine type is not reverted when removing HCO jsonpatch annotation. CNV-75031")

--- a/tests/virt/node/general/test_legacy_machinetype.py
+++ b/tests/virt/node/general/test_legacy_machinetype.py
@@ -83,6 +83,5 @@ def rhel_8_10_vm(unprivileged_client, namespace, golden_image_data_volume_templa
     ],
     indirect=["golden_image_data_source_for_test_scope_function"],
 )
-@pytest.mark.usefixtures("xfail_if_jira_75031_is_open")
 def test_legacy_machine_type(updated_hco_emulated_machine_i440fx, rhel_8_10_vm, expected_machine_type):
     validate_machine_type(vm=rhel_8_10_vm, expected_machine_type=expected_machine_type)

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -133,7 +133,6 @@ def test_migrate_vm(machine_type_from_kubevirt_config, vm):
 )
 @pytest.mark.gating
 @pytest.mark.conformance
-@pytest.mark.usefixtures("xfail_if_jira_75031_is_open")
 def test_machine_type_after_vm_restart(
     machine_type_from_kubevirt_config,
     vm,
@@ -158,7 +157,6 @@ def test_machine_type_after_vm_restart(
 )
 @pytest.mark.rwx_default_storage
 @pytest.mark.gating
-@pytest.mark.usefixtures("xfail_if_jira_75031_is_open")
 def test_machine_type_after_vm_migrate(
     machine_type_from_kubevirt_config, vm, updated_kubevirt_config_machine_type, migrated_vm
 ):
@@ -180,7 +178,6 @@ def test_machine_type_after_vm_migrate(
     indirect=True,
 )
 @pytest.mark.gating
-@pytest.mark.usefixtures("xfail_if_jira_75031_is_open")
 def test_machine_type_kubevirt_config_update(updated_kubevirt_config_machine_type, vm):
     """Test machine type change in kubevirt_config; new VM gets new value"""
     validate_machine_type(vm=vm, expected_machine_type=MachineTypesNames.pc_q35_rhel8_1)


### PR DESCRIPTION
##### Short description:
jira was closed. unblocking machinetype tests

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed conditional expected-failure behavior from multiple tests in the test suite. Tests that were previously expected to fail under specific conditions will now execute with standard pass/fail expectations, providing clearer test outcomes and enabling more complete validation of system functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->