### PR TITLE
CherryPicked: [cnv-4.21] net,tests,vm import: add basic coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dependencies = [
   "openshift-python-wrapper>=11.0.93",
   "marshmallow==3.26.1",
   "cachetools>=6.2.2",
+  "dacite>=1.9.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/network/provider_migration/libprovider.py
+++ b/tests/network/provider_migration/libprovider.py
@@ -1,9 +1,18 @@
+import logging
+from functools import cache
+
 from pyVim.connect import Disconnect, SmartConnect
 from pyVmomi import vim
-from timeout_sampler import retry
+from timeout_sampler import TimeoutExpiredError, retry
+
+LOGGER = logging.getLogger(__name__)
 
 
 class VmNotFoundError(Exception):
+    pass
+
+
+class IfaceNotFoundError(Exception):
     pass
 
 
@@ -31,18 +40,31 @@ class SourceHypervisorProvider:
     def content(self) -> vim.ServiceInstanceContent:
         return self._client.RetrieveContent()
 
-    def power_on_vm(self, vm_name: str) -> None:
-        vm = self._get_vm_by_name(name=vm_name)
+    def power_on_vm(self, vm_name: str) -> vim.VirtualMachine:
+        LOGGER.info(f"Powering on VM '{vm_name}'")
+        vm = self.get_vm_by_name(name=vm_name)
         vm.PowerOn()
-        self._check_for_vm_status(vm=vm, status=vim.VirtualMachine.PowerState.poweredOn)
-        self._check_for_ip_obtained(vm=vm)
+        try:
+            self._check_for_vm_status(vm=vm, status=vim.VirtualMachine.PowerState.poweredOn)
+            self._check_for_ip_obtained(vm=vm)
+        except TimeoutExpiredError:
+            LOGGER.error(f"Timeout while trying to power on VM '{vm_name}' or waiting for IP address assignment")
+            raise
+
+        LOGGER.info(f"Successfully powered on VM '{vm_name}'")
+        return vm
 
     def power_off_vm(self, vm_name: str) -> None:
-        vm = self._get_vm_by_name(name=vm_name)
+        LOGGER.info(f"Powering off VM '{vm_name}'")
+        vm = self.get_vm_by_name(name=vm_name)
         vm.PowerOff()
-        self._check_for_vm_status(vm=vm, status=vim.VirtualMachine.PowerState.poweredOff)
+        try:
+            self._check_for_vm_status(vm=vm, status=vim.VirtualMachine.PowerState.poweredOff)
+        except TimeoutExpiredError:
+            LOGGER.error(f"Timeout while trying to power off VM '{vm_name}'")
+            raise
 
-    def _get_vm_by_name(self, name: str) -> vim.VirtualMachine:
+    def get_vm_by_name(self, name: str) -> vim.VirtualMachine:
         for dc in self.content.rootFolder.childEntity:
             for vm in dc.vmFolder.childEntity:
                 if vm.name == name:
@@ -58,3 +80,14 @@ class SourceHypervisorProvider:
     @retry(wait_timeout=120, sleep=5, exceptions_dict={})
     def _check_for_ip_obtained(vm: vim.VirtualMachine) -> bool:
         return vm.guest.ipAddress is not None
+
+
+@cache
+def extract_vm_primary_network_data(vm: vim.VirtualMachine) -> tuple[str, str]:
+    for device in vm.config.hardware.device:
+        if isinstance(device, vim.vm.device.VirtualEthernetCard):
+            for net in getattr(vm.guest, "net", []):
+                if net.macAddress == device.macAddress and net.ipAddress:
+                    return net.macAddress, net.ipAddress[0]
+    else:
+        raise IfaceNotFoundError("No network interface found in the VM or no IP address assigned.")

--- a/tests/network/provider_migration/test_ip_persistence.py
+++ b/tests/network/provider_migration/test_ip_persistence.py
@@ -1,18 +1,63 @@
+from typing import Final
+
 import pytest
 
-from utilities.constants import QUARANTINED
+from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
+from libs.net.vmspec import IP_ADDRESS, lookup_iface_status, lookup_primary_network
+from utilities.constants import PUBLIC_DNS_SERVER_IP
+from utilities.virt import migrate_vm_and_verify
+
+SERVER_PORT: Final[int] = 1234
+VM_CONSOLE_CMD_TIMEOUT: Final[int] = 20
+
+pytestmark = [pytest.mark.mtv, pytest.mark.ipv4]
 
 
-@pytest.mark.mtv
-@pytest.mark.polarion("CNV-12458")
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: Migration takes very long, tracked in MTV-3947",
-    run=False,
-)
-def test_vm_import(mtv_migration_to_cudn_ns, mtv_migration_plan_to_cudn_ns):
-    mtv_migration_plan_to_cudn_ns.wait_for_condition(
-        condition=mtv_migration_plan_to_cudn_ns.Condition.Type.SUCCEEDED,
-        status=mtv_migration_plan_to_cudn_ns.Condition.Status.TRUE,
-        timeout=1000,
-        sleep_time=10,
+@pytest.mark.polarion("CNV-12208")
+def test_mac_and_ip_preserved_after_vm_import(source_vm_network_data, imported_cudn_vm, subtests):
+    source_vm_mac, source_vm_ip = source_vm_network_data
+    target_vm_iface = lookup_iface_status(
+        vm=imported_cudn_vm, iface_name=lookup_primary_network(vm=imported_cudn_vm).name
     )
+    target_vm_mac, target_vm_ip = target_vm_iface.get("mac", None), target_vm_iface.get(IP_ADDRESS, None)
+
+    with subtests.test("MAC preserved"):
+        assert source_vm_mac == target_vm_mac, (
+            f"The MAC address was not preserved during VM import. Expected: {source_vm_mac}, got: {target_vm_mac}."
+        )
+    with subtests.test("IP preserved"):
+        assert source_vm_ip == target_vm_ip, (
+            f"The IP address was not preserved during VM import. Expected: {source_vm_ip}, got: {target_vm_ip}."
+        )
+
+
+@pytest.mark.polarion("CNV-12207")
+def test_imported_vm_egress_connectivity(imported_cudn_vm):
+    imported_cudn_vm.console(commands=[f"ping -c 3 {PUBLIC_DNS_SERVER_IP}"], timeout=VM_CONSOLE_CMD_TIMEOUT)
+
+
+@pytest.mark.polarion("CNV-12212")
+def test_connectivity_between_imported_and_local_vms(imported_cudn_vm, local_cudn_vm):
+    with client_server_active_connection(
+        client_vm=imported_cudn_vm,
+        server_vm=local_cudn_vm,
+        spec_logical_network=lookup_primary_network(vm=local_cudn_vm).name,
+        port=SERVER_PORT,
+    ) as (client, server):
+        assert is_tcp_connection(server=server, client=client), "TCP connection between imported VM and local VM failed"
+
+
+@pytest.mark.polarion("CNV-12579")
+def test_connectivity_over_inner_migration_between_imported_and_local_vms(
+    admin_client, imported_cudn_vm, local_cudn_vm
+):
+    with client_server_active_connection(
+        client_vm=imported_cudn_vm,
+        server_vm=local_cudn_vm,
+        spec_logical_network=lookup_primary_network(vm=local_cudn_vm).name,
+        port=SERVER_PORT,
+    ) as (client, server):
+        migrate_vm_and_verify(vm=imported_cudn_vm, client=admin_client)
+        assert is_tcp_connection(server=server, client=client), (
+            "TCP connection between imported VM and local VM failed over imported VM inner migration"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -381,6 +381,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dacite"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/a0/7ca79796e799a3e782045d29bf052b5cde7439a2bbb17f15ff44f7aacc63/dacite-1.9.2.tar.gz", hash = "sha256:6ccc3b299727c7aa17582f0021f6ae14d5de47c7227932c47fec4cdfefd26f09", size = 22420, upload-time = "2025-02-05T09:27:29.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/35/386550fd60316d1e37eccdda609b074113298f23cef5bddb2049823fe666/dacite-1.9.2-py3-none-any.whl", hash = "sha256:053f7c3f5128ca2e9aceb66892b1a3c8936d02c686e707bee96e19deef4bc4a0", size = 16600, upload-time = "2025-02-05T09:27:24.345Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1119,6 +1128,7 @@ dependencies = [
     { name = "cachetools" },
     { name = "click" },
     { name = "colorlog" },
+    { name = "dacite" },
     { name = "deepdiff" },
     { name = "dictdiffer" },
     { name = "docker" },
@@ -1184,6 +1194,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=6.2.2" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "colorlog", specifier = ">=6.9.0" },
+    { name = "dacite", specifier = ">=1.9.2" },
     { name = "deepdiff", specifier = ">=8.0.1" },
     { name = "dictdiffer", specifier = ">=0.9.0" },
     { name = "docker", specifier = ">=7.1.0" },


### PR DESCRIPTION
Manual cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/3387.

There was no any manual intervention into the code, only cherry-pick itself.

**Rationale:** 
VM migration from the external provider is a part of 4.21 GA, so, it should be in the current branch. 

**Jira-tickets:** https://issues.redhat.com/browse/CNV-63871, https://issues.redhat.com/browse/CNV-77573