### PR TITLE
WIP:    [T2] [storage] adjust pvc size to match minimumSupportedPvcSize in T2

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -2,6 +2,7 @@
 Clone tests
 """
 
+import bitmath
 import pytest
 from ocp_resources.datavolume import DataVolume
 
@@ -23,7 +24,6 @@ from utilities.storage import (
     create_dv,
     create_vm_from_dv,
     data_volume_template_dict,
-    overhead_size_for_dv,
 )
 from utilities.virt import (
     VirtualMachineForTests,
@@ -278,8 +278,9 @@ def test_clone_from_block_to_fs_using_dv_template(
     namespace,
     cirros_dv_with_block_volume_mode,
     storage_class_with_filesystem_volume_mode,
-    default_fs_overhead,
 ):
+    source_pvc = cirros_dv_with_block_volume_mode.pvc
+    pvc_size = bitmath.parse_string_unsafe(s=source_pvc.instance.spec.resources.requests.storage)
     create_vm_from_clone_dv_template(
         vm_name="vm-5608",
         dv_name="dv-5608",
@@ -287,10 +288,6 @@ def test_clone_from_block_to_fs_using_dv_template(
         source_dv=cirros_dv_with_block_volume_mode,
         client=unprivileged_client,
         volume_mode=DataVolume.VolumeMode.FILE,
-        # add fs overhead and round up the result
-        size=overhead_size_for_dv(
-            image_size=int(cirros_dv_with_block_volume_mode.size[:-2]),
-            overhead_value=default_fs_overhead,
-        ),
+        size=f"{int(pvc_size.to_GiB().value)}Gi",
         storage_class=storage_class_with_filesystem_volume_mode,
     )

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -22,6 +22,7 @@ from utilities.storage import (
     create_dummy_first_consumer_pod,
     create_vm_from_dv,
     get_downloaded_artifact,
+    get_storage_profile_minimum_supported_pvc_size,
     sc_is_hpp_with_immediate_volume_binding,
     sc_volume_binding_mode_is_wffc,
     virtctl_upload_dv,
@@ -275,14 +276,18 @@ def empty_pvc(
     storage_class_matrix__module__,
     storage_class_name_scope_module,
     worker_node1,
+    admin_client,
 ):
+    storage_profile_minimum_supported_pvc_size = get_storage_profile_minimum_supported_pvc_size(
+        storage_class_name=storage_class_name_scope_module, client=admin_client
+    )
     with PersistentVolumeClaim(
         name="empty-pvc",
         namespace=namespace.name,
         storage_class=storage_class_name_scope_module,
         volume_mode=storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"],
         accessmodes=storage_class_matrix__module__[storage_class_name_scope_module]["access_mode"],
-        size=DEFAULT_DV_SIZE,
+        size=storage_profile_minimum_supported_pvc_size or DEFAULT_DV_SIZE,
         hostpath_node=worker_node1.name
         if sc_is_hpp_with_immediate_volume_binding(sc=storage_class_name_scope_module)
         else None,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,6 +46,7 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     ExecCommandOnPod,
 )
+from utilities.storage import get_storage_profile_minimum_supported_pvc_size
 from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
@@ -521,7 +522,8 @@ def create_cirros_vm(
         source="http",
         url=get_http_image_url(image_directory=Images.Cirros.DIR, image_name=Images.Cirros.QCOW2_IMG),
         storage_class=storage_class,
-        size=Images.Cirros.DEFAULT_DV_SIZE,
+        size=get_storage_profile_minimum_supported_pvc_size(storage_class_name=storage_class, client=client)
+        or Images.Cirros.DEFAULT_DV_SIZE,
         api_name="storage",
         volume_mode=volume_mode,
         secret=artifactory_secret,

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -595,6 +595,12 @@ def overhead_size_for_dv(image_size, overhead_value):
     return f"{math.ceil(dv_size)}Mi"
 
 
+def get_storage_profile_minimum_supported_pvc_size(storage_class_name, client):
+    storage_profile = StorageProfile(name=storage_class_name, client=client, ensure_exists=True)
+    annotations = getattr(storage_profile.instance.metadata, "annotations", {}) or {}
+    return annotations.get("cdi.kubevirt.io/minimumSupportedPvcSize")
+
+
 def cdi_feature_gate_list_with_added_feature(feature):
     return [
         *CDIConfig(name="config").instance.to_dict().get("spec", {}).get("featureGates", []),


### PR DESCRIPTION
##### Short description:
Adjust minimum supported PVC size for T2 storage configuration

##### More details:
This PR updates the minimum supported PVC size handling for T2 storage profiles. The change ensures that tests correctly use the minimum supported PVC size as defined in the storage profile annotations, with a fallback to the default value when not specified.

##### What this PR does / why we need it:
- Updates the minimum supported PVC size configuration for T2 storage profiles
- Ensures tests respect the `cdi.kubevirt.io/minimumSupportedPvcSize` annotation from storage profiles
- Prevents test failures due to PVC size mismatches with storage profile requirements
- Maintains backward compatibility with a default fallback value of "1Gi" when the annotation is not present
- 


##### Which issue(s) this PR fixes:
in GCP as well as other cloud providor storage sloution are having minimum supported PVC size, where are few tests
that are creating much smaller pvc size which will lead to unbound/ never bound pvc

current affected tests:
test_clone_from_block_to_fs_using_dv_template
test_virtctl_image_upload_with_exist_pvc
test_virtctl_image_upload_dv_with_exist_pvc
test_import_vm_with_specify_fs_overhead
test_upload_dv_with_specify_fs_overhead


##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-75716
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to read storage-profile minimum PVC sizes for dynamic sizing.

* **Tests**
  * Tests now use dynamic PVC/DV sizing from storage profiles instead of fixed defaults.
  * Improved size parsing and exact-size handling; removed reliance on overhead-based defaults.
  * Tests updated to explicitly specify filesystem access mode where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->