### PR TITLE
net, flat_overlay: Refactor to use ip_address fixture

### DIFF
--- a/tests/network/flat_overlay/test_flat_overlay.py
+++ b/tests/network/flat_overlay/test_flat_overlay.py
@@ -23,10 +23,10 @@ class TestFlatOverlayConnectivity:
     @pytest.mark.polarion("CNV-10158")
     # Not marked as `conformance`; requires NMState
     @pytest.mark.dependency(name="test_flat_overlay_basic_ping")
-    def test_flat_overlay_basic_ping(self, flat_overlay_vma_vmb_nad, vma_flat_overlay, vmb_flat_overlay):
+    def test_flat_overlay_basic_ping(self, vma_flat_overlay, vmb_flat_overlay_ip_address):
         assert_ping_successful(
             src_vm=vma_flat_overlay,
-            dst_ip=lookup_iface_status_ip(vm=vmb_flat_overlay, iface_name=flat_overlay_vma_vmb_nad.name, ip_family=4),
+            dst_ip=vmb_flat_overlay_ip_address,
         )
 
     @pytest.mark.polarion("CNV-10159")
@@ -70,9 +70,8 @@ class TestFlatOverlayConnectivity:
         vme_flat_overlay,
     ):
         assert flat_overlay_vma_vmb_nad.name == flat_overlay_vme_nad.name, (
-            f"NAD names are not identical:\n first NAD's "
-            f"name: {flat_overlay_vma_vmb_nad.name}, second NAD's name: "
-            f"{flat_overlay_vme_nad.name}"
+            f"NAD names are not identical:\n first NAD's name: {flat_overlay_vma_vmb_nad.name}, "
+            f"second NAD's name: {flat_overlay_vme_nad.name}"
         )
         assert_ping_successful(
             src_vm=vma_flat_overlay,


### PR DESCRIPTION
##### Short description:
Refactor the test to use the existing vmb_flat_overlay_ip_address fixture to prevent code duplication.
Fix redundant f-string by rearranging the assertion message.

##### Which issue(s) this PR fixes:
Code duplication and redundant f-string usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reduced test fixture dependencies and streamlined parameter passing to speed up execution and simplify test setup
  * Replaced manual destination/address lookup with a direct test-provided address to improve reliability
  * Simplified assertion messaging for clearer, single-line failure output and easier debugging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->