### PR TITLE
Drop windows 10 and 10 wsl2 and replace it with win 11 and 11 wsl2

### DIFF
--- a/tests/global_config_amd64.py
+++ b/tests/global_config_amd64.py
@@ -12,7 +12,7 @@ from utilities.constants import (
 global config
 
 rhel_os_list = ["rhel-8-10", "rhel-9-6"]
-windows_os_list = ["win-10", "win-2019", "win-11", "win-2022", "win-2025"]
+windows_os_list = ["win-2019", "win-11", "win-2022", "win-2025"]
 fedora_os_list = ["fedora-43"]
 centos_os_list = ["centos-stream-9"]
 

--- a/tests/os_params.py
+++ b/tests/os_params.py
@@ -10,8 +10,6 @@ RHEL_LATEST: dict[str, Any] = py_config.get("latest_rhel_os_dict", {})
 RHEL_LATEST_LABELS: dict[str, Any] = RHEL_LATEST.get("template_labels", {})
 RHEL_LATEST_OS: str | None = RHEL_LATEST_LABELS.get("os")
 
-WINDOWS_10: dict[str, Any] = get_windows_os_dict(windows_version="win-10")
-WINDOWS_10_TEMPLATE_LABELS: dict[str, Any] = WINDOWS_10.get("template_labels", {})
 WINDOWS_11: dict[str, Any] = get_windows_os_dict(windows_version="win-11")
 WINDOWS_11_TEMPLATE_LABELS: dict[str, Any] = WINDOWS_11.get("template_labels", {})
 WINDOWS_2019: dict[str, Any] = get_windows_os_dict(windows_version="win-2019")

--- a/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_tablet_device.py
@@ -11,7 +11,7 @@ import shlex
 import pytest
 from pyhelper_utils.shell import run_ssh_commands
 
-from tests.os_params import WINDOWS_10, WINDOWS_LATEST, WINDOWS_LATEST_LABELS
+from tests.os_params import WINDOWS_11, WINDOWS_LATEST, WINDOWS_LATEST_LABELS
 from tests.virt.cluster.common_templates.utils import check_vm_xml_tablet_device, set_vm_tablet_device_dict
 from utilities.constants import TCP_TIMEOUT_30SEC, VIRTIO
 
@@ -123,7 +123,7 @@ class TestWindowsTabletDevice:
             pytest.param(
                 {
                     "vm_name": "windows-desktop-default-tablet-device",
-                    "template_labels": WINDOWS_10.get("template_labels"),
+                    "template_labels": WINDOWS_11.get("template_labels"),
                 },
                 marks=pytest.mark.polarion("CNV-4150"),
             ),

--- a/tests/virt/cluster/longevity_tests/constants.py
+++ b/tests/virt/cluster/longevity_tests/constants.py
@@ -1,7 +1,7 @@
 from ocp_resources.template import Template
 
 from tests.utils import generate_attached_rhsm_secret_dict, generate_rhsm_cloud_init_data
-from utilities.constants import AMD, INTEL, REGEDIT_PROC_NAME, WIN_10, WIN_11, Images, StorageClassNames
+from utilities.constants import AMD, INTEL, REGEDIT_PROC_NAME, WIN_11, Images, StorageClassNames
 from utilities.virt import (
     fetch_pid_from_linux_vm,
     fetch_pid_from_windows_vm,
@@ -47,36 +47,27 @@ LINUX_DV_PARAMS = [
 WINDOWS_DV_PARAMS = [
     {
         "dv-ocs-win": {
-            "image_path": f"{Images.Windows.UEFI_WIN_DIR}/{Images.Windows.WIN10_IMG}",
+            "image_path": f"{Images.Windows.DIR}/{Images.Windows.WIN11_IMG}",
             "dv_size": Images.Windows.DEFAULT_DV_SIZE,
             "storage_class": StorageClassNames.CEPH_RBD_VIRTUALIZATION,
         }
     },
     {
         "dv-nfs-win": {
-            "image_path": f"{Images.Windows.UEFI_WIN_DIR}/{Images.Windows.WIN10_IMG}",
+            "image_path": f"{Images.Windows.DIR}/{Images.Windows.WIN11_IMG}",
             "dv_size": Images.Windows.DEFAULT_DV_SIZE,
             "storage_class": StorageClassNames.NFS,
         }
     },
 ]
 
-WSL2_DV_PARAMS = [
-    {
-        "dv-win10-wsl2-win": {
-            "image_path": f"{Images.Windows.UEFI_WIN_DIR}/{Images.Windows.WIN10_WSL2_IMG}",
-            "dv_size": Images.Windows.DEFAULT_DV_SIZE,
-            "storage_class": StorageClassNames.CEPH_RBD_VIRTUALIZATION,
-        }
-    },
-    {
-        "dv-win11-wsl2-win": {
-            "image_path": f"{Images.Windows.DIR}/{Images.Windows.WIN11_WSL2_IMG}",
-            "dv_size": Images.Windows.DEFAULT_DV_SIZE,
-            "storage_class": StorageClassNames.CEPH_RBD_VIRTUALIZATION,
-        }
-    },
-]
+WSL2_DV_PARAMS = {
+    "dv-win11-wsl2-win": {
+        "image_path": f"{Images.Windows.DIR}/{Images.Windows.WIN11_WSL2_IMG}",
+        "dv_size": Images.Windows.DEFAULT_DV_SIZE,
+        "storage_class": StorageClassNames.CEPH_RBD_VIRTUALIZATION,
+    }
+}
 
 LINUX_VM_PARAMS = [
     {
@@ -117,7 +108,7 @@ WINDOWS_VM_PARAMS = [
     {
         "windows-multi-mig-ocsdisk-vm": {
             "os_labels": {
-                "os": WIN_10,
+                "os": WIN_11,
                 "workload": Template.Workload.DESKTOP,
                 "flavor": Template.Flavor.MEDIUM,
             },
@@ -127,7 +118,7 @@ WINDOWS_VM_PARAMS = [
     {
         "windows-multi-mig-nfsdisk-vm": {
             "os_labels": {
-                "os": WIN_10,
+                "os": WIN_11,
                 "workload": Template.Workload.DESKTOP,
                 "flavor": Template.Flavor.MEDIUM,
             },
@@ -136,33 +127,17 @@ WINDOWS_VM_PARAMS = [
     },
 ]
 
-WSL2_VM_PARAMS = [
-    {
-        "windows-multi-mig-win10-wsl2-vm": {
-            "os_labels": {
-                "os": WIN_10,
-                "workload": Template.Workload.DESKTOP,
-                "flavor": Template.Flavor.MEDIUM,
-            },
-            "datasource_name": "dv-win10-wsl2-win",
-            "memory_guest": Images.Windows.DEFAULT_MEMORY_SIZE_WSL,
-            "cpu_cores": 16,
-            "cpu_threads": 1,
-            "cpu_features": {INTEL: "vmx", AMD: "svm"},
-        }
-    },
-    {
-        "windows-multi-mig-win11-wsl2-vm": {
-            "os_labels": {
-                "os": WIN_11,
-                "workload": Template.Workload.DESKTOP,
-                "flavor": Template.Flavor.MEDIUM,
-            },
-            "datasource_name": "dv-win11-wsl2-win",
-            "memory_guest": Images.Windows.DEFAULT_MEMORY_SIZE_WSL,
-            "cpu_cores": 16,
-            "cpu_threads": 1,
-            "cpu_features": {INTEL: "vmx", AMD: "svm"},
-        }
-    },
-]
+WSL2_VM_PARAMS = {
+    "windows-multi-mig-win11-wsl2-vm": {
+        "os_labels": {
+            "os": WIN_11,
+            "workload": Template.Workload.DESKTOP,
+            "flavor": Template.Flavor.MEDIUM,
+        },
+        "datasource_name": "dv-win11-wsl2-win",
+        "memory_guest": Images.Windows.DEFAULT_MEMORY_SIZE_WSL,
+        "cpu_cores": 16,
+        "cpu_threads": 1,
+        "cpu_features": {INTEL: "vmx", AMD: "svm"},
+    }
+}

--- a/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
+++ b/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
@@ -59,8 +59,8 @@ def test_migration_storm_windows_vms(windows_vms_with_pids):
     "multi_dv, multi_vms",
     [
         pytest.param(
-            {"dv_params": WSL2_DV_PARAMS},
-            {"vm_params": WSL2_VM_PARAMS},
+            {"dv_params": [WSL2_DV_PARAMS]},
+            {"vm_params": [WSL2_VM_PARAMS]},
             marks=pytest.mark.polarion("CNV-9692"),
         )
     ],

--- a/tests/virt/cluster/longevity_tests/test_multi_vm_upgrade_and_reboot.py
+++ b/tests/virt/cluster/longevity_tests/test_multi_vm_upgrade_and_reboot.py
@@ -10,8 +10,8 @@ pytestmark = [pytest.mark.usefixtures("skip_test_if_no_ocs_sc"), pytest.mark.lon
     "multi_dv, multi_vms",
     [
         pytest.param(
-            {"dv_params": [WSL2_DV_PARAMS[0]]},
-            {"vm_params": [WSL2_VM_PARAMS[0]]},
+            {"dv_params": [WSL2_DV_PARAMS]},
+            {"vm_params": [WSL2_VM_PARAMS]},
             marks=pytest.mark.polarion("CNV-10152"),
         )
     ],

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -22,7 +22,7 @@ from utilities.artifactory import (
     get_artifactory_config_map,
     get_artifactory_secret,
 )
-from utilities.constants import TCP_TIMEOUT_30SEC, TIMEOUT_5MIN, TIMEOUT_30MIN, TIMEOUT_40MIN, TIMEOUT_60MIN, WIN_10
+from utilities.constants import TCP_TIMEOUT_30SEC, TIMEOUT_5MIN, TIMEOUT_30MIN, TIMEOUT_40MIN, TIMEOUT_60MIN
 from utilities.storage import get_test_artifact_server_url
 from utilities.virt import (
     VirtualMachineForTests,
@@ -94,10 +94,11 @@ def reboot_vm(vm):
 
 def start_win_upgrade_multi_vms(vm_list):
     def _set_interface_mtu(vm):
-        interface_name = "Ethernet 2" if WIN_10 in vm.name else "Ethernet Instance 0"
         run_ssh_commands(
             host=vm.ssh_exec,
-            commands=shlex.split(f'netsh interface ipv4 set subinterface "{interface_name}" mtu=1400 store=persistent'),
+            commands=shlex.split(
+                'netsh interface ipv4 set subinterface "Ethernet Instance 0" mtu=1400 store=persistent'
+            ),
         )
 
     def _prepare_win_upgrade(vm):

--- a/tests/virt/constants.py
+++ b/tests/virt/constants.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import bitmath
 
-from tests.os_params import WINDOWS_10, WINDOWS_11
+from tests.os_params import WINDOWS_11
 from utilities.constants import Images
 
 VIRT_PROCESS_MEMORY_LIMITS = {
@@ -19,9 +19,7 @@ STRESS_CPU_MEM_IO_COMMAND = (
 )
 
 
-WINDOWS_10_WSL = deepcopy(WINDOWS_10)
 WINDOWS_11_WSL = deepcopy(WINDOWS_11)
-WINDOWS_10_WSL["image_path"] = f"{Images.Windows.UEFI_WIN_DIR}/{Images.Windows.WIN10_WSL2_IMG}"
 WINDOWS_11_WSL["image_path"] = f"{Images.Windows.DIR}/{Images.Windows.WIN11_WSL2_IMG}"
 
 

--- a/tests/virt/node/general/test_oom.py
+++ b/tests/virt/node/general/test_oom.py
@@ -12,9 +12,9 @@ from ocp_resources.virtual_machine import VirtualMachine
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.os_params import WINDOWS_10_TEMPLATE_LABELS
+from tests.os_params import WINDOWS_11_TEMPLATE_LABELS
 from tests.utils import start_stress_on_vm
-from tests.virt.constants import WINDOWS_10_WSL
+from tests.virt.constants import WINDOWS_11_WSL
 from utilities.constants import STRESS_CPU_MEM_IO_COMMAND, TCP_TIMEOUT_30SEC, TIMEOUT_15MIN, Images
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
@@ -105,10 +105,10 @@ def test_vm_fedora_oom(admin_client, fedora_oom_vm, fedora_oom_stress_started):
     "golden_image_data_source_for_test_scope_function, vm_with_memory_load",
     [
         pytest.param(
-            {"os_dict": WINDOWS_10_WSL},
+            {"os_dict": WINDOWS_11_WSL},
             {
                 "vm_name": "windows-vm-with-memory-load",
-                "template_labels": WINDOWS_10_TEMPLATE_LABELS,
+                "template_labels": WINDOWS_11_TEMPLATE_LABELS,
                 "memory_guest": Images.Windows.DEFAULT_MEMORY_SIZE_WSL,
                 "cpu_cores": 16,
                 "cpu_threads": 1,

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -12,7 +12,7 @@ from ocp_resources.template import Template
 from pyhelper_utils.shell import run_ssh_commands
 
 from tests.utils import verify_wsl2_guest_works
-from tests.virt.constants import WINDOWS_10_WSL, WINDOWS_11_WSL
+from tests.virt.constants import WINDOWS_11_WSL
 from utilities.constants import TCP_TIMEOUT_30SEC, Images
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
@@ -60,7 +60,7 @@ def windows_wsl2_vm(
     modern_cpu_for_migration,
     vm_cpu_flags,
 ):
-    """Create Windows 10/11 VM, Run VM and wait for WSL2 guest to start"""
+    """Create Windows 11 VM, Run VM and wait for WSL2 guest to start"""
     win_ver = request.param["win_ver"]
     with VirtualMachineForTestsFromTemplate(
         name=f"{win_ver}-wsl2",
@@ -88,11 +88,6 @@ def migrated_wsl2_vm(windows_wsl2_vm):
 @pytest.mark.parametrize(
     "golden_image_data_source_for_test_scope_class, windows_wsl2_vm",
     [
-        pytest.param(
-            {"os_dict": WINDOWS_10_WSL},
-            {"win_ver": "win-10"},
-            id="Windows-10",
-        ),
         pytest.param(
             {"os_dict": WINDOWS_11_WSL},
             {"win_ver": "win-11"},

--- a/tests/virt/node/gpu/gpu_pci_passthrough/test_windows_vm_with_gpu_pci_passthrough.py
+++ b/tests/virt/node/gpu/gpu_pci_passthrough/test_windows_vm_with_gpu_pci_passthrough.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 
-from tests.os_params import WINDOWS_10, WINDOWS_10_TEMPLATE_LABELS, WINDOWS_2019, WINDOWS_2019_TEMPLATE_LABELS
+from tests.os_params import WINDOWS_11, WINDOWS_11_TEMPLATE_LABELS, WINDOWS_2019, WINDOWS_2019_TEMPLATE_LABELS
 from tests.virt.node.gpu.constants import GPU_DEVICE_NAME_STR
 from tests.virt.node.gpu.utils import (
     restart_and_check_gpu_exists,
@@ -31,14 +31,14 @@ TESTS_CLASS_NAME = "TestPCIPassthroughWinHostDevicesSpec"
     "golden_image_data_source_for_test_scope_class, gpu_vma",
     [
         pytest.param(
-            {"os_dict": WINDOWS_10},
+            {"os_dict": WINDOWS_11},
             {
-                "vm_name": "win10-passthrough-vm",
-                "template_labels": WINDOWS_10_TEMPLATE_LABELS,
+                "vm_name": "win11-passthrough-vm",
+                "template_labels": WINDOWS_11_TEMPLATE_LABELS,
                 "host_device": GPU_DEVICE_NAME_STR,
                 "cloned_dv_size": Images.Windows.DEFAULT_DV_SIZE,
             },
-            id="test_win10_pci_passthrough",
+            id="test_win11_pci_passthrough",
         ),
         pytest.param(
             {"os_dict": WINDOWS_2019},

--- a/tests/virt/node/gpu/utils.py
+++ b/tests/virt/node/gpu/utils.py
@@ -36,7 +36,7 @@ def verify_gpu_expected_count_updated_on_node(gpu_nodes, device_name, expected_c
 
 
 def install_nvidia_drivers_on_windows_vm(vm, supported_gpu_device):
-    # Installs NVIDIA Drivers placed on the Windows-10 or win2k19 Images.
+    # Installs NVIDIA Drivers placed on the Windows-11 or win2k19 Images.
     # vGPU uses NVIDIA GRID Drivers and GPU Passthrough uses normal NVIDIA Drivers.
     vgpu_device_name = supported_gpu_device[VGPU_DEVICE_NAME_STR]
     gpu_mode = "vgpu" if fetch_gpu_device_name_from_vm_instance(vm) == vgpu_device_name else "gpu"

--- a/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from ocp_resources.template import Template
 
-from tests.os_params import WINDOWS_10, WINDOWS_10_TEMPLATE_LABELS
+from tests.os_params import WINDOWS_11, WINDOWS_11_TEMPLATE_LABELS
 from tests.virt.node.gpu.constants import VGPU_DEVICE_NAME_STR, VGPU_PRETTY_NAME_STR
 from tests.virt.node.gpu.utils import (
     install_nvidia_drivers_on_windows_vm,
@@ -50,10 +50,10 @@ def gpu_vmc(
     VM Fixture for second VM for vGPU based Tests.
     """
     with VirtualMachineForTestsFromTemplate(
-        name="win10-vgpu-gpus-spec-vm2",
+        name="win11-vgpu-gpus-spec-vm2",
         namespace=namespace.name,
         client=unprivileged_client,
-        labels=Template.generate_template_labels(**WINDOWS_10_TEMPLATE_LABELS),
+        labels=Template.generate_template_labels(**WINDOWS_11_TEMPLATE_LABELS),
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         node_selector=gpu_vma.node_selector,
         gpu_name=supported_gpu_device[VGPU_DEVICE_NAME_STR],
@@ -68,14 +68,14 @@ def gpu_vmc(
     "golden_image_data_source_for_test_scope_class, gpu_vma",
     [
         pytest.param(
-            {"os_dict": WINDOWS_10},
+            {"os_dict": WINDOWS_11},
             {
-                "vm_name": "win10-vgpu-gpus-spec-vm",
-                "template_labels": WINDOWS_10_TEMPLATE_LABELS,
+                "vm_name": "win11-vgpu-gpus-spec-vm",
+                "template_labels": WINDOWS_11_TEMPLATE_LABELS,
                 "gpu_device": VGPU_DEVICE_NAME_STR,
                 "cloned_dv_size": DV_SIZE,
             },
-            id="test_win10_vgpu",
+            id="test_win11_vgpu",
         ),
     ],
     indirect=True,
@@ -114,9 +114,9 @@ class TestVGPUWindowsGPUSSpec:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::test_access_vgpus_win_vm"])
     @pytest.mark.polarion("CNV-8573")
-    def test_access_vgpus_in_both_win10_vm(self, gpu_vma, gpu_vmc, supported_gpu_device):
+    def test_access_vgpus_in_both_win11_vm(self, gpu_vma, gpu_vmc, supported_gpu_device):
         """
-        Test vGPU is accessible in both the Windows10 VMs using same GPU, using GPUs spec.
+        Test vGPU is accessible in both the Windows11 VMs using same GPU, using GPUs spec.
         """
         vm_with_no_gpu = [
             vm.name

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -5,10 +5,10 @@ import pytest
 from tests.os_params import (
     FEDORA_LATEST,
     FEDORA_LATEST_LABELS,
-    WINDOWS_10_TEMPLATE_LABELS,
+    WINDOWS_11_TEMPLATE_LABELS,
 )
 from tests.utils import start_stress_on_vm
-from tests.virt.constants import WINDOWS_10_WSL
+from tests.virt.constants import WINDOWS_11_WSL
 from tests.virt.utils import get_stress_ng_pid, verify_stress_ng_pid_not_changed
 from utilities.constants import STRESS_CPU_MEM_IO_COMMAND, TIMEOUT_20MIN, Images
 from utilities.virt import migrate_vm_and_verify
@@ -73,10 +73,10 @@ class TestMigrationVMWithMemoryLoad:
         "golden_image_data_source_for_test_scope_function, vm_with_memory_load",
         [
             pytest.param(
-                {"os_dict": WINDOWS_10_WSL},
+                {"os_dict": WINDOWS_11_WSL},
                 {
                     "vm_name": "windows-vm-with-memory-load",
-                    "template_labels": WINDOWS_10_TEMPLATE_LABELS,
+                    "template_labels": WINDOWS_11_TEMPLATE_LABELS,
                     "memory_guest": Images.Windows.DEFAULT_MEMORY_SIZE_WSL,
                     "cpu_cores": 16,
                     "cpu_threads": 1,

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -9,7 +9,7 @@ from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
 )
 
-from tests.os_params import WINDOWS_10
+from tests.os_params import WINDOWS_11
 from utilities.constants import OS_FLAVOR_WINDOWS, TIMEOUT_3MIN, VIRTIO_WIN
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
 
@@ -87,7 +87,7 @@ def vm_with_guest_tools(
         namespace=namespace.name,
         client=unprivileged_client,
         vm_instance_type=VirtualMachineClusterInstancetype(name="u1.large"),
-        vm_preference=VirtualMachineClusterPreference(name="windows.10"),
+        vm_preference=VirtualMachineClusterPreference(name="windows.11"),
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         termination_grace_period=TIMEOUT_3MIN,
         os_flavor=OS_FLAVOR_WINDOWS,
@@ -115,7 +115,7 @@ def test_win_virtio_image(virtio_win_image, hco_csv_win_virtio_image):
 
 @pytest.mark.parametrize(
     "golden_image_data_source_for_test_scope_class",
-    [pytest.param({"os_dict": WINDOWS_10})],
+    [pytest.param({"os_dict": WINDOWS_11})],
     indirect=True,
 )
 class TestWindowsGuestTools:

--- a/utilities/unittests/conftest.py
+++ b/utilities/unittests/conftest.py
@@ -166,7 +166,6 @@ def mock_os_images():
     mock_windows_class = MagicMock()
     mock_windows_class.LATEST_RELEASE_STR = "win2k25.qcow2"
     mock_windows_class.DEFAULT_DV_SIZE = "60Gi"
-    mock_windows_class.WIN10_IMG = "win10.qcow2"
     mock_windows_class.WIN11_IMG = "win11.qcow2"
     mock_windows_class.WIN2k19_IMG = "win2k19.qcow2"
     mock_windows_class.WIN2022_IMG = "win2022.qcow2"

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -65,17 +65,17 @@ class TestGenerateOsMatrixDict:
         """Test Windows OS matrix generation with UEFI support"""
         mock_images.Windows = mock_os_images["windows"]
 
-        result = generate_os_matrix_dict("windows", ["win-10", "win-2019"])
+        result = generate_os_matrix_dict("windows", ["win-11", "win-2019"])
 
         assert len(result) == 2
 
-        # Check Windows 10 (UEFI + desktop workload)
-        win10 = next(item for item in result if "win-10" in item)["win-10"]
-        assert win10["os_version"] == "10"
-        assert win10["image_name"] == "win10.qcow2"
-        assert win10["image_path"] == "cnv-tests/windows-uefi-images/win10.qcow2"
-        assert win10["template_labels"]["workload"] == "desktop"
-        assert win10["template_labels"]["flavor"] == "medium"
+        # Check Windows 11 (desktop workload)
+        win11 = next(item for item in result if "win-11" in item)["win-11"]
+        assert win11["os_version"] == "11"
+        assert win11["image_name"] == "win11.qcow2"
+        assert win11["image_path"] == "cnv-tests/windows-images/win11.qcow2"
+        assert win11["template_labels"]["workload"] == "desktop"
+        assert win11["template_labels"]["flavor"] == "medium"
 
         # Check Windows 2019 (UEFI + server workload)
         win2019 = next(item for item in result if "win-2019" in item)["win-2019"]
@@ -201,13 +201,13 @@ class TestGenerateOsMatrixDict:
         mock_class = MagicMock()
         mock_class.LATEST_RELEASE_STR = "win2k25.qcow2"
         mock_class.DEFAULT_DV_SIZE = "60Gi"
-        mock_class.WIN10_IMG = "win10.qcow2"
+        mock_class.WIN2k19_IMG = "win2k19.qcow2"
         # Missing UEFI_WIN_DIR
         del mock_class.UEFI_WIN_DIR
         mock_images.Windows = mock_class
 
         with pytest.raises(ValueError, match="windows is missing `UEFI_WIN_DIR` attribute"):
-            generate_os_matrix_dict("windows", ["win-10"])
+            generate_os_matrix_dict("windows", ["win-2019"])
 
 
 class TestGenerateInstanceTypeRhelOsMatrix:
@@ -301,8 +301,8 @@ class TestOsMappingsConstants:
         assert "flavor" in WINDOWS_OS_MAPPING
 
         # Check for UEFI flag where expected
-        assert WINDOWS_OS_MAPPING["win-10"]["uefi"] is True
         assert WINDOWS_OS_MAPPING["win-2019"]["uefi"] is True
+        assert WINDOWS_OS_MAPPING["win-2025"]["uefi"] is True
         assert "uefi" not in WINDOWS_OS_MAPPING["win-2022"]
 
     def test_fedora_os_mapping_structure(self):


### PR DESCRIPTION
##### Short description:
Drop windows 10 and 10 wsl2 since win 10 is EOL,  replace it with win 11 and 11 wsl2 

Assisted-by: Cursor
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
separate jira for tracking the refactor of test_migration_storm_wsl2_vms test 
https://issues.redhat.com/browse/CNV-80534 
##### jira-ticket:
https://issues.redhat.com/browse/CNV-77964
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
https://issues.redhat.com/browse/CNV-77964
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed Windows 10 test coverage and WSL2 variants; migrated fixtures, parameters, IDs, and template labels to Windows 11.
  * Updated VM/image references and mock image data to use Windows 11 images.
  * Standardized network interface selection used during Windows upgrade preparation.
  * Adjusted longevity test parameterization to pass full parameter lists for WSL2 DV/VM scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->