### PR TITLE
net,bgp: exclude external FRR from BGP router nodes

### DIFF
--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -88,11 +88,15 @@ def nad_localnet(
 
 @pytest.fixture(scope="module")
 def frr_configmap(
-    workers: list[Node], cnv_tests_utilities_namespace: Namespace, admin_client: DynamicClient
+    workers: list[Node],
+    cnv_tests_utilities_namespace: Namespace,
+    admin_client: DynamicClient,
+    nncp_localnet_node1: libnncp.NodeNetworkConfigurationPolicy,
 ) -> Generator[ConfigMap]:
+    node_name_with_nncp = nncp_localnet_node1.node_selector["kubernetes.io/hostname"]
     frr_conf = generate_frr_conf(
         external_subnet_ipv4=EXTERNAL_PROVIDER_SUBNET_IPV4,
-        nodes_ipv4_list=[worker.internal_ip for worker in workers],
+        nodes_ipv4_list=[worker.internal_ip for worker in workers if worker.name != node_name_with_nncp],
     )
 
     with ConfigMap(
@@ -197,7 +201,7 @@ def bgp_setup_ready(
     frr_configuration_created: None,
     workers: list[Node],
 ) -> None:
-    node_names = [worker.name for worker in workers]
+    node_names = [worker.name for worker in workers if worker.name != frr_external_pod.pod.instance.spec.nodeName]
     wait_for_bgp_connection_established(node_names=node_names)
 
 

--- a/tests/network/bgp/test_bgp_connectivity.py
+++ b/tests/network/bgp/test_bgp_connectivity.py
@@ -1,17 +1,12 @@
 import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
-from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
     pytest.mark.usefixtures("bgp_setup_ready"),
-    pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Unstable connectivity failure CNV-76552",
-        run=False,
-    ),
 ]
 
 


### PR DESCRIPTION
Sometimes connectivity between UDN VM and external provider network
does not work. The current setup connects external FRR pod to the
cluster nodes network via localnet, and the basic condition is already
complied: external FRR pod and UDN VM are living on different cluster
nodes to avoid connectivity issue. However, it is not enough: the node
where external FRR pod resides should be also excluded from BGP
routing.

**Rationale**: the external FRR pod receives BGP advertisements from all
cluster nodes, including the node it is currently hosted on.
If the local node is used as a BGP nexthop, ECMP may select it,
causing traffic to hairpin via br-ex instead of exiting via eno1.
This breaks return traffic.

Removing the local node from routing guarantees consistent
egress via remote cluster nodes.

#### jira-ticket: https://issues.redhat.com/browse/CNV-76552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved BGP test setup to exclude the node running the external FRR component, yielding more accurate node selection during convergence checks.
  * Removed expected-failure markers and related imports from BGP tests, reflecting increased test reliability and fewer intentional xfail cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->