### PR TITLE
tests, bgp: update FRR deployment name

### DIFF
--- a/tests/network/libs/bgp.py
+++ b/tests/network/libs/bgp.py
@@ -24,7 +24,7 @@ from utilities.infra import get_resources_by_name_prefix
 _CLUSTER_FRR_ASN: Final[int] = 64512
 _EXTERNAL_FRR_ASN: Final[int] = 64000
 _EXTERNAL_FRR_IMAGE: Final[str] = "quay.io/frrouting/frr:9.1.2"
-_FRR_DEPLOYMENT_NAME: Final[str] = "frr-k8s-webhook-server"
+_FRR_DEPLOYMENT_NAME: Final[str] = "frr-k8s-statuscleaner"
 POD_SECONDARY_IFACE_NAME: Final[str] = "net1"
 EXTERNAL_FRR_POD_LABEL: Final[dict] = {"role": "frr-external"}
 


### PR DESCRIPTION
In newer versions, the deployment name has changed from 
`frr-k8s-webhook-server` to `frr-k8s-statuscleaner`. 
This updates the constant to match the new implementation.

##### Special notes for reviewer:
To avoid such fixes in the future it is probably worth to consider more robust 
implementation independent from hardcoded naming. On the other hand, 
with the current implementation we definitely know what Deployment we 
need to ensure the setup is ready. Anyway, I consider this as a follow-up and 
don't want to break coverage. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test deployment configuration to use a renamed FRR deployment identifier, ensuring tests reference the corrected deployment name for network infrastructure scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->