### PR TITLE
net, flat overlay: Mark tests

### DIFF
--- a/tests/network/flat_overlay/test_flat_overlay.py
+++ b/tests/network/flat_overlay/test_flat_overlay.py
@@ -13,13 +13,13 @@ pytestmark = [
     pytest.mark.usefixtures(
         "enable_multi_network_policy_usage",
     ),
+    pytest.mark.ipv4,
 ]
 
 
 @pytest.mark.s390x
 class TestFlatOverlayConnectivity:
     @pytest.mark.gating
-    @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-10158")
     # Not marked as `conformance`; requires NMState
     @pytest.mark.dependency(name="test_flat_overlay_basic_ping")
@@ -93,6 +93,7 @@ class TestFlatOverlayConnectivity:
         )
 
 
+@pytest.mark.jumbo_frame
 class TestFlatOverlayJumboConnectivity:
     @pytest.mark.polarion("CNV-10162")
     @pytest.mark.s390x

--- a/tests/network/flat_overlay/test_multi_network_policy.py
+++ b/tests/network/flat_overlay/test_multi_network_policy.py
@@ -5,10 +5,13 @@ from tests.network.flat_overlay.utils import get_vm_connection_reply
 from tests.network.utils import assert_no_ping
 from utilities.network import assert_ping_successful
 
-pytestmark = pytest.mark.usefixtures(
-    "enable_multi_network_policy_usage",
-    "flat_l2_port",
-)
+pytestmark = [
+    pytest.mark.usefixtures(
+        "enable_multi_network_policy_usage",
+        "flat_l2_port",
+    ),
+    pytest.mark.ipv4,
+]
 
 
 @pytest.mark.polarion("CNV-10644")


### PR DESCRIPTION
Flat overlay tests are not currently supported on IPv6 single-stack clusters, but they are still collected when running tests on such clusters.
In this PR, these tests are marked for IPv4 and jumbo frame accordingly.
Adjustments for IPv6 single-stack clusters will be provided in a follow-up, with L2 overlay support handled in subsequent changes.

##### jira-ticket: https://issues.redhat.com/browse/CNV-74420
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added module-level IPv4 markers to network overlay test suites to ensure consistent test selection across modules.
  * Added a jumbo-frame marker to jumbo connectivity tests for explicit test grouping.
  * Removed a per-test IPv4 marker in favor of broader module/class-level marking to simplify filtering and reduce redundancy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->