### PR TITLE
cherry-pick: [storage][t2][4.20] Remove deprecated disk permission checks and update CNV-4033 to assert populator behavior

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -9,7 +9,6 @@ from tests.os_params import FEDORA_LATEST, WINDOWS_11, WINDOWS_11_TEMPLATE_LABEL
 from tests.storage.utils import (
     assert_pvc_snapshot_clone_annotation,
     assert_use_populator,
-    create_vm_from_dv,
     create_windows_vm_validate_guest_agent_info,
 )
 from utilities.constants import (
@@ -22,6 +21,7 @@ from utilities.constants import (
 from utilities.storage import (
     check_disk_count_in_vm,
     create_dv,
+    create_vm_from_dv,
     data_volume_template_dict,
     overhead_size_for_dv,
 )

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -22,7 +22,6 @@ from tests.storage.constants import (
 from tests.storage.utils import (
     assert_num_files_in_pod,
     assert_use_populator,
-    create_vm_from_dv,
     get_file_url,
     get_importer_pod,
     wait_for_importer_container_message,
@@ -44,6 +43,7 @@ from utilities.storage import (
     ErrorMsg,
     create_dummy_first_consumer_pod,
     create_dv,
+    create_vm_from_dv,
     get_test_artifact_server_url,
     sc_volume_binding_mode_is_wffc,
 )

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -6,13 +6,12 @@ from ocp_resources.datavolume import DataVolume
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE, REGISTRY_STR
 from tests.storage.utils import (
-    create_vm_from_dv,
     get_importer_pod,
     wait_for_importer_container_message,
 )
 from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_5MIN, Images
 from utilities.ssp import wait_for_condition_message_value
-from utilities.storage import ErrorMsg, check_disk_count_in_vm, create_dv
+from utilities.storage import ErrorMsg, check_disk_count_in_vm, create_dv, create_vm_from_dv
 from utilities.virt import running_vm
 
 pytestmark = pytest.mark.post_upgrade

--- a/tests/storage/cdi_upload/conftest.py
+++ b/tests/storage/cdi_upload/conftest.py
@@ -3,18 +3,17 @@ CDI Import
 """
 
 import logging
+import uuid
 
 import pytest
 from ocp_resources.datavolume import DataVolume
 
-from utilities.constants import TIMEOUT_1MIN, Images
-from utilities.storage import (
-    check_upload_virtctl_result,
-    get_downloaded_artifact,
-    virtctl_upload_dv,
-)
+from utilities.constants import TIMEOUT_1MIN, TIMEOUT_2MIN, Images
+from utilities.storage import check_upload_virtctl_result, create_dv, get_downloaded_artifact, virtctl_upload_dv
 
 LOGGER = logging.getLogger(__name__)
+DEFAULT_DV_SIZE = Images.Cdi.DEFAULT_DV_SIZE
+LOCAL_PATH = f"/tmp/{Images.Cdi.QCOW2_IMG}"
 
 
 @pytest.fixture(scope="function")
@@ -62,3 +61,32 @@ def uploaded_dv_with_immediate_binding(
         assert dv.pvc.bound(), f"PVC status is {dv.pvc.status}"
         yield dv
         dv.delete(wait=True)
+
+
+@pytest.fixture(scope="class")
+def uploaded_dv_scope_class(unprivileged_client, namespace, storage_class_name_scope_class):
+    dv_name = f"upload-existing-dv-{str(uuid.uuid4())[:8]}"
+    get_downloaded_artifact(
+        remote_name=f"{Images.Cdi.DIR}/{Images.Cdi.QCOW2_IMG}",
+        local_name=LOCAL_PATH,
+    )
+    with create_dv(
+        source="upload",
+        dv_name=dv_name,
+        namespace=namespace.name,
+        size=DEFAULT_DV_SIZE,
+        storage_class=storage_class_name_scope_class,
+        client=unprivileged_client,
+    ) as dv:
+        dv.wait_for_status(status=DataVolume.Status.UPLOAD_READY, timeout=TIMEOUT_2MIN)
+        with virtctl_upload_dv(
+            namespace=namespace.name,
+            name=dv.name,
+            size=DEFAULT_DV_SIZE,
+            image_path=LOCAL_PATH,
+            insecure=True,
+            storage_class=storage_class_name_scope_class,
+            no_create=True,
+        ) as upload_result:
+            check_upload_virtctl_result(result=upload_result)
+            yield dv

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -583,3 +583,8 @@ def rhel10_data_source_scope_session(golden_images_namespace):
         client=golden_images_namespace.client,
         ensure_exists=True,
     )
+
+
+@pytest.fixture(scope="class")
+def storage_class_name_scope_class(storage_class_matrix__class__):
+    return [*storage_class_matrix__class__][0]

--- a/tests/storage/hpp/test_hpp_csi_cr.py
+++ b/tests/storage/hpp/test_hpp_csi_cr.py
@@ -18,8 +18,7 @@ from tests.storage.hpp.utils import (
     verify_hpp_cr_deleted_successfully,
     verify_hpp_cr_installed_successfully,
 )
-from tests.storage.utils import create_vm_from_dv
-from utilities.storage import HppCsiStorageClass
+from utilities.storage import HppCsiStorageClass, create_vm_from_dv
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -5,7 +5,6 @@ Restricted namespace cloning
 import logging
 
 import pytest
-from ocp_resources.datavolume import DataVolume
 
 from tests.storage.constants import ADMIN_NAMESPACE_PARAM
 from tests.storage.restricted_namespace_cloning.constants import (
@@ -23,7 +22,6 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VERBS_SRC,
 )
 from tests.storage.restricted_namespace_cloning.utils import create_dv_negative, verify_snapshot_used_namespace_transfer
-from tests.storage.utils import verify_vm_disk_image_permission
 from utilities.storage import create_vm_from_dv
 
 LOGGER = logging.getLogger(__name__)
@@ -85,7 +83,7 @@ def test_unprivileged_user_clone_dv_same_namespace_positive(
 )
 def test_user_permissions_positive(
     unprivileged_client,
-    storage_class_matrix__module__,
+    admin_client,
     storage_class_name_scope_module,
     permissions_pvc_destination,
     dv_destination_cloned_from_pvc,
@@ -93,12 +91,8 @@ def test_user_permissions_positive(
 ):
     verify_snapshot_used_namespace_transfer(cdv=dv_destination_cloned_from_pvc, unprivileged_client=unprivileged_client)
     if requested_verify_image_permissions:
-        with create_vm_from_dv(dv=dv_destination_cloned_from_pvc) as vm:
-            if (
-                storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"]
-                == DataVolume.VolumeMode.FILE
-            ):
-                verify_vm_disk_image_permission(vm=vm)
+        with create_vm_from_dv(dv=dv_destination_cloned_from_pvc):
+            pass
 
 
 @pytest.mark.sno

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -155,11 +155,6 @@ def fedora_vm_for_hotplug_scope_class(namespace, param_substring_scope_class, cp
 
 
 @pytest.fixture(scope="class")
-def storage_class_name_scope_class(storage_class_matrix__class__):
-    return [*storage_class_matrix__class__][0]
-
-
-@pytest.fixture(scope="class")
 def blank_disk_dv_multi_storage_scope_class(namespace, param_substring_scope_class, storage_class_name_scope_class):
     with create_dv(
         source="blank",

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -13,7 +13,7 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from tests.storage.constants import CIRROS_QCOW2_IMG
-from tests.storage.utils import create_vm_from_dv, upload_image_to_dv, upload_token_request
+from tests.storage.utils import upload_image_to_dv, upload_token_request
 from utilities.constants import (
     TIMEOUT_2MIN,
     TIMEOUT_4MIN,
@@ -32,6 +32,7 @@ from utilities.storage import (
     check_disk_count_in_vm,
     check_upload_virtctl_result,
     create_dv,
+    create_vm_from_dv,
     data_volume,
     get_downloaded_artifact,
     get_test_artifact_server_url,

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -42,7 +42,6 @@ from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.storage import (
     PodWithPVC,
     create_dv,
-    create_vm_from_dv,
     get_containers_for_pods_with_pvc,
 )
 from utilities.virt import (
@@ -241,21 +240,6 @@ def set_permissions(
             role_ref_name=cluster_role.name,
         ):
             yield
-
-
-def create_vm_and_verify_image_permission(dv: DataVolume) -> None:
-    with create_vm_from_dv(dv=dv) as vm:
-        running_vm(vm=vm, check_ssh_connectivity=False, wait_for_interfaces=False)
-        verify_vm_disk_image_permission(vm=vm)
-
-
-def verify_vm_disk_image_permission(vm: VirtualMachineForTests) -> None:
-    v_pod = vm.vmi.virt_launcher_pod
-    LOGGER.debug("Check image exist, permission and ownership")
-    output = v_pod.execute(command=["ls", "-l", "/var/run/kubevirt-private/vmi-disks/dv-disk"])
-    assert "disk.img" in output
-    assert "-rw-rw----." in output
-    assert "qemu qemu" in output
 
 
 def get_importer_pod(


### PR DESCRIPTION

##### Short description:
cherry-pick https://github.com/RedHatQE/openshift-virtualization-tests/pull/2401 


##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
