### PR TITLE
net, sriov: Refactor sriov_node_policy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1010,13 +1010,15 @@ def sriov_node_policy(
     admin_client,
     sriov_namespace,
 ):
-    return next(
-        SriovNetworkNodePolicy.get(
-            client=admin_client,
-            namespace=sriov_namespace.name,
-        ),
-        None,
-    )
+    if sriov_namespace.exists:
+        return next(
+            SriovNetworkNodePolicy.get(
+                client=admin_client,
+                namespace=sriov_namespace.name,
+            ),
+            None,
+        )
+    return None
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Network sanity is incorrectly failing when running non-SR-IOV tests because
the sriov_node_policy fixture is invoked in the sanity signature.
This PR adds a check in sriov_node_policy to retrieve the SR-IOV policy only if the
SR-IOV namespace exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture robustness by adding namespace existence checks before policy retrieval, preventing failures when namespace is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->