### PR TITLE
unprivileged_client fixture sets admin_client on no_unprivileged_client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -392,7 +392,8 @@ def unprivileged_client(
     Provides none privilege API client
     """
     if skip_unprivileged_client:
-        yield
+        LOGGER.info("no_unprivileged_client was set, using admin_client")
+        yield admin_client
 
     else:
         current_user = check_output("oc whoami", shell=True).decode().strip()  # Get the current admin account

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -130,8 +130,8 @@ def perm_destination_service_account(
 
 
 @pytest.fixture(scope="module")
-def fail_when_no_unprivileged_client_available(unprivileged_client):
-    if not unprivileged_client:
+def fail_when_no_unprivileged_client_available(unprivileged_client, admin_client):
+    if unprivileged_client is admin_client:
         pytest.fail("No unprivileged_client available, failing the test")
 
 


### PR DESCRIPTION
##### Short description:
unprivileged_client fixture sets admin_client on no_unprivileged_client

##### More details:
 - When `no_unprivileged_client` is set, we want to yield admin_client in `unprivileged_client` as mentioned in RUNNING_TESTS.MD
 - Updated `fail_when_no_unprivileged_client_available` to fail the test `if unprivileged_client is admin_client` 

##### What this PR does / why we need it:
On next openshift-python-wrapper returning `None` can cause errors, this aims to avoid them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * When unprivileged testing is skipped, the test setup now falls back to administrator credentials and logs an informational message so tests continue.
  * Updated a related test fixture to explicitly detect when an unprivileged client is the same as the admin client (adjusted its inputs and failure condition) to better validate access restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->