### PR TITLE
Add admin_client to download_file_from_cluster

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1931,23 +1931,27 @@ def os_path_environment():
 
 
 @pytest.fixture(scope="session")
-def virtctl_binary(installing_cnv, os_path_environment, bin_directory):
+def virtctl_binary(installing_cnv, bin_directory, admin_client):
     if installing_cnv:
         return
     installed_virtctl = os.environ.get("CNV_TESTS_VIRTCTL_BIN")
     if installed_virtctl:
         LOGGER.warning(f"Using previously installed: {installed_virtctl}")
         return
-    return download_file_from_cluster(get_console_spec_links_name=VIRTCTL_CLI_DOWNLOADS, dest_dir=bin_directory)
+    return download_file_from_cluster(
+        get_console_spec_links_name=VIRTCTL_CLI_DOWNLOADS, dest_dir=bin_directory, admin_client=admin_client
+    )
 
 
 @pytest.fixture(scope="session")
-def oc_binary(os_path_environment, bin_directory):
+def oc_binary(bin_directory, admin_client):
     installed_oc = os.environ.get("CNV_TESTS_OC_BIN")
     if installed_oc:
         LOGGER.warning(f"Using previously installed: {installed_oc}")
         return
-    return download_file_from_cluster(get_console_spec_links_name="oc-cli-downloads", dest_dir=bin_directory)
+    return download_file_from_cluster(
+        get_console_spec_links_name="oc-cli-downloads", dest_dir=bin_directory, admin_client=admin_client
+    )
 
 
 @pytest.fixture(scope="session")

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -761,9 +761,11 @@ def get_and_extract_file_from_cluster(urls, system_os, dest_dir, machine_type=No
     raise UrlNotFoundError(f"Url not found for system_os={system_os}")
 
 
-def download_file_from_cluster(get_console_spec_links_name, dest_dir):
+def download_file_from_cluster(
+    get_console_spec_links_name: str, dest_dir: os.PathLike[str], admin_client: DynamicClient
+) -> str:
     console_cli_links = get_console_spec_links(
-        admin_client=get_client(),
+        admin_client=admin_client,
         name=get_console_spec_links_name,
     )
     download_urls = get_all_console_links(console_cli_downloads_spec_links=console_cli_links)


### PR DESCRIPTION
##### Short description:
Add admin_client to download_file_from_cluster

##### More details:
Add specific admin client instead of calling get_client()

##### What this PR does / why we need it:
Remove uses of get_client()

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-73718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Test fixtures updated to accept and forward an administrative client; added a fixture that ensures test binaries are prepended to PATH.
  * Internal utility updated to take an administrative client explicitly and made return typing clearer, improving dependency injection.

* **Impact**
  * No user-facing changes; improvements affect tests and internal tooling only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->