### PR TITLE
[IUO]Promote APIServer crypto policy to tier2

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -82,6 +82,7 @@ fcn_exclude_functions =
     as_completed,
     mkdtemp,
     tempfile,
+    setdefaulttimeout,
 
 nit_exclude_imports =
     os_params,

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
@@ -15,7 +15,7 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
 from utilities.constants import TIMEOUT_2MIN, TIMEOUT_10SEC
 
 LOGGER = logging.getLogger(__name__)
-pytestmark = pytest.mark.tier3
+pytestmark = pytest.mark.tier2
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/crypto_policy/test_update_api_server.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_api_server.py
@@ -16,7 +16,7 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
 )
 from utilities.constants import TLS_CUSTOM_POLICY, TLS_OLD_POLICY
 
-pytestmark = pytest.mark.tier3
+pytestmark = pytest.mark.tier2
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/crypto_policy/utils.py
+++ b/tests/install_upgrade_operators/crypto_policy/utils.py
@@ -1,11 +1,13 @@
 import logging
+import socket
 from contextlib import contextmanager
 
 import deepdiff
 from benedict import benedict
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.hyperconverged import HyperConverged
-from ocp_resources.resource import Resource, ResourceEditor
+from ocp_resources.node import Node
+from ocp_resources.resource import Resource
 from packaging.version import Version
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -27,11 +29,13 @@ from tests.install_upgrade_operators.utils import (
 from utilities.constants import (
     CLUSTER,
     TIMEOUT_2MIN,
+    TIMEOUT_5MIN,
     TLS_SECURITY_PROFILE,
 )
-from utilities.hco import ResourceEditorValidateHCOReconcile, wait_for_hco_conditions
+from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import ExecCommandOnPod
 from utilities.operator import wait_for_cluster_operator_stabilize
+from utilities.virt import wait_for_node_schedulable_status
 
 LOGGER = logging.getLogger(__name__)
 
@@ -257,13 +261,23 @@ def update_apiserver_crypto_policy(
     apiserver,
     tls_spec,
 ):
-    with ResourceEditor(
-        patches={apiserver: {"spec": {TLS_SECURITY_PROFILE: tls_spec}}},
-    ):
-        yield
-    wait_for_cluster_operator_stabilize(admin_client=admin_client)
-    wait_for_hco_conditions(
-        admin_client=admin_client,
-        hco_namespace=hco_namespace,
-        list_dependent_crs_to_check=MANAGED_CRS_LIST,
-    )
+    old_timeout = socket.getdefaulttimeout()
+
+    try:
+        socket.setdefaulttimeout(30)
+        with ResourceEditorValidateHCOReconcile(
+            patches={apiserver: {"spec": {TLS_SECURITY_PROFILE: tls_spec}}},
+            admin_client=admin_client,
+            hco_namespace=hco_namespace.name,
+            wait_for_reconcile_post_update=True,
+            list_resource_reconcile=MANAGED_CRS_LIST,
+        ):
+            yield
+
+        wait_for_cluster_operator_stabilize(admin_client=admin_client)
+        nodes = list(Node.get(client=admin_client))
+        for node in nodes:
+            # After APIServer rollout with crypto policy changes, nodes may take longer to become schedulable
+            wait_for_node_schedulable_status(node=node, status=True, timeout=TIMEOUT_5MIN)
+    finally:
+        socket.setdefaulttimeout(old_timeout)


### PR DESCRIPTION
##### Short description:
Promote APIServer crypto policy to tier2, updating markers:
- test_update_api_server.py (tier3 → tier2)
- test_hco_override_api_server_crypto_policy.py (tier3 → tier2)

And stabilize tests adding proper wait right after update the crypto
policy:

###### Root Cause                                                                                                                                                                                                    
During APIServer rollouts (especially crypto policy changes), HTTP connections to the Kubernetes                                                                                                                  
API can be abruptly closed while the client is waiting for a response. Without socket timeouts,                                                                                                                   
the `read()` call blocks indefinitely, preventing the TimeoutSampler retry logic from working.                                                                                                                    
                                                                                                                                                                                                                    
###### Solution                                                                                                                                                                                                      
  - Added 30-second socket timeout to the entire `update_apiserver_crypto_policy()` context                                                                                                                         
  - Timeout covers setup (applying patch), test execution, and teardown (restoring state)                                                                                                                           
  - Increased node schedulability timeout from 2 to 5 minutes for APIServer rollouts                                                                                                                                
  - Socket timeout allows retry mechanisms to function properly when connections are reset                 

##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-71816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Lowered tier classification for select crypto-policy tests from tier3 to tier2.
  * Enhanced validation to wait for cluster/operator stability and per-node schedulable readiness after API server crypto-policy updates.

* **Chores**
  * Added temporary network timeout protection around API server update operations and integrated a validated reconcile workflow.

* **Style**
  * Expanded lint exclusion list to include an additional timeout-related function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->