### PR TITLE
Fix: Handle multi-document YAML in generate_unique_icsp_idms_file

### DIFF
--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -90,12 +90,18 @@ def generate_icsp_idms_file(folder_name, command, is_idms_file, cnv_version=None
 
 
 def generate_unique_icsp_idms_file(file_name, version_string):
-    # update the metadata.name value to generate unique ICSP/IDMS
     with open(file_name) as fd:
-        file_yaml = yaml.safe_load(fd.read())
-    file_yaml["metadata"]["name"] = f"iib-{version_string}"
+        documents = list(yaml.safe_load_all(fd.read()))
+
+    document_index = 0
+    for document in documents:
+        if document and document.get("kind") in ["ImageContentSourcePolicy", "ImageDigestMirrorSet"]:
+            document["metadata"]["name"] = f"iib-{version_string}-{document_index}"
+            document_index += 1
+
     with open(file_name, "w") as current_mirror_file:
-        yaml.dump(file_yaml, current_mirror_file)
+        yaml.dump_all(documents, current_mirror_file, default_flow_style=False)
+
     new_file_name = file_name.replace(file_name, f"{file_name.replace('.yaml', '')}{version_string}.yaml")
     os.rename(file_name, new_file_name)
     return new_file_name

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -765,21 +765,24 @@ class TestGenerateUniqueIcspIdmsFile:
     """Test cases for generate_unique_icsp_idms_file function"""
 
     @patch("utilities.operator.os.rename")
-    @patch("utilities.operator.yaml.dump")
-    @patch("utilities.operator.yaml.safe_load")
+    @patch("utilities.operator.yaml.dump_all")
+    @patch("utilities.operator.yaml.safe_load_all")
     @patch("builtins.open", create=True)
     def test_generate_unique_file_success(
         self,
         mock_open,
-        mock_safe_load,
-        mock_dump,
+        mock_safe_load_all,
+        mock_dump_all,
         mock_rename,
     ):
         """Test generating unique ICSP/IDMS file"""
-        mock_safe_load.return_value = {
-            "metadata": {"name": "original-name"},
-            "spec": {},
-        }
+        mock_safe_load_all.return_value = [
+            {
+                "metadata": {"name": "original-name"},
+                "kind": "ImageContentSourcePolicy",
+                "spec": {},
+            }
+        ]
 
         result = generate_unique_icsp_idms_file(
             file_name="/tmp/imageContentSourcePolicy.yaml",
@@ -793,28 +796,28 @@ class TestGenerateUniqueIcspIdmsFile:
         )
 
     @patch("utilities.operator.os.rename")
-    @patch("utilities.operator.yaml.dump")
-    @patch("utilities.operator.yaml.safe_load")
+    @patch("utilities.operator.yaml.dump_all")
+    @patch("utilities.operator.yaml.safe_load_all")
     @patch("builtins.open", create=True)
     def test_generate_unique_file_metadata_update(
         self,
         mock_open,
-        mock_safe_load,
-        mock_dump,
+        mock_safe_load_all,
+        mock_dump_all,
         mock_rename,
     ):
-        """Test metadata name is updated correctly"""
-        original_yaml = {"metadata": {"name": "original-name"}, "spec": {}}
-        mock_safe_load.return_value = original_yaml
+        """Test metadata name is updated correctly with unique index"""
+        original_yaml = {"metadata": {"name": "original-name"}, "kind": "ImageContentSourcePolicy", "spec": {}}
+        mock_safe_load_all.return_value = [original_yaml]
 
         generate_unique_icsp_idms_file(
             file_name="/tmp/imageDigestMirrorSet.yaml",
             version_string="4210",
         )
 
-        # Verify yaml.dump was called with updated metadata
-        call_args = mock_dump.call_args[0]
-        assert call_args[0]["metadata"]["name"] == "iib-4210"
+        # Verify yaml.dump_all was called with updated metadata containing index
+        call_args = mock_dump_all.call_args[0]
+        assert call_args[0][0]["metadata"]["name"] == "iib-4210-0"
 
 
 class TestCreateIcspIdmsFromFile:


### PR DESCRIPTION
##### Short description:
When YAML files contain multiple ImageContentSourcePolicy or ImageDigestMirrorSet documents, all were assigned the same name (iib-{version}), causing OpenShift resource conflicts.

This fix adds an index to each document name (iib-{version}-0, iib-{version}-1, etc.) ensuring unique resource names within the same file while maintaining backwards compatibility with the delete_existing_icsp_idms function which uses name prefix matching.

##### More details:
Changes:
- Updated generate_unique_icsp_idms_file() to use yaml.safe_load_all() and iterate through all documents with index counter
- Changed from yaml.dump() to yaml.dump_all() to preserve all documents
- Updated tests to verify unique naming for multiple documents

##### What this PR does / why we need it:
Fix upgrade when oc catalog mirror generates more than 1 ICSP.

##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-78256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multi-document YAML file handling with index-based naming for each document.

* **Tests**
  * Updated test cases to validate multi-document YAML processing and metadata renaming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->