### PR TITLE
docs: Fix usage of pytest usefixtures

### DIFF
--- a/docs/CODING_AND_STYLE_GUIDE.md
+++ b/docs/CODING_AND_STYLE_GUIDE.md
@@ -72,7 +72,7 @@ Only add comments when necessary. For example, when using complex regex.
 ## Fixtures
 - Ordering: Always call pytest native fixtures first, then session-scoped fixtures and then any other fixtures.
 - Fixtures should handle setup (and the teardown, if needed) needed for the test(s), including the creation of resources, for example.
-- Fixtures which call other fixtures but without using their return value should be called using `@pytest.mark.usefixtures(<fixture name>)`
+- Tests which call fixtures but without using their return value should be called using `@pytest.mark.usefixtures(<fixture name>)`
 - Fixtures should do one action/functionality only.
 For example, instead of:
 
@@ -127,7 +127,7 @@ def my_secret(request):
 
 
 ## Tests
-- Pytest reports tes failures as `FAILED`.
+- Pytest reports test failures as `FAILED`.
 - Each test should have a clear purpose and should be easy to understand.
 - Each test should verify a single aspect of the product.
 - Preferably, each test should be independent of other tests.


### PR DESCRIPTION
Updated the test documentation to correct
usage of `@pytest.mark.usefixtures` which
is only supported on test functions and classes.
It has no effect when applied to other fixtures.

https://docs.pytest.org/en/stable/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures

