### PR TITLE
net, kmp: Update tests setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,6 @@ from ocp_resources.cdi import CDI
 from ocp_resources.cdi_config import CDIConfig
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.cluster_service_version import ClusterServiceVersion
-from ocp_resources.config_map import ConfigMap
 from ocp_resources.daemonset import DaemonSet
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
@@ -94,7 +93,6 @@ from utilities.constants import (
     KMP_VM_ASSIGNMENT_LABEL,
     KUBECONFIG,
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
-    KUBEMACPOOL_MAC_RANGE_CONFIG,
     LINUX_BRIDGE,
     MIGRATION_POLICY_VM_LABEL,
     NODE_ROLE_KUBERNETES_IO,
@@ -159,7 +157,6 @@ from utilities.infra import (
 )
 from utilities.network import (
     EthernetNetworkConfigurationPolicy,
-    MacPool,
     SriovIfaceNotFound,
     cloud_init,
     create_sriov_node_policy,
@@ -1052,15 +1049,6 @@ def sriov_node_policy(
         sriov_nodes_states=sriov_nodes_states,
         sriov_resource_name="sriov_net",
         client=admin_client,
-    )
-
-
-@pytest.fixture(scope="session")
-def mac_pool(admin_client, hco_namespace):
-    return MacPool(
-        kmp_range=ConfigMap(
-            namespace=hco_namespace.name, name=KUBEMACPOOL_MAC_RANGE_CONFIG, client=admin_client
-        ).instance["data"]
     )
 
 


### PR DESCRIPTION
KMP range is now configured in HCO
Update the KMP tests setup accordingly

##### jira-ticket: https://issues.redhat.com/browse/CNV-75794
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized MAC pool configuration for tests by moving setup into the network test area and integrating it with HCO reconciliation, providing a consistent MAC range for test runs.

* **Chores**
  * Removed the legacy top-level MAC pool fixture and reorganized test fixtures to streamline MAC pool management and reconciliation workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->