### PR TITLE
Virt: replace get_client() usage in utilities/virt.py (part 2)

### DIFF
--- a/tests/scale/test_scale_benchmark.py
+++ b/tests/scale/test_scale_benchmark.py
@@ -448,6 +448,7 @@ class TestScale:
     @pytest.mark.polarion("CNV-8993")
     def test_mass_vm_live_migration(
         self,
+        admin_client,
         skip_if_not_run_live_migration,
         scale_vms,
         vm_migration_info,
@@ -455,6 +456,7 @@ class TestScale:
         for batch in scale_vms:
             for vm in batch:
                 wait_for_migration_finished(
+                    client=admin_client,
                     namespace=vm.namespace,
                     migration=vm_migration_info[vm.name][MIGRATION_INSTANCE_STR],
                 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -160,7 +160,10 @@ def hotplug_instance_type_vm_and_verify(vm, client, instance_type):
 def verify_hotplug(vm, client, sockets=None, memory_guest=None):
     vmim = get_created_migration_job(vm=vm, client=client)
     wait_for_migration_finished(
-        namespace=vm.namespace, migration=vmim, timeout=TIMEOUT_30MIN if "windows" in vm.name else TIMEOUT_10MIN
+        client=client,
+        namespace=vm.namespace,
+        migration=vmim,
+        timeout=TIMEOUT_30MIN if "windows" in vm.name else TIMEOUT_10MIN,
     )
     wait_for_ssh_connectivity(vm=vm)
     vmi_spec_domain = vm.vmi.instance.spec.domain

--- a/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
+++ b/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
@@ -27,8 +27,9 @@ pytestmark = [pytest.mark.longevity, pytest.mark.special_infra]
     ],
     indirect=True,
 )
-def test_migration_storm_linux_vms(linux_vms_with_pids):
+def test_migration_storm_linux_vms(admin_client, linux_vms_with_pids):
     run_migration_loop(
+        client=admin_client,
         iterations=int(py_config["linux_iterations"]),
         vms_with_pids=linux_vms_with_pids,
         os_type=LINUX_OS_PREFIX,
@@ -46,8 +47,9 @@ def test_migration_storm_linux_vms(linux_vms_with_pids):
     ],
     indirect=True,
 )
-def test_migration_storm_windows_vms(windows_vms_with_pids):
+def test_migration_storm_windows_vms(admin_client, windows_vms_with_pids):
     run_migration_loop(
+        client=admin_client,
         iterations=int(py_config["windows_iterations"]),
         vms_with_pids=windows_vms_with_pids,
         os_type=WINDOWS_OS_PREFIX,
@@ -65,8 +67,9 @@ def test_migration_storm_windows_vms(windows_vms_with_pids):
     ],
     indirect=True,
 )
-def test_migration_storm_wsl2_vms(wsl2_vms_with_pids):
+def test_migration_storm_wsl2_vms(admin_client, wsl2_vms_with_pids):
     run_migration_loop(
+        client=admin_client,
         iterations=int(py_config["windows_iterations"]),
         vms_with_pids=wsl2_vms_with_pids,
         os_type=WINDOWS_OS_PREFIX,

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -42,13 +42,13 @@ def decorate_log(msg):
     return f"{msg_decor}{msg}{msg_decor}"
 
 
-def run_migration_loop(iterations, vms_with_pids, os_type, wsl2_guest=False):
+def run_migration_loop(client, iterations, vms_with_pids, os_type, wsl2_guest=False):
     for iteration in range(iterations):
         LOGGER.info(decorate_log(f"Iteration {iteration + 1}"))
 
         LOGGER.info(decorate_log("VM Migration"))
         vm_list = [vms_with_pids[vm_name]["vm"] for vm_name in vms_with_pids]
-        migrate_and_verify_multi_vms(vm_list=vm_list)
+        migrate_and_verify_multi_vms(client, vm_list=vm_list)
 
         LOGGER.info(decorate_log("PID check"))
         verify_pid_after_migrate_multi_vms(vms_with_pids=vms_with_pids, os_type=os_type)

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -166,7 +166,9 @@ def drain_uncordon_node(
 def all_existing_migrations_completed(admin_client, namespace):
     # Descheduler may trigger multiple migrations, need to wait when all succeeded
     for migration in VirtualMachineInstanceMigration.get(client=admin_client, namespace=namespace):
-        wait_for_migration_finished(namespace=namespace.name, migration=migration, timeout=TIMEOUT_5MIN)
+        wait_for_migration_finished(
+            client=admin_client, namespace=namespace.name, migration=migration, timeout=TIMEOUT_5MIN
+        )
 
 
 @pytest.fixture(scope="class")

--- a/tests/virt/node/migration_and_maintenance/test_dedicated_live_migration_network.py
+++ b/tests/virt/node/migration_and_maintenance/test_dedicated_live_migration_network.py
@@ -212,6 +212,7 @@ class TestDedicatedLiveMigrationNetwork:
     @pytest.mark.polarion("CNV-7881")
     def test_migrate_multiple_vms_via_dedicated_network(
         self,
+        admin_client,
         virt_handler_pods_with_migration_network,
         restarted_migration_vm_1,
         migration_vm_2,
@@ -222,7 +223,7 @@ class TestDedicatedLiveMigrationNetwork:
         # is migrating through network
         source_node = vms_deployed_on_same_node
 
-        migrate_and_verify_multi_vms(vm_list=[restarted_migration_vm_1, migration_vm_2])
+        migrate_and_verify_multi_vms(client=admin_client, vm_list=[restarted_migration_vm_1, migration_vm_2])
         for vm in [restarted_migration_vm_1, migration_vm_2]:
             assert_vm_migrated_through_dedicated_network_with_logs(
                 source_node=source_node,

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -127,7 +127,7 @@ def verify_stress_ng_pid_not_changed(vm, initial_pid, windows=False):
     )
 
 
-def migrate_and_verify_multi_vms(vm_list):
+def migrate_and_verify_multi_vms(client, vm_list):
     vms_dict = {}
     failed_migrations_list = []
 
@@ -139,7 +139,7 @@ def migrate_and_verify_multi_vms(vm_list):
 
     for vm in vm_list:
         migration = vms_dict[vm.name]["vm_mig"]
-        wait_for_migration_finished(namespace=vm.namespace, migration=migration)
+        wait_for_migration_finished(client=client, namespace=vm.namespace, migration=migration)
         migration.clean_up()
 
     for vm in vm_list:

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1824,7 +1824,7 @@ def migrate_vm_and_verify(
     ) as migration:
         if not wait_for_migration_success:
             return migration
-        wait_for_migration_finished(namespace=vm.namespace, migration=migration, timeout=timeout)
+        wait_for_migration_finished(client=client, namespace=vm.namespace, migration=migration, timeout=timeout)
 
     verify_vm_migrated(
         vm=vm,
@@ -1835,7 +1835,7 @@ def migrate_vm_and_verify(
     return None
 
 
-def wait_for_migration_finished(namespace, migration, timeout=TIMEOUT_12MIN):
+def wait_for_migration_finished(client, namespace, migration, timeout=TIMEOUT_12MIN):
     sleep = TIMEOUT_10SEC
     samples = TimeoutSampler(wait_timeout=timeout, sleep=sleep, func=lambda: migration.instance.status.phase)
     counter = 0
@@ -1851,7 +1851,7 @@ def wait_for_migration_finished(namespace, migration, timeout=TIMEOUT_12MIN):
                 if counter >= TIMEOUT_4MIN / sleep:
                     # Get status/events for PODs in non-running or failed state
                     for pod in utilities.infra.get_pod_by_name_prefix(
-                        client=get_client(),
+                        client=client,
                         pod_prefix=VIRT_LAUNCHER,
                         namespace=namespace,
                         get_all=True,
@@ -2207,7 +2207,10 @@ def check_migration_process_after_node_drain(client, vm):
     wait_for_node_schedulable_status(node=source_node, status=False)
     vmim = get_created_migration_job(vm=vm, client=client, timeout=TIMEOUT_5MIN)
     wait_for_migration_finished(
-        namespace=vm.namespace, migration=vmim, timeout=TIMEOUT_30MIN if "windows" in vm.name else TIMEOUT_10MIN
+        client=client,
+        namespace=vm.namespace,
+        migration=vmim,
+        timeout=TIMEOUT_30MIN if "windows" in vm.name else TIMEOUT_10MIN,
     )
 
     target_pod = vm.privileged_vmi.virt_launcher_pod


### PR DESCRIPTION

##### Short description:
Drop the get_client() called in `wait_for_migration_finished fucniton`, pass an extra 'client' param, and changed relevant places

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-73714



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced VM migration testing with improved client context propagation across test cases.
  * Strengthened migration verification with better logging and diagnostic capabilities for stuck migrations.
  * Extended WSL2 guest verification in migration longevity tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->