### PR TITLE
[VIRT] Fix for vm+ceph migration test

### DIFF
--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -6,7 +6,7 @@ from utilities.storage import data_volume_template_with_source_ref_dict
 from utilities.virt import migrate_vm_and_verify, vm_instance_from_template
 
 
-@pytest.fixture()
+@pytest.fixture
 def vm_with_cephfs_storage(
     request,
     unprivileged_client,
@@ -40,7 +40,7 @@ def xfail_if_no_odf_cephfs_sc(cluster_storage_classes_names):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_source_for_test_scope_function,vm_with_cephfs_storage",
+    ("golden_image_data_source_for_test_scope_function", "vm_with_cephfs_storage"),
     [
         pytest.param(
             {"os_dict": FEDORA_LATEST},
@@ -50,5 +50,6 @@ def xfail_if_no_odf_cephfs_sc(cluster_storage_classes_names):
     ],
     indirect=True,
 )
-def test_vm_with_odf_cephfs_storage_class_migrates(xfail_if_no_odf_cephfs_sc, vm_with_cephfs_storage):
+@pytest.mark.usefixtures("xfail_if_no_odf_cephfs_sc")
+def test_vm_with_odf_cephfs_storage_class_migrates(vm_with_cephfs_storage):
     migrate_vm_and_verify(vm=vm_with_cephfs_storage)


### PR DESCRIPTION
Avoid using default storage class

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Streamlined VM migration tests to use a unified data-volume helper for CephFS-backed VMs and renamed the VM fixture for clarity.
  * Simplified test parametrization by removing redundant storage-class entries and consolidating setup; test behavior (including expected xfail) is preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->