### PR TITLE
[Chaos][OADP] Automate cases: Delete Pods during OADP Restore

### DIFF
--- a/tests/chaos/oadp/conftest.py
+++ b/tests/chaos/oadp/conftest.py
@@ -2,29 +2,41 @@ import datetime
 import logging
 
 import pytest
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.daemonset import DaemonSet
 from ocp_resources.deployment import Deployment
-from timeout_sampler import TimeoutSampler
+from ocp_resources.namespace import Namespace
+from ocp_resources.resource import ResourceEditor
+from ocp_resources.virtual_machine import VirtualMachine
 
-from tests.chaos.utils import create_pod_deleting_thread, pod_deleting_process_recover
+from tests.chaos.utils import (
+    create_pod_deleting_thread,
+    pod_deleting_process_recover,
+    wait_for_oadp_phase,
+)
 from utilities.constants import (
     BACKUP_STORAGE_LOCATION,
     FILE_NAME_FOR_BACKUP,
+    OADP_BACKUP_TERMINAL_STATUSES,
+    OADP_RESTORE_TERMINAL_STATUSES,
     TEXT_TO_TEST,
     TIMEOUT_1MIN,
     TIMEOUT_3MIN,
+    TIMEOUT_5MIN,
     TIMEOUT_10MIN,
+    TIMEOUT_20MIN,
+    TIMEOUT_30MIN,
     Images,
 )
