### PR TITLE
[IUO] Add install test assigning default storage class

### DIFF
--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -8,7 +8,9 @@ from ocp_resources.hostpath_provisioner import HostPathProvisioner
 from ocp_resources.hyperconverged import HyperConverged
 from ocp_resources.installplan import InstallPlan
 from ocp_resources.persistent_volume import PersistentVolume
+from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import py_config
+from timeout_sampler import TimeoutSampler
 
 from tests.install_upgrade_operators.product_install.constants import (
     HCO_NOT_INSTALLED_ALERT,
@@ -26,6 +28,7 @@ from utilities.constants import (
     PENDING_STR,
     PRODUCTION_CATALOG_SOURCE,
     TIMEOUT_5MIN,
+    TIMEOUT_5SEC,
     TIMEOUT_10MIN,
     StorageClassNames,
 )
@@ -320,3 +323,23 @@ def cnv_version_to_install_info(is_production_source, ocp_current_version, cnv_i
     if not latest_z_stream:
         pytest.exit(reason="CNV version can't be determined for this run", returncode=INSTALLATION_VERSION_MISMATCH)
     return latest_z_stream
+
+
+@pytest.fixture
+def default_storage_class(admin_client):
+    # if its not on the matrix - we dont need to test it.
+    default_storage_class_name = py_config["default_storage_class"]
+    if not any(default_storage_class_name in sc_dict for sc_dict in py_config["storage_class_matrix"]):
+        pytest.xfail(f"Storage class {default_storage_class_name} not found in the storage class matrix")
+
+    LOGGER.info(f"Waiting for storage class {default_storage_class_name} to be created")
+    default_storage_class = StorageClass(client=admin_client, name=default_storage_class_name)
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_5MIN,
+        sleep=TIMEOUT_5SEC,
+        func=lambda: default_storage_class.exists,
+    ):
+        if sample:
+            break
+
+    return default_storage_class

--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -325,7 +325,7 @@ def cnv_version_to_install_info(is_production_source, ocp_current_version, cnv_i
     return latest_z_stream
 
 
-@pytest.fixture
+@pytest.fixture()
 def default_storage_class(admin_client):
     # if its not on the matrix - we dont need to test it.
     default_storage_class_name = py_config["default_storage_class"]

--- a/tests/install_upgrade_operators/product_install/constants.py
+++ b/tests/install_upgrade_operators/product_install/constants.py
@@ -37,6 +37,7 @@ CLUSTER_RESOURCE_ALLOWLIST = {
         "olm.og.openshift-cnv-",
         "kubevirt-ipam-controller-manager-role",
         "kubevirt-synchronization-controller",
+        "kubevirt-migration-controller",
     ],
     "ClusterRoleBinding": [
         "hostpath-provisioner-operator-service-system:auth-delegator",
@@ -60,6 +61,7 @@ CLUSTER_RESOURCE_ALLOWLIST = {
         "olm.og.openshift-cnv-kubevirt-ipam-controller-manager-rolebinding",
         "kubevirt-synchronization-controller",
         "kubevirt-ipam-controller-manager-rolebinding",
+        "kubevirt-migration-sa",
     ],
     "Namespace": ["openshift-cnv", "openshift-virtualization-os-images"],
     "Project": ["openshift-cnv", "openshift-virtualization-os-images"],

--- a/tests/install_upgrade_operators/product_install/constants.py
+++ b/tests/install_upgrade_operators/product_install/constants.py
@@ -101,6 +101,14 @@ CLUSTER_RESOURCE_ALLOWLIST = {
 }
 NAMESPACED_IGNORE_KINDS = ["Event", "Template"]
 NAMESPACED_RESOURCE_ALLOWLIST = {
+    "openshift-kube-apiserver": {
+        "Pod": ["installer-", "revision-pruner-"],
+        "PodMetrics": ["installer-", "revision-pruner-"],
+    },
+    "openshift-monitoring": {
+        "Pod": ["metrics-server", "prometheus-k8s", "alertmanager-main"],
+        "PodMetrics": ["metrics-server", "prometheus-k8s", "alertmanager-main"],
+    },
     "kube-system": {
         "RoleBinding": [
             "hostpath-provisioner-operator-service-auth-reader",

--- a/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
+++ b/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from ocp_resources.storage_class import StorageClass
 
 from tests.install_upgrade_operators.product_install.constants import (
     CLUSTER_RESOURCE_ALLOWLIST,
@@ -26,6 +27,7 @@ from utilities.monitoring import (
     wait_for_firing_alert_clean_up,
     wait_for_gauge_metrics_value,
 )
+from utilities.storage import persist_storage_class_default, verify_boot_sources_reimported
 
 CNV_INSTALLATION_TEST = "test_cnv_installation"
 CNV_ALERT_CLEANUP_TEST = "test_cnv_installation_alert_cleanup"
@@ -168,6 +170,25 @@ def test_cnv_resources_installed_namespace_scoped(
     if mismatch_namespaced:
         LOGGER.error(f"Mismatched namespaced resources: {mismatch_namespaced}")
         raise ResourceMismatch(f"Unexpected namespaced resources found post cnv installation: {mismatch_namespaced}")
+
+
+@pytest.mark.polarion("CNV-12453")
+@pytest.mark.order(after=CNV_INSTALLATION_TEST)
+@pytest.mark.dependency(depends=[CNV_INSTALLATION_TEST])
+def test_default_storage_class_set(admin_client, golden_images_namespace, default_storage_class):
+    if (
+        default_storage_class.instance.metadata.get("annotations", {}).get(
+            StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS
+        )
+        != "true"
+    ):
+        # et the default storage class as default for the smoke tests afterwards
+        for storage_class in StorageClass.get(client=admin_client):
+            is_default = True if storage_class.name == default_storage_class.name else False
+            persist_storage_class_default(default=is_default, storage_class=storage_class)
+    assert verify_boot_sources_reimported(
+        admin_client=admin_client, namespace=golden_images_namespace.name, consecutive_checks_count=3
+    ), "Failed to re-import boot sources"
 
 
 @pytest.mark.polarion("CNV-10528")

--- a/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
+++ b/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
@@ -88,6 +88,7 @@ def test_cnv_installation_alert_cleanup(prometheus):
     wait_for_firing_alert_clean_up(prometheus=prometheus, alert_name=HCO_NOT_INSTALLED_ALERT)
 
 
+# TODO: check if this test is still required
 @pytest.mark.polarion("CNV-10076")
 @pytest.mark.order(after=CNV_ALERT_CLEANUP_TEST)
 @pytest.mark.dependency(
@@ -126,6 +127,7 @@ def test_cnv_resources_installed_cluster_scoped(
         raise ResourceMismatch(f"Unexpected cluster resources found post cnv installation: {mismatch_cluster_scoped}")
 
 
+# TODO: check if this test is still required
 @pytest.mark.order(after=CNV_ALERT_CLEANUP_TEST)
 @pytest.mark.dependency(
     depends=[CNV_INSTALLATION_TEST],
@@ -178,6 +180,7 @@ def test_cnv_resources_installed_namespace_scoped(
 
 @pytest.mark.polarion("CNV-12453")
 @pytest.mark.order(after=CNV_INSTALLATION_TEST)
+# Dependency: CNV must be installed before storage class configuration can be verified
 @pytest.mark.dependency(depends=[CNV_INSTALLATION_TEST])
 def test_default_storage_class_set(admin_client, golden_images_namespace, default_storage_class):
     if not is_storage_class_with_default_annotation(storage_class=default_storage_class):

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -755,15 +755,6 @@ def get_default_storage_class(client: DynamicClient) -> StorageClass:
     raise ValueError("No default storage class defined")
 
 
-def is_storage_class_with_default_annotation(storage_class: StorageClass) -> bool:
-    """Check if storage class is marked as default or virt-default."""
-    sc_annotations = storage_class.instance.metadata.get("annotations", {})
-    return (
-        sc_annotations.get(StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS) == "true"
-        or sc_annotations.get(StorageClass.Annotations.IS_DEFAULT_CLASS) == "true"
-    )
-
-
 def is_snapshot_supported_by_sc(sc_name, client):
     sc_instance = StorageClass(client=client, name=sc_name).instance
     for vsc in VolumeSnapshotClass.get(client=client):
@@ -1092,7 +1083,11 @@ def verify_boot_sources_reimported(
 def remove_default_storage_classes(cluster_storage_classes):
     sc_resources = []
     for sc in cluster_storage_classes:
-        if is_storage_class_with_default_annotation(storage_class=sc):
+        sc_annotations = sc.instance.metadata.get("annotations", {})
+        if (
+            sc_annotations.get(StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS) == "true"
+            or sc_annotations.get(StorageClass.Annotations.IS_DEFAULT_CLASS) == "true"
+        ):
             sc_resources.append(
                 ResourceEditor(
                     patches={


### PR DESCRIPTION
##### Short description:
Starting from 4.19 - ODF team doesn't set ocs-virt storage class as the default virt-sc while fresh-installing ocs-virt.
After discussing with storage team, we are fine with this behaviour and this will be the default.

##### More details:
In order to make sure it doesn't happen again, we need to add a test to verify this behaviour.

The test should run after test_cnv_installation, and:
1. Get the default storageclass from the matrix.
2. If not virt-default, set it as default storageclass and make sure all the others are not default.
3. Make sure that the all golden images resources are imported successfully.


##### What this PR does / why we need it:
To make sure the expected sc is default post-installation, to make sure this behaviour is consistent.
If not, it will harm our production testing(install lane + smoke + console test for each relealse.

##### Which issue(s) this PR fixes:
In addition, it fixes system resources that can be recreated with differnt suffix and fail the test.
Added to-do to redesign the test in the near future.
##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-64256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests and supporting fixtures to ensure the configured default storage class is applied and that boot sources are reliably reimported.

* **Chores**
  * Expanded resource allowlists to include KubeVirt migration and additional OpenShift monitoring/API server pods.
  * Enhanced storage utilities to persist default storage-class annotations, make boot-source verification configurable, and handle timeouts/errors more gracefully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->