### PR TITLE
Set Windows latest release to 2022

### DIFF
--- a/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
+++ b/tests/network/rdp/test_rdp_for_exposed_vm_svc.py
@@ -9,7 +9,7 @@ from ocp_resources.service import Service
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 
-from tests.os_params import WINDOWS_LATEST, WINDOWS_LATEST_OS
+from tests.os_params import WINDOWS_2019, WINDOWS_2019_OS
 from utilities.constants import (
     OS_FLAVOR_WINDOWS,
     TIMEOUT_5MIN,
@@ -91,15 +91,15 @@ def configure_rdp_on_server_windows_vm(vm: VirtualMachineForTests) -> None:
     [
         pytest.param(
             {
-                "dv_name": WINDOWS_LATEST_OS,
-                "image": WINDOWS_LATEST.get("image_path"),
+                "dv_name": WINDOWS_2019_OS,
+                "image": WINDOWS_2019.get("image_path"),
                 "storage_class": py_config["default_storage_class"],
-                "dv_size": WINDOWS_LATEST.get("dv_size"),
+                "dv_size": WINDOWS_2019.get("dv_size"),
             },
             {
-                "vm_name": f"win{WINDOWS_LATEST.get('os_version')}-vm-test",
-                "os_version": WINDOWS_LATEST.get("os_version"),
-                "template_labels": WINDOWS_LATEST.get("template_labels"),
+                "vm_name": f"win{WINDOWS_2019.get('os_version')}-vm-test",
+                "os_version": WINDOWS_2019.get("os_version"),
+                "template_labels": WINDOWS_2019.get("template_labels"),
                 "network_model": "virtio",
             },
             marks=(pytest.mark.polarion("CNV-235")),

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -503,9 +503,9 @@ def test_vm_from_dv_on_different_node(
     [
         pytest.param(
             {
-                "dv_name": "dv-win-19",
+                "dv_name": "dv-win-22",
                 "source": HTTP,
-                "image": f"{Images.Windows.UEFI_WIN_DIR}/{Images.Windows.WIN19_RAW}",
+                "image": f"{Images.Windows.DIR}/{Images.Windows.WIN2022_IMG}",
                 "dv_size": Images.Windows.DEFAULT_DV_SIZE,
             },
             {

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -110,7 +110,7 @@ class ArchImages:
             WIN2022_ISO_IMG="Windows_Server_2022_x64FRE_en-us.iso",
             WIN2025_ISO_IMG="windows_server_2025_x64_dvd_eval.iso",
         )
-        Windows.LATEST_RELEASE_STR = Windows.WIN2k19_IMG
+        Windows.LATEST_RELEASE_STR = Windows.WIN2022_IMG
 
         Fedora = Fedora(
             FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",


### PR DESCRIPTION
Update Windows.LATEST_RELEASE_STR so latest_windows_os_dict now resolves to win-2022.

Depends on: https://github.com/kubevirt/kubevirt/pull/16853

**Note to Network team:** 

- **test_rdp_for_exposed_win_vm_as_node_port_svc** - Pinned to Win2K19 (was WINDOWS_LATEST/Win2K22). On Win2K22, TermService defaults to Stopped/Manual; after starting it, xfreerdp still fails with exit code 147. The same test passes on Win2K19 without issues.

https://redhat.atlassian.net/browse/CNV-86246

**Note to Storage team:** 

- **test_successful_vm_from_imported_dv_windows** - Updated DV from Win2K19 to Win2K22 to avoid a mismatch between the DV image and the OS version derived from LATEST_WINDOWS_OS_DICT. The DV params (dv_name, image). 

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-77280 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default AMD64 Windows image from Windows Server 2019 to Windows Server 2022 so new deployments and defaults use the newer Windows version.

* **Tests**
  * Adjusted automated tests to use the updated default Windows image and selection so CI reflects the new default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->