### PR TITLE
AWS and ARM64 global config - make IO2 storage default

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -33,7 +33,6 @@ storage_class_matrix = [
             "snapshot": True,
             "online_resize": True,
             "wffc": False,
-            "default": True,
         }
     },
     {
@@ -43,6 +42,7 @@ storage_class_matrix = [
             "snapshot": True,
             "online_resize": True,
             "wffc": True,
+            "default": True,
         }
     },
     {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES},

--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -18,7 +18,6 @@ storage_class_matrix = [
             "snapshot": True,
             "online_resize": True,
             "wffc": False,
-            "default": True,
         }
     },
     {
@@ -46,12 +45,13 @@ storage_class_matrix = [
             "snapshot": True,
             "online_resize": True,
             "wffc": True,
+            "default": True,
         }
     },
 ]
 
-storage_class_a = StorageClassNames.CEPH_RBD_VIRTUALIZATION
-storage_class_b = StorageClassNames.CEPH_RBD_VIRTUALIZATION
+storage_class_a = StorageClassNames.IO2_CSI
+storage_class_b = StorageClassNames.IO2_CSI
 
 for _dir in dir():
     if not config:  # noqa: F821


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated default storage class configuration to use IO2_CSI as the default storage class in test environments across multiple platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->