### PR TITLE
Add missing virtualmachinebackups CRDs to expected list

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -651,6 +651,8 @@ ALL_CNV_CRDS = [
     f"objecttransfers.{Resource.ApiGroup.CDI_KUBEVIRT_IO}",
     f"ssps.{Resource.ApiGroup.SSP_KUBEVIRT_IO}",
     f"storageprofiles.{Resource.ApiGroup.CDI_KUBEVIRT_IO}",
+    f"virtualmachinebackups.backup.{Resource.ApiGroup.KUBEVIRT_IO}",
+    f"virtualmachinebackuptrackers.backup.{Resource.ApiGroup.KUBEVIRT_IO}",
     f"virtualmachineclusterinstancetypes.{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}",
     f"virtualmachineinstancetypes.{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}",
     f"virtualmachineinstancemigrations.{Resource.ApiGroup.KUBEVIRT_IO}",


### PR DESCRIPTION
##### Short description:
Adding virtualmachinebackups.backup.kubevirt.io and virtualmachinebackuptrackers.backup.kubevirt.io to ALL_CNV_CRDS

##### More details:
New CRDs introduced in https://github.com/kubevirt/kubevirt/pull/16081 and https://github.com/kubevirt/kubevirt/pull/16285

##### What this PR does / why we need it:
part of detecting early 4.99 failures for 4.22.0

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-78336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for virtual machine backup resources and backup tracker resources to extend backup management capabilities for virtualized environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->