### PR TITLE
net: Reorder l2 ovs linux bridge tests

### DIFF
--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
-import contextlib
 import shlex
-from ipaddress import ip_interface
 
 import pytest
 from pyhelper_utils.shell import run_ssh_commands
 
+from tests.network.l2_bridge.libl2bridge import DHCP_INTERFACE_NAME, bridge_attached_vm
 from tests.network.libs.dhcpd import (
     DHCP_IP_RANGE_END,
     DHCP_IP_RANGE_START,
@@ -16,19 +14,12 @@ from tests.network.libs.dhcpd import (
     verify_dhcpd_activated,
 )
 from tests.network.libs.ip import random_ipv4_address
-from tests.network.utils import update_cloud_init_extra_user_data
 from utilities.data_utils import name_prefix
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
-    cloud_init_network_data,
     get_vmi_mac_address_by_iface_name,
     network_device,
     network_nad,
-)
-from utilities.virt import (
-    VirtualMachineForTests,
-    fedora_vm_body,
-    prepare_cloud_init_user_data,
 )
 
 #: Test setup example (third octet is random)
@@ -43,7 +34,6 @@ VMA_MPLS_LOOPBACK_IP = f"{random_ipv4_address(net_seed=5, host_address=1)}/32"
 VMA_MPLS_ROUTE_TAG = 100
 VMB_MPLS_LOOPBACK_IP = f"{random_ipv4_address(net_seed=6, host_address=1)}/32"
 VMB_MPLS_ROUTE_TAG = 200
-DHCP_INTERFACE_NAME = "eth3"
 
 
 @pytest.fixture(scope="class")
