### PR TITLE
add dedicated cpu instancetype test

### DIFF
--- a/tests/infrastructure/instance_types/conftest.py
+++ b/tests/infrastructure/instance_types/conftest.py
@@ -1,11 +1,32 @@
 import pytest
+from ocp_resources.data_source import DataSource
+from ocp_resources.datavolume import DataVolume
 from ocp_resources.resource import Resource
+from ocp_resources.validating_admission_policy import ValidatingAdmissionPolicy
+from ocp_resources.validating_admission_policy_binding import ValidatingAdmissionPolicyBinding
 from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
 )
 from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
 )
+from pytest_testconfig import config as py_config
+
+from tests.infrastructure.instance_types.constants import WINDOWS_DEDICATED_CPU_MESSAGE, WINDOWS_VCPU_OVERCOMMIT_STR
+from utilities.artifactory import (
+    cleanup_artifactory_secret_and_config_map,
+    get_artifactory_config_map,
+    get_artifactory_secret,
+    get_test_artifact_server_url,
+)
+from utilities.constants import CONTAINER_DISK_IMAGE_PATH_STR, DATA_SOURCE_STR, OS_FLAVOR_WIN_CONTAINER_DISK, Images
+from utilities.storage import (
+    create_dummy_first_consumer_pod,
+    data_volume_template_with_source_ref_dict,
+    generate_data_source_dict,
+    sc_volume_binding_mode_is_wffc,
+)
+from utilities.virt import VirtualMachineForTests
 
 COMMON_INSTANCETYPE_SELECTOR = f"{Resource.ApiGroup.INSTANCETYPE_KUBEVIRT_IO}/vendor=redhat.com"
 
@@ -28,3 +49,121 @@ def base_vm_cluster_instancetypes(unprivileged_client):
             label_selector=COMMON_INSTANCETYPE_SELECTOR,
         )
     )
