### PR TITLE
infra, net: Refactor network collect data on test failure

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -93,7 +93,7 @@ TEAM_MARKERS = {
 }
 NAMESPACE_COLLECTION = {
     "storage": [NamespacesNames.OPENSHIFT_STORAGE],
-    "network": [NamespacesNames.OPENSHIFT_NMSTATE],
+    "network": [],
     "virt": [],
 }
 MUST_GATHER_IGNORE_EXCEPTION_LIST = [
@@ -884,7 +884,8 @@ def get_inspect_command_namespace_string(node: Node, test_name: str) -> str:
                 namespaces_to_collect.extend([NamespacesNames.OPENSHIFT_FRR_K8S, NamespacesNames.CNV_TESTS_UTILITIES])
             if "mtv" in all_markers:
                 namespaces_to_collect.append(NamespacesNames.OPENSHIFT_MTV)
-
+            if "nmstate" in all_markers:
+                namespaces_to_collect.append(NamespacesNames.OPENSHIFT_NMSTATE)
         namespace_str = " ".join([f"namespace/{namespace}" for namespace in namespaces_to_collect])
     return namespace_str
 


### PR DESCRIPTION
##### Short description:
Restrict nmstate namespace inspect collection to tests that use nmstate.

##### More details:
Previously, any test under the network segment triggered collection of the openshift-nmstate namespace on failure, causing a direct dependency on the nmstate operator existence on the cluster. Many network tests (UDN, pod network, etc.) are not dependent on nmstate, so this dependency should be changed.

##### What this PR does / why we need it:
Change the default collection logic - on failure, only collect data from the nmstate namespace if tests collected are dependent on the nmstate operator.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-78255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * NMState network data is now collected only when an explicit nmstate marker is present, reducing unnecessary namespace retrieval and diagnostic noise.

* **Refactor**
  * Default inclusion of the NMState namespace has been removed in favor of marker-driven collection, simplifying diagnostics and making namespace sampling more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->