### PR TITLE
net, bgp: Edit import and error msg of IpNotFound

### DIFF
--- a/tests/network/libs/bgp.py
+++ b/tests/network/libs/bgp.py
@@ -17,9 +17,9 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.route_advertisements import RouteAdvertisements
 from timeout_sampler import retry
 
+from libs.net.vmspec import IpNotFound
 from utilities.constants import NET_UTIL_CONTAINER_IMAGE
 from utilities.infra import get_resources_by_name_prefix
-from utilities.network import IpNotFound
 
 _CLUSTER_FRR_ASN: Final[int] = 64512
 _EXTERNAL_FRR_ASN: Final[int] = 64000
@@ -255,7 +255,7 @@ def _acquire_dhcp_ipv4(pod: Pod, iface_name: str) -> str:
             if addr["family"] == "inet":
                 return addr["local"]
 
-    raise IpNotFound(iface_name)  # type: ignore[no-untyped-call]
+    raise IpNotFound(f"No IPv4 address found on interface {iface_name}")  # type: ignore[no-untyped-call]
 
 
 def wait_for_bgp_connection_established(node_names: list) -> None:


### PR DESCRIPTION
In recent merges IpNotFound exception has moved and requires different import and an error message in
bgp net lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for IPv4 address acquisition failures on network interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->