+
+
+@pytest.fixture(scope="class")
+def windows_validating_admission_policy(admin_client):
+    with ValidatingAdmissionPolicy(
+        client=admin_client,
+        name=WINDOWS_VCPU_OVERCOMMIT_STR,
+        failure_policy="Fail",
+        match_conditions=[
+            {
+                "expression": (
+                    "(('kubevirt.io/preference-name' in object.metadata.annotations) && "
+                    "(object.metadata.annotations['kubevirt.io/preference-name'].lowerAscii().contains('windows'))) || "
+                    "(('kubevirt.io/cluster-preference-name' in object.metadata.annotations) && "
+                    "(object.metadata.annotations['kubevirt.io/cluster-preference-name']"
+                    ".lowerAscii().contains('windows'))) || "
+                    "(('vm.kubevirt.io/os' in object.metadata.annotations) && "
+                    "(object.metadata.annotations['vm.kubevirt.io/os'].lowerAscii().contains('windows')))"
+                ),
+                "name": WINDOWS_VCPU_OVERCOMMIT_STR,
+            }
+        ],
+        match_constraints={
+            "resourceRules": [
+                {
+                    "apiGroups": ["kubevirt.io"],
+                    "apiVersions": ["*"],
+                    "operations": ["CREATE", "UPDATE"],
+                    "resources": ["virtualmachineinstances"],
+                }
+            ]
+        },
+        validations=[
+            {
+                "expression": (
+                    "has(object.spec.domain.cpu.dedicatedCpuPlacement) && "
+                    "object.spec.domain.cpu.dedicatedCpuPlacement == true"
+                ),
+                "message": WINDOWS_DEDICATED_CPU_MESSAGE,
+            }
+        ],
+    ) as vap:
+        yield vap
+
+
+@pytest.fixture(scope="class")
+def windows_validating_admission_policy_binding(admin_client):
+    with ValidatingAdmissionPolicyBinding(
+        client=admin_client,
+        name=f"{WINDOWS_VCPU_OVERCOMMIT_STR}-binding",
+        policy_name=WINDOWS_VCPU_OVERCOMMIT_STR,
+        validation_actions=["Deny"],
+    ) as vapb:
+        yield vapb
+
+
+@pytest.fixture(scope="class")
+def latest_windows_data_volume(
+    unprivileged_client,
+    default_sc,
+    namespace,
+):
+    secret = get_artifactory_secret(namespace=namespace.name)
+    cert = get_artifactory_config_map(namespace=namespace.name)
+    with DataVolume(
+        client=unprivileged_client,
+        name="latest-windows",
+        namespace=namespace.name,
+        api_name="storage",
+        source="registry",
+        size=Images.Windows.CONTAINER_DISK_DV_SIZE,
+        storage_class=default_sc.name,
+        url=f"{get_test_artifact_server_url(schema='registry')}/"
+        f"{py_config['latest_windows_os_dict'][CONTAINER_DISK_IMAGE_PATH_STR]}",
+        secret=secret,
+        cert_configmap=cert.name,
+    ) as win_dv:
+        if sc_volume_binding_mode_is_wffc(sc=default_sc.name, client=win_dv.client):
+            create_dummy_first_consumer_pod(pvc=win_dv.pvc)
+        yield win_dv
+    cleanup_artifactory_secret_and_config_map(artifactory_secret=secret, artifactory_config_map=cert)
+
+
+@pytest.fixture(scope="class")
+def latest_windows_data_source(
+    unprivileged_client,
+    latest_windows_data_volume,
+):
+    with DataSource(
+        name=latest_windows_data_volume.name,
+        namespace=latest_windows_data_volume.namespace,
+        client=unprivileged_client,
+        source=generate_data_source_dict(dv=latest_windows_data_volume),
+    ) as win_ds:
+        yield win_ds
+
+
+@pytest.fixture()
+def windows_vm_for_dedicated_cpu(request, unprivileged_client, namespace, latest_windows_data_source):
+    with VirtualMachineForTests(
+        client=unprivileged_client,
+        name=request.param["vm_name"],
+        namespace=namespace.name,
+        vm_instance_type=VirtualMachineClusterInstancetype(
+            client=unprivileged_client, name=request.param["instance_type_name"]
+        ),
+        vm_preference=VirtualMachineClusterPreference(
+            client=unprivileged_client,
+            name=py_config["latest_windows_os_dict"][DATA_SOURCE_STR].replace("win", "windows."),
+        ),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=latest_windows_data_source,
+        ),
+        os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
+        disk_type=None,
+    ) as vm:
+        vm.start()
+        yield vm

--- a/tests/infrastructure/instance_types/constants.py
+++ b/tests/infrastructure/instance_types/constants.py
@@ -1,0 +1,4 @@
+WINDOWS_VCPU_OVERCOMMIT_STR = "windows-vcpu-overcommit"
+WINDOWS_DEDICATED_CPU_MESSAGE = (
+    "Windows VMIs require dedicated CPU placement. Set spec.domain.cpu.dedicatedCpuPlacement to true."
+)

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -14,6 +14,7 @@ from utilities.constants import (
     CONTAINER_DISK_IMAGE_PATH_STR,
     DATA_SOURCE_NAME,
     DATA_SOURCE_STR,
+    OS_FLAVOR_WIN_CONTAINER_DISK,
     RHEL8_PREFERENCE,
     Images,
 )
@@ -133,7 +134,7 @@ def golden_image_windows_vm(
             name=windows_os_matrix__module__[os_name][DATA_SOURCE_STR].replace("win", "windows."),
         ),
         data_volume_template=windows_data_volume_template.res,
-        os_flavor="win-container-disk",
+        os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
         disk_type=None,
         cpu_model=modern_cpu_for_migration,
     )

--- a/tests/infrastructure/instance_types/test_common_vm_instancetype.py
+++ b/tests/infrastructure/instance_types/test_common_vm_instancetype.py
@@ -3,8 +3,12 @@ from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
 )
 
