### PR TITLE
Virt: Fix timeout in run_os_command for Windows operations

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -86,6 +86,7 @@ from utilities.constants import (
     TIMEOUT_12MIN,
     TIMEOUT_25MIN,
     TIMEOUT_30MIN,
+    TIMEOUT_30SEC,
     VIRT_HANDLER,
     VIRT_LAUNCHER,
     VIRTCTL,
@@ -2759,19 +2760,39 @@ def guest_reboot(vm: VirtualMachineForTests, os_type: str) -> None:
     }
 
     LOGGER.info("Stopping user agent")
-    run_os_command(vm=vm, command=commands["stop-user-agent"][os_type])
+    run_os_command(
+        vm=vm,
+        command=commands["stop-user-agent"][os_type],
+        ssh_timeout=TIMEOUT_30SEC if os_type == OS_FLAVOR_WINDOWS else TIMEOUT_5SEC,
+    )
     wait_for_user_agent_down(vm=vm, timeout=TIMEOUT_2MIN)
 
     LOGGER.info(f"Rebooting {vm.name} from guest")
-    run_os_command(vm=vm, command=commands["reboot"][os_type])
+    run_os_command(
+        vm=vm,
+        command=commands["reboot"][os_type],
+        ssh_timeout=TIMEOUT_30SEC if os_type == OS_FLAVOR_WINDOWS else TIMEOUT_5SEC,
+    )
 
 
-def run_os_command(vm: VirtualMachineForTests, command: str) -> Optional[str]:
+def run_os_command(vm: VirtualMachineForTests, command: str, ssh_timeout: int = TIMEOUT_5SEC) -> Optional[str]:
+    """Run a command over VM SSH.
+
+    Args:
+        vm (VirtualMachineForTests): Target VM.
+        command (str): Command to execute remotely.
+        ssh_timeout (int): SSH command timeout in seconds.
+
+    Returns:
+        str: Command output.
+        None: When command contains "reboot" and ProxyCommandFailure occurs
+          (expected behavior as SSH disconnects during reboot).
+    """
     try:
         return run_ssh_commands(
             host=vm.ssh_exec,
             commands=shlex.split(command),
-            timeout=5,
+            timeout=ssh_timeout,
             tcp_timeout=TCP_TIMEOUT_30SEC,
         )[0]
     except ProxyCommandFailure:


### PR DESCRIPTION


##### Short description:
Windows service operations like Stop-Service can take 10-20 seconds to complete, causing tests such as`test_vmi_guest_agent_info_after_guest_reboot` to fail with TimeoutError. Increase default SSH timeout from 5 to 30 seconds while maintaining backward compatibility.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reboot-related failures now return gracefully instead of raising exceptions, reducing unexpected error crashes during guest reboots.

* **Refactor**
  * SSH timeout handling made configurable per operation and OS-aware—Windows operations use a longer timeout and overall TCP timeouts have been extended to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->