### PR TITLE
Remove redundant OVS bridge scenario

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -27,7 +27,6 @@ from utilities.constants import (
     NamespacesNames,
 )
 from utilities.infra import (
-    ExecCommandOnPod,
     get_deployment_by_name,
     get_node_selector_dict,
     wait_for_pods_running,
@@ -67,11 +66,6 @@ def virt_handler_pod(admin_client):
 @pytest.fixture(scope="session")
 def dual_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
     return ipv4_supported_cluster and ipv6_supported_cluster
-
-
-@pytest.fixture()
-def worker_node1_pod_executor(workers_utility_pods, worker_node1):
-    return ExecCommandOnPod(utility_pods=workers_utility_pods, node=worker_node1)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### Short description:
_test_ovs_bridge_sanity_ coverage is already covered in _test_ipv4_ovs_bridge["L2_bridge_network"]_ (CNV-11126). Since _test_ipv4_ovs_bridge["L2_bridge_network"]_ covers the same OVS bridge connectivity scenario using NNCP-created bridges, _test_ovs_bridge_sanity_ should be removed.

##### What this PR does / why we need it:
- Removes inappropriate manual bridge creation testing (via `ovs-vsctl` commands).
- Eliminates redundant test coverage for OVS bridge connectivit.
- The same scenario is already covered by `test_ipv4_ovs_bridge["L2_bridge_network"]` (CNV-11126), which uses NNCP-created bridges (the appropriate method for OpenShift Virtualization).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified L2 bridge test setup, reoriented to VLAN-focused connectivity checks while preserving same-node, different-node, and negative VLAN scenarios.
  * Reduced per-VM scaffolding in favor of compact, reusable VLAN-enabled fixtures to improve readability and maintenance.

* **Chores**
  * Removed an obsolete per-node pod executor fixture and unused import to streamline test utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->