### PR TITLE
test(network): move network test constants into tests/network/constants

### DIFF
--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -20,7 +20,6 @@ from tests.network.utils import get_vlan_index_number
 from utilities.constants import (
     CLUSTER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
-    ISTIO_SYSTEM_DEFAULT_NS,
     VIRT_HANDLER,
     NamespacesNames,
 )
@@ -34,6 +33,7 @@ from utilities.network import (
 from utilities.pytest_utils import exit_pytest_execution
 
 LOGGER = logging.getLogger(__name__)
+ISTIO_SYSTEM_DEFAULT_NS = "istio-system"
 
 
 def get_index_number():

--- a/tests/network/nmstate/conftest.py
+++ b/tests/network/nmstate/conftest.py
@@ -4,8 +4,9 @@ import logging
 
 import pytest
 
+from tests.network.nmstate.libnmstate import NMSTATE_HANDLER
 from tests.network.utils import wait_for_address_on_iface
-from utilities.constants import LINUX_BRIDGE, NMSTATE_HANDLER
+from utilities.constants import LINUX_BRIDGE
 from utilities.data_utils import name_prefix
 from utilities.infra import get_daemonset_by_name, get_node_pod, get_node_selector_dict
 from utilities.network import network_device

--- a/tests/network/nmstate/libnmstate.py
+++ b/tests/network/nmstate/libnmstate.py
@@ -1,0 +1,3 @@
+"""NMState library constants and utilities."""
+
+NMSTATE_HANDLER = "nmstate-handler"

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -7,6 +7,7 @@ from timeout_sampler import TimeoutSampler
 
 from libs.net.vmspec import lookup_iface_status_ip
 from tests.network.libs.ip import random_ipv4_address
+from tests.network.nmstate.libnmstate import NMSTATE_HANDLER
 from tests.network.utils import (
     assert_nncp_successfully_configured,
     assert_ssh_alive,
@@ -14,7 +15,6 @@ from tests.network.utils import (
 )
 from utilities.constants import (
     LINUX_BRIDGE,
-    NMSTATE_HANDLER,
     TIMEOUT_1MIN,
     TIMEOUT_5SEC,
 )

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -8,10 +8,9 @@ from ocp_resources.template import Template
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutSampler
 
-from tests.network.sriov.libsriov import VM_SRIOV_IFACE_NAME, sriov_cloud_init_data, sriov_vm, vm_sriov_mac
+from tests.network.sriov.libsriov import MTU_9000, VM_SRIOV_IFACE_NAME, sriov_cloud_init_data, sriov_vm, vm_sriov_mac
 from utilities.constants import (
     CNV_SUPPLEMENTAL_TEMPLATES_URL,
-    MTU_9000,
     NODE_HUGE_PAGES_1GI_KEY,
     SRIOV,
     TIMEOUT_10MIN,

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -1,3 +1,5 @@
+"""SR-IOV library constants and utilities."""
+
 from tests.network.libs.ip import random_ipv4_address, random_ipv6_address
 from utilities.constants import SRIOV
 from utilities.infra import get_node_selector_dict
@@ -5,6 +7,7 @@ from utilities.network import compose_cloud_init_data_dict, sriov_network_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 VM_SRIOV_IFACE_NAME = "sriov1"
+MTU_9000 = 9000
 
 
 def vm_sriov_mac(mac_suffix_index):

--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -2,8 +2,9 @@ import pytest
 
 from libs.net.vmspec import lookup_iface_status
 from tests.network.libs.ip import filter_link_local_addresses
+from tests.network.sriov.libsriov import MTU_9000
 from tests.network.utils import assert_no_ping
-from utilities.constants import MTU_9000, QUARANTINED
+from utilities.constants import QUARANTINED
 from utilities.network import assert_ping_successful
 from utilities.virt import migrate_vm_and_verify
 

--- a/tests/network/upgrade/conftest.py
+++ b/tests/network/upgrade/conftest.py
@@ -2,9 +2,9 @@ import pytest
 from ocp_resources.virtual_machine import VirtualMachine
 
 from tests.network.libs.ip import random_ipv4_address
+from tests.network.upgrade.libupgrade import KMP_DISABLED_LABEL
 from utilities.constants import (
     ES_NONE,
-    KMP_DISABLED_LABEL,
     KMP_VM_ASSIGNMENT_LABEL,
     LINUX_BRIDGE,
 )

--- a/tests/network/upgrade/libupgrade.py
+++ b/tests/network/upgrade/libupgrade.py
@@ -1,0 +1,3 @@
+"""Upgrade library constants and utilities."""
+
+KMP_DISABLED_LABEL = "ignore"

--- a/tests/network/upgrade/test_upgrade_network.py
+++ b/tests/network/upgrade/test_upgrade_network.py
@@ -5,6 +5,7 @@ from ipaddress import ip_interface
 import pytest
 
 from libs.net.vmspec import lookup_iface_status_ip
+from tests.network.upgrade.libupgrade import KMP_DISABLED_LABEL
 from tests.network.upgrade.utils import assert_label_in_namespace
 from tests.upgrade_params import (
     IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
@@ -12,7 +13,6 @@ from tests.upgrade_params import (
 )
 from utilities.constants import (
     DEPENDENCY_SCOPE_SESSION,
-    KMP_DISABLED_LABEL,
     KMP_VM_ASSIGNMENT_LABEL,
 )
 from utilities.network import (

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -212,7 +212,6 @@ VIRTCTL_CLI_DOWNLOADS = f"{VIRTCTL}-clidownloads-kubevirt-hyperconverged"
 #  Network constants
 SRIOV = "sriov"
 IP_FAMILY_POLICY_PREFER_DUAL_STACK = "PreferDualStack"
-MTU_9000 = 9000
 IPV4_STR = "ipv4"
 IPV6_STR = "ipv6"
 CLUSTER_NETWORK_ADDONS_OPERATOR = "cluster-network-addons-operator"
@@ -225,8 +224,6 @@ KUBEMACPOOL_CERT_MANAGER = "kubemacpool-cert-manager"
 KUBEMACPOOL_MAC_CONTROLLER_MANAGER = "kubemacpool-mac-controller-manager"
 KUBEVIRT_IPAM_CONTROLLER_MANAGER = "kubevirt-ipam-controller-manager"
 KUBEMACPOOL_MAC_RANGE_CONFIG = "kubemacpool-mac-range-config"
-NMSTATE_HANDLER = "nmstate-handler"
-ISTIO_SYSTEM_DEFAULT_NS = "istio-system"
 SSH_PORT_22 = 22
 PORT_80 = 80
 ACTIVE_BACKUP = "active-backup"
@@ -342,7 +339,6 @@ CLOUD_INIT_NO_CLOUD = "cloudInitNoCloud"
 # Kubemacpool constants
 KMP_VM_ASSIGNMENT_LABEL = "mutatevirtualmachines.kubemacpool.io"
 KMP_ENABLED_LABEL = "allocate"
-KMP_DISABLED_LABEL = "ignore"
 
 # SSH constants
 CNV_VM_SSH_KEY_PATH = "CNV-SSH-KEY-PATH"


### PR DESCRIPTION
Move MTU_9000, NMSTATE_HANDLER, ISTIO_SYSTEM_DEFAULT_NS, and KMP_DISABLED_LABEL
from utilities/constants.py . This variables are used locally by network only.

Assisted-by: Cursor

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-78360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized constants from a centralized location into respective module libraries for improved code organization and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->