### PR TITLE
[IUO] Expect only stable channel in manifest

### DIFF
--- a/tests/install_upgrade_operators/csv/test_subscription_channels.py
+++ b/tests/install_upgrade_operators/csv/test_subscription_channels.py
@@ -4,10 +4,11 @@ pytestmark = [pytest.mark.sno, pytest.mark.s390x, pytest.mark.skip_must_gather_c
 
 
 @pytest.mark.polarion("CNV-7169")
-def test_channels_in_manifest(kubevirt_package_manifest_channels):
-    expected_channels = {"stable", "candidate"}
-    missing_channels = expected_channels - {channel.name for channel in kubevirt_package_manifest_channels}
-    assert not missing_channels, f"Missing channels: {missing_channels}"
+def test_stable_channel_in_manifest(kubevirt_package_manifest_channels):
+    channels_names_from_manifest = [channel.name for channel in kubevirt_package_manifest_channels]
+    assert "stable" in channels_names_from_manifest, (
+        f"Stable channel must be on package manifest\nAvailable channels: {channels_names_from_manifest}"
+    )
 
 
 @pytest.mark.polarion("CNV-11944")


### PR DESCRIPTION
##### Short description:
For fresh Y streams,
candidate channel won't be on manifest.
This is because candidate won't be created yet until 4.Y.0 release.

We should check only stable channel,
because this is the default one and must exist.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-77281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test validation to focus on verification of the "stable" channel in package manifest.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->