-from utilities.infra import ExecCommandOnPod, wait_for_node_status
-from utilities.oadp import VeleroBackup, create_rhel_vm
+from utilities.infra import ExecCommandOnPod, unique_name, wait_for_node_status
+from utilities.oadp import VeleroBackup, VeleroRestore, create_rhel_vm
 from utilities.storage import write_file
 from utilities.virt import node_mgmt_console, wait_for_node_schedulable_status
 
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def rhel_vm_with_dv_running(admin_client, chaos_namespace, snapshot_storage_class_name_scope_module):
     """
     Create a RHEL VM with a DataVolume.
@@ -91,6 +103,7 @@ def drain_vm_source_node(admin_client, rhel_vm_with_dv_running, oadp_backup_in_p
 def pod_deleting_thread_during_oadp_operations(request, admin_client):
     pod_prefix = request.param["pod_prefix"]
     namespace_name = request.param["namespace_name"]
+    resources = request.param.get("resources")
 
     thread, stop_event = create_pod_deleting_thread(
         client=admin_client,
@@ -106,6 +119,7 @@ def pod_deleting_thread_during_oadp_operations(request, admin_client):
         "stop_event": stop_event,
         "namespace_name": namespace_name,
         "pod_prefix": pod_prefix,
+        "resources": resources,
     }
 
     stop_event.set()
@@ -124,28 +138,19 @@ def backup_with_pod_deletion_orchestration(
 
     thread.start()
 
-    terminal_statuses = {
-        backup.Backup.Status.COMPLETED,
-        backup.Backup.Status.FAILED,
-        backup.Backup.Status.PARTIALLYFAILED,
-        backup.Backup.Status.FAILEDVALIDATION,
-    }
-
-    final_status = None
-
     try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_10MIN,
+        final_status = wait_for_oadp_phase(
+            resource=oadp_backup_in_progress,
+            timeout=TIMEOUT_10MIN,
             sleep=5,
-            func=lambda: backup.instance.status.phase,
-        ):
-            if sample in terminal_statuses:
-                final_status = sample
-                break
+            terminal_statuses=OADP_BACKUP_TERMINAL_STATUSES,
+        )
+        LOGGER.info(f"Backup {backup.name} completed with status {final_status}")
 
         yield final_status
 
     finally:
+        LOGGER.info("Stopping pod deletion chaos thread")
         stop_event.set()
         if thread.is_alive():
             thread.join(timeout=TIMEOUT_1MIN)
@@ -157,10 +162,147 @@ def backup_with_pod_deletion_orchestration(
                 namespace=pod_deleting_thread_during_oadp_operations["namespace_name"],
                 pod_prefix=pod_deleting_thread_during_oadp_operations["pod_prefix"],
             )
-        except Exception:
+        except ResourceNotFoundError, ValueError, TypeError:
             LOGGER.error(
                 f"Recovery failed for prefix "
                 f"{pod_deleting_thread_during_oadp_operations['pod_prefix']} "
                 f"in namespace {pod_deleting_thread_during_oadp_operations['namespace_name']}"
             )
+            raise
+
+
+@pytest.fixture()
+def oadp_backup_completed(admin_client, chaos_namespace, rhel_vm_with_dv_running):
+    """
+    Create a Velero backup and wait until it reaches Completed phase.
+
+    This fixture:
+    - creates backup
+    - waits for completion
+    - asserts Completed
+    - yields backup object
+    - deletes backup automatically on teardown
+    """
+    backup_name = unique_name(name="backup")
+
+    with VeleroBackup(
+        name=backup_name,
+        included_namespaces=[chaos_namespace.name],
+        snapshot_move_data=True,
+        storage_location=BACKUP_STORAGE_LOCATION,
+        client=admin_client,
+        wait_complete=False,  # we wait manually
+    ) as backup:
+        with ResourceEditor({
+            backup: {
+                "spec": {
+                    "defaultVolumesToFsBackup": True,
+                }
+            }
+        }):
+            wait_for_oadp_phase(
+                resource=backup,
+                timeout=TIMEOUT_20MIN,
+                sleep=10,
+                terminal_statuses=OADP_BACKUP_TERMINAL_STATUSES,
+                expected_phase=backup.Backup.Status.COMPLETED,
+            )
+
+        yield backup
+
+
+@pytest.fixture()
+def chaos_vms_cleanup(admin_client, chaos_namespace):
+    namespace_name = chaos_namespace.name
+
+    LOGGER.info(f"Fetching all VMs in namespace {namespace_name}")
+
+    vms = list(VirtualMachine.get(client=admin_client, namespace=namespace_name))
+    if not vms:
+        LOGGER.info(f"No VMs found in namespace {namespace_name}")
+        return
+
+    LOGGER.info(f"Cleaning up {len(vms)} VMs in namespace {namespace_name}")
+    for vm in vms:
+        vm.clean_up(wait=True, timeout=TIMEOUT_3MIN)
+
+    LOGGER.info(f"All VMs in namespace {namespace_name} have been deleted")
+
+
+@pytest.fixture()
+def deleted_chaos_namespace(chaos_namespace, admin_client, chaos_vms_cleanup):
+    """
+    Specialized fixture to delete the chaos namespace using framework-provided cleanup method.
+    """
+    ns = next(Namespace.get(name=chaos_namespace.name, client=admin_client), None)
+    if ns:
+        ns.clean_up(wait=True, timeout=TIMEOUT_5MIN)
+
+
+@pytest.fixture()
+def oadp_restore_started(admin_client, oadp_backup_completed, deleted_chaos_namespace):
+    restore_name = f"restore-{oadp_backup_completed.name}"
+
+    with VeleroRestore(
+        name=restore_name,
+        namespace=oadp_backup_completed.namespace,
+        backup_name=oadp_backup_completed.name,
+        client=admin_client,
+        wait_complete=False,
+    ) as restore:
+        yield restore
+
+
+@pytest.fixture()
+def restore_with_pod_deletion_orchestration(
+    oadp_restore_started,
+    pod_deleting_thread_during_oadp_operations,
+):
+    """
+    Orchestrate OADP restore while continuously deleting target pods.
+
+    Flow:
+    - Start pod deleting thread
+    - Wait for restore to reach terminal phase
+    - Stop chaos and recover workloads
+    - Yield final restore phase (stable state)
+    """
+
+    thread = pod_deleting_thread_during_oadp_operations["thread"]
+    namespace = pod_deleting_thread_during_oadp_operations["namespace_name"]
+    pod_prefix = pod_deleting_thread_during_oadp_operations["pod_prefix"]
+
+    # Start chaos
+    thread.start()
+
+    terminal_statuses = OADP_RESTORE_TERMINAL_STATUSES
+
+    allowed_statuses = {
+        oadp_restore_started.Status.COMPLETED,
+        oadp_restore_started.Status.FAILED,
+    }
+
+    try:
+        final_status = wait_for_oadp_phase(
+            resource=oadp_restore_started,
+            terminal_statuses=terminal_statuses,
+            timeout=TIMEOUT_30MIN,
+        )
+        assert final_status in allowed_statuses, f"Restore ended in unexpected terminal phase: {final_status}"
+        yield final_status
+
+    finally:
+        pod_deleting_thread_during_oadp_operations["stop_event"].set()
+        if thread.is_alive():
+            thread.join(timeout=TIMEOUT_1MIN)
+
+        # Recovery only — thread teardown handled by pod_deleting_thread fixture
+        try:
+            pod_deleting_process_recover(
+                resources=[Deployment, DaemonSet],
+                namespace=namespace,
+                pod_prefix=pod_prefix,
+            )
+        except ResourceNotFoundError, ValueError, TypeError:
+            LOGGER.error(f"Recovery failed for prefix {pod_prefix} in namespace {namespace}")
             raise

--- a/tests/chaos/oadp/test_oadp.py
+++ b/tests/chaos/oadp/test_oadp.py
@@ -1,9 +1,13 @@
 import logging
 
 import pytest
+from ocp_resources.daemonset import DaemonSet
+from ocp_resources.deployment import Deployment
 
+from tests.chaos.utils import wait_for_restored_vm
 from tests.os_params import RHEL_LATEST
-from utilities.constants import TIMEOUT_10MIN
+from utilities.constants import FILE_NAME_FOR_BACKUP, TEXT_TO_TEST, TIMEOUT_5MIN, TIMEOUT_10MIN
+from utilities.oadp import check_file_in_running_vm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -128,8 +132,7 @@ def test_delete_pods_during_backup(
     1. Create a healthy VM and persist data inside the guest.
     2. Trigger an OADP Backup.
     3. Start a background process that continuously deletes critical OADP-related
-       pods (e.g. controller-manager, node-agent, velero, minio) while the Backup
-       is in progress.
+       pods (e.g. controller-manager, node-agent, velero) while the Backup is in progress.
     4. Wait for the OADP Backup to reach a terminal state.
     5. Stop the pod deletion process once the Backup finishes.
     6. Verify the final Backup status matches the expected result.
@@ -138,3 +141,90 @@ def test_delete_pods_during_backup(
     assert backup_with_pod_deletion_orchestration == expected_status, (
         f"Expected backup status {expected_status}, got {backup_with_pod_deletion_orchestration}"
     )
+
+
+@pytest.mark.destructive
+@pytest.mark.tier3
+@pytest.mark.chaos
+@pytest.mark.parametrize(
+    ("pod_deleting_thread_during_oadp_operations", "expected_status"),
+    [
+        pytest.param(
+            {
+                "pod_prefix": "velero",
+                "namespace_name": "openshift-adp",
+                "ratio": 1.0,
+                "interval": 30,
+                "max_duration": 300,
+                "resources": [Deployment],
+            },
+            "Completed",
+            marks=pytest.mark.polarion("CNV-12027"),
+            id="velero",
+        ),
+        pytest.param(
+            {
+                "pod_prefix": "openshift-adp-controller-manager",
+                "namespace_name": "openshift-adp",
+                "ratio": 1.0,
+                "interval": 10,
+                "max_duration": 120,
+                "resources": [Deployment],
+            },
+            "Completed",
+            marks=pytest.mark.polarion("CNV-12025"),
+            id="openshift-adp-controller-manager",
+        ),
+        pytest.param(
+            {
+                "pod_prefix": "node-agent",
+                "namespace_name": "openshift-adp",
+                "ratio": 1.0,
+                "interval": 10,
+                "max_duration": 300,
+                "resources": [DaemonSet],
+            },
+            "Completed",
+            marks=pytest.mark.polarion("CNV-12023"),
+            id="node-agent",
+        ),
+    ],
+    indirect=["pod_deleting_thread_during_oadp_operations"],
+)
+def test_delete_pods_during_restore(
+    admin_client,
+    chaos_namespace,
+    rhel_vm_with_dv_running,
+    restore_with_pod_deletion_orchestration,
+    expected_status,
+):
+    """
+    This test verifies OADP restore resilience under control-plane disruptions.
+
+    Preconditions:
+        - A healthy VM exists and guest data was written before backup.
+
+    Steps:
+        1. Take a successful OADP backup.
+        2. Delete the original VM and namespace.
+        3. Delete OADP pods while the restore is in progress.
+        4. Wait for the restore to reach a terminal status.
+
+    Expected:
+        - The restore reaches the expected final status.
+        - The VM is recreated and reaches Running.
+        - The guest data is preserved after restore.
+    """
+
+    assert restore_with_pod_deletion_orchestration == expected_status, (
+        f"Expected restore status {expected_status}, got {restore_with_pod_deletion_orchestration}"
+    )
+
+    restored_vm = wait_for_restored_vm(
+        admin_client=admin_client,
+        namespace=chaos_namespace,
+        vm_name=rhel_vm_with_dv_running.name,
+        timeout=TIMEOUT_5MIN,
+    )
+
+    check_file_in_running_vm(vm=restored_vm, file_name=FILE_NAME_FOR_BACKUP, file_content=TEXT_TO_TEST)

--- a/tests/chaos/utils.py
+++ b/tests/chaos/utils.py
@@ -14,6 +14,7 @@ from ocp_resources.deployment import Deployment
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
+from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
 )
@@ -80,7 +81,7 @@ def create_pod_deleting_process(
                 wait_timeout=max_duration,
                 sleep=interval,
                 func=delete_pods,
-                _client=client,
+                client=client,
                 pod_prefix=pod_prefix,
                 namespace_name=namespace_name,
                 ratio=ratio,
@@ -393,12 +394,10 @@ def pod_deleting_process_recover(resources, namespace, pod_prefix):
         found_any = True
 
         for resource_obj in resource_objs:
-            if resource_obj.kind == Deployment.kind:
-                LOGGER.info(f"Waiting for Deployment {resource_obj.name} to recover replicas")
+            LOGGER.info(f"Waiting for {resource.kind} {resource_obj.name} to recover")
+            if resource is Deployment:
                 resource_obj.wait_for_replicas()
-
-            elif resource_obj.kind == DaemonSet.kind:
-                LOGGER.info(f"Waiting for DaemonSet {resource_obj.name} to recover")
+            else:
                 resource_obj.wait_until_deployed()
 
     if found_any:
@@ -428,11 +427,18 @@ def delete_pods(client, pod_prefix, namespace_name, ratio):
         client: OpenShift/Kubernetes client used to query and delete pods.
         pod_prefix (str): Prefix of pod names to match.
         namespace_name (str): Namespace where pods are located.
-        ratio (float): Fraction of pods to delete (0 < ratio <= 1).
+        ratio (float): Fraction of pods to delete (0 <= ratio <= 1). If ratio is 0, no pods are deleted.
 
     Raises:
         ResourceNotFoundError: If no matching pods are found.
     """
+    if ratio == 0:
+        LOGGER.info(f"No-op: ratio=0, skipping pod deletion for prefix {pod_prefix}")
+        return
+
+    if not (0 < ratio <= 1):
+        raise ValueError(f"ratio must be between 0 and 1, got {ratio}")
+
     pods = get_pod_by_name_prefix(
         client=client,
         pod_prefix=pod_prefix,
@@ -456,7 +462,7 @@ def delete_pods(client, pod_prefix, namespace_name, ratio):
         try:
             pod.wait_deleted(timeout=TIMEOUT_30SEC)
         except TimeoutExpiredError:
-            LOGGER.warning(f"Pod {pod.name} was not deleted")
+            LOGGER.info(f"Pod {pod.name} was not deleted")
 
 
 def delete_pods_continuously(
@@ -501,7 +507,8 @@ def delete_pods_continuously(
             )
         except ResourceNotFoundError:
             LOGGER.info(f"No pods found with prefix {pod_prefix} in this iteration")
-
+        # Using stop_event.wait() intentionally to support cooperative thread cancellation via threading.Event.
+        # Because TimeoutSampler doesn't support threading.Event based shutdown.
         stop_event.wait(timeout=interval)
 
 
@@ -514,10 +521,6 @@ def create_pod_deleting_thread(
     max_duration=TIMEOUT_1MIN,
 ):
     """Create a background thread for continuous pod deletion.
-
-    The returned thread is configured but NOT started. Call ``thread.start()``
-    to begin deleting pods. Pod deletion can be stopped by calling
-    ``stop_event.set()``.
 
     Args:
         client: OpenShift/Kubernetes client.
@@ -550,3 +553,133 @@ def create_pod_deleting_thread(
     )
 
     return thread, stop_event
+
+
+def wait_until_vm_running(vm: VirtualMachine, timeout=TIMEOUT_5MIN, sleep=5) -> None:
+    LOGGER.info(f"Waiting for VM {vm.name} to reach Running state")
+
+    def is_running():
+        return vm.printable_status == "Running"
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=sleep,
+            func=is_running,
+        ):
+            if sample:
+                LOGGER.info(f"VM {vm.name} is Running")
+                return
+
+    except TimeoutExpiredError as error:
+        LOGGER.error(f"VM {vm.name} did not reach Running state in {timeout}s")
+        raise TimeoutError(f"VM {vm.name} did not reach Running state in {timeout}s") from error
+
+
+def wait_for_restored_vm(
+    admin_client,
+    namespace,
+    vm_name,
+    timeout=TIMEOUT_5MIN,
+    sleep=5,
+) -> VirtualMachine:
+    """
+    Wait for a restored VirtualMachine to appear and reach Running state.
+    """
+
+    LOGGER.info(f"Waiting for restored VM {vm_name}")
+
+    namespace_name = namespace.name if hasattr(namespace, "name") else namespace
+
+    vm = None
+
+    def try_get_and_wait_running():
+        nonlocal vm
+
+        try:
+            vm_iter = VirtualMachine.get(client=admin_client, namespace=namespace_name, name=vm_name)
+            vm_obj = next(vm_iter, None)
+            if vm_obj:
+                test_vm = VirtualMachineForTests(
+                    client=admin_client,
+                    name=vm_name,
+                    namespace=namespace_name,
+                )
+                test_vm.name = vm_name
+                vm = test_vm
+                return vm
+        except ResourceNotFoundError:
+            return None
+
+    try:
+        for sample in TimeoutSampler(wait_timeout=timeout, sleep=sleep, func=try_get_and_wait_running):
+            if sample:
+                break
+
+    except TimeoutExpiredError as error:
+        LOGGER.error(f"VM {vm_name} was not found in namespace {namespace_name} within {timeout}s")
+        raise TimeoutError(
+            f"VM {vm_name} not found or not running in namespace {namespace} within {timeout}s"
+        ) from error
+
+    if vm is None:
+        raise AssertionError("Unreachable: vm should be set after TimeoutSampler loop")
+
+    LOGGER.info(f"VM {vm.name} found, waiting for Running")
+    wait_until_vm_running(vm=vm, timeout=timeout, sleep=sleep)
+
+    LOGGER.info(f"Restored VM {vm_name} is Running")
+    return vm
+
+
+def wait_for_oadp_phase(resource, terminal_statuses, timeout, sleep=5, expected_phase=None) -> str:
+    """
+    Wait for an OADP resource to reach one of the final phases, and optionally validate the final phase.
+
+    Args:
+        resource: Resource object with `.instance.status.phase` attribute.
+        terminal_statuses (set[str]): Set of final phases.
+        timeout (int): Total timeout in seconds.
+        sleep (int, optional): Poll interval. Default 5s.
+        expected_phase (str, optional): Expected final phase. If provided, the function asserts that
+            the reached phase matches this value.
+
+    Returns:
+        str: Final phase reached.
+
+    Raises:
+        AssertionError: If `expected_phase` is provided and does not match the final phase.
+        TimeoutError: If no final phase is reached within timeout.
+    """
+    final_phase = None
+
+    def get_phase():
+        nonlocal final_phase
+        phase = getattr(resource.instance.status, "phase", None)
+        if phase:
+            LOGGER.info(f"{resource.name} phase: {phase}")
+            final_phase = phase
+
+            if phase in terminal_statuses:
+                return phase
+
+        return None
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=sleep,
+            func=get_phase,
+        ):
+            if sample:
+                LOGGER.info(f"{resource.name} phase: {sample}")
+                if expected_phase:
+                    if sample != expected_phase:
+                        raise AssertionError(f"{resource.name} ended with phase {sample}, expected {expected_phase}")
+                return sample
+
+    except TimeoutExpiredError as error:
+        LOGGER.error(f"{resource.name} did not reach a terminal phase within {timeout}s; last phase={final_phase}")
+        raise TimeoutError(f"{resource.name} did not reach final phase {final_phase} in {timeout}s") from error
+
+    raise AssertionError("Unreachable: TimeoutSampler always raises or returns")

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -1041,6 +1041,14 @@ ADP_NAMESPACE = "openshift-adp"
 FILE_NAME_FOR_BACKUP = "file_before_backup.txt"
 TEXT_TO_TEST = "text"
 BACKUP_STORAGE_LOCATION = "dpa-1"
+OADP_TERMINAL_STATUSES = frozenset({
+    "Completed",
+    "Failed",
+    "PartiallyFailed",
+    "FailedValidation",
+})
+OADP_BACKUP_TERMINAL_STATUSES = OADP_TERMINAL_STATUSES
+OADP_RESTORE_TERMINAL_STATUSES = OADP_TERMINAL_STATUSES
 
 # AAQ
 AAQ_NAMESPACE_LABEL = {"application-aware-quota/enable-gating": ""}


### PR DESCRIPTION
##### Short description:
Polarion cases: CNV-12023, CNV-12025, CNV-12027

Need https://github.com/RedHatQE/openshift-virtualization-tests/pull/3002 as its dependence. 

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a destructive restore test that runs pod‑deletion chaos, asserts restore terminal status, waits for the restored VM, and verifies guest file contents.
  * Expanded fixtures to orchestrate backup → VM/namespace cleanup → restore flows; VM setup/teardown now runs per test for stronger isolation.

* **Chores**
  * Added shared wait helpers and explicit terminal‑status constants for robust polling.
  * Improved logging, tightened exception handling, made pod‑deletion loops cooperative, and added a zero‑ratio no‑op for deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->