### PR TITLE
tests,net: quarantine test_connectivity_is_preserved_during_server_live_migration

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -8,7 +8,7 @@ from libs.net.traffic_generator import VMTcpClient as TcpClient
 from libs.net.udn import UDN_BINDING_DEFAULT_PLUGIN_NAME
 from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
 from tests.network.libs.vm_factory import udn_vm
-from utilities.constants import PUBLIC_DNS_SERVER_IP, TIMEOUT_1MIN
+from utilities.constants import PUBLIC_DNS_SERVER_IP, QUARANTINED, TIMEOUT_1MIN
 from utilities.virt import migrate_vm_and_verify
 
 IP_ADDRESS = "ipAddress"
@@ -114,6 +114,10 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-12177")
     @pytest.mark.single_nic
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Failed migration of vm in UDN: CNV-72782",
+        run=False,
+    )
     def test_connectivity_is_preserved_during_server_live_migration(self, server, client):
         migrate_vm_and_verify(vm=server.vm)
         assert is_tcp_connection(server=server, client=client)


### PR DESCRIPTION
The migration fails time to time as nodes didn't match pod anti-affinity rules. 
Test should be quarantined until the issue is resolved.

##### jira-ticket: https://issues.redhat.com/browse/CNV-72782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Two tests marked as quarantined and configured to skip from normal execution while being tracked as expected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->