### PR TITLE
WIP: [gating][t2] quarantine: test_dv_template_has_the_different_priority_as_vm_when_specify

### DIFF
--- a/tests/storage/test_priority_class.py
+++ b/tests/storage/test_priority_class.py
@@ -7,7 +7,7 @@ from pytest_testconfig import config as py_config
 from tests.os_params import RHEL_LATEST
 from tests.storage.utils import get_importer_pod
 from utilities.artifactory import get_test_artifact_server_url
-from utilities.constants import Images
+from utilities.constants import QUARANTINED, Images
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 
@@ -116,6 +116,13 @@ def test_dv_template_has_the_same_priority_as_vm_when_not_specified(
         ),
     ],
     indirect=True,
+)
+@pytest.mark.xfail(
+    reason=(
+        f"{QUARANTINED}: Test fails during setup with network timeout "
+        "when fetching image info from registry. Tracked in CNV-75757"
+    ),
+    run=False,
 )
 @pytest.mark.s390x
 def test_dv_template_has_the_different_priority_as_vm_when_specify(


### PR DESCRIPTION
##### Short description:

quarantine test_dv_template_has_the_different_priority_as_vm_when_specify

##### More details:

Test fails during setup with network timeout when fetching image info
from registry. The get_oc_image_info function times out after 10 seconds
when trying to retrieve image configuration from quay.io registry.



##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
please cherry-pick to 4.20 when its merged

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test imports to support additional test scenarios.

---

**Note:** This release contains internal test infrastructure updates with no end-user facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->