-from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_label
+from tests.infrastructure.instance_types.constants import WINDOWS_DEDICATED_CPU_MESSAGE
+from tests.infrastructure.instance_types.utils import (
+    assert_mismatch_vendor_label,
+)
 from utilities.constants import VIRT_OPERATOR, Images
+from utilities.ssp import wait_for_condition_message_value
 from utilities.virt import VirtualMachineForTests, running_vm
 
 
@@ -44,3 +48,52 @@ def test_common_instancetype_owner(base_vm_cluster_instancetypes):
         ):
             failed_ins_type.append(vm_cluster_instancetype.name)
     assert not failed_ins_type, f"The following instance types do no have {VIRT_OPERATOR} owner: {failed_ins_type}"
+
+
+@pytest.mark.usefixtures(
+    "windows_validating_admission_policy",
+    "windows_validating_admission_policy_binding",
+)
+class TestDedicatedInstancetypeProfile:
+    @pytest.mark.polarion("CNV-13437")
+    @pytest.mark.parametrize(
+        "windows_vm_for_dedicated_cpu",
+        [
+            pytest.param(
+                {
+                    "vm_name": "windows-d1-profile",
+                    "instance_type_name": "d1.large",
+                },
+            ),
+        ],
+        indirect=True,
+    )
+    def test_d1_instancetype_profile(
+        self,
+        windows_vm_for_dedicated_cpu,
+    ):
+        running_vm(vm=windows_vm_for_dedicated_cpu)
+
+    @pytest.mark.polarion("CNV-13438")
+    @pytest.mark.parametrize(
+        "windows_vm_for_dedicated_cpu",
+        [
+            pytest.param(
+                {
+                    "vm_name": "windows-dedicated-cpu-validation",
+                    "instance_type_name": "u1.large",
+                },
+            ),
+        ],
+        indirect=True,
+    )
+    def test_dedicated_cpu_validation_error(
+        self,
+        windows_vm_for_dedicated_cpu,
+    ):
+        expected_message = (
+            f'Failure while starting VMI: virtualmachineinstances.kubevirt.io "{windows_vm_for_dedicated_cpu.name}" '
+            "is forbidden: ValidatingAdmissionPolicy 'windows-vcpu-overcommit' with binding "
+            f"'windows-vcpu-overcommit-binding' denied request: {WINDOWS_DEDICATED_CPU_MESSAGE}"
+        )
+        wait_for_condition_message_value(resource=windows_vm_for_dedicated_cpu, expected_message=expected_message)

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -50,6 +50,7 @@ OS_FLAVOR_ALPINE = "alpine"
 OS_FLAVOR_WINDOWS = "win"
 OS_FLAVOR_RHEL = "rhel"
 OS_FLAVOR_FEDORA = "fedora"
+OS_FLAVOR_WIN_CONTAINER_DISK = "win-container-disk"
 
 FEDORA_DISK_DEMO = "fedora-cloud-registry-disk-demo"
 CIRROS_DISK_DEMO = "cirros-registry-disk-demo"


### PR DESCRIPTION
##### Short description:
add dedicated cpu instancetype test

##### More details:
Openshift ships with `d1` series instance types, which have the `DedicatedCPUPlacement` field set.
Some instances of OpenShift deployment enforce the user to use `DedicatedCPUPlacement` in combination of windows, the added tests aim to replica the validation which occurs on the cluster and verify it is kept across future versions.

##### What this PR does / why we need it:
Add tests coverage for customer use case of d1 instance types

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-76513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Windows VM test infrastructure with registry-backed storage, data source provisioning, admission-policy scaffolding, and new fixtures to provision Windows images and VMs.
  * Added tests to verify dedicated CPU placement (vCPU pinning) and to assert admission-denied behavior for non-compliant Windows instance types.
  * Added a utility to validate vCPU pinning for dedicated CPU profiles.
* **Chores**
  * Introduced a named OS flavor constant to standardize Windows VM selection in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->