### PR TITLE
[VIRT] Increase the number of parallel migrations in upgrade tests

### DIFF
--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -57,7 +57,10 @@ pytestmark = [
 ]
 
 
-@pytest.mark.usefixtures("base_templates")
+@pytest.mark.usefixtures(
+    "base_templates",
+    "parallel_live_migrations_increased",
+)
 class TestUpgradeVirt:
     """Pre-upgrade tests"""
 


### PR DESCRIPTION
In upgrade with multiple SIGs we have too many non-migratable vms which may block the migration of the good (migratable) vms.
Increasing the parallel migrations helps to unblock tests where we need to migrate the VMs (even when non-migratable blocked the lane for 5 minutes - we have extra lanes for good (migratable) VMs

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixture for configuring increased parallel live migrations during upgrade scenarios, enabling more comprehensive testing of concurrent migration handling during system upgrades.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->