### PR TITLE
change client for custom_pipeline_namespace

### DIFF
--- a/tests/infrastructure/tekton/conftest.py
+++ b/tests/infrastructure/tekton/conftest.py
@@ -234,8 +234,10 @@ def resource_editor_efi_pipelines(
 
 
 @pytest.fixture(scope="module")
-def custom_pipeline_namespace(admin_client):
-    yield from create_ns(name="test-custom-pipeline-ns", admin_client=admin_client)
+def custom_pipeline_namespace(unprivileged_client, admin_client):
+    yield from create_ns(
+        name="test-custom-pipeline-ns", admin_client=admin_client, unprivileged_client=unprivileged_client
+    )
 
 
 @pytest.fixture(scope="module")
@@ -327,15 +329,13 @@ def quay_disk_uploader_secret(admin_client, custom_pipeline_namespace):
 
 
 @pytest.fixture(scope="module")
-def vm_for_disk_uploader(unprivileged_client, custom_pipeline_namespace, golden_images_namespace):
+def vm_for_disk_uploader(admin_client, custom_pipeline_namespace, golden_images_namespace):
     with VirtualMachineForTests(
         name="fedora-vm-diskuploader",
         namespace=custom_pipeline_namespace.name,
-        client=unprivileged_client,
+        client=admin_client,
         data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=DataSource(
-                name=OS_FLAVOR_FEDORA, namespace=golden_images_namespace.name, client=unprivileged_client
-            ),
+            data_source=DataSource(name=OS_FLAVOR_FEDORA, namespace=golden_images_namespace.name, client=admin_client),
             storage_class=py_config["default_storage_class"],
         ),
         vm_instance_type_infer=True,


### PR DESCRIPTION
##### Short description:
change client for custom_pipeline_namespace

##### More details:
The Tekton resource requires admin privileges to run GET, which prevents the wait-validation function from executing, this is because an admin client creates the namespace instead of unprivileged client.
Changing the namespace to a Project which is created by an unprivileged client fixes the issue.

##### What this PR does / why we need it:
Fix failing tests due to privileges issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test fixture configuration to improve access control testing in the infrastructure test suite. Modified namespace and virtual machine creation fixtures to use appropriate privilege levels during testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->