### PR TITLE
Add webhooks sanity and vm  dry-run creation to cluster_health_check

### DIFF
--- a/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
+++ b/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
@@ -93,9 +93,7 @@ def test_storage_sanity(cluster_storage_classes_names):
 
 
 @pytest.mark.cluster_health_check
-def test_boot_volume_health(
-    golden_images_namespace, hco_managed_data_import_crons, data_import_cron_managed_datasources
-):
+def test_boot_volume_health(hco_managed_data_import_crons, data_import_cron_managed_datasources):
     """Test that all DataImportCron-managed DataSources are ready."""
     assert len(hco_managed_data_import_crons) == len(data_import_cron_managed_datasources)
     LOGGER.info(f"All dataimport crons: {hco_managed_data_import_crons}")


### PR DESCRIPTION
##### Short description:
Add webhoos health check and vm dry run creattion to tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
Add short dosctrings to the all tests with info on what is checked

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added health validation checks for webhook endpoints in the post-deployment sanity suite.
  * Added VM creation capability verification tests to ensure cluster can provision VMs.
* **Documentation**
  * Enhanced test descriptions to clarify the purpose and scope of existing health checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->