### PR TITLE
CherryPicked: [cnv-4.20] Remove Artifactory dependency from CPU affinity test (#3134)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -854,23 +854,6 @@ def data_volume_scope_class(request, namespace, schedulable_nodes):
     )
 
 
-@pytest.fixture(scope="class")
-def golden_image_data_volume_scope_class(request, admin_client, golden_images_namespace, schedulable_nodes):
-    yield from data_volume(
-        request=request,
-        namespace=golden_images_namespace,
-        storage_class=request.param["storage_class"],
-        schedulable_nodes=schedulable_nodes,
-        check_dv_exists=True,
-        admin_client=admin_client,
-    )
-
-
-@pytest.fixture(scope="class")
-def golden_image_data_source_scope_class(admin_client, golden_image_data_volume_scope_class):
-    yield from create_or_update_data_source(admin_client=admin_client, dv=golden_image_data_volume_scope_class)
-
-
 @pytest.fixture(scope="module")
 def golden_image_data_volume_scope_module(request, admin_client, golden_images_namespace, schedulable_nodes):
     yield from data_volume(
@@ -2348,22 +2331,6 @@ def rhel_vm_with_instance_type_and_preference(
             vm_preference=vm_preference,
         ) as vm:
             yield vm
-
-
-@pytest.fixture(scope="class")
-def vm_from_template_scope_class(
-    request,
-    unprivileged_client,
-    namespace,
-    golden_image_data_source_scope_class,
-):
-    with vm_instance_from_template(
-        request=request,
-        unprivileged_client=unprivileged_client,
-        namespace=namespace,
-        data_source=golden_image_data_source_scope_class,
-    ) as vm:
-        yield vm
 
 
 @pytest.fixture(scope="session")

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -578,3 +578,16 @@ def aaq_resource_hard_limit_and_used(application_aware_resource_quota):
         for key, value in resource_used.items()
     }
     return formatted_hard_limit, formatted_used_value
+
+
+@pytest.fixture(scope="class")
+def expected_cpu_affinity_metric_value(vm_with_cpu_spec):
+    """Calculate expected kubevirt_vmi_node_cpu_affinity metric value."""
+    # Calculate VM CPU count
+    vm_cpu = vm_with_cpu_spec.vmi.instance.spec.domain.cpu
+    cpu_count_from_vm = (vm_cpu.threads or 1) * (vm_cpu.cores or 1) * (vm_cpu.sockets or 1)
+    # Get node CPU capacity
+    cpu_count_from_vm_node = int(vm_with_cpu_spec.privileged_vmi.node.instance.status.capacity.cpu)
+
+    # return multiplication for multi-CPU VMs
+    return str(cpu_count_from_vm_node * cpu_count_from_vm)

--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -30,3 +30,5 @@ KUBEVIRT_VMI_PHASE_TRANSITION_TIME_FROM_DELETION_SECONDS_SUM_SUCCEEDED = (
 )
 BINDING_NAME = "binding_name"
 BINDING_TYPE = "binding_type"
+
+KUBEVIRT_VMI_NODE_CPU_AFFINITY = "kubevirt_vmi_node_cpu_affinity{{kubernetes_vmi_label_kubevirt_io_domain='{vm_name}'}}"

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -3,13 +3,10 @@ import logging
 import pytest
 from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine import VirtualMachine
-from pytest_testconfig import config as py_config
 
-from tests.observability.metrics.utils import (
-    validate_vmi_node_cpu_affinity_with_prometheus,
-)
+from tests.observability.metrics.constants import KUBEVIRT_VMI_NODE_CPU_AFFINITY
+from tests.observability.metrics.utils import validate_vmi_node_cpu_affinity_with_prometheus
 from tests.observability.utils import validate_metrics_value
-from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 KUBEVIRT_VM_TAG = f"{Resource.ApiGroup.KUBEVIRT_IO}/vm"
@@ -41,37 +38,23 @@ def fedora_vm_without_name_in_label(
         client=unprivileged_client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:
-        running_vm(vm=vm, check_ssh_connectivity=False)
+        running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
         yield vm
 
 
 class TestVmiNodeCpuAffinityLinux:
-    @pytest.mark.parametrize(
-        "golden_image_data_volume_scope_class, vm_from_template_scope_class",
-        [
-            pytest.param(
-                {
-                    "dv_name": RHEL_LATEST_OS,
-                    "image": RHEL_LATEST["image_path"],
-                    "storage_class": py_config["default_storage_class"],
-                    "dv_size": RHEL_LATEST["dv_size"],
-                },
-                {
-                    "vm_name": "rhel-latest",
-                    "template_labels": RHEL_LATEST_LABELS,
-                    "guest_agent": False,
-                    "ssh": False,
-                },
-            ),
-        ],
-        indirect=True,
-    )
     @pytest.mark.polarion("CNV-7295")
     @pytest.mark.s390x
-    def test_kubevirt_vmi_node_cpu_affinity(self, prometheus, vm_from_template_scope_class):
-        validate_vmi_node_cpu_affinity_with_prometheus(
-            vm=vm_from_template_scope_class,
+    def test_kubevirt_vmi_node_cpu_affinity(
+        self,
+        prometheus,
+        vm_with_cpu_spec,
+        expected_cpu_affinity_metric_value,
+    ):
+        validate_metrics_value(
             prometheus=prometheus,
+            metric_name=KUBEVIRT_VMI_NODE_CPU_AFFINITY.format(vm_name=vm_with_cpu_spec.name),
+            expected_value=expected_cpu_affinity_metric_value,
         )
 
 


### PR DESCRIPTION
The test for kubevirt_vmi_node_cpu_affinity is flaky duo to connectivity issues with the artifactory, in this PR I modified the test to not rely on the artifactory to avoid this kind of failures to stabilize the observability lanes.

https://issues.redhat.com/browse/CNV-75209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

* **Tests**
* Removed several class-scoped fixtures that provisioned golden-image VMs from templates.
* Added a class-scoped fixture that computes the expected CPU-affinity metric value for a VM.
  * Introduced a new metric identifier constant for CPU affinity checks.
* Refactored the CPU-affinity test to use the VM-with-cpu-spec fixture and the new validation path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
