### PR TITLE
Set explicit API Version for HyperConverged

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -653,6 +653,7 @@ def get_hyperconverged_resource(client, hco_ns_name):
         namespace=hco_ns_name,
         name=hco_name,
     )
+    hco.api_version = hco.ApiVersion.V1BETA1
     if hco.exists:
         return hco
     raise ResourceNotFoundError(f"Hyperconverged: {hco_name} not found in {hco_ns_name}")


### PR DESCRIPTION
##### Short description:
As a preparation for the planned introduction of the `v1` API of the `HyperConverged` resource, explicitly set its API version to `v1beta1`.

##### More details:
The planned `v1` API of the HyperConverged resource, is going to restructure fields, moving them around, deprecating several fields and so on.

The current implementation takes the latest version of the API, so once the new version is introduced, the client will try to read or write the `HyperConverged` resource as `v1`, while the code is using its `v1beta1` API. This will break any test uses this type.

To avoid that, and give the developers some time to adjust, this PR explicitly sets the API version of the `HyperConverged` type to `v1beta1`, when fetching it from Kubernetes.

That way, the client will explicitly read and write the `HyperConverged` resource as `v1beta1`, and with the planned conversion webhook, the addition of the new `v1` API version will be transparent.

##### What this PR does / why we need it:
See above. Without this PR, the tests will fail once HCO v1 API will be introduced.

##### Which issue(s) this PR fixes:
n/a

##### Special notes for reviewer:
None

##### jira-ticket:
https://issues.redhat.com/browse/CNV-78901


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HyperConverged resource lookups now use the v1beta1 API version, improving reliability of resource discovery and reducing inconsistent "not found" results across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->