### PR TITLE
Storage: remove pvc.client from create_dummy_first_consumer_pod

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -98,7 +98,6 @@ def create_dummy_first_consumer_pod(volume_mode=DataVolume.VolumeMode.FILE, dv=N
         name=f"first-consumer-{pvc.name}",
         pvc_name=pvc.name,
         containers=get_containers_for_pods_with_pvc(volume_mode=volume_mode, pvc_name=pvc.name),
-        client=pvc.client,
     ) as pod:
         LOGGER.info(
             f"Created dummy pod {pod.name} to be the first consumer of the PVC, "


### PR DESCRIPTION
##### Short description:
This change caused regression in unprivileged client tests with WFFC storage.
Reverting it as we are close to code freeze. 
A proper fix will be issued separately.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed persistent volume claim client parameter handling to use default initialization instead of incorrect client forwarding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->