### PR TITLE
[t2] [storage] Fix cross-namespace RBAC for DataImportCron and unquarantine TestDataImportCronPvcSource

### DIFF
--- a/tests/storage/data_import_cron/conftest.py
+++ b/tests/storage/data_import_cron/conftest.py
@@ -1,9 +1,12 @@
 import logging
 
 import pytest
+from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.data_source import DataSource
+from ocp_resources.resource import Resource
 
+from tests.storage.utils import create_role_binding
 from utilities.constants import BIND_IMMEDIATE_ANNOTATION, OS_FLAVOR_RHEL, TIMEOUT_10MIN, Images
 from utilities.infra import create_ns
 from utilities.storage import create_dv, data_volume_template_with_source_ref_dict
@@ -59,6 +62,7 @@ def data_import_cron_with_pvc_source(
     dv_source_for_data_import_cron,
     imported_data_source,
     storage_class_name_scope_module,
+    cdi_cloner_rbac,
     unprivileged_client,
 ):
     with DataImportCron(
@@ -93,3 +97,41 @@ def data_import_cron_with_pvc_source(
 @pytest.fixture(scope="class")
 def imported_data_source(data_import_cron_pvc_target_namespace):
     yield DataSource(namespace=data_import_cron_pvc_target_namespace.name, name="target-data-source")
+
+
+@pytest.fixture(scope="class")
+def cdi_cloner_rbac(dv_source_for_data_import_cron, data_import_cron_pvc_target_namespace, admin_client):
+    """
+    Creates a ClusterRole for DataVolume cloning and a RoleBinding in the source
+        namespace to allow the target namespace's ServiceAccount to clone DataVolumes.
+
+    Args:
+        dv_source_for_data_import_cron: DataVolume fixture that provides the source
+            namespace.
+        data_import_cron_pvc_target_namespace: Namespace fixture representing the
+            target namespace.
+        admin_client: Admin client used to create and manage cluster-scoped RBAC
+            resources.
+    """
+
+    with ClusterRole(
+        name="datavolume-cloner",
+        client=admin_client,
+        rules=[
+            {
+                "apiGroups": [Resource.ApiGroup.CDI_KUBEVIRT_IO],
+                "resources": ["datavolumes", "datavolumes/source"],
+                "verbs": ["*"],
+            }
+        ],
+    ) as cluster_role:
+        with create_role_binding(
+            name=f"allow-clone-to-{data_import_cron_pvc_target_namespace.name}",
+            namespace=dv_source_for_data_import_cron.namespace,
+            subjects_kind="ServiceAccount",
+            subjects_name="default",
+            subjects_namespace=data_import_cron_pvc_target_namespace.name,
+            role_ref_kind=cluster_role.kind,
+            role_ref_name=cluster_role.name,
+        ):
+            yield

--- a/tests/storage/data_import_cron/test_data_import_cron_pvc_source.py
+++ b/tests/storage/data_import_cron/test_data_import_cron_pvc_source.py
@@ -2,15 +2,9 @@ import logging
 
 import pytest
 
-from utilities.constants import QUARANTINED
-
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.xfail(
-    reason=(f"{QUARANTINED}: Change in behavior caused setup to fail. tracked in CNV-75576"),
-    run=False,
-)
 class TestDataImportCronPvcSource:
     @pytest.mark.polarion("CNV-11842")
     def test_data_import_cron_with_pvc_source_ready(


### PR DESCRIPTION
##### Short description:
Cross-namespace cloning failure. Recent security hardening (CVE fixes) in the Containerized Data Interface (CDI) prevents DataImportCron from implicitly accessing PVCs in other namespaces. This causes the cron job to fail with a NotAuthorized status, leaving the DataSource empty and breaking downstream VM creation.

##### More details:

Following recent security hardening ([CVE-related updates](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/virtualization/storage#virt-enabling-user-permissions-to-clone-datavolumes)) in OpenShift Virtualization and CDI, the Containerized Data Interface (CDI) controller no longer has implicit permission to clone data volumes across namespaces.


##### What this PR does / why we need it:

The fix implements a mandatory RBAC Handshake between the source and target namespaces.

ClusterRole: Defines a global capability to use a DataVolume as a source (datavolumes/source).

RoleBinding: Must be placed in the Source Namespace to explicitly "allow" the ServiceAccount from the Target Namespace to read the data.



##### Which issue(s) this PR fixes:

This PR fixes a cross-namespace authorization failure in DataImportCron caused by security hardening (CVE fixes) in OpenShift Virtualization's Containerized Data Interface (CDI).

impacted test's:
test_data_import_cron_with_pvc_source_ready
test_data_import_cron_vm_from_import_pvc

##### Special notes for reviewer:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/virtualization/storage#virt-enabling-user-permissions-to-clone-datavolumes

##### jira-ticket:
https://issues.redhat.com/browse/CNV-75576
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added RBAC scaffolding to data-import cloning tests and integrated it into fixtures to better simulate realistic permissions and improve reliability.
  * Removed quarantine/xfail markers from PVC-source data import tests so they run normally and validate end-to-end data import workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->