### PR TITLE
Test for kubevirt_configuration_emulation_enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.11
+    rev: v0.14.10
     hooks:
       - id: ruff
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.11
     hooks:
       - id: ruff
         stages: [pre-commit]

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -3,17 +3,15 @@ import shlex
 
 import bitmath
 import pytest
-from contextlib import contextmanager
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
-from ocp_resources.resource import ResourceEditor, Resource
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.storage_class import StorageClass
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
-from ocp_resources.kubevirt import KubeVirt
 from packaging.version import Version
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import py_config
@@ -68,10 +66,12 @@ from utilities.constants import (
     TWO_CPU_THREADS,
     U1_MEDIUM_STR,
     VIRT_TEMPLATE_VALIDATOR,
-    Images, DEFAULT_HCO_CONDITIONS,
+    Images,
 )
-from utilities.hco import ResourceEditorValidateHCOReconcile, enabled_aaq_in_hco, update_hco_annotations, \
-    wait_for_hco_conditions
+from utilities.hco import (
+    ResourceEditorValidateHCOReconcile,
+    enabled_aaq_in_hco,
+)
 from utilities.infra import (
     create_ns,
     get_linux_guest_agent_version,
@@ -713,22 +713,3 @@ def emulation_config_value(hyperconverged_resource_scope_class):
     hco_spec = hyperconverged_resource_scope_class.instance.to_dict()["spec"]
     developer_config = hco_spec.get("configuration", {}).get("developerConfiguration", {})
     return developer_config.get("useEmulation", False)
-
-
-@contextmanager
-def toggle_emulation_in_hco(admin_client, hco_namespace, hyperconverged_resource, enable_emulation):
-    with update_hco_annotations(
-            resource=hyperconverged_resource,
-            path="developerConfiguration/useEmulation",
-            value=enable_emulation,
-            component="kubevirt",
-    ):
-        wait_for_hco_conditions(
-            admin_client=admin_client,
-            hco_namespace=hco_namespace,
-            expected_conditions={
-                **DEFAULT_HCO_CONDITIONS,
-                "TaintedConfiguration": Resource.Condition.Status.TRUE,
-            },
-        )
-        yield

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -3,15 +3,17 @@ import shlex
 
 import bitmath
 import pytest
+from contextlib import contextmanager
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
-from ocp_resources.resource import ResourceEditor
+from ocp_resources.resource import ResourceEditor, Resource
 from ocp_resources.storage_class import StorageClass
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
+from ocp_resources.kubevirt import KubeVirt
 from packaging.version import Version
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import py_config
@@ -66,9 +68,10 @@ from utilities.constants import (
     TWO_CPU_THREADS,
     U1_MEDIUM_STR,
     VIRT_TEMPLATE_VALIDATOR,
-    Images,
+    Images, DEFAULT_HCO_CONDITIONS,
 )
-from utilities.hco import ResourceEditorValidateHCOReconcile, enabled_aaq_in_hco
+from utilities.hco import ResourceEditorValidateHCOReconcile, enabled_aaq_in_hco, update_hco_annotations, \
+    wait_for_hco_conditions
 from utilities.infra import (
     create_ns,
     get_linux_guest_agent_version,
@@ -703,3 +706,29 @@ def expected_cpu_affinity_metric_value(vm_with_cpu_spec):
 
     # return multiplication for multi-CPU VMs
     return str(cpu_count_from_vm_node * cpu_count_from_vm)
+
+
+@pytest.fixture
+def emulation_config_value(hyperconverged_resource_scope_class):
+    hco_spec = hyperconverged_resource_scope_class.instance.to_dict()["spec"]
+    developer_config = hco_spec.get("configuration", {}).get("developerConfiguration", {})
+    return developer_config.get("useEmulation", False)
+
+
+@contextmanager
+def toggle_emulation_in_hco(admin_client, hco_namespace, hyperconverged_resource, enable_emulation):
+    with update_hco_annotations(
+            resource=hyperconverged_resource,
+            path="developerConfiguration/useEmulation",
+            value=enable_emulation,
+            component="kubevirt",
+    ):
+        wait_for_hco_conditions(
+            admin_client=admin_client,
+            hco_namespace=hco_namespace,
+            expected_conditions={
+                **DEFAULT_HCO_CONDITIONS,
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
+            },
+        )
+        yield

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -710,6 +710,7 @@ def expected_cpu_affinity_metric_value(vm_with_cpu_spec):
 
 @pytest.fixture
 def emulation_config_value(hyperconverged_resource_scope_class):
+    # gets HCO CR's spec.configuration.developerConfiguration.useEmulation value, default false
     hco_spec = hyperconverged_resource_scope_class.instance.to_dict()["spec"]
     developer_config = hco_spec.get("configuration", {}).get("developerConfiguration", {})
     return developer_config.get("useEmulation", False)

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -4,11 +4,9 @@ import pytest
 from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine import VirtualMachine
 
-from tests.observability.metrics.conftest import toggle_emulation_in_hco
 from tests.observability.metrics.constants import KUBEVIRT_VMI_NODE_CPU_AFFINITY
-from tests.observability.metrics.utils import validate_vmi_node_cpu_affinity_with_prometheus
+from tests.observability.metrics.utils import toggle_emulation_in_hco, validate_vmi_node_cpu_affinity_with_prometheus
 from tests.observability.utils import validate_metrics_value
-from utilities.constants import TIMEOUT_5MIN
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 KUBEVIRT_VM_TAG = f"{Resource.ApiGroup.KUBEVIRT_IO}/vm"
@@ -103,12 +101,12 @@ class TestVirtHCOSingleStackIpv6:
 class TestConfigurationEmulationEnabled:
     @pytest.mark.polarion("CNV-99999")
     def test_kubevirt_configuration_emulation_enabled(
-            self,
-            admin_client,
-            hco_namespace,
-            prometheus,
-            hyperconverged_resource_scope_class,
-            emulation_config_value,
+        self,
+        admin_client,
+        hco_namespace,
+        prometheus,
+        hyperconverged_resource_scope_class,
+        emulation_config_value,
     ):
         new_emulation_value = not emulation_config_value
         with toggle_emulation_in_hco(

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -98,8 +98,9 @@ class TestVirtHCOSingleStackIpv6:
         )
 
 
+@pytest.mark.tier2
 class TestConfigurationEmulationEnabled:
-    @pytest.mark.polarion("CNV-99999")
+    @pytest.mark.polarion("CNV-12588")
     def test_kubevirt_configuration_emulation_enabled(
         self,
         admin_client,

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -853,6 +853,18 @@ def validate_values_from_kube_application_aware_resourcequota_metric(
 
 @contextmanager
 def toggle_emulation_in_hco(admin_client, hco_namespace, hyperconverged_resource, enable_emulation):
+    """
+    Toggle useEmulation in HCO developerConfiguration and wait for reconciliation.
+
+    Args:
+        admin_client: Kubernetes client with admin privileges.
+        hco_namespace: Namespace containing the HyperConverged resource.
+        hyperconverged_resource: HyperConverged resource to patch.
+        enable_emulation: Boolean value to set for useEmulation.
+
+    Yields:
+        None: Yields after HCO conditions are met, restores original state on exit.
+    """
     with update_hco_annotations(
         resource=hyperconverged_resource,
         path="developerConfiguration/useEmulation",


### PR DESCRIPTION
##### Short description: test for kubevirt_configuration_emulation_enabled

##### More details:

##### What this PR does / why we need it: part of 4.21 observability backlog

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-54892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a fixture to read emulation configuration from the system under test.
  * Added a test validating the kubevirt configuration emulation metric toggles between enabled/disabled.
  * Added a test utility to toggle emulation state during tests and ensure it is restored afterward.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->