### PR TITLE
[4.19] Add wait for boot sources reimported

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2473,9 +2473,11 @@ def migrated_vm_multiple_times(request, vm_for_migration_test):
 
 
 @pytest.fixture()
-def removed_default_storage_classes(cluster_storage_classes):
+def removed_default_storage_classes(admin_client, golden_images_namespace, cluster_storage_classes):
     with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
         yield
+    if not verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name):
+        pytest.fail("Failed to reimport all boot sources at teardown")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
##### Short description:
Add wait for boot sources re-imported after changing the default storage class in the cluster

##### More details:
After changing the default storage class, the data import crons re-import the data sources using the new storage class. this causes issues in following tests if we do not wait for the sources to complete the import.

Manual cherry-pick of - https://github.com/RedHatQE/openshift-virtualization-tests/pull/3428