### PR TITLE
tests, net, udn, ip-spec: Add an external connectivity test

### DIFF
--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -20,6 +20,7 @@ from tests.network.user_defined_network.ip_specification.libipspec import (
     ip_address_annotation,
     read_guest_interface_ipv4,
 )
+from utilities.constants import PUBLIC_DNS_SERVER_IP
 
 FIRST_GUEST_IFACE_NAME: Final[str] = "eth0"
 
@@ -97,7 +98,7 @@ class TestVMWithExplicitIPAddressSpecification:
             assert is_tcp_connection(server=server, client=client)
 
     @pytest.mark.polarion("CNV-12582")
-    def test_successful_external_connectivity(self) -> None:
+    def test_successful_external_connectivity(self, vm_under_test: BaseVirtualMachine) -> None:
         """
         Test that a VM with an explicit IP address specified is reaching an external IP address.
 
@@ -111,8 +112,7 @@ class TestVMWithExplicitIPAddressSpecification:
         Expected:
             - Verify that the ping command succeeds with 0% packet loss.
         """
-
-    test_successful_external_connectivity.__test__ = False
+        assert vm_under_test.console(commands=[f"ping -c 3 {PUBLIC_DNS_SERVER_IP}"], timeout=30)
 
     @pytest.mark.polarion("CNV-12586")
     def test_seamless_in_cluster_connectivity_is_preserved_over_live_migration(self) -> None:


### PR DESCRIPTION
##### What this PR does / why we need it:

Test that a VM with an explicit IP address specified is reaching an external IP address.

> **Note**: The public external IP needs to be changed for all network tests (potentially beyond).
> It is not safe to use an IP which is not controlled by the CI setup.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-76572


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled external connectivity validation for virtual machines with explicit IP address specifications to ensure proper network access to external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->