### PR TITLE
Fix _sc_name_for_storage_api

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1016,8 +1016,9 @@ class VirtualMachineForTests(VirtualMachine):
                 sc_name = self.vm_preference.instance.spec.get("volumes", {}).get("preferredStorageClassName")
                 if sc_name:
                     return sc_name
-            else:
-                return get_default_storage_class(client=self.client).name
+            default_sc = get_default_storage_class(client=self.client).name
+            LOGGER.info(f"Using default storage class: {default_sc} for access mode field")
+            return default_sc
 
         api_name = "pvc" if self.data_volume_template and self.data_volume_template["spec"].get("pvc") else "storage"
         return (


### PR DESCRIPTION
##### Short description:
Fix _sc_name_for_storage_api

##### More details:
There are cases where the field `vm_preference` exists, but the preference does not have `preferredStorageClassName`. in such a case the storage class should be fetched from the cluster default storage class.
This fixes such an issue where the function return `None`, instead of moving to the next default option.


##### What this PR does / why we need it:
Fix error when preference exists but no storage class defined in it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal fallback logic for storage selection to improve maintainability.
  * Added informational logging when the default storage option is used.
  * No changes to public behavior or exported interfaces; existing functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->