### PR TITLE
net, network policy, ipv6: Adjust tests

### DIFF
--- a/tests/network/network_policy/libnetpolicy.py
+++ b/tests/network/network_policy/libnetpolicy.py
@@ -1,17 +1,38 @@
+from typing import Final
+
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.network_policy import NetworkPolicy
+
+TEST_PORTS: Final[list[int]] = [9080, 9081]
+_CURL_TIMEOUT: Final[int] = 5
 
 
 class ApplyNetworkPolicy(NetworkPolicy):
-    def __init__(self, name, namespace, client, ports=None, teardown=True):
+    def __init__(
+        self,
+        name: str,
+        namespace: str,
+        client: DynamicClient,
+        ports: list[int] | None = None,
+        teardown: bool = True,
+    ) -> None:
         super().__init__(name=name, namespace=namespace, client=client, teardown=teardown, pod_selector={})
         self.ports = ports
 
-    def to_dict(self):
+    def to_dict(self) -> None:
         super().to_dict()
         _ports = []
         if self.ports:
             for port in self.ports:
                 _ports.append({"protocol": "TCP", "port": port})
 
-        if _ports:
-            self.res["spec"]["ingress"] = [{"ports": _ports}]
+        self.res["spec"]["policyTypes"] = ["Ingress"]
+
+        # Default deny all ingress traffic if no ports specified
+        self.res["spec"]["ingress"] = [{"ports": _ports}] if _ports else []
+
+
+def format_curl_command(ip_address: str, port: int, head: bool = False) -> str:
+    url = f"[{ip_address}]:{port}" if ":" in ip_address else f"{ip_address}:{port}"
+    head_flag = "--head " if head else ""
+    return f"curl {head_flag}{url} --connect-timeout {_CURL_TIMEOUT}"

--- a/tests/network/network_policy/test_network_policy.py
+++ b/tests/network/network_policy/test_network_policy.py
@@ -1,81 +1,78 @@
-"""
-Network policy tests
-"""
-
 import shlex
 
 import pytest
 from pyhelper_utils.exceptions import CommandExecFailed
 from pyhelper_utils.shell import run_ssh_commands
 
-from utilities.constants import PORT_80
-
-PORT_81 = 81
-CURL_TIMEOUT = 5
+from tests.network.network_policy.libnetpolicy import TEST_PORTS, format_curl_command
 
 pytestmark = pytest.mark.sno
 
 
-@pytest.mark.order(before="test_network_policy_allow_http80")
+@pytest.mark.usefixtures("deny_all_http_ports")
+@pytest.mark.order(before="test_network_policy_allow_single_http_port")
 @pytest.mark.polarion("CNV-369")
 @pytest.mark.single_nic
 @pytest.mark.s390x
 def test_network_policy_deny_all_http(
-    deny_all_http_ports,
+    subtests,
     network_policy_vma,
     network_policy_vmb,
-    running_network_policy_vma,
-    running_network_policy_vmb,
 ):
-    dst_ip = network_policy_vma.vmi.virt_launcher_pod.instance.status.podIP
-    with pytest.raises(CommandExecFailed):
-        run_ssh_commands(
-            host=network_policy_vmb.ssh_exec,
-            commands=[
-                shlex.split(f"curl --head {dst_ip}:{port} --connect-timeout {CURL_TIMEOUT}")
-                for port in [PORT_80, PORT_81]
-            ],
-        )
+    pod_ips = network_policy_vma.vmi.virt_launcher_pod.instance.status.podIPs
+    for pod_ip_entry in pod_ips:
+        dst_ip = pod_ip_entry["ip"]
+        with subtests.test(msg=f"Testing {dst_ip}"):
+            for port in TEST_PORTS:
+                with pytest.raises(CommandExecFailed):
+                    run_ssh_commands(
+                        host=network_policy_vmb.ssh_exec,
+                        commands=[shlex.split(format_curl_command(ip_address=dst_ip, port=port))],
+                    )
 
 
+@pytest.mark.usefixtures("allow_single_http_port")
 @pytest.mark.order(before="test_network_policy_allow_all_http")
 @pytest.mark.polarion("CNV-2775")
 @pytest.mark.single_nic
 @pytest.mark.s390x
