### PR TITLE
Add tox verify-bugs-are-open-gh to add this check as a check run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ setenv =
 deps =
     python-utility-scripts
 commands =
-    pyutils-jira --url https://issues.redhat.com --target-versions "vfuture,4.22.0,4.22.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
+    pyutils-jira --url https://issues.redhat.com --target-versions "4.19.0,4.19.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --verbose
 
 #Unused code
 [testenv:unused-code]


### PR DESCRIPTION
##### Short description:
To allow open bugs check to be a GH check run, integrated with myk-org/github-webhook-server#961 - tox was updated with an explicit command
Manual cherrypick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/3048

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
