### PR TITLE
[IUO] Add test to test assigning default storage class

### DIFF
--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -8,7 +8,9 @@ from ocp_resources.hostpath_provisioner import HostPathProvisioner
 from ocp_resources.hyperconverged import HyperConverged
 from ocp_resources.installplan import InstallPlan
 from ocp_resources.persistent_volume import PersistentVolume
+from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import py_config
+from timeout_sampler import TimeoutSampler
 
 from tests.install_upgrade_operators.product_install.constants import (
     HCO_NOT_INSTALLED_ALERT,
@@ -26,6 +28,7 @@ from utilities.constants import (
     PENDING_STR,
     PRODUCTION_CATALOG_SOURCE,
     TIMEOUT_5MIN,
+    TIMEOUT_5SEC,
     TIMEOUT_10MIN,
     StorageClassNames,
 )
@@ -320,3 +323,23 @@ def cnv_version_to_install_info(is_production_source, ocp_current_version, cnv_i
     if not latest_z_stream:
         pytest.exit(reason="CNV version can't be determined for this run", returncode=INSTALLATION_VERSION_MISMATCH)
     return latest_z_stream
+
+
+@pytest.fixture
+def default_storage_class(admin_client):
+    # if its not on the matrix - we dont need to test it.
+    default_storage_class_name = py_config["default_storage_class"]
+    if not any(default_storage_class_name in sc_dict for sc_dict in py_config["storage_class_matrix"]):
+        pytest.xfail(f"Storage class {default_storage_class_name} not found in the storage class matrix")
+
+    LOGGER.info(f"Waiting for storage class {default_storage_class_name} to be created")
+    default_storage_class = StorageClass(client=admin_client, name=default_storage_class_name)
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_5MIN,
+        sleep=TIMEOUT_5SEC,
+        func=default_storage_class.exists,
+    ):
+        if sample:
+            break
+
+    return default_storage_class

--- a/tests/install_upgrade_operators/product_install/constants.py
+++ b/tests/install_upgrade_operators/product_install/constants.py
@@ -37,6 +37,7 @@ CLUSTER_RESOURCE_ALLOWLIST = {
         "olm.og.openshift-cnv-",
         "kubevirt-ipam-controller-manager-role",
         "kubevirt-synchronization-controller",
+        "kubevirt-migration-controller",
     ],
     "ClusterRoleBinding": [
         "hostpath-provisioner-operator-service-system:auth-delegator",
@@ -60,6 +61,7 @@ CLUSTER_RESOURCE_ALLOWLIST = {
         "olm.og.openshift-cnv-kubevirt-ipam-controller-manager-rolebinding",
         "kubevirt-synchronization-controller",
         "kubevirt-ipam-controller-manager-rolebinding",
+        "kubevirt-migration-sa",
     ],
     "Namespace": ["openshift-cnv", "openshift-virtualization-os-images"],
     "Project": ["openshift-cnv", "openshift-virtualization-os-images"],

--- a/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
+++ b/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from ocp_resources.storage_class import StorageClass
 
 from tests.install_upgrade_operators.product_install.constants import (
     CLUSTER_RESOURCE_ALLOWLIST,
@@ -26,6 +27,7 @@ from utilities.monitoring import (
     wait_for_firing_alert_clean_up,
     wait_for_gauge_metrics_value,
 )
+from utilities.storage import persist_storage_class_default, verify_boot_sources_reimported
 
 CNV_INSTALLATION_TEST = "test_cnv_installation"
 CNV_ALERT_CLEANUP_TEST = "test_cnv_installation_alert_cleanup"
@@ -168,6 +170,25 @@ def test_cnv_resources_installed_namespace_scoped(
     if mismatch_namespaced:
         LOGGER.error(f"Mismatched namespaced resources: {mismatch_namespaced}")
         raise ResourceMismatch(f"Unexpected namespaced resources found post cnv installation: {mismatch_namespaced}")
+
+
+@pytest.mark.polarion("CNV-12453")
+@pytest.mark.order(after=CNV_INSTALLATION_TEST)
+@pytest.mark.dependency(depends=[CNV_INSTALLATION_TEST])
+def test_default_storage_class_set(admin_client, golden_images_namespace, default_storage_class):
+    if (
+        default_storage_class.instance.metadata.get("annotations", {}).get(
+            StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS
+        )
+        != "true"
+    ):
+        # et the default storage class as default for the smoke tests afterwards
+        for storage_class in StorageClass.get(client=admin_client):
+            is_default = True if storage_class.name == default_storage_class.name else False
+            persist_storage_class_default(default=is_default, storage_class=storage_class)
+    assert verify_boot_sources_reimported(
+        admin_client=admin_client, namespace=golden_images_namespace.name, consecutive_checks_count=3
+    ), "Failed to re-import boot sources"
 
 
 @pytest.mark.polarion("CNV-10528")

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1052,7 +1052,9 @@ def get_data_sources_managed_by_data_import_cron(namespace):
     )
 
 
-def verify_boot_sources_reimported(admin_client: DynamicClient, namespace: str) -> bool:
+def verify_boot_sources_reimported(
+    admin_client: DynamicClient, namespace: str, consecutive_checks_count: int = 6
+) -> bool:
     """
     Verify that the boot sources are re-imported while changing a storage class.
     """
@@ -1065,7 +1067,7 @@ def verify_boot_sources_reimported(admin_client: DynamicClient, namespace: str) 
                 resource_kind=DataSource,
                 namespace=namespace,
                 total_timeout=TIMEOUT_10MIN,
-                consecutive_checks_count=6,
+                consecutive_checks_count=consecutive_checks_count,
                 resource_name=data_source.name,
             )
         return True
@@ -1131,3 +1133,29 @@ def validate_file_exists_in_url(url):
         raise UrlNotFoundError(url_request=response)
 
     return True
+
+
+def persist_storage_class_default(default: bool, storage_class: StorageClass) -> None:
+    """
+    Update the default storage class to be persistent.
+
+    Args:
+        default (bool): Whether the storage class should be the default storage class.
+        storage_class (StorageClass): The storage class to update.
+    """
+    is_default = str(default).lower()
+    editor = ResourceEditor(
+        patches={
+            storage_class: {
+                "metadata": {
+                    "annotations": {
+                        StorageClass.Annotations.IS_DEFAULT_CLASS: is_default,
+                        StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS: is_default,
+                    },
+                    "name": storage_class.name,
+                },
+            }
+        }
+    )
+    # Apply the changes to be persistent without backup for restoration
+    editor.update(backup_resources=False)


### PR DESCRIPTION
##### Short description:
Starting from 4.19 - ODF team doesn't set ocs-virt storage class as the default virt-sc while fresh-installing ocs-virt.
After discussing with storage team, we are fine with this behaviour and this will be the default.

##### More details:
In order to make sure it doesn't happen again, we need to add a test to verify this behaviour.

The test should run after test_cnv_installation, and:
1. Get the default storageclass from the matrix.
2. If not virt-default, set it as default storageclass and make sure all the others are not default.
3. Make sure that the all golden images resources are imported successfully.


##### What this PR does / why we need it:
To make sure the expected sc is default post-installation, to make sure this behaviour is consistent.
If not, it will harm our production testing(install lane + smoke + console test for each relealse.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to verify the cluster's default storage class is set correctly during OpenShift Virtualization installation and that boot sources are reimported after changes.
* **Chores**
  * Utilities updated to allow configurable verification retries and to programmatically mark a storage class as the default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->