### PR TITLE
add client to cluster_instance_type_for_hot_plug

### DIFF
--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -80,25 +80,25 @@ def hotplug_preference(admin_client):
 
 
 @pytest.fixture(scope="class")
-def four_sockets_instance_type(modern_cpu_for_migration):
+def four_sockets_instance_type(admin_client, modern_cpu_for_migration):
     with cluster_instance_type_for_hot_plug(
-        guest_sockets=FOUR_CPU_SOCKETS, cpu_model=modern_cpu_for_migration
+        client=admin_client, guest_sockets=FOUR_CPU_SOCKETS, cpu_model=modern_cpu_for_migration
     ) as instance_type:
         yield instance_type
 
 
 @pytest.fixture(scope="class")
-def six_sockets_instance_type(modern_cpu_for_migration):
+def six_sockets_instance_type(admin_client, modern_cpu_for_migration):
     with cluster_instance_type_for_hot_plug(
-        guest_sockets=SIX_CPU_SOCKETS, cpu_model=modern_cpu_for_migration
+        client=admin_client, guest_sockets=SIX_CPU_SOCKETS, cpu_model=modern_cpu_for_migration
     ) as instance_type:
         yield instance_type
 
 
 @pytest.fixture(scope="class")
-def ten_sockets_instance_type(modern_cpu_for_migration):
+def ten_sockets_instance_type(admin_client, modern_cpu_for_migration):
     with cluster_instance_type_for_hot_plug(
-        guest_sockets=TEN_CPU_SOCKETS, cpu_model=modern_cpu_for_migration
+        client=admin_client, guest_sockets=TEN_CPU_SOCKETS, cpu_model=modern_cpu_for_migration
     ) as instance_type:
         yield instance_type
 

--- a/utilities/ssp.py
+++ b/utilities/ssp.py
@@ -305,8 +305,11 @@ def verify_ssp_pod_is_running(
             raise
 
 
-def cluster_instance_type_for_hot_plug(guest_sockets: int, cpu_model: str | None) -> VirtualMachineClusterInstancetype:
+def cluster_instance_type_for_hot_plug(
+    client: DynamicClient, guest_sockets: int, cpu_model: str | None
+) -> VirtualMachineClusterInstancetype:
     return VirtualMachineClusterInstancetype(
+        client=client,
         name=f"hot-plug-{guest_sockets}-cpu-instance-type",
         memory={"guest": FOUR_GI_MEMORY},
         cpu={

--- a/utilities/unittests/test_ssp.py
+++ b/utilities/unittests/test_ssp.py
@@ -547,8 +547,9 @@ class TestClusterInstanceTypeForHotPlug:
         """Test successful creation of cluster instance type for hot plug"""
         mock_instance_type = MagicMock()
         mock_instance_type_class.return_value = mock_instance_type
+        mock_client = MagicMock()
 
-        result = cluster_instance_type_for_hot_plug(guest_sockets=2, cpu_model="host-model")
+        result = cluster_instance_type_for_hot_plug(client=mock_client, guest_sockets=2, cpu_model="host-model")
 
         assert result == mock_instance_type
         mock_instance_type_class.assert_called_once()
@@ -558,8 +559,9 @@ class TestClusterInstanceTypeForHotPlug:
         """Test cluster instance type creation with None CPU model"""
         mock_instance_type = MagicMock()
         mock_instance_type_class.return_value = mock_instance_type
+        mock_client = MagicMock()
 
-        result = cluster_instance_type_for_hot_plug(guest_sockets=4, cpu_model=None)
+        result = cluster_instance_type_for_hot_plug(client=mock_client, guest_sockets=4, cpu_model=None)
 
         assert result == mock_instance_type
         mock_instance_type_class.assert_called_once()


### PR DESCRIPTION
##### Short description:
add client to cluster_instance_type_for_hot_plug

##### More details:
Add client to cluster_instance_type_for_hot_plug function

##### What this PR does / why we need it:
client is a mandatory field for openshift-wrappe-r objects from next release

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated instance-type hotplug tests to run using an administrative client across multiple socket configurations.

* **Refactor**
  * Instance-type factory now accepts and propagates a client/context so created cluster instance-types are associated with the correct client.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->