### PR TITLE
[VIRT] Reduce use of privileged_vmi to use vm.vmi

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -899,7 +899,7 @@ def vm_instance_from_template_multi_storage_scope_function(
 
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_multi_storage_scope_function,
         vm_cpu_model=(cpu_for_migration if request.param.get("set_vm_common_cpu") else None),
@@ -922,7 +922,7 @@ def golden_image_vm_instance_from_template_multi_storage_scope_function(
 
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_multi_storage_scope_function,
         vm_cpu_model=(cpu_for_migration if request.param.get("set_vm_common_cpu") else None),
@@ -2246,7 +2246,7 @@ def vm_from_template_with_existing_dv(
     """create VM from template using an existing DV (and not a golden image)"""
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_scope_function,
     ) as vm:

--- a/tests/infrastructure/vhostmd/test_vhostmd.py
+++ b/tests/infrastructure/vhostmd/test_vhostmd.py
@@ -78,7 +78,7 @@ def vhostmd_vm1(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_scope_function,
         node_selector=get_node_selector_dict(node_selector=worker_node1.name),
@@ -97,7 +97,7 @@ def vhostmd_vm2(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_scope_function,
         node_selector=get_node_selector_dict(node_selector=worker_node1.name),

--- a/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
+++ b/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
@@ -33,7 +33,7 @@ def rdp_vm(
         request=request,
         namespace=namespace,
         data_source=golden_image_data_source_scope_function,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
     ) as rdp_vm:
         wait_for_windows_vm(vm=rdp_vm, version=request.param["os_version"])
         configure_rdp_on_server_windows_vm(vm=rdp_vm)

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -689,7 +689,7 @@ def vm_with_rwo_dv(request, unprivileged_client, namespace):
     dv_res = dv.res
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template={"metadata": dv_res["metadata"], "spec": dv_res["spec"]},
     ) as vm:

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -193,7 +193,7 @@ def rhel9_golden_image_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=rhel9_data_source_scope_session,

--- a/tests/storage/memory_dump/conftest.py
+++ b/tests/storage/memory_dump/conftest.py
@@ -21,7 +21,7 @@ def windows_vm_for_memory_dump(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_source=golden_image_data_source_scope_function,
     ) as vm:

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -205,7 +205,7 @@ def vm_for_storage_class_migration_from_template_with_existing_dv(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_scope_class,
     ) as vm:

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -87,7 +87,7 @@ def vm_instance_from_template_multi_storage_scope_class(
     """
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         existing_data_volume=data_volume_multi_storage_scope_class,
         vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -127,7 +127,7 @@ def create_windows_vm_validate_guest_agent_info(
         request=vm_params,
         existing_data_volume=dv,
         namespace=namespace,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
     ) as vm_dv:
         wait_for_windows_vm(vm=vm_dv, version=vm_params["os_version"], timeout=TIMEOUT_30MIN)
         validate_os_info_vmi_vs_windows_os(vm=vm_dv)

--- a/tests/virt/cluster/common_templates/conftest.py
+++ b/tests/virt/cluster/common_templates/conftest.py
@@ -144,7 +144,7 @@ def tablet_device_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -43,7 +43,7 @@ def assert_vm_restarts_after_node_drain(source_node, vmi, vmi_old_uid):
 
 @pytest.fixture()
 def drained_node(admin_client, vm_for_test_from_template_scope_class):
-    source_node = vm_for_test_from_template_scope_class.privileged_vmi.node
+    source_node = vm_for_test_from_template_scope_class.vmi.node
     with node_mgmt_console(admin_client=admin_client, node=source_node, node_mgmt="drain"):
         yield source_node
 

--- a/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_data_persistency.py
@@ -51,7 +51,7 @@ def vm_generated_new_password():
 def persistence_vm(request, golden_image_data_volume_template_for_test_scope_class, unprivileged_client, namespace):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -173,9 +173,9 @@ def verify_vm_action(vm, vm_action, run_strategy):
 
 
 def pause_unpause_vmi_and_verify_status(vm):
-    vm.privileged_vmi.pause(wait=True)
+    vm.vmi.pause(wait=True)
     assert vm.printable_status == vm.Status.PAUSED, f"VM is not paused, status: {vm.printable_status}"
-    vm.privileged_vmi.unpause(wait=True)
+    vm.vmi.unpause(wait=True)
     verify_vm_ready_status(vm=vm)
 
 

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -362,14 +362,14 @@ def golden_image_data_volume_template_for_test_scope_function(
 @pytest.fixture(scope="class")
 def vm_for_test_from_template_scope_class(
     request,
-    unprivileged_client,
+    admin_client,
     namespace,
     golden_image_data_volume_template_for_test_scope_class,
     modern_cpu_for_migration,
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=admin_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         vm_cpu_model=modern_cpu_for_migration,

--- a/tests/virt/node/conftest.py
+++ b/tests/virt/node/conftest.py
@@ -41,7 +41,7 @@ def vm_with_memory_load(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_function,
         vm_cpu_model=modern_cpu_for_migration,
@@ -73,7 +73,7 @@ def vmx_disabled_flag(nodes_cpu_architecture):
 def hotplugged_vm(
     request,
     namespace,
-    unprivileged_client,
+    admin_client,
     golden_image_data_volume_template_for_test_scope_class,
     modern_cpu_for_migration,
     vmx_disabled_flag,
@@ -84,7 +84,7 @@ def hotplugged_vm(
         additional_labels=request.param.get("additional_labels"),
         labels=Template.generate_template_labels(**request.param["template_labels"]),
         namespace=namespace.name,
-        client=unprivileged_client,
+        client=admin_client,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         cpu_max_sockets=EIGHT_CPU_SOCKETS,
         # s390x doesn't support maxGuest as it doesn't support hotplug memory

--- a/tests/virt/node/general/test_disk_io_option.py
+++ b/tests/virt/node/general/test_disk_io_option.py
@@ -42,7 +42,7 @@ def disk_options_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:

--- a/tests/virt/node/general/test_networkinterfacemultiqueue_feature.py
+++ b/tests/virt/node/general/test_networkinterfacemultiqueue_feature.py
@@ -73,7 +73,7 @@ def network_interface_multiqueue_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as multiqueue_vm:

--- a/tests/virt/node/gpu/conftest.py
+++ b/tests/virt/node/gpu/conftest.py
@@ -25,7 +25,7 @@ def gpu_vma(
     params = request.param
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         vm_affinity=build_node_affinity_dict(values=[nodes_with_supported_gpus[0].name]),

--- a/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
@@ -87,7 +87,7 @@ def node_mdevtype_gpu_vm(
     with vm_instance_from_template(
         request=request,
         namespace=namespace,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         vm_affinity=build_node_affinity_dict(values=[[*nodes_with_supported_gpus][1].name]),
         gpu_name=supported_gpu_device[VGPU_GRID_NAME_STR],

--- a/tests/virt/node/high_performance_vm/test_high_performance_templates.py
+++ b/tests/virt/node/high_performance_vm/test_high_performance_templates.py
@@ -53,7 +53,7 @@ def high_performance_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:

--- a/tests/virt/node/high_performance_vm/test_iothreads_policy.py
+++ b/tests/virt/node/high_performance_vm/test_iothreads_policy.py
@@ -28,7 +28,7 @@ def iothreads_policy_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as iothreads_policy_vm:

--- a/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
+++ b/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
@@ -27,7 +27,7 @@ def isolated_emulatorthread_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         vm_cpu_model=cpu_for_migration,

--- a/tests/virt/node/hyperv_support/test_hyperv_features_in_vm.py
+++ b/tests/virt/node/hyperv_support/test_hyperv_features_in_vm.py
@@ -26,7 +26,7 @@ def hyperv_vm(
         request.param["vm_dict"] = {"spec": {"template": {"spec": {"domain": {"features": {"hyperv": hyperv_dict}}}}}}
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
     ) as vm:

--- a/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
+++ b/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
@@ -67,7 +67,7 @@ def node_filter(pod, schedulable_nodes):
 
 @pytest.fixture()
 def vm_container_disk_fedora(
-    unprivileged_client,
+    admin_client,
     cpu_for_migration,
     namespace,
 ):
@@ -77,7 +77,7 @@ def vm_container_disk_fedora(
         namespace=namespace.name,
         cpu_model=cpu_for_migration,
         body=fedora_vm_body(name=name),
-        client=unprivileged_client,
+        client=admin_client,
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -116,9 +116,8 @@ def test_node_drain_using_console_fedora(
     admin_client,
     vm_container_disk_fedora,
 ):
-    privileged_virt_launcher_pod = vm_container_disk_fedora.privileged_vmi.virt_launcher_pod
     drain_using_console(
-        admin_client=admin_client, source_node=privileged_virt_launcher_pod.node, vm=vm_container_disk_fedora
+        admin_client=admin_client, source_node=vm_container_disk_fedora.vmi.node, vm=vm_container_disk_fedora
     )
 
 
@@ -145,7 +144,7 @@ class TestNodeMaintenanceRHEL:
         vm_for_test_from_template_scope_class,
     ):
         vm = vm_for_test_from_template_scope_class
-        drain_using_console(admin_client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm)
+        drain_using_console(admin_client=admin_client, source_node=vm.vmi.node, vm=vm)
 
     @pytest.mark.polarion("CNV-4995")
     def test_migration_when_multiple_nodes_unschedulable_using_console_rhel(
@@ -169,11 +168,11 @@ class TestNodeMaintenanceRHEL:
         """
         vm = vm_for_test_from_template_scope_class
         cordon_nodes = node_filter(
-            pod=vm.privileged_vmi.virt_launcher_pod,
+            pod=vm.vmi.virt_launcher_pod,
             schedulable_nodes=schedulable_nodes,
         )
         with node_mgmt_console(admin_client=admin_client, node=cordon_nodes[0], node_mgmt="cordon"):
-            drain_using_console(admin_client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm)
+            drain_using_console(admin_client=admin_client, source_node=vm.vmi.node, vm=vm)
 
 
 @pytest.mark.parametrize(
@@ -200,9 +199,7 @@ class TestNodeCordonAndDrain:
         vm_for_test_from_template_scope_class,
     ):
         vm = vm_for_test_from_template_scope_class
-        drain_using_console_windows(
-            admin_client=admin_client, source_node=vm.privileged_vmi.virt_launcher_pod.node, vm=vm
-        )
+        drain_using_console_windows(admin_client=admin_client, source_node=vm.vmi.node, vm=vm)
 
     @pytest.mark.polarion("CNV-4906")
     def test_node_cordon_template_windows(
@@ -213,7 +210,7 @@ class TestNodeCordonAndDrain:
         vm = vm_for_test_from_template_scope_class
         with node_mgmt_console(
             admin_client=admin_client,
-            node=vm.privileged_vmi.virt_launcher_pod.node,
+            node=vm.vmi.virt_launcher_pod.node,
             node_mgmt="cordon",
         ):
             with pytest.raises(TimeoutExpiredError):

--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -16,7 +16,7 @@ def vm_with_cephfs_storage(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=golden_image_data_source_for_test_scope_function,

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -75,7 +75,7 @@ def migrated_hotplugged_vm(hotplugged_vm):
 
 @pytest.fixture()
 def drained_node_with_hotplugged_vm(admin_client, hotplugged_vm):
-    with node_mgmt_console(admin_client=admin_client, node=hotplugged_vm.privileged_vmi.node, node_mgmt="drain"):
+    with node_mgmt_console(admin_client=admin_client, node=hotplugged_vm.vmi.node, node_mgmt="drain"):
         check_migration_process_after_node_drain(client=admin_client, vm=hotplugged_vm)
     clean_up_migration_jobs(client=admin_client, vm=hotplugged_vm)
 

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -26,7 +26,7 @@ def vm_with_fio(
         request.param["cpu_threads"] = 1
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         vm_cpu_model=cpu_for_migration,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,

--- a/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_unscheduled_node.py
@@ -20,7 +20,7 @@ def unscheduled_node_vm(
 ):
     with vm_instance_from_template(
         request=request,
-        unprivileged_client=unprivileged_client,
+        client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_function,
         vm_affinity=build_node_affinity_dict(values=[worker_node1.hostname]),
@@ -61,7 +61,7 @@ def test_schedule_vm_on_cordoned_node(admin_client, worker_node1, unscheduled_no
         wait_for_node_schedulable_status(node=worker_node1, status=False)
         unscheduled_node_vm.start()
     unscheduled_node_vm.vmi.wait_for_status(status=VirtualMachineInstance.Status.RUNNING)
-    vmi_node_name = unscheduled_node_vm.privileged_vmi.virt_launcher_pod.node.name
+    vmi_node_name = unscheduled_node_vm.vmi.node.name
     assert vmi_node_name == worker_node1.name, (
         f"VMI is running on {vmi_node_name} and not on the expected node {worker_node1.name}"
     )

--- a/tests/virt/node/migration_and_maintenance/utils.py
+++ b/tests/virt/node/migration_and_maintenance/utils.py
@@ -66,7 +66,7 @@ def assert_vm_migrated_through_dedicated_network_with_logs(source_node, vm, virt
 
 
 def assert_node_drain_and_vm_migration(admin_client, vm, virt_handler_pods):
-    source_node = vm.privileged_vmi.node
+    source_node = vm.vmi.node
     with node_mgmt_console(admin_client=admin_client, node=source_node, node_mgmt="drain"):
         check_migration_process_after_node_drain(client=admin_client, vm=vm)
         assert_vm_migrated_through_dedicated_network_with_logs(

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1932,7 +1932,7 @@ def prepare_cloud_init_user_data(section, data):
 @contextmanager
 def vm_instance_from_template(
     request,
-    unprivileged_client,
+    client,
     namespace,
     data_source=None,
     data_volume_template=None,
@@ -1964,7 +1964,7 @@ def vm_instance_from_template(
     with VirtualMachineForTestsFromTemplate(
         name=vm_name,
         namespace=namespace.name,
-        client=unprivileged_client,
+        client=client,
         labels=Template.generate_template_labels(**params["template_labels"]),
         data_source=data_source,
         data_volume_template=data_volume_template,


### PR DESCRIPTION
privileged_vmi comes from VirtualMachineForTests and uses get_client()
(admin client); vmi uses the test client.

This PR:
- Allows vm_instance_from_template to honor the provided client instead of
  forcing unprivileged_client, enabling replacement of privileged_vmi.

- Updates virt tests to use vm.vmi instead of privileged_vmi for
  node/virt-launcher access.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests & Chores**
  * Refactored VM/VMI data access patterns across test suites and utilities to use consistent VMI references throughout node maintenance and migration test scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->