### PR TITLE
Change architecture constant to AMD_64 from X86_64

### DIFF
--- a/tests/virt/node/conftest.py
+++ b/tests/virt/node/conftest.py
@@ -12,13 +12,13 @@ from tests.utils import (
 )
 from tests.virt.utils import append_feature_gate_to_hco
 from utilities.constants import (
+    AMD_64,
     EIGHT_CPU_SOCKETS,
     FOUR_CPU_SOCKETS,
     FOUR_GI_MEMORY,
     ONE_CPU_CORE,
     ONE_CPU_THREAD,
     TEN_GI_MEMORY,
-    X86_64,
 )
 from utilities.jira import is_jira_open
 from utilities.virt import (
@@ -64,7 +64,7 @@ def vmx_disabled_flag(nodes_cpu_architecture):
                 }
             ]
         }
-        if nodes_cpu_architecture == X86_64 and is_jira_open("CNV-62851")
+        if nodes_cpu_architecture == AMD_64 and is_jira_open("CNV-62851")
         else None
     )
 


### PR DESCRIPTION
##### Short description:
In fixture vmx_disabled_flag, architecture check now refers to AMD_64 constant instead of AMD_64

##### More details:
This is a regression from earlier [PR](https://github.com/RedHatQE/openshift-virtualization-tests/pull/2577) merged, so fixing here.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
@dshchedr : Thanks for pointing on the issue/fix. Please review. I will verify it before merge

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal CPU architecture detection constants to use more accurate and current naming conventions that reflect system specifications and requirements.
  * Aligned dependent system configuration and platform gating logic with the updated architecture detection constants to ensure consistent behavior and proper CPU architecture identification across all platform components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->