@@ -173,142 +163,6 @@ def dot1q_nad(
 @pytest.fixture(scope="class")
 def l2_bridge_all_nads(dhcp_nad, custom_eth_type_llpd_nad, mpls_nad, dot1q_nad):
     return [custom_eth_type_llpd_nad.name, mpls_nad.name, dhcp_nad.name, dot1q_nad.name]
-
-
-def _cloud_init_data(
-    vm_name,
-    ip_addresses,
-    mpls_local_ip,
-    mpls_local_tag,
-    mpls_dest_ip,
-    mpls_dest_tag,
-    mpls_route_next_hop,
-    cloud_init_extra_user_data,
-):
-    network_data_data = {
-        "ethernets": {
-            "eth1": {"addresses": [f"{ip_addresses[0]}/24"]},
-            "eth2": {"addresses": [f"{ip_addresses[1]}/24"]},
-            "eth4": {"addresses": [f"{ip_addresses[3]}/24"]},
-        },
-    }
-    # Only DHCP server VM (vm-fedora-1) should have IP on eth3 interface
-    if vm_name == "vm-fedora-1":
-        network_data_data["ethernets"][DHCP_INTERFACE_NAME] = {"addresses": [f"{ip_addresses[2]}/24"]}
-
-    # DHCP client VM (vm-fedora-2) should be with dhcp=false, will be activated in test 'test_dhcp_broadcast'.
-    if vm_name == "vm-fedora-2":
-        network_data_data["ethernets"][DHCP_INTERFACE_NAME] = {"dhcp4": False}
-
-    runcmd = [
-        "modprobe mpls_router",  # In order to test mpls we need to load driver
-        "sysctl -w net.mpls.platform_labels=1000",  # Activate mpls labeling feature
-        "sysctl -w net.mpls.conf.eth4.input=1",  # Allow incoming mpls traffic
-        "sysctl -w net.ipv4.conf.all.arp_ignore=1",  # 2 kernel flags are used to disable wrong arp behavior
-        "sysctl -w net.ipv4.conf.all.arp_announce=2",  # Send arp reply only if ip belongs to the interface
-        f"ip addr add {mpls_local_ip} dev lo",
-        f"ip -f mpls route add {mpls_local_tag} dev lo",
-        "nmcli connection up eth4",  # In order to add mpls route we need to make sure that connection is UP
-        f"ip route add {mpls_dest_ip} encap mpls {mpls_dest_tag} via inet {mpls_route_next_hop}",
-        "nmcli connection up eth2",
-        "ip route add 224.0.0.0/4 dev eth2",
-    ]
-
-    cloud_init_data = prepare_cloud_init_user_data(section="runcmd", data=runcmd)
-    cloud_init_data.update(cloud_init_network_data(data=network_data_data))
-
-    if cloud_init_extra_user_data:
-        update_cloud_init_extra_user_data(
-            cloud_init_data=cloud_init_data["userData"],
-            cloud_init_extra_user_data=cloud_init_extra_user_data,
-        )
-
-    return cloud_init_data
-
-
-class VirtualMachineAttachedToBridge(VirtualMachineForTests):
-    def __init__(
-        self,
-        name,
-        namespace,
-        interfaces,
-        ip_addresses,
-        mpls_local_tag,
-        mpls_local_ip,
-        mpls_dest_ip,
-        mpls_dest_tag,
-        mpls_route_next_hop,
-        client=None,
-        cloud_init_data=None,
-        node_selector=None,
-    ):
-        self.cloud_init_data = cloud_init_data
-        self.mpls_local_tag = mpls_local_tag
-        self.ip_addresses = ip_addresses
-        self.mpls_local_ip = ip_interface(address=mpls_local_ip).ip
-        self.mpls_dest_ip = mpls_dest_ip
-        self.mpls_dest_tag = mpls_dest_tag
-        self.mpls_route_next_hop = mpls_route_next_hop
-
-        networks = {}
-        for network in interfaces:
-            networks.update({network: network})
-
-        super().__init__(
-            name=name,
-            namespace=namespace,
-            interfaces=interfaces,
-            networks=networks,
-            client=client,
-            cloud_init_data=cloud_init_data,
-            node_selector=node_selector,
-        )
-
-    def to_dict(self):
-        self.body = fedora_vm_body(name=self.name)
-        super().to_dict()
-
-
-@contextlib.contextmanager
-def bridge_attached_vm(
-    name,
-    namespace,
-    interfaces,
-    ip_addresses,
-    mpls_local_tag,
-    mpls_dest_ip,
-    mpls_dest_tag,
-    mpls_route_next_hop,
-    mpls_local_ip,
-    cloud_init_extra_user_data=None,
-    client=None,
-    node_selector=None,
-):
-    cloud_init_data = _cloud_init_data(
-        vm_name=name,
-        ip_addresses=ip_addresses,
-        mpls_local_ip=mpls_local_ip,
-        mpls_local_tag=mpls_local_tag,
-        mpls_dest_ip=mpls_dest_ip,
-        mpls_dest_tag=mpls_dest_tag,
-        mpls_route_next_hop=mpls_route_next_hop,
-        cloud_init_extra_user_data=cloud_init_extra_user_data,
-    )
-    with VirtualMachineAttachedToBridge(
-        namespace=namespace,
-        name=name,
-        interfaces=interfaces,
-        ip_addresses=ip_addresses,
-        mpls_local_tag=mpls_local_tag,
-        mpls_local_ip=mpls_local_ip,
-        mpls_dest_ip=mpls_dest_ip,
-        mpls_dest_tag=mpls_dest_tag,
-        mpls_route_next_hop=mpls_route_next_hop,
-        client=client,
-        cloud_init_data=cloud_init_data,
-        node_selector=node_selector,
-    ) as vm:
-        yield vm
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -2,7 +2,9 @@ import contextlib
 import logging
 import re
 import time
+from ipaddress import ip_interface
 
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -22,10 +24,12 @@ from utilities.constants import (
 from utilities.infra import get_pod_by_name_prefix
 from utilities.network import (
     IfaceNotFound,
+    cloud_init_network_data,
     compose_cloud_init_data_dict,
     network_device,
+    ping,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body
+from utilities.virt import VirtualMachineForTests, fedora_vm_body, prepare_cloud_init_user_data
 
 LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +38,7 @@ NETWORK_MANAGER_UNMANAGE_RUNCMD = [
     "sudo systemctl restart NetworkManager",
 ]
 IPV4_ADDRESS_SUBNET_PREFIX_LENGTH = 24
+DHCP_INTERFACE_NAME = "eth3"
 
 
 def _lookup_vmi_interface(vmi, interface_name):
@@ -327,3 +332,166 @@ def create_vm_with_hot_plugged_sriov_interface(
             sriov=True,
         )
         yield vm
+
+
+def wait_for_no_packet_loss_after_connection(src_vm, dst_ip, interface=None):
+    sleep_count_value = 10
+
+    def _get_ping_state():
+        return (
+            ping(
+                src_vm=src_vm,
+                dst_ip=dst_ip,
+                count=sleep_count_value,
+                interface=interface,
+            )
+            == 0
+        )
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_2MIN,
+            sleep=sleep_count_value,
+            func=_get_ping_state,
+        ):
+            if sample:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"Ping from {src_vm.name} to {dst_ip} failed.")
+        raise
+
+
+@contextlib.contextmanager
+def bridge_attached_vm(
+    name,
+    namespace,
+    interfaces,
+    ip_addresses,
+    mpls_local_tag,
+    mpls_dest_ip,
+    mpls_dest_tag,
+    mpls_route_next_hop,
+    mpls_local_ip,
+    cloud_init_extra_user_data=None,
+    client=None,
+    node_selector=None,
+):
+    cloud_init_data = _cloud_init_data(
+        vm_name=name,
+        ip_addresses=ip_addresses,
+        mpls_local_ip=mpls_local_ip,
+        mpls_local_tag=mpls_local_tag,
+        mpls_dest_ip=mpls_dest_ip,
+        mpls_dest_tag=mpls_dest_tag,
+        mpls_route_next_hop=mpls_route_next_hop,
+        cloud_init_extra_user_data=cloud_init_extra_user_data,
+    )
+    with VirtualMachineAttachedToBridge(
+        namespace=namespace,
+        name=name,
+        interfaces=interfaces,
+        ip_addresses=ip_addresses,
+        mpls_local_tag=mpls_local_tag,
+        mpls_local_ip=mpls_local_ip,
+        mpls_dest_ip=mpls_dest_ip,
+        mpls_dest_tag=mpls_dest_tag,
+        mpls_route_next_hop=mpls_route_next_hop,
+        client=client,
+        cloud_init_data=cloud_init_data,
+        node_selector=node_selector,
+    ) as vm:
+        yield vm
+
+
+def _cloud_init_data(
+    vm_name,
+    ip_addresses,
+    mpls_local_ip,
+    mpls_local_tag,
+    mpls_dest_ip,
+    mpls_dest_tag,
+    mpls_route_next_hop,
+    cloud_init_extra_user_data,
+):
+    network_data_data = {
+        "ethernets": {
+            "eth1": {"addresses": [f"{ip_addresses[0]}/24"]},
+            "eth2": {"addresses": [f"{ip_addresses[1]}/24"]},
+            "eth4": {"addresses": [f"{ip_addresses[3]}/24"]},
+        },
+    }
+    # Only DHCP server VM (vm-fedora-1) should have IP on eth3 interface
+    if vm_name == "vm-fedora-1":
+        network_data_data["ethernets"][DHCP_INTERFACE_NAME] = {"addresses": [f"{ip_addresses[2]}/24"]}
+
+    # DHCP client VM (vm-fedora-2) should be with dhcp=false, will be activated in test 'test_dhcp_broadcast'.
+    if vm_name == "vm-fedora-2":
+        network_data_data["ethernets"][DHCP_INTERFACE_NAME] = {"dhcp4": False}
+
+    runcmd = [
+        "modprobe mpls_router",  # In order to test mpls we need to load driver
+        "sysctl -w net.mpls.platform_labels=1000",  # Activate mpls labeling feature
+        "sysctl -w net.mpls.conf.eth4.input=1",  # Allow incoming mpls traffic
+        "sysctl -w net.ipv4.conf.all.arp_ignore=1",  # 2 kernel flags are used to disable wrong arp behavior
+        "sysctl -w net.ipv4.conf.all.arp_announce=2",  # Send arp reply only if ip belongs to the interface
+        f"ip addr add {mpls_local_ip} dev lo",
+        f"ip -f mpls route add {mpls_local_tag} dev lo",
+        "nmcli connection up eth4",  # In order to add mpls route we need to make sure that connection is UP
+        f"ip route add {mpls_dest_ip} encap mpls {mpls_dest_tag} via inet {mpls_route_next_hop}",
+        "nmcli connection up eth2",
+        "ip route add 224.0.0.0/4 dev eth2",
+    ]
+
+    cloud_init_data = prepare_cloud_init_user_data(section="runcmd", data=runcmd)
+    cloud_init_data.update(cloud_init_network_data(data=network_data_data))
+
+    if cloud_init_extra_user_data:
+        update_cloud_init_extra_user_data(
+            cloud_init_data=cloud_init_data["userData"],
+            cloud_init_extra_user_data=cloud_init_extra_user_data,
+        )
+
+    return cloud_init_data
+
+
+class VirtualMachineAttachedToBridge(VirtualMachineForTests):
+    def __init__(
+        self,
+        name: str,
+        namespace: str,
+        interfaces: list[str],
+        ip_addresses: list[str],
+        mpls_local_tag: int,
+        mpls_local_ip: str,
+        mpls_dest_ip: str,
+        mpls_dest_tag: int,
+        mpls_route_next_hop: str,
+        client: DynamicClient | None = None,
+        cloud_init_data: dict[str, dict] | None = None,
+        node_selector: dict[str, str] | None = None,
+    ):
+        self.cloud_init_data = cloud_init_data
+        self.mpls_local_tag = mpls_local_tag
+        self.ip_addresses = ip_addresses
+        self.mpls_local_ip = ip_interface(address=mpls_local_ip).ip
+        self.mpls_dest_ip = mpls_dest_ip
+        self.mpls_dest_tag = mpls_dest_tag
+        self.mpls_route_next_hop = mpls_route_next_hop
+
+        networks = {}
+        for network in interfaces:
+            networks.update({network: network})
+
+        super().__init__(  # type: ignore[no-untyped-call]
+            name=name,
+            namespace=namespace,
+            interfaces=interfaces,
+            networks=networks,
+            client=client,
+            cloud_init_data=cloud_init_data,
+            node_selector=node_selector,
+        )
+
+    def to_dict(self) -> None:
+        self.body = fedora_vm_body(name=self.name)
+        super().to_dict()  # type: ignore[no-untyped-call]

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -4,7 +4,7 @@ import pytest
 
 from libs.net import netattachdef
 from libs.net.vmspec import lookup_iface_status_ip
-from tests.network.l2_bridge.utils import (
+from tests.network.l2_bridge.libl2bridge import (
     check_mac_released,
     create_bridge_interface_for_hot_plug,
     create_vm_for_hot_plug,


### PR DESCRIPTION
Reorder of `tests/network/l2_bridge/test_l2_ovs_linux_bridge.py`:
    - Rename utils.py -> libl2bridge.py
    - Move helpers to libl2bridge.py
    - Move class VMAttachedToBridge to libl2bridge.py
    - Rename test class, edit class description
    
Add ipv4 mark: tests are adjusted to IPv4.
In order to adjust tests to IPv6, need further investigtion.


##### jira-ticket: https://issues.redhat.com/browse/CNV-74435
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored L2 bridge test suite to use a shared test library; renamed tests and updated markers and signatures to align with L2 bridge nomenclature and IPv4 focus.
  * Removed duplicated in-file VM and cloud-init scaffolding in favor of consolidated helpers.

* **New Features**
  * Added centralized connectivity/packet-loss check and standardized DHCP interface support for bridge VM setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->