### PR TITLE
 CherryPick: [4.19] [INFRA] refactor:  data import cron test fixtures and utilities (#3050)

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/conftest.py
+++ b/tests/infrastructure/golden_images/update_boot_source/conftest.py
@@ -5,21 +5,37 @@ from kubernetes.dynamic.exceptions import NotFoundError
 from ocp_resources.cdi import CDI
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.data_source import DataSource
+from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.ssp import SSP
-from ocp_resources.volume_snapshot import VolumeSnapshot
-from timeout_sampler import TimeoutSampler
+from pytest_testconfig import py_config
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.infrastructure.golden_images.constants import DEFAULT_FEDORA_REGISTRY_URL
 from tests.infrastructure.golden_images.update_boot_source.utils import (
     generate_data_import_cron_dict,
+    get_all_dic_volume_names,
     get_all_release_versions_from_docs,
 )
-from utilities.constants import TIMEOUT_2MIN
+from utilities.constants import (
+    BIND_IMMEDIATE_ANNOTATION,
+    TIMEOUT_1MIN,
+    TIMEOUT_2MIN,
+    TIMEOUT_5SEC,
+    TIMEOUT_10MIN,
+    Images,
+)
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     enable_common_boot_image_import_spec_wait_for_data_import_cron,
 )
-from utilities.storage import RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL
+from utilities.infra import create_ns
+from utilities.ssp import (
+    wait_for_condition_message_value,
+)
+from utilities.storage import data_volume_template_with_source_ref_dict
+from utilities.virt import VirtualMachineForTests, running_vm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,26 +63,6 @@ def enabled_common_boot_image_import_feature_gate_scope_class(
         hco_resource=hyperconverged_resource_scope_class,
         admin_client=admin_client,
         namespace=golden_images_namespace,
-    )
-
-
-@pytest.fixture()
-def golden_images_persistent_volume_claims_scope_function(golden_images_namespace):
-    return list(
-        PersistentVolumeClaim.get(
-            namespace=golden_images_namespace.name,
-            label_selector=RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
-        )
-    )
-
-
-@pytest.fixture()
-def golden_images_volume_snapshot_scope_function(golden_images_namespace):
-    return list(
-        VolumeSnapshot.get(
-            namespace=golden_images_namespace.name,
-            label_selector=RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
-        )
     )
 
 