-def test_network_policy_allow_http80(
-    allow_http80_port,
+def test_network_policy_allow_single_http_port(
+    subtests,
     network_policy_vma,
     network_policy_vmb,
-    running_network_policy_vma,
-    running_network_policy_vmb,
 ):
-    dst_ip = network_policy_vma.vmi.virt_launcher_pod.instance.status.podIP
-    run_ssh_commands(
-        host=network_policy_vmb.ssh_exec,
-        commands=[shlex.split(f"curl --head {dst_ip}:{PORT_80} --connect-timeout {CURL_TIMEOUT}")],
-    )
+    pod_ips = network_policy_vma.vmi.virt_launcher_pod.instance.status.podIPs
+    for pod_ip_entry in pod_ips:
+        dst_ip = pod_ip_entry["ip"]
+        with subtests.test(msg=f"Testing {dst_ip}"):
+            run_ssh_commands(
+                host=network_policy_vmb.ssh_exec,
+                commands=[shlex.split(format_curl_command(ip_address=dst_ip, port=TEST_PORTS[0], head=True))],
+            )
 
-    with pytest.raises(CommandExecFailed):
-        run_ssh_commands(
-            host=network_policy_vmb.ssh_exec,
-            commands=[shlex.split(f"curl --head {dst_ip}:{PORT_81} --connect-timeout {CURL_TIMEOUT}")],
-        )
+            with pytest.raises(CommandExecFailed):
+                run_ssh_commands(
+                    host=network_policy_vmb.ssh_exec,
+                    commands=[shlex.split(format_curl_command(ip_address=dst_ip, port=TEST_PORTS[1], head=True))],
+                )
 
 
+@pytest.mark.usefixtures("allow_all_http_ports")
 @pytest.mark.polarion("CNV-2774")
 @pytest.mark.single_nic
 @pytest.mark.s390x
 def test_network_policy_allow_all_http(
-    allow_all_http_ports,
+    subtests,
     network_policy_vma,
     network_policy_vmb,
-    running_network_policy_vma,
-    running_network_policy_vmb,
 ):
-    dst_ip = network_policy_vma.vmi.virt_launcher_pod.instance.status.podIP
-    run_ssh_commands(
-        host=network_policy_vmb.ssh_exec,
-        commands=[
-            shlex.split(f"curl --head {dst_ip}:{port} --connect-timeout {CURL_TIMEOUT}") for port in [PORT_80, PORT_81]
-        ],
-    )
+    pod_ips = network_policy_vma.vmi.virt_launcher_pod.instance.status.podIPs
+    for pod_ip_entry in pod_ips:
+        dst_ip = pod_ip_entry["ip"]
+        with subtests.test(msg=f"Testing {dst_ip}"):
+            run_ssh_commands(
+                host=network_policy_vmb.ssh_exec,
+                commands=[
+                    shlex.split(format_curl_command(ip_address=dst_ip, port=port, head=True)) for port in TEST_PORTS
+                ],
+            )


### PR DESCRIPTION
Currently the network policy tests have multiple problems:
- The tests depend on existing http servers that run on the VM's virt-launcher pod while in the polarion tests cases we can see that the http servers need to be created in the VM during setup.
- The tests are not adjusted to run on IPv6 single-stack clusters.

While working on this change for IPv6, the tests fail for not reaching any http server on port 81.
This dependency was removed and now during test setup, we create http servers on vma on ports 9080/9081 which listen for both IPv4 and IPv6, as described in the polarion test cases.
Now the tests are also agnostic to the IP address family and verify network policy behavior for all pod IPs according to the cluster's network stack (IPv4-only, IPv6-only, or dual-stack).

##### jira-ticket: https://issues.redhat.com/browse/CNV-75731
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fixtures to provision isolated namespaces, network policies (deny-all, allow-single-port, allow-all-ports) and two IPv6-enabled VMs running HTTP servers for realistic network-policy scenarios.
  * Introduced shared test utilities: standardized test ports and a curl-command formatter plus a reusable network-policy helper.
  * Reworked tests to iterate over all pod IPs and ports using subtests for finer per-IP/per-port verification and improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->