### PR TITLE
Revert " net, sriov: Use existing sriov policy"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,11 @@ from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.oauth import OAuth
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
-from ocp_resources.resource import ResourceEditor, get_client
+from ocp_resources.resource import Resource, ResourceEditor, get_client
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
-from ocp_resources.sriov_network_node_policy import SriovNetworkNodePolicy
+from ocp_resources.sriov_network_node_state import SriovNetworkNodeState
 from ocp_resources.storage_class import StorageClass
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_cluster_instancetype import (
@@ -160,7 +160,9 @@ from utilities.infra import (
 from utilities.network import (
     EthernetNetworkConfigurationPolicy,
     MacPool,
+    SriovIfaceNotFound,
     cloud_init,
+    create_sriov_node_policy,
     enable_hyperconverged_ovs_annotations,
     get_cluster_cni_type,
     network_device,
@@ -996,7 +998,16 @@ def worker_node3(schedulable_nodes):
 
 @pytest.fixture(scope="session")
 def sriov_namespace(admin_client):
-    return Namespace(name="openshift-sriov-network-operator", client=admin_client)
+    return Namespace(name=py_config["sriov_namespace"], client=admin_client)
+
+
+@pytest.fixture(scope="session")
+def sriov_nodes_states(admin_client, sriov_namespace, sriov_workers):
+    sriov_nns_list = [
+        SriovNetworkNodeState(client=admin_client, namespace=sriov_namespace.name, name=worker.name)
+        for worker in sriov_workers
+    ]
+    return sriov_nns_list
 
 
 @pytest.fixture(scope="session")
@@ -1006,16 +1017,43 @@ def sriov_workers(schedulable_nodes):
 
 
 @pytest.fixture(scope="session")
+def sriov_ifaces(sriov_nodes_states, workers_utility_pods):
+    node = sriov_nodes_states[0]
+    state_up = Resource.Interface.State.UP
+    ifaces_list = [
+        iface
+        for iface in node.instance.status.interfaces
+        if (
+            iface.totalvfs
+            and ExecCommandOnPod(utility_pods=workers_utility_pods, node=node).interface_status(interface=iface.name)
+            == state_up
+        )
+    ]
+
+    if not ifaces_list:
+        raise SriovIfaceNotFound(
+            f"no sriov interface with '{state_up}' status was found, "
+            f"please make sure at least one sriov interface is {state_up}"
+        )
+
+    return ifaces_list
+
+
+@pytest.fixture(scope="session")
 def sriov_node_policy(
     admin_client,
+    sriov_unused_ifaces,
+    sriov_nodes_states,
+    workers_utility_pods,
     sriov_namespace,
 ):
-    return next(
-        SriovNetworkNodePolicy.get(
-            client=admin_client,
-            namespace=sriov_namespace.name,
-        ),
-        None,
+    yield from create_sriov_node_policy(
+        nncp_name="test-sriov-policy",
+        namespace=sriov_namespace.name,
+        sriov_iface=sriov_unused_ifaces[0],
+        sriov_nodes_states=sriov_nodes_states,
+        sriov_resource_name="sriov_net",
+        client=admin_client,
     )
 
 
@@ -2516,6 +2554,17 @@ def vm_for_migration_test(request, namespace, unprivileged_client, cpu_for_migra
 @pytest.fixture(scope="class")
 def ssp_resource_scope_class(admin_client, hco_namespace):
     return get_ssp_resource(admin_client=admin_client, namespace=hco_namespace)
+
+
+@pytest.fixture(scope="session")
+def sriov_unused_ifaces(sriov_ifaces):
+    """
+    This fixture returns SRIOV interfaces which are not used. If an interface has
+    some VFs in use but still have available VFs, it will be seen as used and will
+    not be included in the returned list.
+    """
+    available_ifaces_list = [interface for interface in sriov_ifaces if not interface.numVfs]
+    return available_ifaces_list
 
 
 @pytest.fixture(scope="session")

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -219,8 +219,6 @@ def network_sanity(
     conformance_tests,
     nmstate_namespace,
     mtv_namespace_scope_session,
-    sriov_namespace,
-    sriov_node_policy,
 ):
     """
     Ensures the test cluster meets network requirements before executing tests.
@@ -292,25 +290,20 @@ def network_sanity(
     def _verify_sriov():
         if any(test.get_closest_marker("sriov") for test in collected_tests):
             LOGGER.info("Verifying if the cluster supports running SRIOV tests...")
-            if not sriov_namespace.exists:
+            if not Namespace(name=py_config["sriov_namespace"], client=admin_client).exists:
                 failure_msgs.append(
-                    f"SRIOV operator is not installed, the '{sriov_namespace.name}' namespace does not exist"
+                    f"SRIOV operator is not installed, the '{py_config['sriov_namespace']}' namespace does not exist"
                 )
-                return
             if len(sriov_workers) < 2:
                 failure_msgs.append(
                     "SRIOV tests require at least 2 SRIOV-capable worker nodes, but fewer were detected"
                 )
-                return
-            if not sriov_node_policy:
-                failure_msgs.append(f"No SR-IOV network node policy found in namespace {sriov_namespace.name}")
-                return
-            LOGGER.info(
-                "Validated SRIOV operator is running against a valid cluster with "
-                f"'{sriov_namespace.name}' namespace, "
-                f"has {len(sriov_workers)} SRIOV-capable worker nodes "
-                f"and '{sriov_node_policy.name}' {sriov_node_policy.kind}"
-            )
+            else:
+                LOGGER.info(
+                    "Validated SRIOV operator is running against a valid cluster with "
+                    f"'{py_config['sriov_namespace']}' namespace and "
+                    f"has {len(sriov_workers)} SRIOV-capable worker nodes"
+                )
 
     def _verify_ip_family(family, is_supported_in_cluster):
         if any(test.get_closest_marker(family) for test in collected_tests):

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -431,7 +431,7 @@ def sriov_network_for_hot_plug(admin_client, sriov_node_policy, namespace, sriov
     with network_nad(
         nad_type=SRIOV,
         nad_name="sriov-hot-plug-test-network",
-        sriov_resource_name=sriov_node_policy.instance.spec.resourceName,
+        sriov_resource_name=sriov_node_policy.resource_name,
         namespace=sriov_namespace,
         sriov_network_namespace=namespace.name,
         client=admin_client,

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -95,7 +95,7 @@ def sriov_network(admin_client, sriov_node_policy, namespace, sriov_namespace):
         client=admin_client,
         nad_type=SRIOV,
         nad_name="sriov-test-network",
-        sriov_resource_name=sriov_node_policy.instance.spec.resourceName,
+        sriov_resource_name=sriov_node_policy.resource_name,
         namespace=sriov_namespace,
         sriov_network_namespace=namespace.name,
     ) as sriov_network:
@@ -110,7 +110,7 @@ def sriov_network_vlan(admin_client, sriov_node_policy, namespace, sriov_namespa
     with network_nad(
         nad_type=SRIOV,
         nad_name="sriov-test-network-vlan",
-        sriov_resource_name=sriov_node_policy.instance.spec.resourceName,
+        sriov_resource_name=sriov_node_policy.resource_name,
         namespace=sriov_namespace,
         sriov_network_namespace=namespace.name,
         vlan=next(vlan_index_number),

--- a/tests/virt/node/high_performance_vm/test_numa.py
+++ b/tests/virt/node/high_performance_vm/test_numa.py
@@ -39,7 +39,7 @@ def sriov_net(admin_client, sriov_node_policy, namespace):
     with SriovNetwork(
         name="numa-sriov-test-net",
         namespace=sriov_node_policy.namespace,
-        resource_name=sriov_node_policy.instance.spec.resourceName,
+        resource_name=sriov_node_policy.resource_name,
         network_namespace=namespace.name,
         client=admin_client,
     ) as net:

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -33,6 +33,7 @@ from utilities.constants import (
     IPV4_STR,
     IPV6_STR,
     LINUX_BRIDGE,
+    MTU_9000,
     OVS_BRIDGE,
     SRIOV,
     TIMEOUT_3MIN,
@@ -992,6 +993,50 @@ def is_destination_pingable_from_vm(
 
 def get_cluster_cni_type(admin_client):
     return Network(client=admin_client, name="cluster").instance.status.networkType
+
+
+def wait_for_ready_sriov_nodes(snns):
+    for status in (INPROGRESS, SriovNetworkNodePolicy.Status.SUCCEEDED):
+        for sriov_node_network_state in snns:
+            LOGGER.info(f"Checking state: {sriov_node_network_state.name}")
+            try:
+                sriov_node_network_state.wait_for_status_sync(wanted_status=status)
+            except TimeoutExpiredError:
+                if (
+                    status == INPROGRESS
+                    and sriov_node_network_state.instance.status.syncStatus == SriovNetworkNodePolicy.Status.SUCCEEDED
+                ):
+                    continue
+                else:
+                    LOGGER.error(
+                        f"Current status: {sriov_node_network_state.instance.status.syncStatus} expected: {status}"
+                    )
+                    raise
+
+
+def create_sriov_node_policy(
+    nncp_name,
+    namespace,
+    sriov_iface,
+    sriov_nodes_states,
+    sriov_resource_name,
+    client,
+    mtu=MTU_9000,
+):
+    with network_device(
+        interface_type=SRIOV,
+        nncp_name=nncp_name,
+        namespace=namespace,
+        sriov_iface=sriov_iface,
+        sriov_resource_name=sriov_resource_name,
+        # sriov operator doesnt pass the mtu to the VFs when using vfio-pci device driver (the one we are using)
+        # so the mtu parameter only affects the PF. we need to change the mtu manually on the VM.
+        mtu=mtu,
+        client=client,
+    ) as policy:
+        wait_for_ready_sriov_nodes(snns=sriov_nodes_states)
+        yield policy
+    wait_for_ready_sriov_nodes(snns=sriov_nodes_states)
 
 
 def wait_for_node_marked_by_bridge(bridge_nad: LinuxBridgeNetworkAttachmentDefinition, node: Node) -> None:


### PR DESCRIPTION
Reverts RedHatQE/openshift-virtualization-tests#3072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored SR-IOV test fixtures to dynamically compute node states and interfaces instead of static retrieval.
  * Made SR-IOV namespace configuration flexible, now derived from test configuration.
  * Simplified SR-IOV resource name attribute access across multiple test suites.

* **New Features**
  * Added utility functions for SR-IOV node policy creation and status validation in test infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->