### PR TITLE
[gating] [T2] quarantine: test_regular_user_can_create_vm_from_cloned_dv

### DIFF
--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -8,7 +8,7 @@ from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS
 from utilities.artifactory import get_test_artifact_server_url
-from utilities.constants import PVC, TIMEOUT_20MIN
+from utilities.constants import PVC, QUARANTINED, TIMEOUT_20MIN
 from utilities.storage import ErrorMsg, create_dv
 from utilities.virt import wait_for_ssh_connectivity
 
@@ -116,6 +116,13 @@ def test_regular_user_cant_delete_dv_from_cloned_dv(
         ),
     ],
     indirect=True,
+)
+@pytest.mark.xfail(
+    reason=(
+        f"{QUARANTINED}: Template label selector fails with BadRequestError "
+        "during VM creation from template. Tracked in CNV-75736"
+    ),
+    run=False,
 )
 @pytest.mark.s390x
 def test_regular_user_can_create_vm_from_cloned_dv(


### PR DESCRIPTION
##### Short description:
quarantine test_regular_user_can_create_vm_from_cloned_dv


##### More details:

failed on setup with "kubernetes.dynamic.exceptions.BadRequestError: 400
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Audit-Id': '5decd9af-ebd6-4742-bb49-51295a0fb218, 5decd9af-ebd6-4742-bb49-51295a0fb218', 'Cache-Control': 'no-cache, private, no-store', 'Content-Length': '158', 'Content-Type': 'application/json', 'Date': 'Fri, 26 Dec 2025 10:37:47 GMT', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': 'a1fd0498-be36-4d99-832f-224a4667f1c3', 'X-Kubernetes-Pf-Prioritylevel-Uid': '33bf3a40-1ad7-468b-92db-c2d3f42a891d'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"found \'=\', expected: \',\' or \'end of string\'","reason":"BadRequest","code":400}\

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked specific test cases as expected failures related to VM creation from templates due to a known issue with template label selector.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->