### PR TITLE
Add auto-retest workflow for PRs affected by merged changes

### DIFF
--- a/.github/workflows/auto-retest-needs-rebase.yml
+++ b/.github/workflows/auto-retest-needs-rebase.yml
@@ -9,6 +9,10 @@ permissions:
   pull-requests: write
   contents: read
 
+concurrency:
+  group: auto-retest-main
+  cancel-in-progress: false
+
 jobs:
   check-open-prs:
     if: github.event.pull_request.merged == true
@@ -53,7 +57,7 @@ jobs:
           set -euo pipefail
 
           # Get all open PRs with main as base branch (excluding drafts)
-          OPEN_PRS=$(gh pr list --base main --state open --json number,isDraft --jq '.[] | select(.isDraft == false) | .number')
+          OPEN_PRS=$(gh pr list --base main --state open --limit 100 --json number,isDraft --jq '.[] | select(.isDraft == false) | .number')
 
           if [ -z "$OPEN_PRS" ]; then
             echo "No open PRs targeting main branch"


### PR DESCRIPTION
##### Short description:
When PRs are merged, other open PRs targeting the same files may have outdated CI results.

Addin a nw workflow `.github/workflows/auto-retest-needs-rebase.yml` that:

  1. **Triggers** when a PR is merged to `main` (for now)
  2. **Analyzes** files changed in the merged PR
  3. **Checks** all open PRs for file overlap
  4. **Posts** `/retest all` comment on affected PRs

  ### Skip Conditions

  The workflow skips PRs that:
  - Are in **draft** state
  - Have `has-conflict` label
  - Have `hold` label
  - Have `wip` label

  ### Example Comment Posted

 ```
  /retest all

  Auto-triggered: Files in this PR were modified by merged PR #123.

  ▶ Overlapping files  ← Click to expand

  When expanded:
  conftest.py
  utilities/network.py
```

Generated-by: Claude cli

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that, after a merge to main, scans open PRs for overlapping changed files and posts retest requests on affected PRs (skipping drafts and PRs marked hold/wip/has-conflict). Actions and outcomes are logged for traceability, reducing manual retest work and helping surface regressions sooner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->