### PR TITLE
[VIRT] Stabilize node drain/cordon console

### DIFF
--- a/tests/chaos/oadp/conftest.py
+++ b/tests/chaos/oadp/conftest.py
@@ -74,8 +74,8 @@ def rebooted_vm_source_node(rhel_vm_with_dv_running, oadp_backup_in_progress, wo
 
 
 @pytest.fixture()
-def drain_vm_source_node(rhel_vm_with_dv_running, oadp_backup_in_progress):
+def drain_vm_source_node(admin_client, rhel_vm_with_dv_running, oadp_backup_in_progress):
     vm_node = rhel_vm_with_dv_running.vmi.node
-    with node_mgmt_console(node=vm_node, node_mgmt="drain"):
+    with node_mgmt_console(admin_client=admin_client, node=vm_node, node_mgmt="drain"):
         wait_for_node_schedulable_status(node=vm_node, status=False)
         yield vm_node

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -42,9 +42,9 @@ def assert_vm_restarts_after_node_drain(source_node, vmi, vmi_old_uid):
 
 
 @pytest.fixture()
-def drained_node(vm_for_test_from_template_scope_class):
+def drained_node(admin_client, vm_for_test_from_template_scope_class):
     source_node = vm_for_test_from_template_scope_class.privileged_vmi.node
-    with node_mgmt_console(node=source_node, node_mgmt="drain"):
+    with node_mgmt_console(admin_client=admin_client, node=source_node, node_mgmt="drain"):
         yield source_node
 
 
@@ -124,7 +124,10 @@ class TestEvictionStrategy:
     def test_hco_evictionstrategy_livemigrate_vm_no_evictionstrategy(
         self, unprivileged_client, vm_for_test_from_template_scope_class, drained_node
     ):
-        check_migration_process_after_node_drain(client=unprivileged_client, vm=vm_for_test_from_template_scope_class)
+        check_migration_process_after_node_drain(
+            client=unprivileged_client,
+            vm=vm_for_test_from_template_scope_class,
+        )
 
     @pytest.mark.polarion("CNV-10088")
     def test_hco_evictionstrategy_none_vm_no_evictionstrategy(
@@ -166,4 +169,7 @@ class TestEvictionStrategy:
         added_vm_evictionstrategy,
         drained_node,
     ):
-        check_migration_process_after_node_drain(client=unprivileged_client, vm=vm_for_test_from_template_scope_class)
+        check_migration_process_after_node_drain(
+            client=unprivileged_client,
+            vm=vm_for_test_from_template_scope_class,
+        )

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -150,12 +150,13 @@ def node_to_drain(
 
 @pytest.fixture()
 def drain_uncordon_node(
+    admin_client,
     deployed_vms_for_descheduler_test,
     vms_orig_nodes_before_node_drain,
     node_to_drain,
 ):
     """Return when node is schedulable again after uncordon"""
-    with node_mgmt_console(node=node_to_drain, node_mgmt="drain"):
+    with node_mgmt_console(admin_client=admin_client, node=node_to_drain, node_mgmt="drain"):
         wait_for_node_schedulable_status(node=node_to_drain, status=False)
         for vm in deployed_vms_for_descheduler_test:
             if vms_orig_nodes_before_node_drain[vm.name].name == node_to_drain.name:

--- a/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
+++ b/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
@@ -3,10 +3,11 @@ Draining node by Node Maintenance Operator
 """
 
 import logging
-import random
 
 import pytest
-from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
+from ocp_resources.virtual_machine_instance_migration import (
+    VirtualMachineInstanceMigration,
+)
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.os_params import (
@@ -33,17 +34,20 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.rwx_default_storage]
 LOGGER = logging.getLogger(__name__)
 
 
-def drain_using_console(client, source_node, vm):
+def drain_using_console(admin_client, source_node, vm):
     with running_sleep_in_linux(vm=vm):
-        with node_mgmt_console(node=source_node, node_mgmt="drain"):
-            check_migration_process_after_node_drain(client=client, vm=vm)
+        with node_mgmt_console(admin_client=admin_client, node=source_node, node_mgmt="drain"):
+            check_migration_process_after_node_drain(client=admin_client, vm=vm)
 
 
-def drain_using_console_windows(client, source_node, vm):
+def drain_using_console_windows(admin_client, source_node, vm):
     process_name = OS_PROC_NAME["windows"]
-    pre_migrate_processid = start_and_fetch_processid_on_windows_vm(vm=vm, process_name=process_name)
-    with node_mgmt_console(node=source_node, node_mgmt="drain"):
-        check_migration_process_after_node_drain(client=client, vm=vm)
+    pre_migrate_processid = start_and_fetch_processid_on_windows_vm(
+        vm=vm,
+        process_name=process_name,
+    )
+    with node_mgmt_console(admin_client=admin_client, node=source_node, node_mgmt="drain"):
+        check_migration_process_after_node_drain(client=admin_client, vm=vm)
         post_migrate_processid = fetch_pid_from_windows_vm(vm=vm, process_name=process_name)
         assert post_migrate_processid == pre_migrate_processid, (
             f"Post migrate processid is: {post_migrate_processid}. Pre migrate processid is: {pre_migrate_processid}"
@@ -62,8 +66,12 @@ def node_filter(pod, schedulable_nodes):
 
 
 @pytest.fixture()
-def vm_container_disk_fedora(cpu_for_migration, namespace, unprivileged_client):
-    name = f"vm-nodemaintenance-{random.randrange(99999)}"
+def vm_container_disk_fedora(
+    unprivileged_client,
+    cpu_for_migration,
+    namespace,
+):
+    name = "vm-nodemaintenance"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
@@ -82,7 +90,10 @@ def get_migration_job(client, namespace):
 
 @pytest.fixture()
 def no_migration_job(admin_client, vm_for_test_from_template_scope_class):
-    migration_job = get_migration_job(client=admin_client, namespace=vm_for_test_from_template_scope_class.namespace)
+    migration_job = get_migration_job(
+        client=admin_client,
+        namespace=vm_for_test_from_template_scope_class.namespace,
+    )
     if migration_job:
         migration_job.delete(wait=True)
 
@@ -106,7 +117,9 @@ def test_node_drain_using_console_fedora(
     vm_container_disk_fedora,
 ):
     privileged_virt_launcher_pod = vm_container_disk_fedora.privileged_vmi.virt_launcher_pod
-    drain_using_console(client=admin_client, source_node=privileged_virt_launcher_pod.node, vm=vm_container_disk_fedora)
+    drain_using_console(
+        admin_client=admin_client, source_node=privileged_virt_launcher_pod.node, vm=vm_container_disk_fedora
+    )
 
 
 @pytest.mark.parametrize(
@@ -123,15 +136,23 @@ def test_node_drain_using_console_fedora(
     indirect=True,
 )
 @pytest.mark.ibm_bare_metal
+@pytest.mark.usefixtures("no_migration_job")
 class TestNodeMaintenanceRHEL:
     @pytest.mark.polarion("CNV-2292")
-    def test_node_drain_using_console_rhel(self, no_migration_job, vm_for_test_from_template_scope_class, admin_client):
+    def test_node_drain_using_console_rhel(
+        self,
+        admin_client,
+        vm_for_test_from_template_scope_class,
+    ):
         vm = vm_for_test_from_template_scope_class
-        drain_using_console(client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm)
+        drain_using_console(admin_client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm)
 
     @pytest.mark.polarion("CNV-4995")
     def test_migration_when_multiple_nodes_unschedulable_using_console_rhel(
-        self, no_migration_job, vm_for_test_from_template_scope_class, schedulable_nodes, admin_client
+        self,
+        admin_client,
+        schedulable_nodes,
+        vm_for_test_from_template_scope_class,
     ):
         """Test VMI migration, when multiple nodes are unschedulable.
 
@@ -147,9 +168,12 @@ class TestNodeMaintenanceRHEL:
         4. Make sure the VMI is migrated to the other node.
         """
         vm = vm_for_test_from_template_scope_class
-        cordon_nodes = node_filter(pod=vm.privileged_vmi.virt_launcher_pod, schedulable_nodes=schedulable_nodes)
-        with node_mgmt_console(node=cordon_nodes[0], node_mgmt="cordon"):
-            drain_using_console(client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm)
+        cordon_nodes = node_filter(
+            pod=vm.privileged_vmi.virt_launcher_pod,
+            schedulable_nodes=schedulable_nodes,
+        )
+        with node_mgmt_console(admin_client=admin_client, node=cordon_nodes[0], node_mgmt="cordon"):
+            drain_using_console(admin_client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm)
 
 
 @pytest.mark.parametrize(
@@ -167,16 +191,34 @@ class TestNodeMaintenanceRHEL:
     indirect=True,
 )
 @pytest.mark.ibm_bare_metal
+@pytest.mark.usefixtures("no_migration_job")
 class TestNodeCordonAndDrain:
     @pytest.mark.polarion("CNV-2048")
-    def test_node_drain_template_windows(self, no_migration_job, vm_for_test_from_template_scope_class, admin_client):
+    def test_node_drain_template_windows(
+        self,
+        admin_client,
+        vm_for_test_from_template_scope_class,
+    ):
         vm = vm_for_test_from_template_scope_class
-        drain_using_console_windows(client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm)
+        drain_using_console_windows(
+            admin_client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm
+        )
 
     @pytest.mark.polarion("CNV-4906")
-    def test_node_cordon_template_windows(self, no_migration_job, vm_for_test_from_template_scope_class, admin_client):
+    def test_node_cordon_template_windows(
+        self,
+        admin_client,
+        vm_for_test_from_template_scope_class,
+    ):
         vm = vm_for_test_from_template_scope_class
-        with node_mgmt_console(node=vm.privileged_vmi.virt_launcher_pod.node, node_mgmt="cordon"):
+        with node_mgmt_console(
+            admin_client=admin_client,
+            node=vm.privileged_vmi.virt_launcher_pod.node,
+            node_mgmt="cordon",
+        ):
             with pytest.raises(TimeoutExpiredError):
-                migration_job_sampler(client=admin_client, namespace=vm.namespace)
+                migration_job_sampler(
+                    client=admin_client,
+                    namespace=vm.namespace,
+                )
                 pytest.fail("Cordon of a Node should not trigger VMI migration.")

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -75,7 +75,7 @@ def migrated_hotplugged_vm(hotplugged_vm):
 
 @pytest.fixture()
 def drained_node_with_hotplugged_vm(admin_client, hotplugged_vm):
-    with node_mgmt_console(node=hotplugged_vm.privileged_vmi.node, node_mgmt="drain"):
+    with node_mgmt_console(admin_client=admin_client, node=hotplugged_vm.privileged_vmi.node, node_mgmt="drain"):
         check_migration_process_after_node_drain(client=admin_client, vm=hotplugged_vm)
     clean_up_migration_jobs(client=admin_client, vm=hotplugged_vm)
 

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -46,7 +46,7 @@ def unscheduled_node_vm(
     indirect=True,
 )
 @pytest.mark.polarion("CNV-4157")
-def test_schedule_vm_on_cordoned_node(worker_node1, unscheduled_node_vm):
+def test_schedule_vm_on_cordoned_node(admin_client, worker_node1, unscheduled_node_vm):
     """Test VM scheduling on a node under maintenance.
     1. Cordon the target node specified in the VM's nodeAffinity (worker_node1).
     2. Wait until the node status becomes 'Ready,SchedulingDisabled'.
@@ -57,7 +57,7 @@ def test_schedule_vm_on_cordoned_node(worker_node1, unscheduled_node_vm):
     7. Verify that the VMI is running on the expected node (worker_node1).
     """
 
-    with node_mgmt_console(node=worker_node1, node_mgmt="cordon"):
+    with node_mgmt_console(admin_client=admin_client, node=worker_node1, node_mgmt="cordon"):
         wait_for_node_schedulable_status(node=worker_node1, status=False)
         unscheduled_node_vm.start()
     unscheduled_node_vm.vmi.wait_for_status(status=VirtualMachineInstance.Status.RUNNING)

--- a/tests/virt/node/migration_and_maintenance/utils.py
+++ b/tests/virt/node/migration_and_maintenance/utils.py
@@ -65,10 +65,10 @@ def assert_vm_migrated_through_dedicated_network_with_logs(source_node, vm, virt
     assert len(matches) == 6, f"Not all migration logs found. Found {len(matches)} of 6"
 
 
-def assert_node_drain_and_vm_migration(client, vm, virt_handler_pods):
+def assert_node_drain_and_vm_migration(admin_client, vm, virt_handler_pods):
     source_node = vm.privileged_vmi.node
-    with node_mgmt_console(node=source_node, node_mgmt="drain"):
-        check_migration_process_after_node_drain(client=client, vm=vm)
+    with node_mgmt_console(admin_client=admin_client, node=source_node, node_mgmt="drain"):
+        check_migration_process_after_node_drain(client=admin_client, vm=vm)
         assert_vm_migrated_through_dedicated_network_with_logs(
             source_node=source_node, vm=vm, virt_handler_pods=virt_handler_pods
         )


### PR DESCRIPTION
[VIRT] Run node_mgmt_console drain/cordon with drain cleanup and wait for HCO stabilization
- Keep oc adm drain/cordon running in background (nohup ... &)
- Terminate any running oc adm drain processes on exit
- Add wait_for_kv_stabilize in finally

This fix purpose is to protect all tests using node_mgmt_console from webhook
availability issues during node maintenance operations.

Signed-off-by: Samuel Albershtein <salbersh@redhat.com>
Assisted-by: Claude <noreply@anthropic.com>

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node cordon/drain and Windows drain flows now run with an authenticated admin context, include explicit drain cleanup, and wait for post-operation cluster stabilization for more reliable migrations.

* **Tests**
  * Many fixtures and test cases updated to propagate the authenticated admin context so maintenance, cordon/drain, descheduler and migration scenarios are validated end-to-end.

* **Chores**
  * Utility routines updated to require and use the admin context and cluster namespace for node management and stabilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->