### PR TITLE
net, bgp: fix unstable connectivity issue

### DIFF
--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -86,11 +86,14 @@ def nad_localnet(
 
 @pytest.fixture(scope="module")
 def frr_configmap(
-    workers: list[Node], cnv_tests_utilities_namespace: Namespace, admin_client: DynamicClient
+    workers: list[Node],
+    cnv_tests_utilities_namespace: Namespace,
+    admin_client: DynamicClient,
+    worker_node1: Node,
 ) -> Generator[ConfigMap]:
     frr_conf = generate_frr_conf(
         external_subnet_ipv4=EXTERNAL_PROVIDER_SUBNET_IPV4,
-        nodes_ipv4_list=[worker.internal_ip for worker in workers],
+        nodes_ipv4_list=[worker.internal_ip for worker in workers if worker != worker_node1],
     )
 
     with ConfigMap(
@@ -195,7 +198,7 @@ def bgp_setup_ready(
     frr_configuration_created: None,
     workers: list[Node],
 ) -> None:
-    node_names = [worker.name for worker in workers]
+    node_names = [worker.name for worker in workers if worker.name != frr_external_pod.pod.instance.spec.nodeName]
     wait_for_bgp_connection_established(node_names=node_names)
 
 

--- a/tests/network/bgp/test_bgp_connectivity.py
+++ b/tests/network/bgp/test_bgp_connectivity.py
@@ -1,17 +1,12 @@
 import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
-from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
     pytest.mark.usefixtures("bgp_setup_ready"),
-    pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Unstable connectivity failure CNV-76552",
-        run=False,
-    ),
 ]
 
 


### PR DESCRIPTION
Sometimes connectivity between UDN VM and external provider network
does not work. The current setup connects external FRR pod to the
cluster nodes network via localnet, and the basic condition is already
complied: external FRR pod and UDN VM are living on different cluster
nodes to avoid connectivity issue. However, it is not enough: the node
where external FRR pod resides should be also excluded from BGP
routing. The current fix is implementing such exclusion.

#### jira-ticket: https://issues.redhat.com/browse/CNV-76552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * BGP connectivity tests are now enabled (previous expected-failure marker removed), improving test coverage and reliability.
  * Test infrastructure refined to exclude a specific worker node from BGP configuration and readiness checks, ensuring more accurate validation of BGP behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->