### PR TITLE
CherryPicked: [cnv-4.18] Remove Artifactory dependency from CPU affinity

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -396,3 +396,16 @@ def pvc_size_bytes(vm_for_vm_disk_allocation_size_test):
         name=vm_for_vm_disk_allocation_size_test.instance.spec.dataVolumeTemplates[0].metadata.name,
         namespace=vm_for_vm_disk_allocation_size_test.namespace,
     ).instance.spec.resources.requests.storage
+
+
+@pytest.fixture(scope="class")
+def expected_cpu_affinity_metric_value(vm_with_cpu_spec):
+    """Calculate expected kubevirt_vmi_node_cpu_affinity metric value."""
+    # Calculate VM CPU count
+    vm_cpu = vm_with_cpu_spec.vmi.instance.spec.domain.cpu
+    cpu_count_from_vm = (vm_cpu.threads or 1) * (vm_cpu.cores or 1) * (vm_cpu.sockets or 1)
+    # Get node CPU capacity
+    cpu_count_from_vm_node = int(vm_with_cpu_spec.privileged_vmi.node.instance.status.capacity.cpu)
+
+    # return multiplication for multi-CPU VMs
+    return str(cpu_count_from_vm_node * cpu_count_from_vm)

--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -48,3 +48,5 @@ KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES = "kubevirt_vmi_migration_dirty_m
 KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES = "kubevirt_vmi_migration_data_total_bytes{{name='{vm_name}'}}"
 BINDING_NAME = "binding_name"
 BINDING_TYPE = "binding_type"
+
+KUBEVIRT_VMI_NODE_CPU_AFFINITY = "kubevirt_vmi_node_cpu_affinity{{kubernetes_vmi_label_kubevirt_io_domain='{vm_name}'}}"

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -3,13 +3,9 @@ import logging
 import pytest
 from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine import VirtualMachine
-from pytest_testconfig import config as py_config
 
-from tests.observability.metrics.utils import (
-    validate_vmi_node_cpu_affinity_with_prometheus,
-)
+from tests.observability.metrics.constants import KUBEVIRT_VMI_NODE_CPU_AFFINITY
 from tests.observability.utils import validate_metrics_value
-from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 KUBEVIRT_VM_TAG = f"{Resource.ApiGroup.KUBEVIRT_IO}/vm"
@@ -41,36 +37,17 @@ def fedora_vm_without_name_in_label(
         client=unprivileged_client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:
-        running_vm(vm=vm, check_ssh_connectivity=False)
+        running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
         yield vm
 
 
-@pytest.mark.parametrize(
-    "golden_image_data_volume_scope_class, vm_from_template_scope_class",
-    [
-        pytest.param(
-            {
-                "dv_name": RHEL_LATEST_OS,
-                "image": RHEL_LATEST["image_path"],
-                "storage_class": py_config["default_storage_class"],
-                "dv_size": RHEL_LATEST["dv_size"],
-            },
-            {
-                "vm_name": "rhel-latest",
-                "template_labels": RHEL_LATEST_LABELS,
-                "guest_agent": False,
-                "ssh": False,
-            },
-        ),
-    ],
-    indirect=True,
-)
 class TestVmiNodeCpuAffinity:
     @pytest.mark.polarion("CNV-7295")
-    def test_kubevirt_vmi_node_cpu_affinity(self, prometheus, vm_from_template_scope_class):
-        validate_vmi_node_cpu_affinity_with_prometheus(
-            vm=vm_from_template_scope_class,
+    def test_kubevirt_vmi_node_cpu_affinity(self, prometheus, vm_with_cpu_spec, expected_cpu_affinity_metric_value):
+        validate_metrics_value(
             prometheus=prometheus,
+            metric_name=KUBEVIRT_VMI_NODE_CPU_AFFINITY.format(vm_name=vm_with_cpu_spec.name),
+            expected_value=expected_cpu_affinity_metric_value,
         )
 
 


### PR DESCRIPTION
The test for kubevirt_vmi_node_cpu_affinity is flaky duo to connectivity issues with the artifactory, in this PR I modified the test to not rely on the artifactory to avoid this kind of failures to stabilize the observability lanes.

https://issues.redhat.com/browse/CNV-75209
original PR:https://github.com/RedHatQE/openshift-virtualization-tests/pull/3134
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-75854
