### PR TITLE
[4.21] Storage: updated bug info for storage tests

### DIFF
--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -16,7 +16,7 @@ from pytest_testconfig import config as py_config
 
 from tests.storage.cdi_upload.utils import get_storage_profile_minimum_supported_pvc_size
 from tests.storage.utils import assert_use_populator, create_windows_vm_validate_guest_agent_info
-from utilities.constants import CDI_UPLOADPROXY, TIMEOUT_1MIN, Images
+from utilities.constants import CDI_UPLOADPROXY, QUARANTINED, TIMEOUT_1MIN, Images
 from utilities.storage import (
     ErrorMsg,
     check_upload_virtctl_result,
@@ -132,6 +132,10 @@ def test_image_upload_with_overridden_url(
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-3031")
 @pytest.mark.s390x
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: Test fails when running from container; tracked in CNV-18870",
+    run=False,
+)
 def test_virtctl_image_upload_with_ca(
     unprivileged_client,
     enabled_ca,

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -50,7 +50,6 @@ from utilities.constants import (
     CDI_OPERATOR,
     CDI_UPLOADPROXY,
     CNV_TEST_SERVICE_ACCOUNT,
-    CNV_TESTS_CONTAINER,
     OS_FLAVOR_RHEL,
     RHEL10_PREFERENCE,
     SECURITY_CONTEXT,
@@ -67,7 +66,6 @@ from utilities.infra import (
     INTERNAL_HTTP_SERVER_ADDRESS,
     ExecCommandOnPod,
 )
-from utilities.jira import is_jira_open
 from utilities.storage import data_volume_template_with_source_ref_dict, get_downloaded_artifact, write_file_via_ssh
 from utilities.virt import VirtualMachineForTests, running_vm
 
@@ -375,14 +373,7 @@ def temp_router_cert(tmpdir, router_cert_secret):
 
 
 @pytest.fixture()
-def skip_from_container_if_jira_18870_not_closed():
-    jira_id = "CNV-18870"
-    if os.environ.get(CNV_TESTS_CONTAINER) and is_jira_open(jira_id=jira_id):
-        pytest.skip(f"Skipping the test because it's running from the container and jira card {jira_id} not closed")
-
-
-@pytest.fixture()
-def enabled_ca(skip_from_container_if_jira_18870_not_closed, temp_router_cert):
+def enabled_ca(temp_router_cert):
     update_ca_trust_command = "sudo update-ca-trust"
     ca_path = "/etc/pki/ca-trust/source/anchors/"
     # copy to the trusted secure list and update

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -20,6 +20,7 @@ from timeout_sampler import TimeoutSampler
 
 from utilities.constants import (
     CDI_SECRETS,
+    QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_3MIN,
     TIMEOUT_5SEC,
@@ -305,6 +306,10 @@ def downloaded_cirros_image(tmpdir):
 
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-5708")
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: Test fails when running from container; tracked in CNV-18870",
+    run=False,
+)
 def test_cert_exposure_rotation(
     enabled_ca,
     updated_certconfig_in_hco_cr,

--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -6,7 +6,7 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
 from tests.storage.utils import create_cirros_dv
-from utilities.constants import TIMEOUT_1MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
+from utilities.constants import QUARANTINED, TIMEOUT_1MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
 from utilities.infra import login_with_user_password
 
 pytestmark = pytest.mark.post_upgrade
@@ -67,7 +67,6 @@ def client_for_test(request, admin_client, unprivileged_client):
         )
 
 
-@pytest.mark.jira("CNV-62312", run=False)
 @pytest.mark.parametrize(
     (
         "client_for_test",
@@ -86,6 +85,10 @@ def client_for_test(request, admin_client, unprivileged_client):
         ),
     ],
     indirect=True,
+)
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: Timeout exceeded. Tracked in CNV-62312",
+    run=False,
 )
 @pytest.mark.s390x
 def test_virtctl_libguestfs_with_specific_user(


### PR DESCRIPTION
##### Short description:
Updated with the relevant bugs to fix:
```
/tests/storage/test_libguestfs.py: CNV-62312 target versions: ['4.21.0'], do not match expected version ['vfuture', '4.22.0', '4.22.z'].
/tests/storage/conftest.py: CNV-18870 target versions: ['4.21.0'], do not match expected version ['vfuture', '4.22.0', '4.22.z'].
/tests/storage/cdi_upload/test_upload_virtctl.py: CNV-74020 target versions: ['4.21.0'], do not match expected version ['vfuture', '4.22.0', '4.22.z'].
```

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
