### PR TITLE
Fixed return None on missing metric for filter_metric_by_component

### DIFF
--- a/tests/install_upgrade_operators/json_patch/utils.py
+++ b/tests/install_upgrade_operators/json_patch/utils.py
@@ -63,9 +63,12 @@ def get_metrics_value_with_annotation(prometheus, query_string, component_name):
 def filter_metric_by_component(metrics, metric_name, component_name):
     annotation_name = get_annotation_name_for_component(component_name=component_name)
     for metric in metrics:
-        if metric["metric"]["annotation_name"] == annotation_name and metric["metric"]["__name__"] == metric_name:
-            return int(metric["value"][1])
-    LOGGER.warning(f"Metric {metric_name} with annotation {annotation_name} not found in metrics {metrics}")
+        if (
+            metric.get("metric", {}).get("annotation_name") == annotation_name
+            and metric.get("metric", {}).get("__name__") == metric_name
+        ):
+            return int(metric.get("value")[1])
+    LOGGER.warning(f"No results found when filtering for {metric_name} and annotation {annotation_name} in {metrics}.")
     return 0
 
 
@@ -80,7 +83,7 @@ def wait_for_metrics_value_update(prometheus, component_name, query_string, prev
     )
     try:
         for sample in samples:
-            if sample == previous_value + 1:
+            if sample and sample == previous_value + 1:
                 return sample
     except TimeoutExpiredError:
         LOGGER.error(f"Query string: {query_string} for component: {component_name}, previous value: {previous_value}.")

--- a/tests/install_upgrade_operators/json_patch/utils.py
+++ b/tests/install_upgrade_operators/json_patch/utils.py
@@ -65,6 +65,8 @@ def filter_metric_by_component(metrics, metric_name, component_name):
     for metric in metrics:
         if metric["metric"]["annotation_name"] == annotation_name and metric["metric"]["__name__"] == metric_name:
             return int(metric["value"][1])
+    LOGGER.warning(f"Metric {metric_name} with annotation {annotation_name} not found in metrics {metrics}")
+    return 0
 
 
 def wait_for_metrics_value_update(prometheus, component_name, query_string, previous_value):

--- a/tests/install_upgrade_operators/json_patch/utils.py
+++ b/tests/install_upgrade_operators/json_patch/utils.py
@@ -67,7 +67,9 @@ def filter_metric_by_component(metrics, metric_name, component_name):
             metric.get("metric", {}).get("annotation_name") == annotation_name
             and metric.get("metric", {}).get("__name__") == metric_name
         ):
-            return int(metric.get("value")[1])
+            metric_value = metric.get("value", [])
+            if len(metric_value) > 1:
+                return int(metric_value[1])
     LOGGER.warning(f"No results found when filtering for {metric_name} and annotation {annotation_name} in {metrics}.")
     return 0
 


### PR DESCRIPTION
##### Short description: 
`test_cdi_json_patch_metrics` uses the function `filter_metric_by_component` which returns None instead of 0 if the metric isn't found. The None value is used in later addition in `wait_for_metrics_value_update`, causing a type error

##### More details:
having trouble reproducing issue on local cluster, so trying to future-proof with a warning and new return statement

##### What this PR does / why we need it:
part of detecting early 4.99 failures for 4.22.0

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-78331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved metric handling in test utilities: missing or malformed metrics now log a warning and return a safe default numeric value.
  * Sampling logic tightened to ignore empty or falsy samples before performing comparisons to prevent false positives.
  * Timeout failures are now logged and re-raised so test harnesses reliably detect and handle timing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->