### PR TITLE
[gcp]t2] adjust empty_pvc fixture to match the minimumSupportedPvcSize

### DIFF
--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -14,6 +14,7 @@ from ocp_resources.route import Route
 from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import config as py_config
 
+from tests.storage.cdi_upload.utils import get_storage_profile_minimum_supported_pvc_size
 from tests.storage.utils import assert_use_populator, create_windows_vm_validate_guest_agent_info
 from utilities.constants import CDI_UPLOADPROXY, TIMEOUT_1MIN, Images
 from utilities.storage import (
@@ -281,13 +282,18 @@ def empty_pvc(
     storage_class_matrix__module__,
     storage_class_name_scope_module,
 ):
+    storage_profile_minimum_supported_pvc_size = get_storage_profile_minimum_supported_pvc_size(
+        storage_class_name=storage_class_name_scope_module,
+        client=namespace.client,
+    )
+    sc_config = storage_class_matrix__module__[storage_class_name_scope_module]
     with PersistentVolumeClaim(
         name="empty-pvc",
         namespace=namespace.name,
         storage_class=storage_class_name_scope_module,
-        volume_mode=storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"],
-        accessmodes=storage_class_matrix__module__[storage_class_name_scope_module]["access_mode"],
-        size=DEFAULT_DV_SIZE,
+        volume_mode=sc_config["volume_mode"],
+        accessmodes=sc_config["access_mode"],
+        size=storage_profile_minimum_supported_pvc_size or DEFAULT_DV_SIZE,
         client=namespace.client,
     ) as pvc:
         if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_module, client=namespace.client):

--- a/tests/storage/cdi_upload/utils.py
+++ b/tests/storage/cdi_upload/utils.py
@@ -1,0 +1,28 @@
+import logging
+from typing import Optional
+
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.resource import Resource
+from ocp_resources.storage_profile import StorageProfile
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_storage_profile_minimum_supported_pvc_size(storage_class_name: str, client: DynamicClient) -> Optional[str]:
+    """
+    Get the minimum supported PVC size from the storage profile annotations.
+
+    Args:
+        storage_class_name: Name of the storage class to get the minimum PVC size for
+        client: DynamicClient for API operations
+
+    Returns:
+        The minimum supported PVC size string (e.g., "1Gi") from the storage profile annotation
+        'cdi.kubevirt.io/minimumSupportedPvcSize', or None if not set
+    """
+    storage_profile = StorageProfile(name=storage_class_name, client=client, ensure_exists=True)
+    min_pvc_size = storage_profile.instance.metadata.get("annotations", {}).get(
+        f"{Resource.ApiGroup.CDI_KUBEVIRT_IO}/minimumSupportedPvcSize"
+    )
+    LOGGER.info(f"Minimum supported PVC size from the StorageProfile: {min_pvc_size}")
+    return min_pvc_size


### PR DESCRIPTION
##### Short description:
Use storage profile minimum PVC size for empty PVC creation in CDI upload tests.


##### More details:
Some storage classes (e.g., GCP) don't support empty or very small PVCs (< 4Gi). Storage profiles expose a minimum supported PVC size via the cdi.kubevirt.io/minimumSupportedPvcSize annotation. This PR adds a utility function to read this value and updates the empty_pvc fixture to use it when creating PVCs for upload tests.
The changes include:
Created tests/storage/cdi_upload/utils.py with get_storage_profile_minimum_supported_pvc_size() function
Updated empty_pvc fixture to query the storage profile for minimum supported size
Falls back to DEFAULT_DV_SIZE if the annotation is not set


##### What this PR does / why we need it:
Prevents test failures when creating empty PVCs with storage classes that have minimum size requirements (e.g., GCP requires at least 4Gi)
Ensures PVCs are created with sizes that comply with storage class constraints
Makes tests more robust by respecting storage profile configurations
Centralizes the logic for retrieving minimum PVC size in a reusable utility function


##### Which issue(s) this PR fixes:
Fixes test failures in CDI upload tests when using storage classes (like GCP) that don't support empty or small PVCs (< 4Gi). The tests now use the minimum supported PVC size from the storage profile annotation, ensuring PVC creation succeeds regardless of storage class requirements.

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-76200
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test infra now reads minimum PVC sizes from storage profile metadata when present, falling back to a default size.
  * PVC creation in tests derives volume mode and access modes from the storage class configuration instead of static defaults.
  * Added a test utility to fetch and log the storage-profile min PVC size and its source (profile vs default).
  * Existing binding logic for WFFC remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->