### PR TITLE
 [GCP] [T2] Xfail online resize tests for GCP storage class with ReadWriteMany (RWX) access mode.

### DIFF
--- a/tests/storage/online_resize/conftest.py
+++ b/tests/storage/online_resize/conftest.py
@@ -14,7 +14,7 @@ from tests.storage.online_resize.utils import (
     expand_pvc,
     wait_for_resize,
 )
-from utilities.constants import OS_FLAVOR_RHEL, Images
+from utilities.constants import OS_FLAVOR_RHEL, Images, StorageClassNames
 from utilities.storage import create_dv, is_snapshot_supported_by_sc
 from utilities.virt import VirtualMachineForTests, running_vm
 
@@ -29,6 +29,13 @@ def xfail_if_storage_for_online_resize_does_not_support_snapshots(
         client=admin_client,
     ):
         pytest.xfail(f"Storage class for online resize '{sc_name}' doesn't support snapshots")
+
+
+@pytest.fixture(scope="module")
+def xfail_if_gcp_storage_class(storage_class_matrix_online_resize_matrix__module__):
+    sc_name = next(iter(storage_class_matrix_online_resize_matrix__module__))
+    if sc_name == StorageClassNames.GCP:
+        pytest.xfail("Online resize is not supported for GCP storage class for RWX Datavolume")
 
 
 @pytest.fixture()

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -24,6 +24,8 @@ from utilities.virt import migrate_vm_and_verify, running_vm
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.usefixtures("xfail_if_gcp_storage_class")
+
 
 @pytest.mark.gating
 @pytest.mark.conformance


### PR DESCRIPTION
##### Short description:
Mark online resize tests as expected to fail (xfail) for GCP storage class.

##### More details:
Online resize (expanding PVCs while VMs are running) is not supported for the GCP storage class sp-balanced-storage when using ReadWriteMany (RWX) access mode. 
is PR adds a fixture xfail_if_gcp_storage_class that marks tests as expected to fail when the storage class is GCP. The fixture is applied to all online resize tests via pytestmark at the module level in test_online_resize.py.




##### What this PR does / why we need it:
Prevents test failures when running online resize tests against GCP storage class with RWX access mode
Correctly reflects that GCP storage class does not support online resize functionality for ReadWriteMany access mode
Uses pytest.xfail() to mark tests as expected to fail, allowing them to run but tracking the known limitation
Uses a fixture-based approach to conditionally mark tests based on storage class

##### Which issue(s) this PR fixes:
Prevents test failures in online resize test suite when executed with GCP storage class using ReadWriteMany (RWX) access mode, where online resize functionality is not supported. Tests will continue to run for GCP with other access modes.

##### Special notes for reviewer:
Prevents test failures in online resize test suite when executed with GCP storage class using ReadWriteMany (RWX) access mode, where online resize functionality is not supported.


##### jira-ticket:
https://issues.redhat.com/browse/CNV-75815
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Online-resize tests now include a module-scoped condition that marks runs against GCP RWX storage as expected-to-fail. This is applied across the online-resize test module via a fixture/marker mechanism and does not change individual test logic or other fixtures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->