### PR TITLE
net, kmp: Mark KMP tests with IPv4

### DIFF
--- a/tests/network/dry_run/test_dry_run_kubemacpool.py
+++ b/tests/network/dry_run/test_dry_run_kubemacpool.py
@@ -9,6 +9,9 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = [
+    pytest.mark.ipv4,
+]
 
 MAC_ADDRESS = "macAddress"
 

--- a/tests/network/kubemacpool/explicit_range/test_kmp_custom_range.py
+++ b/tests/network/kubemacpool/explicit_range/test_kmp_custom_range.py
@@ -1,5 +1,9 @@
 import pytest
 
+pytestmark = [
+    pytest.mark.ipv4,
+]
+
 
 @pytest.mark.polarion("CNV-12568")
 def test_kmp_random_custom_range_hco(


### PR DESCRIPTION
On this change, KubeMacPool tests are marked as IPv4 because they should not be collected on IPv6 single-stack clusters. KMP tests are currently not adapted for running on IPv6 single-stack clusters and would require changes such as assigning IPv6 addresses to the test VMs.
These adjustments are unnecessary, as the existing IPv4 coverage is sufficient to validate the KMP component.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added module-level IPv4 test markers to improve test organization and execution scope; test behavior and logic remain unchanged. This strengthens test categorization and collection across the suite without altering functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->