### PR TITLE
Add sample exists condition to wait_for_condition_message_value

### DIFF
--- a/utilities/ssp.py
+++ b/utilities/ssp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -5,6 +7,7 @@ import re
 import shlex
 import urllib.request
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import NotFoundError
@@ -16,6 +19,9 @@ from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClu
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+if TYPE_CHECKING:
+    from ocp_resources.resource import Resource
 
 import utilities.infra
 import utilities.storage
@@ -130,7 +136,7 @@ def wait_for_ssp_conditions(
     )
 
 
-def wait_for_condition_message_value(resource, expected_message):
+def wait_for_condition_message_value(resource: Resource, expected_message: str) -> None:
     LOGGER.info(f"Verify {resource.name} conditions contain expected message: {expected_message}")
     sample = None
     try:
@@ -139,7 +145,7 @@ def wait_for_condition_message_value(resource, expected_message):
             sleep=TIMEOUT_5SEC,
             func=lambda: resource.instance.status.conditions,
         ):
-            if any([condition["message"] == expected_message for condition in sample]):
+            if sample and any(condition.get("message") == expected_message for condition in sample):
                 return
     except TimeoutExpiredError:
         LOGGER.error(


### PR DESCRIPTION
##### Short description:
Add sample exists condition to wait_for_condition_message_value

##### More details:
There can be occasions where the resource API call haven't been fully processed yet and as such the `resource.instance.status.conditions` field returns `None`.
In this PR, we wait for conditions to be populated, and we only iterate when `sample` is not None

##### What this PR does / why we need it:
Prevent race condition failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when evaluating conditions on empty or missing samples and expanded timeout error messages to include the observed sample for clearer diagnostics.

* **Refactor**
  * Added type annotations and typing guards to improve code clarity and reduce runtime issues during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->