### PR TITLE
Revert changes for kubevirt_ipv6_single_stack_cluster metric test

### DIFF
--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -89,11 +89,10 @@ class TestVmNameInLabel:
 class TestVirtHCOSingleStackIpv6:
     @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11740")
+    @pytest.mark.s390x
     def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus, ipv6_single_stack_cluster):
-        if not ipv6_single_stack_cluster:
-            pytest.fail("The cluster is not ipv6 single stack")
         validate_metrics_value(
             prometheus=prometheus,
             metric_name="kubevirt_hco_single_stack_ipv6",
-            expected_value="1",
+            expected_value="1" if ipv6_single_stack_cluster else "0",
         )


### PR DESCRIPTION
##### Short description:
This metric should report 0 in case it is not ipv6 single stack so I am revering the changes, because it should not fail if the cluster is not single stack it just needs to return 0.
The bug with this metric is for 4.18, for later versions it should work fine.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-75769


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test compatibility for s390x architecture platforms.
  * Enhanced IPv6 single-stack cluster test handling with conditional configuration support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->