### PR TITLE
Remove SR-IOV tests from post-upgrade lanes

### DIFF
--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -18,7 +18,6 @@ pytestmark = [pytest.mark.special_infra, pytest.mark.sriov]
 
 
 class TestPingConnectivity:
-    @pytest.mark.post_upgrade
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-3963")
     def test_sriov_basic_connectivity(
@@ -73,7 +72,6 @@ class TestPingConnectivity:
             dst_ip=lookup_iface_status_ip(vm=sriov_vm4, iface_name=sriov_network_vlan.name, ip_family=4),
         )
 
-    @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-4768")
     def test_sriov_interfaces_post_reboot(
         self,


### PR DESCRIPTION
All network post-upgrade lanes fail on sanity. The reason is that they are executed on a cluster that doesn't support SR-IOV, but without the 'not sriov' marker filter. We submitted CNV-70036 for DevOps to either add this filter or run on an SR-IOV-supporting cluster, but until it is done, we want the other post-upgrade network tests to run.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-70036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed pytest post-upgrade markers from two SR-IOV connectivity test methods, affecting test execution categorization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->