### PR TITLE
CherryPicked: [cnv-4.19][IUO] skip collection for simple tests to reduce time

### DIFF
--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -12,7 +12,13 @@ from utilities.constants import BASE_EXCEPTIONS_DICT, TIMEOUT_3MIN, TIMEOUT_10SE
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = [pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64, pytest.mark.conformance]
+pytestmark = [
+    pytest.mark.sno,
+    pytest.mark.gating,
+    pytest.mark.arm64,
+    pytest.mark.conformance,
+    pytest.mark.skip_must_gather_collection,
+]
 
 
 @retry(

--- a/tests/install_upgrade_operators/csv/test_csv.py
+++ b/tests/install_upgrade_operators/csv/test_csv.py
@@ -3,7 +3,12 @@ from base64 import b64decode
 import pytest
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade,
+    pytest.mark.sno,
+    pytest.mark.arm64,
+    pytest.mark.skip_must_gather_collection,
+]
 
 # Check CSV properties like keywords, title, provided by, links etc.
 

--- a/tests/install_upgrade_operators/csv/test_hco_api_version.py
+++ b/tests/install_upgrade_operators/csv/test_hco_api_version.py
@@ -1,7 +1,7 @@
 import pytest
 from ocp_resources.resource import Resource
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.skip_must_gather_collection]
 
 
 @pytest.mark.polarion("CNV-5832")

--- a/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
+++ b/tests/install_upgrade_operators/csv/test_hco_cr_explainable.py
@@ -3,7 +3,7 @@ import shlex
 import pytest
 from pyhelper_utils.shell import run_command
 
-pytestmark = [pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.skip_must_gather_collection]
 
 
 @pytest.mark.polarion("CNV-5884")

--- a/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
+++ b/tests/install_upgrade_operators/csv/test_immutable_image_using_sha.py
@@ -1,6 +1,6 @@
 import pytest
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.skip_must_gather_collection]
 
 
 @pytest.mark.polarion("CNV-4751")

--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -1,6 +1,6 @@
 import pytest
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.skip_must_gather_collection]
 
 
 @pytest.mark.polarion("CNV-7169")

--- a/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
+++ b/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
@@ -3,7 +3,12 @@ import pytest
 from utilities.constants import ALL_CNV_DAEMONSETS, ALL_CNV_DAEMONSETS_NO_HPP_CSI
 from utilities.infra import get_daemonsets
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade,
+    pytest.mark.sno,
+    pytest.mark.arm64,
+    pytest.mark.skip_must_gather_collection,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -76,6 +76,7 @@ def test_cnv_deployment_priority_class_name(
         )
 
 
+@pytest.mark.skip_must_gather_collection
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-8289")

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -24,7 +24,7 @@ from tests.install_upgrade_operators.utils import (
 )
 from utilities.constants import CDI_KUBEVIRT_HYPERCONVERGED, KUBEVIRT_HCO_NAME
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.skip_must_gather_collection]
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -19,7 +19,7 @@ from utilities.constants import (
     KUBEVIRT_KUBEVIRT_HYPERCONVERGED,
 )
 
-pytestmark = pytest.mark.sno
+pytestmark = [pytest.mark.sno, pytest.mark.skip_must_gather_collection]
 
 
 class TestHardcodedFeatureGates:

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -12,6 +12,8 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 
 FEATUREGATE_NAME_KEY_STR = "featuregate_name"
 
+pytestmark = [pytest.mark.skip_must_gather_collection]
+
 
 @pytest.fixture()
 def updated_fg_hco(

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -39,6 +39,7 @@ def cnv_pods_by_type_no_hpp_csi_hpp_pool(cnv_pod_priority_class_matrix__function
     return pod_list
 
 
+@pytest.mark.skip_must_gather_collection
 @pytest.mark.polarion("CNV-7261")
 def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
     all_pods = ALL_CNV_PODS.copy()

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -14,7 +14,13 @@ from tests.install_upgrade_operators.relationship_labels.utils import (
 )
 from utilities.constants import VERSION_LABEL_KEY
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade,
+    pytest.mark.sno,
+    pytest.mark.gating,
+    pytest.mark.arm64,
+    pytest.mark.skip_must_gather_collection,
+]
 LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
+++ b/tests/install_upgrade_operators/resource_params/test_hco_status_conditions.py
@@ -9,7 +9,13 @@ from tests.install_upgrade_operators.resource_params.utils import (
 from utilities.hco import wait_for_hco_conditions
 from utilities.infra import get_hyperconverged_resource
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade,
+    pytest.mark.sno,
+    pytest.mark.gating,
+    pytest.mark.arm64,
+    pytest.mark.skip_must_gather_collection,
+]
 LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -11,6 +11,8 @@ from utilities.constants import ALL_CNV_DEPLOYMENTS_NO_HPP_POOL
 REQUIRED_SCC_ANNOTATION = "openshift.io/required-scc"
 REQUIRED_SCC_VALUE = "restricted-v2"
 
+pytestmark = [pytest.mark.skip_must_gather_collection]
+
 
 @pytest.fixture(scope="module")
 def required_scc_deployment_check(admin_client, hco_namespace):

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -16,7 +16,13 @@ from utilities.constants import (
     LINUX_BRIDGE,
 )
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade,
+    pytest.mark.sno,
+    pytest.mark.gating,
+    pytest.mark.arm64,
+    pytest.mark.skip_must_gather_collection,
+]
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/install_upgrade_operators/security/scc/test_default_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_default_scc.py
@@ -7,7 +7,12 @@ Tests to check, the default Security Context Constraint
 import pytest
 from ocp_resources.security_context_constraints import SecurityContextConstraints
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade,
+    pytest.mark.gating,
+    pytest.mark.arm64,
+    pytest.mark.skip_must_gather_collection,
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -6,7 +6,12 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
 )
 from utilities.constants import ALL_HCO_RELATED_OBJECTS
 
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64]
+pytestmark = [
+    pytest.mark.post_upgrade,
+    pytest.mark.sno,
+    pytest.mark.arm64,
+    pytest.mark.skip_must_gather_collection,
+]
 
 
 class TestRelatedObjects:


### PR DESCRIPTION
##### Short description:
If the test is simple, and the fail message is clear enough, we shouldn't collect must gather on failure point. This significantly reduces execution time during
multiple test failures.
Cherry pick from https://github.com/RedHatQE/openshift-virtualization-tests/pull/3219
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: