### PR TITLE
CherryPicked: [cnv-4.20] Modified vm with cpu spec fixture to support s390x

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ from utilities.constants import (
     RHEL9_STR,
     RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
     RHSM_SECRET_NAME,
+    S390X,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
@@ -2901,3 +2902,8 @@ def application_aware_resource_quota(admin_client, namespace):
         hard=ARQ_QUOTA_HARD_SPEC,
     ) as arq:
         yield arq
+
+
+@pytest.fixture(scope="session")
+def is_s390x_cluster(nodes_cpu_architecture):
+    return nodes_cpu_architecture == S390X

--- a/tests/infrastructure/vhostmd/test_vhostmd.py
+++ b/tests/infrastructure/vhostmd/test_vhostmd.py
@@ -12,7 +12,7 @@ from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
-from utilities.constants import TIMEOUT_3MIN, TIMEOUT_30SEC
+from utilities.constants import S390X, TIMEOUT_3MIN, TIMEOUT_30SEC
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import get_artifactory_header, get_node_selector_dict, get_node_selector_name
 from utilities.virt import (
@@ -56,7 +56,7 @@ def enabled_downward_metrics_hco_featuregate(hyperconverged_resource_scope_modul
 
 
 @pytest.fixture(scope="module")
-def rpm_file_name(nodes_cpu_architecture):
+def rpm_file_name(is_s390x_cluster):
     soup_page = BeautifulSoup(
         markup=requests.get(RPMS_REPO_URL, headers=get_artifactory_header(), verify=False, timeout=TIMEOUT_30SEC).text,
         features="html.parser",
@@ -64,9 +64,7 @@ def rpm_file_name(nodes_cpu_architecture):
     rpm_file_names = [link.get("href") for link in soup_page.find_all("a", href=re.compile(r"\.rpm$"))]
     assert rpm_file_names, f"No RPM files found at the URL - {RPMS_REPO_URL}"
 
-    return next(
-        file_name for file_name in rpm_file_names if ("s390x" in file_name) == (nodes_cpu_architecture == "s390x")
-    )
+    return next(file_name for file_name in rpm_file_names if (S390X in file_name) == is_s390x_cluster)
 
 
 @pytest.fixture()

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -48,6 +48,7 @@ from utilities.constants import (
     KUBEVIRT_VMI_MEMORY_USABLE_BYTES,
     MIGRATION_POLICY_VM_LABEL,
     ONE_CPU_CORE,
+    ONE_CPU_THREAD,
     OS_FLAVOR_FEDORA,
     SSP_OPERATOR,
     STRESS_CPU_MEM_IO_COMMAND,
@@ -242,14 +243,14 @@ def windows_vm_for_test_interface_name(windows_vm_for_test):
 
 
 @pytest.fixture(scope="class")
-def vm_with_cpu_spec(namespace, unprivileged_client):
+def vm_with_cpu_spec(namespace, unprivileged_client, is_s390x_cluster):
     name = "vm-resource-test"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         cpu_cores=TWO_CPU_CORES,
         cpu_sockets=TWO_CPU_SOCKETS,
-        cpu_threads=TWO_CPU_THREADS,
+        cpu_threads=ONE_CPU_THREAD if is_s390x_cluster else TWO_CPU_THREADS,
         body=fedora_vm_body(name=name),
         client=unprivileged_client,
     ) as vm:


### PR DESCRIPTION
##### Short description:
s390x arc is supporting only one thread, this led to errors in the setup on tests that trying to create a vm with more than one thread, in this PR, added validation that if the arc is s390x then the cpu threads will be only 1.

original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/3275
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-76342
