### PR TITLE
Quarantine SR-IOV+VLAN tests

### DIFF
--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -8,7 +8,7 @@ import pytest
 
 from libs.net.vmspec import lookup_iface_status_ip
 from tests.network.utils import assert_no_ping
-from utilities.constants import MTU_9000
+from utilities.constants import MTU_9000, QUARANTINED
 from utilities.network import assert_ping_successful
 from utilities.virt import migrate_vm_and_verify
 
@@ -49,6 +49,10 @@ class TestPingConnectivity:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-3958")
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: fails in CI due to issue in specific cluster; tracked in CNV-75730",
+        run=False,
+    )
     def test_sriov_basic_connectivity_vlan(
         self,
         sriov_network_vlan,
@@ -62,6 +66,10 @@ class TestPingConnectivity:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-4713")
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: fails in CI due to issue in specific cluster; tracked in CNV-75730",
+        run=False,
+    )
     def test_sriov_no_connectivity_no_vlan_to_vlan(
         self,
         sriov_network_vlan,


### PR DESCRIPTION
These tests constantly fail on a specific cluster, which is used for all SR-IOV tests (in all branches).
Once CNV-75730 is resolved, either by replacing the cluster or fixing it in that cluster, these tests will be enabled.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-31351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Two SR‑IOV connectivity tests have been marked as expected failures and disabled to improve CI reporting accuracy and reduce noise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->