### PR TITLE
net, migration, ipv6: Adjust test_connectivity_after_migration

### DIFF
--- a/tests/network/libs/connectivity.py
+++ b/tests/network/libs/connectivity.py
@@ -1,0 +1,18 @@
+import ipaddress
+
+
+def build_ping_command(dst_ip: str, count: int, timeout: int) -> str:
+    """
+    Build a ping command string that handles both IPv4 and IPv6 addresses.
+
+    Args:
+        dst_ip: Destination IP address to ping.
+        count: Number of packets to send.
+        timeout: Timeout in seconds.
+
+    Returns:
+        str: Ping command string ready to execute.
+    """
+    ip = ipaddress.ip_address(address=dst_ip)
+    ping_ipv6_flag = " -6" if ip.version == 6 else ""
+    return f"ping{ping_ipv6_flag} {dst_ip} -c {count} -w {timeout}"


### PR DESCRIPTION
This test is failing on IPv6 single-stack clusters because the ping command is not adjusted to IPv6.
The test was also adjusted to test all guest VM ip family addresses.

##### jira-ticket: https://issues.redhat.com/browse/CNV-78295
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced migration/connectivity tests to verify connectivity for every IP on an interface using per-address subtests and broader interface IP checks.

* **Utilities**
  * Added IPv6-aware ping command builder.
  * Improved IP parsing with clearer type handling and safer invalid-address behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->