### PR TITLE
drop win16 from os matrix tests

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -51,7 +51,6 @@ class Windows:
     WIN10_IMG: str | None = None
     WIN10_WSL2_IMG: str | None = None
     WIN10_ISO_IMG: str | None = None
-    WIN2k16_IMG: str | None = None
     WIN2k19_IMG: str | None = None
     WIN2k25_IMG: str | None = None
     WIN2k19_HA_IMG: str | None = None

--- a/tests/global_config_x86_64.py
+++ b/tests/global_config_x86_64.py
@@ -28,7 +28,6 @@ windows_os_matrix = generate_os_matrix_dict(
     os_name="windows",
     supported_operating_systems=[
         "win-10",
-        "win-2016",
         "win-2019",
         "win-11",
         "win-2022",

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -88,7 +88,6 @@ class ArchImages:
             WIN10_IMG="win_10_uefi.qcow2",
             WIN10_WSL2_IMG="win_10_wsl2_uefi.qcow2",
             WIN10_ISO_IMG="Win10_22H2_English_x64.iso",
-            WIN2k16_IMG="win_2k16_uefi.qcow2",
             WIN2k19_IMG="win_2k19_uefi.qcow2",
             WIN2k25_IMG="win_2k25_uefi.qcow2",
             WIN2k19_HA_IMG="win_2019_virtio.qcow2",
@@ -924,7 +923,6 @@ WIN_10 = "win10"
 WIN_11 = "win11"
 WIN_2K25 = "win2k25"
 WIN_2K22 = "win2k22"
-WIN_2K16 = "win2k16"
 WIN_2K19 = "win2k19"
 
 HYPERV_FEATURES_LABELS_DOM_XML = [

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -18,7 +18,6 @@ from utilities.constants import (
     OS_VERSION_STR,
     PREFERENCE_STR,
     TEMPLATE_LABELS_STR,
-    WIN_2K16,
     WIN_2K19,
     WIN_2K22,
     WIN_2K25,
@@ -73,14 +72,6 @@ WINDOWS_OS_MAPPING: dict[str, dict[str, str | Any]] = {
         "uefi": True,
         DATA_SOURCE_STR: WIN_10,
         CONTAINER_DISK_IMAGE_PATH_STR: get_windows_container_disk_path(os_value=WIN_10),
-    },
-    "win-2016": {
-        IMAGE_NAME_STR: "WIN2k16_IMG",
-        OS_VERSION_STR: "2016",
-        OS_STR: WIN_2K16,
-        "uefi": True,
-        DATA_SOURCE_STR: WIN_2K16,
-        CONTAINER_DISK_IMAGE_PATH_STR: get_windows_container_disk_path(os_value=WIN_2K16),
     },
     "win-2019": {
         IMAGE_NAME_STR: "WIN2k19_IMG",

--- a/utilities/unittests/conftest.py
+++ b/utilities/unittests/conftest.py
@@ -168,7 +168,6 @@ def mock_os_images():
     mock_windows_class.DEFAULT_DV_SIZE = "60Gi"
     mock_windows_class.WIN10_IMG = "win10.qcow2"
     mock_windows_class.WIN11_IMG = "win11.qcow2"
-    mock_windows_class.WIN2k16_IMG = "win2k16.qcow2"
     mock_windows_class.WIN2k19_IMG = "win2k19.qcow2"
     mock_windows_class.WIN2022_IMG = "win2022.qcow2"
     mock_windows_class.WIN2k25_IMG = "win2k25.qcow2"

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -63,7 +63,7 @@ class TestGenerateOsMatrixDict:
         """Test Windows OS matrix generation with UEFI support"""
         mock_images.Windows = mock_os_images["windows"]
 
-        result = generate_os_matrix_dict("windows", ["win-10", "win-2016"])
+        result = generate_os_matrix_dict("windows", ["win-10", "win-2019"])
 
         assert len(result) == 2
 
@@ -75,10 +75,10 @@ class TestGenerateOsMatrixDict:
         assert win10["template_labels"]["workload"] == "desktop"
         assert win10["template_labels"]["flavor"] == "medium"
 
-        # Check Windows 2016 (UEFI + server workload)
-        win2016 = next(item for item in result if "win-2016" in item)["win-2016"]
-        assert win2016["image_path"] == "cnv-tests/windows-uefi-images/win2k16.qcow2"
-        assert win2016["template_labels"]["workload"] == "server"
+        # Check Windows 2019 (UEFI + server workload)
+        win2019 = next(item for item in result if "win-2019" in item)["win-2019"]
+        assert win2019["image_path"] == "cnv-tests/windows-uefi-images/win2k19.qcow2"
+        assert win2019["template_labels"]["workload"] == "server"
 
     @patch("utilities.os_utils.Images")
     def test_generate_windows_os_matrix_without_uefi(self, mock_images, mock_os_images):
@@ -300,7 +300,7 @@ class TestOsMappingsConstants:
 
         # Check for UEFI flag where expected
         assert WINDOWS_OS_MAPPING["win-10"]["uefi"] is True
-        assert WINDOWS_OS_MAPPING["win-2016"]["uefi"] is True
+        assert WINDOWS_OS_MAPPING["win-2019"]["uefi"] is True
         assert "uefi" not in WINDOWS_OS_MAPPING["win-2022"]
 
     def test_fedora_os_mapping_structure(self):


### PR DESCRIPTION
##### Short description:
Drop windows 2016 from os matrix tests

Assisted-by: Cursor

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-77279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Windows Server 2016 from supported operating system versions.
  * Updated test configurations to use Windows Server 2019 instead of Windows Server 2016 for compatibility verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->