### PR TITLE
net, BGP: quarantine test suite due to unstable fails

### DIFF
--- a/tests/network/bgp/test_bgp_connectivity.py
+++ b/tests/network/bgp/test_bgp_connectivity.py
@@ -1,9 +1,18 @@
 import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
+from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
-pytestmark = [pytest.mark.bgp, pytest.mark.ipv4, pytest.mark.usefixtures("bgp_setup_ready")]
+pytestmark = [
+    pytest.mark.bgp,
+    pytest.mark.ipv4,
+    pytest.mark.usefixtures("bgp_setup_ready"),
+    pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Unstable connectivity failure CNV-76552",
+        run=False,
+    ),
+]
 
 
 @pytest.mark.polarion("CNV-12276")


### PR DESCRIPTION
In some rare cases on some clusters the connectivity can be 
broken between external provider network and UDN VM. 
The issue should be investigated, the suite is quarantined.

jira-ticket: https://issues.redhat.com/browse/CNV-76552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * BGP connectivity tests marked as quarantined and excluded from test execution to prevent failure reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->