### PR TITLE
[storage][T2][Main] Wait for PVC creation before VM deploy in public registry DV setup

### DIFF
--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -210,6 +210,7 @@ def dvs_and_vms_from_public_registry(unprivileged_client, namespace, storage_cla
             )
             dv.create()
             dvs.append(dv)
+            dv.pvc.wait(timeout=TIMEOUT_1MIN)
 
         for dv in dvs:
             vm = VirtualMachineForTests(


### PR DESCRIPTION
##### Short description:
Wait for PVC creation before VM deploy in public registry DV setup
Ensure public-registry DataVolume PVCs exist before creating VMs.


##### More details:
Add a short wait after DataVolume creation so the corresponding PVC is created before VM deployment reads data_volume.pvc.instance.


##### What this PR does / why we need it:
Fixes a setup race where the VM deployment fails with 404 because the PVC isn’t created yet.


##### Which issue(s) this PR fixes:
N/A (test setup race for test_public_registry_multiple_data_volume)


##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved storage import test reliability by waiting for each persistent storage claim to be ready before proceeding (replacing a fixed timeout), reducing race conditions and flaky failures during VM deployment.
  * Increases determinism of test runs and makes CI outcomes more stable and predictable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->