### PR TITLE
Virt: replace get_client() usage in utilities/virt.py (part 1)

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1096,7 +1096,7 @@ class VirtualMachineForTests(VirtualMachine):
 
     @property
     def privileged_vmi(self):
-        return VirtualMachineInstance(client=get_client(), name=self.name, namespace=self.namespace)
+        return VirtualMachineInstance(client=self.client, name=self.name, namespace=self.namespace)
 
     def wait_for_agent_connected(self, timeout: int = TIMEOUT_5MIN):
         self.vmi.wait_for_condition(
@@ -1370,7 +1370,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         if self.template_params:
             template_kwargs.update(self.template_params)
 
-        resources_list = template_object.process(client=get_client(), **template_kwargs)
+        resources_list = template_object.process(client=self.client, **template_kwargs)
         for resource in resources_list:
             if resource["kind"] == VirtualMachine.kind and resource["metadata"]["name"] == self.name:
                 return resource
@@ -1508,7 +1508,7 @@ class ServiceForVirtualMachineForTests(Service):
             return self.instance.spec.clusterIP
 
         vm_node = Node(
-            client=get_client(),
+            client=self.client,
             name=self.vmi.instance.status.nodeName,
         )
         if self.service_type == Service.Type.NODE_PORT:


### PR DESCRIPTION
##### Short description:
Replace the get_client() used in VirtualMachineForTestsFromTemplate object and ServiceForVirtualMachineForTests object with self.client

##### More details:
As drop get_client() in utilities/virt.py will lead to many relevant places change, this PR only updates the objects where get_client() can be directly replaced with self.client 
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-73714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched VM-related operations to use instance-specific API clients rather than a global client, streamlining client context for virtual machine creation, template processing, and node/pod lookups. This reduces ambiguity in client usage and improves reliability of VM workflows across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->