### PR TITLE
CherryPicked: [cnv-4.20] Remove Artifactory dependency from kubevirt_vmi_non_evictable test

### DIFF
--- a/tests/infrastructure/golden_images/constants.py
+++ b/tests/infrastructure/golden_images/constants.py
@@ -1,4 +1,3 @@
-DEFAULT_FEDORA_REGISTRY_URL = "docker://quay.io/containerdisks/fedora:latest"
 DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE = "DataSource is ready to be consumed"
 CUSTOM_DATA_IMPORT_CRON_NAME = "custom-data-import-cron"
 CUSTOM_DATA_SOURCE_NAME = "custom-data-source"

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -14,11 +14,11 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from tests.infrastructure.golden_images.constants import (
     CUSTOM_DATA_IMPORT_CRON_NAME,
     CUSTOM_DATA_SOURCE_NAME,
-    DEFAULT_FEDORA_REGISTRY_URL,
 )
 from tests.infrastructure.golden_images.update_boot_source.utils import get_all_dic_volume_names, get_image_version
 from utilities.constants import (
     BIND_IMMEDIATE_ANNOTATION,
+    DEFAULT_FEDORA_REGISTRY_URL,
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -14,11 +14,10 @@ from tests.infrastructure.golden_images.constants import (
     CUSTOM_DATA_IMPORT_CRON_NAME,
     CUSTOM_DATA_SOURCE_NAME,
     DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE,
-    DEFAULT_FEDORA_REGISTRY_URL,
     PVC_NOT_FOUND_ERROR,
 )
 from tests.utils import get_parameters_from_template
-from utilities.constants import DATA_SOURCE_NAME, TIMEOUT_5MIN, TIMEOUT_10MIN, Images
+from utilities.constants import DATA_SOURCE_NAME, DEFAULT_FEDORA_REGISTRY_URL, TIMEOUT_5MIN, TIMEOUT_10MIN, Images
 from utilities.exceptions import ResourceValueError
 from utilities.infra import (
     cleanup_artifactory_secret_and_config_map,

--- a/tests/infrastructure/golden_images/update_boot_source/utils.py
+++ b/tests/infrastructure/golden_images/update_boot_source/utils.py
@@ -9,10 +9,7 @@ from ocp_resources.template import Template
 from ocp_resources.volume_snapshot import VolumeSnapshot
 from packaging.version import Version
 
-from tests.infrastructure.golden_images.constants import (
-    DEFAULT_FEDORA_REGISTRY_URL,
-)
-from utilities.constants import TIMEOUT_30SEC, WILDCARD_CRON_EXPRESSION
+from utilities.constants import DEFAULT_FEDORA_REGISTRY_URL, TIMEOUT_30SEC, WILDCARD_CRON_EXPRESSION
 from utilities.infra import generate_openshift_pull_secret_file
 from utilities.storage import RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL
 from utilities.virt import get_oc_image_info

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -4,6 +4,7 @@ import shlex
 import bitmath
 import pytest
 from ocp_resources.data_source import DataSource
+from ocp_resources.datavolume import DataVolume
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
@@ -39,6 +40,7 @@ from tests.observability.utils import validate_metrics_value
 from tests.utils import create_vms, start_stress_on_vm
 from utilities import console
 from utilities.constants import (
+    DEFAULT_FEDORA_REGISTRY_URL,
     IPV4_STR,
     KUBEVIRT_VMI_MEMORY_PGMAJFAULT_TOTAL,
     KUBEVIRT_VMI_MEMORY_PGMINFAULT_TOTAL,
@@ -50,6 +52,7 @@ from utilities.constants import (
     ONE_CPU_CORE,
     ONE_CPU_THREAD,
     OS_FLAVOR_FEDORA,
+    REGISTRY_STR,
     SSP_OPERATOR,
     STRESS_CPU_MEM_IO_COMMAND,
     TIMEOUT_2MIN,
@@ -85,6 +88,7 @@ from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
     running_vm,
+    vm_instance_from_template,
 )
 from utilities.vnc_utils import VNCConnection
 
@@ -660,3 +664,27 @@ def expected_cpu_affinity_metric_value(vm_with_cpu_spec):
 
     # return multiplication for multi-CPU VMs
     return str(cpu_count_from_vm_node * cpu_count_from_vm)
+
+
+@pytest.fixture()
+def vm_with_rwo_dv(request, unprivileged_client, namespace):
+    dv = DataVolume(
+        client=unprivileged_client,
+        source=REGISTRY_STR,
+        name="non-evictable-vm-dv-for-test",
+        namespace=namespace.name,
+        url=DEFAULT_FEDORA_REGISTRY_URL,
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=py_config["default_storage_class"],
+        access_modes=DataVolume.AccessMode.RWO,
+        api_name="storage",
+    )
+    dv.to_dict()
+    dv_res = dv.res
+    with vm_instance_from_template(
+        request=request,
+        unprivileged_client=unprivileged_client,
+        namespace=namespace,
+        data_volume_template={"metadata": dv_res["metadata"], "spec": dv_res["spec"]},
+    ) as vm:
+        yield vm

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -3,13 +3,11 @@ from datetime import datetime, timezone
 
 import bitmath
 import pytest
-from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance_migration import (
     VirtualMachineInstanceMigration,
 )
-from pytest_testconfig import py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.observability.metrics.constants import (
@@ -26,7 +24,7 @@ from tests.observability.metrics.utils import (
     validate_vnic_info,
 )
 from tests.observability.utils import validate_metrics_value
-from tests.os_params import FEDORA_LATEST_LABELS, RHEL_LATEST
+from tests.os_params import FEDORA_LATEST_LABELS
 from utilities.constants import (
     CAPACITY,
     LIVE_MIGRATE,
@@ -372,16 +370,9 @@ class TestVmResourceLimits:
 
 class TestKubevirtVmiNonEvictable:
     @pytest.mark.parametrize(
-        "data_volume_scope_function, vm_from_template_with_existing_dv",
+        "vm_with_rwo_dv",
         [
             pytest.param(
-                {
-                    "dv_name": "non-evictable-dv",
-                    "image": RHEL_LATEST["image_path"],
-                    "storage_class": py_config["default_storage_class"],
-                    "dv_size": RHEL_LATEST["dv_size"],
-                    "access_modes": DataVolume.AccessMode.RWO,
-                },
                 {
                     "vm_name": "non-evictable-vm",
                     "template_labels": FEDORA_LATEST_LABELS,
@@ -398,8 +389,7 @@ class TestKubevirtVmiNonEvictable:
     def test_kubevirt_vmi_non_evictable(
         self,
         prometheus,
-        data_volume_scope_function,
-        vm_from_template_with_existing_dv,
+        vm_with_rwo_dv,
     ):
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -12,7 +12,6 @@ from tests.storage.constants import (
     HPP_STORAGE_CLASSES,
     HTTP,
     QUAY_FEDORA_CONTAINER_IMAGE,
-    REGISTRY_STR,
 )
 from tests.storage.utils import (
     clean_up_multiprocess,
@@ -23,6 +22,7 @@ from tests.storage.utils import (
 from utilities.constants import (
     LINUX_BRIDGE,
     OS_FLAVOR_FEDORA,
+    REGISTRY_STR,
     TIMEOUT_1MIN,
     TIMEOUT_4MIN,
     Images,

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -4,13 +4,13 @@ import pytest
 from kubernetes.client.rest import ApiException
 from ocp_resources.datavolume import DataVolume
 
-from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE, REGISTRY_STR
+from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
 from tests.storage.utils import (
     create_vm_from_dv,
     get_importer_pod,
     wait_for_importer_container_message,
 )
-from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_5MIN, Images
+from utilities.constants import OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_5MIN, Images
 from utilities.ssp import wait_for_condition_message_value
 from utilities.storage import ErrorMsg, check_disk_count_in_vm, create_dv
 from utilities.virt import running_vm

--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -12,7 +12,6 @@ HPP_STORAGE_CLASSES = [
     HppCsiStorageClass.Name.HOSTPATH_CSI_PVC_BLOCK,
 ]
 
-REGISTRY_STR = "registry"
 INTERNAL_HTTP_CONFIGMAP_NAME = "internal-https-configmap"
 HTTPS_CONFIG_MAP_NAME = "https-cert"
 HTTP = "http"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -968,3 +968,5 @@ STRESS_CPU_MEM_IO_COMMAND = (
     "nohup stress-ng --vm {workers} --vm-bytes {memory} --vm-method all "
     "--verify -t {timeout} -v --hdd 1 --io 1 --vm-keep &> /dev/null &"
 )
+DEFAULT_FEDORA_REGISTRY_URL = "docker://quay.io/containerdisks/fedora:latest"
+REGISTRY_STR = "registry"


### PR DESCRIPTION
##### Short description:
The test for kubevirt_vmi_non_evictable is flaky duo to connectivity issues with the artifactory, in this PR I modified the test to not rely on the artifactory to avoid this kind of failures to stabilize the observability lanes.
Original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/3137
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-77296