@@ -138,13 +134,158 @@ def latest_rhel_release_versions_dict():
         e.g., {rhel8: "8.10", rhel9: "9.7", rhel10: "10.1"}
     """
     latest_versions = {}
-    not_found_versions = []
 
     for major_ver_num in [8, 9, 10]:
         all_versions = get_all_release_versions_from_docs(major_ver_num=major_ver_num)
         if not all_versions:
-            not_found_versions.append(major_ver_num)
+            raise ValueError(f"Failed to find RHEL {major_ver_num} versions from documentation")
         latest_versions[major_ver_num] = max(all_versions)
 
-    assert not not_found_versions, f"Failed to find RHEL {major_ver_num} versions from documentation"
     return {f"rhel{major}": f"{major}.{minor}" for major, minor in latest_versions.items()}
+
+
+@pytest.fixture()
+def failed_volume_creation(custom_data_import_cron_scope_function):
+    LOGGER.info("Verify volume was not created.")
+    wait_for_condition_message_value(
+        resource=custom_data_import_cron_scope_function,
+        expected_message="No current import",
+    )
+
+
+@pytest.fixture()
+def updated_data_import_cron(
+    updated_hco_with_custom_data_import_cron_scope_function,
+    hyperconverged_resource_scope_function,
+):
+    updated_hco_with_custom_data_import_cron_scope_function["spec"]["template"]["spec"]["source"]["registry"]["url"] = (
+        DEFAULT_FEDORA_REGISTRY_URL
+    )
+    with ResourceEditor(
+        patches={
+            hyperconverged_resource_scope_function: {
+                "spec": {"dataImportCronTemplates": [updated_hco_with_custom_data_import_cron_scope_function]}
+            }
+        }
+    ):
+        yield
+
+
+@pytest.fixture()
+def reconciled_custom_data_source(custom_data_source_scope_function):
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_10MIN,
+            sleep=TIMEOUT_5SEC,
+            func=lambda: custom_data_source_scope_function.source.exists,
+        ):
+            if sample:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(
+            f"DataSource '{custom_data_source_scope_function.name}' was not reconciled "
+            f"to reference a PVC or VolumeSnapshot, "
+            f"DataSource spec: {custom_data_source_scope_function.instance.spec}"
+        )
+        raise
+
+
+@pytest.fixture()
+def vm_from_custom_data_import_cron(custom_data_source_scope_function, namespace, unprivileged_client):
+    with VirtualMachineForTests(
+        name=f"{custom_data_source_scope_function.name}-vm",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        data_volume_template=data_volume_template_with_source_ref_dict(data_source=custom_data_source_scope_function),
+    ) as vm:
+        running_vm(vm=vm)
+        yield vm
+
+
+@pytest.fixture()
+def data_import_cron_namespace(admin_client, unprivileged_client):
+    yield from create_ns(
+        admin_client=admin_client,
+        unprivileged_client=unprivileged_client,
+        name="data-import-cron-using-default-sc",
+    )
+
+
+@pytest.fixture()
+def created_persistent_volume_claim(unprivileged_client, data_import_cron_namespace):
+    def _get_first_pvc():
+        return next(
+            PersistentVolumeClaim.get(
+                dyn_client=unprivileged_client,
+                namespace=data_import_cron_namespace.name,
+            ),
+            None,
+        )
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_1MIN,
+            sleep=TIMEOUT_5SEC,
+            func=_get_first_pvc,
+        ):
+            if sample:
+                created_dv = DataVolume(
+                    name=sample.name,
+                    namespace=sample.namespace,
+                    client=unprivileged_client,
+                )
+                created_dv.wait_for_dv_success()
+                yield sample
+                created_dv.clean_up()
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"No PVCs were created in {data_import_cron_namespace.name}")
+        raise
+
+
+@pytest.fixture(scope="class")
+def golden_images_data_import_cron_spec(
+    golden_images_data_import_crons_scope_class,
+):
+    assert golden_images_data_import_crons_scope_class, (
+        f"No data import cron job found in {py_config['golden_images_namespace']}"
+    )
+    selected_dic = min(golden_images_data_import_crons_scope_class, key=lambda dic: dic.name)
+    LOGGER.info(f"Using spec from DataImportCron '{selected_dic.name}' as template")
+    return selected_dic.instance.spec
+
+
+@pytest.fixture()
+def created_data_import_cron(
+    unprivileged_client,
+    data_import_cron_namespace,
+    golden_images_data_import_cron_spec,
+):
+    cron_template_spec = golden_images_data_import_cron_spec.template.spec
+    with DataImportCron(
+        name="data-import-cron-for-test",
+        namespace=data_import_cron_namespace.name,
+        managed_data_source=golden_images_data_import_cron_spec.managedDataSource,
+        schedule=golden_images_data_import_cron_spec.schedule,
+        annotations=BIND_IMMEDIATE_ANNOTATION,
+        template={
+            "spec": {
+                "source": {
+                    "registry": {
+                        "url": cron_template_spec.source.registry.url,
+                        "pullMethod": "node",
+                    }
+                },
+                "storage": {
+                    "resources": {"requests": {"storage": cron_template_spec.storage.resources.requests.storage}}
+                },
+            }
+        },
+    ) as data_import_cron:
+        yield data_import_cron
+
+
+@pytest.fixture()
+def existing_dic_volumes_before_disable(admin_client, golden_images_namespace):
+    return get_all_dic_volume_names(client=admin_client, namespace=golden_images_namespace.name)

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
@@ -3,11 +3,11 @@ import logging
 import pytest
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
-from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.infrastructure.golden_images.update_boot_source.utils import (
+    get_all_dic_volume_names,
     template_labels,
 )
 from tests.infrastructure.golden_images.utils import (
@@ -50,18 +50,21 @@ def rhel9_data_source(golden_images_namespace):
 
 @pytest.fixture()
 def existing_data_source_volume(
-    golden_images_persistent_volume_claims_scope_function,
-    golden_images_volume_snapshot_scope_function,
+    admin_client,
+    golden_images_namespace,
     matrix_data_source,
 ):
+    existing_volume_names = get_all_dic_volume_names(
+        client=admin_client,
+        namespace=golden_images_namespace.name,
+    )
+
     source = matrix_data_source.source
-    if source.kind == PersistentVolumeClaim.kind:
-        cluster_volumes = golden_images_persistent_volume_claims_scope_function
-    else:
-        cluster_volumes = golden_images_volume_snapshot_scope_function
-    assert any([source.name in volume.name for volume in cluster_volumes]), (
+
+    assert any(source.name in name for name in existing_volume_names), (
         f"DataSource source {source.kind} {source.name} is missing"
     )
+
     return matrix_data_source
 
 

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -1,14 +1,9 @@
 import logging
-import re
 
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.data_source import DataSource
-from ocp_resources.datavolume import DataVolume
-from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
-from ocp_resources.resource import ResourceEditor
-from pytest_testconfig import py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.infrastructure.golden_images.constants import (
@@ -16,491 +11,28 @@ from tests.infrastructure.golden_images.constants import (
     CUSTOM_DATA_SOURCE_NAME,
     DEFAULT_FEDORA_REGISTRY_URL,
 )
-from tests.infrastructure.golden_images.update_boot_source.utils import get_image_version
+from tests.infrastructure.golden_images.update_boot_source.utils import (
+    get_all_dic_volume_names,
+    get_image_version,
+    wait_for_created_volume_from_data_import_cron,
+    wait_for_existing_auto_update_data_import_crons,
+)
 from utilities.constants import (
-    BIND_IMMEDIATE_ANNOTATION,
-    TIMEOUT_1MIN,
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,
-    TIMEOUT_10MIN,
-    Images,
+    TIMEOUT_5SEC,
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.infra import create_ns
 from utilities.ssp import (
-    get_data_import_crons,
-    matrix_auto_boot_data_import_cron_prefixes,
-    wait_for_condition_message_value,
     wait_for_deleted_data_import_crons,
 )
-from utilities.storage import DATA_IMPORT_CRON_SUFFIX, data_volume_template_with_source_ref_dict
+from utilities.storage import data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, running_vm
 
 LOGGER = logging.getLogger(__name__)
 
 
 pytestmark = pytest.mark.post_upgrade
-
-
-def wait_for_existing_auto_update_data_import_crons(admin_client, namespace):
-    def _get_missing_data_import_crons(_client, _namespace, _auto_boot_data_import_cron_prefixes):
-        data_import_crons = get_data_import_crons(admin_client=_client, namespace=_namespace)
-        return [
-            data_import_cron_prefix
-            for data_import_cron_prefix in _auto_boot_data_import_cron_prefixes
-            if data_import_cron_prefix
-            not in [
-                re.sub(DATA_IMPORT_CRON_SUFFIX, "", data_import_cron.name) for data_import_cron in data_import_crons
-            ]
-        ]
-
-    sample = None
-    auto_boot_data_import_cron_prefixes = matrix_auto_boot_data_import_cron_prefixes()
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_2MIN,
-            sleep=5,
-            func=_get_missing_data_import_crons,
-            _client=admin_client,
-            _namespace=namespace,
-            _auto_boot_data_import_cron_prefixes=auto_boot_data_import_cron_prefixes,
-        ):
-            if not sample:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(f"Some dataImportCron resources are missing: {sample}")
-        raise
-
-
-def wait_for_created_volume_from_data_import_cron(custom_data_source):
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_5MIN,
-            sleep=5,
-            func=lambda: custom_data_source.source.exists,
-        ):
-            if sample:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(
-            f"Volume was not created under {custom_data_source.namespace} namespace, "
-            f"DataSource conditions: {custom_data_source.instance.get('status', {}).get('conditions')}"
-        )
-        raise
-
-
-def create_vm_with_infer_from_volume(
-    client,
-    namespace,
-    data_source_for_test,
-):
-    with VirtualMachineForTests(
-        name="vm-with-infer-from-volume",
-        namespace=namespace.name,
-        client=client,
-        vm_instance_type_infer=True,
-        vm_preference_infer=True,
-        data_volume_template=data_volume_template_with_source_ref_dict(data_source=data_source_for_test),
-    ) as vm:
-        return vm
-
-
-def verify_expected_volumes_exist(existing_volume_names, expected_volume_names):
-    LOGGER.info("Verify volumes are not deleted after opt-out.")
-    assert all([
-        any([expected_name in existing_name for existing_name in existing_volume_names])
-        for expected_name in expected_volume_names
-    ]), f"Not all Volumes exist!\nExisting: {existing_volume_names}\nExpected: {expected_volume_names}"
-
-
-@pytest.fixture()
-def failed_volume_creation(custom_data_import_cron_scope_function):
-    LOGGER.info("Verify volume was not created.")
-    wait_for_condition_message_value(
-        resource=custom_data_import_cron_scope_function,
-        expected_message="No current import",
-    )
-
-
-@pytest.fixture()
-def updated_data_import_cron(
-    updated_hco_with_custom_data_import_cron_scope_function,
-    hyperconverged_resource_scope_function,
-):
-    updated_hco_with_custom_data_import_cron_scope_function["spec"]["template"]["spec"]["source"]["registry"]["url"] = (
-        DEFAULT_FEDORA_REGISTRY_URL
-    )
-    ResourceEditor(
-        patches={
-            hyperconverged_resource_scope_function: {
-                "spec": {"dataImportCronTemplates": [updated_hco_with_custom_data_import_cron_scope_function]}
-            }
-        }
-    ).update()
-
-
-@pytest.fixture()
-def reconciled_custom_data_source(custom_data_source_scope_function):
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_10MIN,
-            sleep=5,
-            func=lambda: custom_data_source_scope_function.source.exists,
-        ):
-            if sample:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(
-            "DataSource was not reconciled to reference a PVC or VolumeSnapshot, "
-            f"DataSource spec: {custom_data_source_scope_function.instance.get('spec')}"
-        )
-        raise
-
-
-@pytest.fixture()
-def vm_from_custom_data_import_cron(custom_data_source_scope_function, namespace, unprivileged_client):
-    with VirtualMachineForTests(
-        name=f"{custom_data_source_scope_function.name}-vm",
-        namespace=namespace.name,
-        client=unprivileged_client,
-        memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-        data_volume_template=data_volume_template_with_source_ref_dict(data_source=custom_data_source_scope_function),
-    ) as vm:
-        running_vm(vm=vm)
-        yield vm
-
-
-@pytest.fixture()
-def data_import_cron_namespace(admin_client, unprivileged_client):
-    yield from create_ns(
-        admin_client=admin_client,
-        unprivileged_client=unprivileged_client,
-        name="data-import-cron-using-default-sc",
-    )
-
-
-@pytest.fixture()
-def created_persistent_volume_claim(unprivileged_client, data_import_cron_namespace):
-    def _get_pvc():
-        return list(
-            PersistentVolumeClaim.get(
-                dyn_client=unprivileged_client,
-                namespace=data_import_cron_namespace.name,
-            )
-        )[0]
-
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_1MIN,
-            sleep=1,
-            func=_get_pvc,
-            exceptions_dict={IndexError: []},
-        ):
-            if sample:
-                created_dv = DataVolume(name=sample.name, namespace=sample.namespace)
-                created_dv.wait_for_dv_success()
-                yield sample
-                created_dv.clean_up()
-                break
-    except TimeoutExpiredError:
-        LOGGER.error(f"No PVCs were created in {data_import_cron_namespace.name}")
-        raise
-
-
-@pytest.fixture(scope="class")
-def golden_images_data_import_cron_spec(
-    golden_images_data_import_crons_scope_class,
-):
-    assert golden_images_data_import_crons_scope_class, (
-        f"No data import cron job found in {py_config['golden_images_namespace']}"
-    )
-    return golden_images_data_import_crons_scope_class[0].instance.spec
-
-
-@pytest.fixture()
-def created_data_import_cron(
-    unprivileged_client,
-    data_import_cron_namespace,
-    golden_images_data_import_cron_spec,
-):
-    cron_template_spec = golden_images_data_import_cron_spec.template.spec
-    with DataImportCron(
-        name="data-import-cron-for-test",
-        namespace=data_import_cron_namespace.name,
-        managed_data_source=golden_images_data_import_cron_spec.managedDataSource,
-        schedule=golden_images_data_import_cron_spec.schedule,
-        annotations=BIND_IMMEDIATE_ANNOTATION,
-        template={
-            "spec": {
-                "source": {
-                    "registry": {
-                        "url": cron_template_spec.source.registry.url,
-                        "pullMethod": "node",
-                    }
-                },
-                "storage": {
-                    "resources": {"requests": {"storage": cron_template_spec.storage.resources.requests.storage}}
-                },
-            }
-        },
-    ) as data_import_cron:
-        yield data_import_cron
-
-
-@pytest.fixture()
-def existing_golden_images_volumes_scope_function(
-    golden_images_persistent_volume_claims_scope_function,
-    golden_images_volume_snapshot_scope_function,
-    golden_images_data_import_crons_scope_function,
-):
-    if golden_images_data_import_crons_scope_function[0].instance.status.sourceFormat == "pvc":
-        cluster_volumes = golden_images_persistent_volume_claims_scope_function
-    else:
-        cluster_volumes = golden_images_volume_snapshot_scope_function
-
-    return [volume.name for volume in cluster_volumes if volume.exists]
-
-
-@pytest.mark.polarion("CNV-7531")
-def test_opt_in_data_import_cron_creation(
-    admin_client,
-    golden_images_namespace,
-):
-    LOGGER.info("Verify all DataImportCrons are created when opted in")
-    wait_for_existing_auto_update_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
-
-
-@pytest.mark.parametrize(
-    "updated_hco_with_custom_data_import_cron_scope_function",
-    [
-        pytest.param(
-            {
-                "data_import_cron_name": CUSTOM_DATA_IMPORT_CRON_NAME,
-                "data_import_cron_source_url": DEFAULT_FEDORA_REGISTRY_URL,
-                "managed_data_source_name": CUSTOM_DATA_SOURCE_NAME,
-            },
-            marks=(pytest.mark.polarion("CNV-7885")),
-        ),
-    ],
-    indirect=True,
-)
-def test_custom_data_import_cron_via_hco(
-    updated_hco_with_custom_data_import_cron_scope_function,
-    reconciled_custom_data_source,
-    vm_from_custom_data_import_cron,
-):
-    LOGGER.info(
-        "Test VM running using DataSource from custom DataImportCron "
-        f"{updated_hco_with_custom_data_import_cron_scope_function['metadata']['name']}"
-    )
-    running_vm(vm=vm_from_custom_data_import_cron)
-
-
-@pytest.mark.parametrize(
-    "updated_hco_with_custom_data_import_cron_scope_function",
-    [
-        pytest.param(
-            {
-                "data_import_cron_name": CUSTOM_DATA_IMPORT_CRON_NAME,
-                "data_import_cron_source_url": DEFAULT_FEDORA_REGISTRY_URL,
-                "managed_data_source_name": CUSTOM_DATA_SOURCE_NAME,
-            },
-            marks=(pytest.mark.polarion("CNV-8096")),
-        ),
-    ],
-    indirect=True,
-)
-def test_opt_out_custom_data_import_cron_via_hco_not_deleted(
-    admin_client,
-    updated_hco_with_custom_data_import_cron_scope_function,
-    disabled_common_boot_image_import_hco_spec_scope_function,
-    golden_images_namespace,
-):
-    LOGGER.info("Test Custom DataImportCron is not deleted after opt-out")
-    assert DataImportCron(
-        client=admin_client,
-        name=CUSTOM_DATA_IMPORT_CRON_NAME,
-        namespace=golden_images_namespace.name,
-    ).exists, f"Custom DataImportCron {CUSTOM_DATA_IMPORT_CRON_NAME} not found after opt out"
-
-
-class TestDataImportCronDefaultStorageClass:
-    @pytest.mark.polarion("CNV-7594")
-    def test_data_import_cron_using_default_storage_class(
-        self,
-        updated_default_storage_class_scope_function,
-        created_data_import_cron,
-        created_persistent_volume_claim,
-    ):
-        LOGGER.info(
-            "Test DataImportCron and DV creation when using default storage class "
-            f"{updated_default_storage_class_scope_function.name}"
-        )
-        current_sc = created_persistent_volume_claim.instance.spec.storageClassName
-        assert current_sc == updated_default_storage_class_scope_function.name, (
-            f"PVC {created_persistent_volume_claim.name} expected storage class: "
-            f"{updated_default_storage_class_scope_function.name}, "
-            f"current storage class: {created_persistent_volume_claim}"
-        )
-
-
-@pytest.mark.jira("CNV-64764", run=False)
-@pytest.mark.polarion("CNV-7532")
-def test_data_import_cron_deletion_on_opt_out(
-    golden_images_data_import_crons_scope_function,
-    existing_golden_images_volumes_scope_function,
-    disabled_common_boot_image_import_hco_spec_scope_function,
-):
-    LOGGER.info("Verify DataImportCrons are deleted after opt-out.")
-    wait_for_deleted_data_import_crons(data_import_crons=golden_images_data_import_crons_scope_function)
-    expected_volume_names = [list(datasource)[0] for datasource in py_config["auto_update_data_source_matrix"]]
-    verify_expected_volumes_exist(
-        existing_volume_names=existing_golden_images_volumes_scope_function,
-        expected_volume_names=expected_volume_names,
-    )
-
-
-@pytest.mark.polarion("CNV-7569")
-def test_data_import_cron_reconciled_after_deletion(
-    golden_images_data_import_crons_scope_function,
-):
-    data_import_cron = golden_images_data_import_crons_scope_function[0]
-    LOGGER.info(f"Verify dataImportCron {data_import_cron.name} is reconciled after deletion.")
-
-    data_import_cron_orig_uid = data_import_cron.instance.metadata.uid
-    # Not passing 'wait' as creation time is almost instant
-    data_import_cron.delete()
-
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_5MIN,
-            sleep=5,
-            func=lambda: data_import_cron.instance.metadata.uid != data_import_cron_orig_uid,
-        ):
-            if sample:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error("DataImportCron was not reconciled after deletion")
-        raise
-
-
-@pytest.mark.polarion("CNV-8032")
-def test_data_import_cron_blocked_update(
-    golden_images_data_import_crons_scope_function,
-):
-    updated_data_import_cron = golden_images_data_import_crons_scope_function[0]
-    LOGGER.info(f"Verify dataImportCron {updated_data_import_cron.name} cannot be updated.")
-    with pytest.raises(UnprocessibleEntityError, match=r".*Cannot update DataImportCron Spec.*"):
-        with ResourceEditorValidateHCOReconcile(
-            patches={updated_data_import_cron: {"spec": {"managedDataSource": CUSTOM_DATA_SOURCE_NAME}}},
-        ):
-            return
-
-
-@pytest.mark.parametrize(
-    "updated_hco_with_custom_data_import_cron_scope_function",
-    [
-        pytest.param(
-            {
-                "data_import_cron_name": "dic-non-existing-source",
-                "data_import_cron_source_url": "docker://non-existing-url",
-                "managed_data_source_name": "non-existing-url-data-source",
-            },
-            marks=(pytest.mark.polarion("CNV-7575")),
-        ),
-    ],
-    indirect=True,
-)
-def test_custom_data_import_cron_image_updated_via_hco(
-    admin_client,
-    updated_hco_with_custom_data_import_cron_scope_function,
-    custom_data_source_scope_function,
-    failed_volume_creation,
-    updated_data_import_cron,
-):
-    LOGGER.info("Verify custom volume is created after DataImportCron update with a valid registry URL.")
-    wait_for_created_volume_from_data_import_cron(custom_data_source=custom_data_source_scope_function)
-
-
-@pytest.mark.polarion("CNV-7669")
-def test_data_import_cron_recreated_after_opt_out_opt_in(
-    admin_client,
-    golden_images_namespace,
-    disabled_common_boot_image_import_hco_spec_scope_function,
-    enabled_common_boot_image_import_feature_gate_scope_function,
-):
-    LOGGER.info("Verify dataImportCron is re-created after opt-out -> opt-in")
-    wait_for_existing_auto_update_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
-
-
-@pytest.mark.parametrize(
-    "updated_hco_with_custom_data_import_cron_scope_function",
-    [
-        pytest.param(
-            {
-                "data_import_cron_name": "data-import-cron-with-invalid-source-url",
-                "data_import_cron_source_url": "non-existing-url",
-                "managed_data_source_name": "invalid-source-url-data-source",
-            },
-            marks=(pytest.mark.polarion("CNV-8078")),
-        ),
-    ],
-    indirect=True,
-)
-def test_data_import_cron_invalid_source_url_failed_creation(
-    updated_hco_with_custom_data_import_cron_scope_function,
-    ssp_resource_scope_function,
-):
-    def get_ssp_degraded_condition(_ssp_cr):
-        return [
-            condition
-            for condition in _ssp_cr.instance.status.conditions
-            if condition["type"] == ssp_resource_scope_function.Condition.DEGRADED
-        ]
-
-    LOGGER.info("verify SSP reports invalid source URL in custom dataImportCron.")
-    expected_degradation_message = "Illegal registry source URL scheme"
-    sample = None
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_2MIN,
-            sleep=5,
-            func=get_ssp_degraded_condition,
-            _ssp_cr=ssp_resource_scope_function,
-        ):
-            if sample and expected_degradation_message in sample[0]["message"]:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(
-            "SSP degraded conditions do not report failed dataImportCron configuration; "
-            f"excepted error: {expected_degradation_message}, actual conditions: {sample}"
-        )
-        raise
-
-
-@pytest.mark.polarion("CNV-9917")
-def test_data_source_instancetype_preference_label(
-    unprivileged_client,
-    namespace,
-    golden_images_namespace,
-    golden_images_data_import_crons_scope_function,
-):
-    failed_data_source_list = []
-    for data_source in golden_images_data_import_crons_scope_function:
-        data_source_name = data_source.instance.spec.managedDataSource
-        try:
-            with create_vm_with_infer_from_volume(
-                client=unprivileged_client,
-                namespace=namespace,
-                data_source_for_test=DataSource(name=data_source_name, namespace=golden_images_namespace.name),
-            ):
-                pass
-        except Exception as exp:
-            failed_data_source_list.append(data_source_name)
-            LOGGER.error(f"VM with data source: {data_source_name} creation failed from unexpected reason: {exp}")
-    assert not failed_data_source_list, (
-        f"Could not create VMs with the following data sources: {failed_data_source_list}"
-    )
 
 
 @pytest.mark.parametrize(
@@ -531,3 +63,261 @@ def test_updated_rhel_image(
     managed_data_source = rhel_instance_dict.spec.managedDataSource
     assert managed_data_source, "spec.managedDataSource doesn't exists"
     assert latest_rhel_release_versions_dict[managed_data_source] == image_reference_version
+
+
+class TestDataImportCronValidation:
+    """verify existing DICs behavior"""
+
+    @pytest.mark.polarion("CNV-7531")
+    def test_opt_in_data_import_cron_creation(self, admin_client, golden_images_namespace):
+        LOGGER.info("Verify all DataImportCrons are created when opted in")
+        wait_for_existing_auto_update_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
+
+    @pytest.mark.polarion("CNV-8032")
+    def test_data_import_cron_blocked_update(self, golden_images_data_import_crons_scope_function):
+        first_data_import_cron = golden_images_data_import_crons_scope_function[0]
+        LOGGER.info(f"Verify dataImportCron {first_data_import_cron.name} cannot be updated.")
+        with pytest.raises(UnprocessibleEntityError, match=r".*Cannot update DataImportCron Spec.*"):
+            with ResourceEditorValidateHCOReconcile(
+                patches={first_data_import_cron: {"spec": {"managedDataSource": CUSTOM_DATA_SOURCE_NAME}}},
+            ):
+                pytest.fail("Expected UnprocessibleEntityError was not raised")
+
+
+class TestDataImportCronOptOutOptIn:
+    """Tests for DICs opt-out/opt-in."""
+
+    @pytest.mark.polarion("CNV-7532")
+    def test_data_import_cron_deletion_on_opt_out(
+        self,
+        admin_client,
+        golden_images_namespace,
+        existing_dic_volumes_before_disable,
+        golden_images_data_import_crons_scope_function,
+        disabled_common_boot_image_import_hco_spec_scope_function,
+    ):
+        LOGGER.info("Verify DataImportCrons are deleted after opt-out.")
+        wait_for_deleted_data_import_crons(data_import_crons=golden_images_data_import_crons_scope_function)
+        volumes_after = get_all_dic_volume_names(client=admin_client, namespace=golden_images_namespace.name)
+        missing_volumes = set(existing_dic_volumes_before_disable) - set(volumes_after)
+        assert not missing_volumes, (
+            f"DataImportCron deletion should not affect existing volumes.\n"
+            f"Missing volumes: {sorted(missing_volumes)}\n"
+            f"Volumes before: {sorted(existing_dic_volumes_before_disable)}\n"
+            f"Volumes after: {sorted(volumes_after)}"
+        )
+
+    @pytest.mark.parametrize(
+        "updated_hco_with_custom_data_import_cron_scope_function",
+        [
+            pytest.param(
+                {
+                    "data_import_cron_name": CUSTOM_DATA_IMPORT_CRON_NAME,
+                    "data_import_cron_source_url": DEFAULT_FEDORA_REGISTRY_URL,
+                    "managed_data_source_name": CUSTOM_DATA_SOURCE_NAME,
+                },
+                marks=(pytest.mark.polarion("CNV-8096")),
+            ),
+        ],
+        indirect=True,
+    )
+    def test_opt_out_preserves_custom_dics(
+        self,
+        admin_client,
+        updated_hco_with_custom_data_import_cron_scope_function,
+        disabled_common_boot_image_import_hco_spec_scope_function,
+        golden_images_namespace,
+    ):
+        LOGGER.info("Test Custom DataImportCron is not deleted after opt-out")
+        assert DataImportCron(
+            client=admin_client,
+            name=CUSTOM_DATA_IMPORT_CRON_NAME,
+            namespace=golden_images_namespace.name,
+        ).exists, f"Custom DataImportCron {CUSTOM_DATA_IMPORT_CRON_NAME} not found after opt out"
+
+    @pytest.mark.polarion("CNV-7669")
+    def test_opt_in_recreates_all_default_dics(
+        self,
+        admin_client,
+        golden_images_namespace,
+        disabled_common_boot_image_import_hco_spec_scope_function,
+        enabled_common_boot_image_import_feature_gate_scope_function,
+    ):
+        LOGGER.info("Verify dataImportCron is re-created after opt-out -> opt-in")
+        wait_for_existing_auto_update_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
+
+
+class TestDataImportCronReconciliation:
+    """Tests for DIC recreation after deletion"""
+
+    @pytest.mark.polarion("CNV-7569")
+    def test_data_import_cron_auto_recreation_after_deletion(self, golden_images_data_import_crons_scope_function):
+        data_import_cron = golden_images_data_import_crons_scope_function[0]
+        LOGGER.info(f"Verify dataImportCron {data_import_cron.name} is reconciled after deletion.")
+        data_import_cron_orig_uid = data_import_cron.instance.metadata.uid
+        data_import_cron.delete()
+
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=TIMEOUT_5MIN,
+                sleep=TIMEOUT_5SEC,
+                func=lambda: data_import_cron.instance.metadata.uid != data_import_cron_orig_uid,
+            ):
+                if sample:
+                    return
+        except TimeoutExpiredError:
+            LOGGER.error("DataImportCron was not reconciled after deletion")
+            raise
+
+
+class TestCustomDataImportCron:
+    """Tests for user-defined custom DataImportCrons"""
+
+    @pytest.mark.parametrize(
+        "updated_hco_with_custom_data_import_cron_scope_function",
+        [
+            pytest.param(
+                {
+                    "data_import_cron_name": CUSTOM_DATA_IMPORT_CRON_NAME,
+                    "data_import_cron_source_url": DEFAULT_FEDORA_REGISTRY_URL,
+                    "managed_data_source_name": CUSTOM_DATA_SOURCE_NAME,
+                },
+                marks=(pytest.mark.polarion("CNV-7885")),
+            ),
+        ],
+        indirect=True,
+    )
+    def test_custom_data_import_cron_creation(
+        self,
+        updated_hco_with_custom_data_import_cron_scope_function,
+        reconciled_custom_data_source,
+        vm_from_custom_data_import_cron,
+    ):
+        LOGGER.info(
+            "Test VM running using DataSource from custom DataImportCron "
+            f"{updated_hco_with_custom_data_import_cron_scope_function['metadata']['name']}"
+        )
+        running_vm(vm=vm_from_custom_data_import_cron)
+
+    @pytest.mark.parametrize(
+        "updated_hco_with_custom_data_import_cron_scope_function",
+        [
+            pytest.param(
+                {
+                    "data_import_cron_name": "dic-non-existing-source",
+                    "data_import_cron_source_url": "docker://non-existing-url",
+                    "managed_data_source_name": "non-existing-url-data-source",
+                },
+                marks=(pytest.mark.polarion("CNV-7575")),
+            ),
+        ],
+        indirect=True,
+    )
+    def test_custom_data_import_cron_image_update(
+        self,
+        admin_client,
+        updated_hco_with_custom_data_import_cron_scope_function,
+        custom_data_source_scope_function,
+        failed_volume_creation,
+        updated_data_import_cron,
+    ):
+        LOGGER.info("Verify custom volume is created after DataImportCron update with a valid registry URL.")
+        wait_for_created_volume_from_data_import_cron(custom_data_source=custom_data_source_scope_function)
+
+    @pytest.mark.parametrize(
+        "updated_hco_with_custom_data_import_cron_scope_function",
+        [
+            pytest.param(
+                {
+                    "data_import_cron_name": "data-import-cron-with-invalid-source-url",
+                    "data_import_cron_source_url": "non-existing-url",
+                    "managed_data_source_name": "invalid-source-url-data-source",
+                },
+                marks=(pytest.mark.polarion("CNV-8078")),
+            ),
+        ],
+        indirect=True,
+    )
+    def test_custom_data_import_cron_invalid_source_validation(
+        self,
+        updated_hco_with_custom_data_import_cron_scope_function,
+        ssp_resource_scope_function,
+    ):
+        def get_ssp_degraded_condition(_ssp_cr):
+            return [
+                condition
+                for condition in _ssp_cr.instance.status.conditions
+                if condition["type"] == ssp_resource_scope_function.Condition.DEGRADED
+            ]
+
+        LOGGER.info("verify SSP reports invalid source URL in custom dataImportCron.")
+        expected_degradation_message = "Illegal registry source URL scheme"
+        sample = None
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=TIMEOUT_2MIN,
+                sleep=TIMEOUT_5SEC,
+                func=get_ssp_degraded_condition,
+                _ssp_cr=ssp_resource_scope_function,
+            ):
+                if sample and expected_degradation_message in sample[0]["message"]:
+                    return
+        except TimeoutExpiredError:
+            LOGGER.error(
+                "SSP degraded conditions do not report failed dataImportCron configuration; "
+                f"excepted error: {expected_degradation_message}, actual conditions: {sample}"
+            )
+            raise
+
+
+class TestDataSourceVmCreation:
+    """verify vm creation for datasources created from SSP data import cron"""
+
+    @pytest.mark.polarion("CNV-9917")
+    def test_all_datasources_support_vm_creation(
+        self,
+        unprivileged_client,
+        namespace,
+        golden_images_namespace,
+        golden_images_data_import_crons_scope_function,
+    ):
+        failed_data_source_list = []
+        for data_source in golden_images_data_import_crons_scope_function:
+            data_source_name = data_source.instance.spec.managedDataSource
+            try:
+                with VirtualMachineForTests(
+                    name=f"vm-{data_source_name}",
+                    namespace=namespace.name,
+                    client=unprivileged_client,
+                    vm_instance_type_infer=True,
+                    vm_preference_infer=True,
+                    data_volume_template=data_volume_template_with_source_ref_dict(
+                        data_source=DataSource(name=data_source_name, namespace=golden_images_namespace.name)
+                    ),
+                ):
+                    pass
+            except Exception as exp:
+                failed_data_source_list.append(data_source_name)
+                LOGGER.error(f"VM with data source: {data_source_name} creation failed from unexpected reason: {exp}")
+        assert not failed_data_source_list, (
+            f"Could not create VMs with the following data sources: {failed_data_source_list}"
+        )
+
+
+class TestDataImportCronDefaultStorageClass:
+    """Tests for DataImportCron with different storage classes"""
+
+    @pytest.mark.polarion("CNV-7594")
+    def test_data_import_cron_uses_default_storage_class(
+        self, updated_default_storage_class_scope_function, created_data_import_cron, created_persistent_volume_claim
+    ):
+        LOGGER.info(
+            "Test DataImportCron and DV creation when using default storage class "
+            f"{updated_default_storage_class_scope_function.name}"
+        )
+        current_sc = created_persistent_volume_claim.instance.spec.storageClassName
+        assert current_sc == updated_default_storage_class_scope_function.name, (
+            f"PVC {created_persistent_volume_claim.name} expected storage class: "
+            f"{updated_default_storage_class_scope_function.name}, "
+            f"current storage class: {current_sc}"
+        )

--- a/tests/infrastructure/golden_images/update_boot_source/utils.py
+++ b/tests/infrastructure/golden_images/update_boot_source/utils.py
@@ -3,14 +3,34 @@ import re
 
 import requests
 from bs4 import BeautifulSoup
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.data_source import DataSource
+from ocp_resources.namespace import Namespace
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.template import Template
+from ocp_resources.volume_snapshot import VolumeSnapshot
 from packaging.version import Version
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.infrastructure.golden_images.constants import (
     DEFAULT_FEDORA_REGISTRY_URL,
 )
-from utilities.constants import TIMEOUT_30SEC, WILDCARD_CRON_EXPRESSION
+from utilities.constants import (
+    TIMEOUT_2MIN,
+    TIMEOUT_5MIN,
+    TIMEOUT_5SEC,
+    TIMEOUT_30SEC,
+    WILDCARD_CRON_EXPRESSION,
+)
 from utilities.infra import generate_openshift_pull_secret_file
+from utilities.ssp import (
+    get_data_import_crons,
+    matrix_auto_boot_data_import_cron_prefixes,
+)
+from utilities.storage import (
+    DATA_IMPORT_CRON_SUFFIX,
+    RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
+)
 from utilities.virt import get_oc_image_info
 
 LOGGER = logging.getLogger(__name__)
@@ -51,6 +71,36 @@ def template_labels(os):
         workload=Template.Workload.SERVER,
         flavor=Template.Flavor.SMALL,
     )
+
+
+def get_all_dic_volume_names(client: DynamicClient, namespace: str) -> list[str]:
+    """
+    Retrieve all DataImportCron-managed volume names from a namespace.
+
+    The function fetches both PersistentVolumeClaims and VolumeSnapshots that are
+    managed by DataImportCron (identified by the appropriate label selector) and
+    returns their names.
+
+    Args:
+        client (DynamicClient): Dynamic client for resource queries.
+        namespace (str): The namespace to search for volumes.
+
+    Returns:
+        list[str]: Combined list of PVC and VolumeSnapshot names managed by DataImportCron.
+    """
+
+    def _fetch_volume_names(resource_cls: type[PersistentVolumeClaim] | type[VolumeSnapshot]) -> list[str]:
+        return [
+            volume.name
+            for volume in resource_cls.get(
+                client=client,
+                namespace=namespace,
+                label_selector=RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
+            )
+            if volume.exists
+        ]
+
+    return _fetch_volume_names(PersistentVolumeClaim) + _fetch_volume_names(VolumeSnapshot)
 
 
 def get_all_release_versions_from_docs(major_ver_num: int) -> list[int]:
@@ -114,3 +164,75 @@ def get_image_version(image: str) -> str | None:
     except (ValueError, AttributeError, TypeError):
         LOGGER.warning(f"No RHEL version was found from: {image}")
         return None
+
+
+def wait_for_existing_auto_update_data_import_crons(admin_client: DynamicClient, namespace: Namespace) -> None:
+    """
+    Wait for all expected auto-update DataImportCrons to be created in the namespace.
+
+    The function polls for the presence of DataImportCrons matching the expected
+    auto-boot prefixes and returns when all are found or raises TimeoutExpiredError
+    if any are missing after the timeout period.
+
+    Args:
+        admin_client (DynamicClient): Admin client for resource queries.
+        namespace (Namespace): The namespace to check for DataImportCrons.
+
+    Raises:
+        TimeoutExpiredError: If not all expected DataImportCrons are created within 2 minutes.
+    """
+
+    def _get_missing_data_import_crons(
+        _client: DynamicClient, _namespace: Namespace, _auto_boot_data_import_cron_prefixes: list[str]
+    ) -> list[str]:
+        data_import_crons = get_data_import_crons(admin_client=_client, namespace=_namespace)
+
+        extract_existing_dic_prefixes = {re.sub(DATA_IMPORT_CRON_SUFFIX, "", dic.name) for dic in data_import_crons}
+
+        return list(set(_auto_boot_data_import_cron_prefixes) - extract_existing_dic_prefixes)
+
+    sample = None
+    auto_boot_data_import_cron_prefixes = matrix_auto_boot_data_import_cron_prefixes()
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_2MIN,
+            sleep=TIMEOUT_5SEC,
+            func=_get_missing_data_import_crons,
+            _client=admin_client,
+            _namespace=namespace,
+            _auto_boot_data_import_cron_prefixes=auto_boot_data_import_cron_prefixes,
+        ):
+            if not sample:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"Some dataImportCron resources are missing: {sample}")
+        raise
+
+
+def wait_for_created_volume_from_data_import_cron(custom_data_source: DataSource) -> None:
+    """
+    Wait for a DataImportCron to create a volume referenced by a DataSource.
+
+    The function polls the DataSource's source reference and waits until it exists,
+    indicating that the DataImportCron has successfully created the backing volume.
+
+    Args:
+        custom_data_source (DataSource): The DataSource resource to monitor for volume creation.
+
+    Raises:
+        TimeoutExpiredError: If the volume is not created within 5 minutes.
+    """
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_5MIN,
+            sleep=TIMEOUT_5SEC,
+            func=lambda: custom_data_source.source.exists,
+        ):
+            if sample:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(
+            f"Volume was not created under {custom_data_source.namespace} namespace, "
+            f"DataSource conditions: {custom_data_source.instance.get('status', {}).get('conditions')}"
+        )
+        raise


### PR DESCRIPTION
- Move shared pytest fixtures from test file to conftest.py
- Move code to utils.py (wait_for_existing_auto_update_data_import_crons,
wait_for_created_volume_from_data_import_cron,
create_vm_with_infer_from_volume)
- Replacing hardcoded numbers with constants (TIMEOUT_5SEC)
- Reorganize test class order for better logical grouping
- Update test assertions and error messages for clarity

code cleanup, refactoring and having classes for all major use cases .

Expected to provide better stability for flaky behavior seen in https://issues.redhat.com/browse/CNV-64764

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
