### PR TITLE
tests, net, udn: Adjust package fixtures scope and reference

### DIFF
--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -6,7 +6,7 @@ from tests.network.libs.ip import random_ipv4_address
 from utilities.infra import create_ns
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="package")
 def udn_namespace(admin_client):
     yield from create_ns(
         admin_client=admin_client,
@@ -15,7 +15,7 @@ def udn_namespace(admin_client):
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="package", autouse=True)
 def namespaced_layer2_user_defined_network(admin_client, udn_namespace):
     with Layer2UserDefinedNetwork(
         name="layer2-udn",
@@ -32,6 +32,6 @@ def namespaced_layer2_user_defined_network(admin_client, udn_namespace):
         yield udn
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="package")
 def udn_affinity_label():
     return affinity.new_label(key_prefix="udn")

--- a/tests/network/user_defined_network/ip_specification/conftest.py
+++ b/tests/network/user_defined_network/ip_specification/conftest.py
@@ -17,7 +17,6 @@ from tests.network.libs.vm_factory import udn_vm
 @pytest.fixture(scope="module")
 def vm_under_test(
     udn_namespace: Namespace,
-    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
     udn_affinity_label: tuple[str, str],
     admin_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine, None, None]:
@@ -34,7 +33,6 @@ def vm_under_test(
 @pytest.fixture(scope="module")
 def vm_for_connectivity_ref(
     udn_namespace: Namespace,
-    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
     udn_affinity_label: tuple[str, str],
     admin_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine, None, None]:

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -16,7 +16,7 @@ SERVER_PORT = 5201
 
 
 @pytest.fixture(scope="class")
-def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+def vma_udn(udn_namespace, udn_affinity_label, admin_client):
     with udn_vm(
         namespace_name=udn_namespace.name,
         name="vma-udn",
@@ -30,7 +30,7 @@ def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_
 
 
 @pytest.fixture(scope="class")
-def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+def vmb_udn(udn_namespace, udn_affinity_label, admin_client):
     with udn_vm(
         namespace_name=udn_namespace.name,
         name="vmb-udn",

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -5,7 +5,6 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.hyperconverged import HyperConverged
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.namespace import Namespace
-from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from timeout_sampler import TimeoutExpiredError, retry
 
 from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
@@ -47,7 +46,6 @@ def passt_enabled_in_hco(
 @pytest.fixture(scope="module")
 def passt_running_vm_pair(
     udn_namespace: Namespace,
-    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
     udn_affinity_label: tuple[str, str],
     admin_client: DynamicClient,
     passt_enabled_in_hco,


### PR DESCRIPTION
##### What this PR does / why we need it:

The UDN namespace, the primary UDN resource and the computed affinity label have been changed to "package" scope. These serve all UDN package and its sub-packages and can be re-used.

The UDN resource is special, it is always needed even if not directly referenced by the tests. Therefore, its fixture is set with 'autouse', as no matter which test is to be collected in the UDN package, all need it.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted test fixture lifecycles to use broader scope and enable automatic setup where needed, improving test execution predictability across related modules.

* **Refactor**
  * Removed unnecessary fixture dependencies and simplified test signatures to streamline test setup, improving maintainability and reducing setup complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->