### PR TITLE
Updated fedora container-disk and qcow2 to 43

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,9 @@
+# Containers and image artifacts
+
+- **fedora/** – Build the **customized** Fedora container-disk image (sysprepped qcow2 in a container). See [fedora/README.md](fedora/README.md). The resulting qcow2 can be published to Artifactory as the main test image for that arch.
+
+- **fedora_artifacts/** – Build **base** Fedora disk artifacts (qcow2, raw, .gz, .xz) for a given version. Output goes to `fedora_artifacts/out/` for upload to Artifactory. Optionally copy the customized qcow2 from `fedora/` into `out/` so all artifacts are in one place. See [fedora_artifacts/README.md](fedora_artifacts/README.md).
+
+- **internal_http/** – Build the internal HTTP server container image used by storage/CDI tests. See team Confluence for build instructions.
+
+- **utility/** – Utility container image. See [utility/README.md](utility/README.md).

--- a/containers/fedora_artifacts/README.md
+++ b/containers/fedora_artifacts/README.md
@@ -1,0 +1,93 @@
+# Fedora base disk artifacts for Artifactory
+
+This directory builds **base** (official) Fedora cloud disk images in all formats used by tests: qcow2, raw, qcow2.gz, qcow2.xz, raw.gz, raw.xz. Output is written to `out/` for upload to Artifactory.
+
+The **customized** qcow2 (sysprepped, with stress-ng etc.) is produced by [containers/fedora/build.sh](../fedora/build.sh) and is separate; see optional step below to collect everything in one place.
+
+## Requirements
+
+- `wget`, `qemu-img`, `gzip`, `xz`
+
+Install commands:
+
+**macOS (ARM64):**
+```bash
+brew install wget qemu gzip xz
+```
+(`qemu-img` is provided by the `qemu` package.)
+
+**Linux (amd64):**
+```bash
+# Debian / Ubuntu
+sudo apt-get update && sudo apt-get install -y wget qemu-utils gzip xz-utils
+
+# RHEL / Fedora
+sudo dnf install -y wget qemu-img gzip xz
+```
+
+## Usage
+
+```bash
+# From repo root or from this directory
+FEDORA_VERSION=43-1.6 ./containers/fedora_artifacts/build.sh
+
+# Or pass version as first argument
+./containers/fedora_artifacts/build.sh 43-1.6
+```
+
+Builds for **x86_64**, **aarch64**, and **s390x**. Artifacts are placed in `containers/fedora_artifacts/out/`. Allow **30 minutes or more** for a full run (downloads and compression).
+
+## Output layout (per arch)
+
+For each architecture the script produces:
+
+- `Fedora-Cloud-Base-Generic-<version>.<arch>.qcow2` → renamed to **`Fedora-qcow2-<arch>.img`**
+- `Fedora-Cloud-Base-Generic-<version>.<arch>.qcow2.gz`
+- `Fedora-Cloud-Base-Generic-<version>.<arch>.qcow2.xz`
+- `Fedora-Cloud-Base-Generic-<version>.<arch>.raw`
+- `Fedora-Cloud-Base-Generic-<version>.<arch>.raw.gz`
+- `Fedora-Cloud-Base-Generic-<version>.<arch>.raw.xz`
+
+## Optional: use customized qcow2 in `out/`
+
+If you have already built the **customized** Fedora image with `containers/fedora/build.sh` for an arch, you can copy it into `out/` so all artifacts to upload to Artifactory are in one place.
+
+Example for s390x (after running `containers/fedora/build.sh` with s390x):
+
+```bash
+cp containers/fedora/fedora_build_s390x/Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2 \
+   containers/fedora_artifacts/out/
+```
+
+Then upload the contents of `containers/fedora_artifacts/out/` to Artifactory.
+
+## Upload to Artifactory (JFrog CLI)
+
+**Install (macOS):**
+```bash
+brew install jfrog-cli
+```
+Other platforms: [JFrog CLI](https://jfrog.com/getcli/) (`jf`).
+
+**1. Log in:**
+```bash
+jf login
+```
+- Enter your JFrog Platform URL: `https://cnv-qe-artifactory.<...>.redhat.com/`
+- Enter "save and continue"
+- Authenticate in the browser when prompted
+
+**2. Upload artifacts from `out/`:**
+```bash
+cd containers/fedora_artifacts/out
+
+# Upload all s390x artifacts
+jf rt upload "*s390x*" cnv-qe-server-local/cnv-tests/fedora-images/
+```
+
+**Caution:** Before uploading all architectures, ensure you are selecting the right files (e.g. by arch or version) so you do not overwrite existing artifacts in Artifactory.
+
+```bash
+# Upload all architectures (x86_64, aarch64, s390x)
+jf rt upload "*" cnv-qe-server-local/cnv-tests/fedora-images/
+```

--- a/containers/fedora_artifacts/build.sh
+++ b/containers/fedora_artifacts/build.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Build base Fedora disk artifacts (qcow2, raw, .gz, .xz) for a given version.
+# Output goes to containers/fedora_artifacts/out/ for upload to Artifactory.
+#
+# Usage:
+#   FEDORA_VERSION=41-1.4 ./build.sh
+#   ./build.sh 43-1.6
+#
+# Requires: wget, qemu-img, gzip, xz, sha256sum
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${SCRIPT_DIR}/out"
+FEDORA_VERSION="${FEDORA_VERSION:-${1:-}}"
+
+if [[ -z "${FEDORA_VERSION}" ]]; then
+  echo "Usage: FEDORA_VERSION=41-1.4 ./build.sh   OR   ./build.sh 41-1.4" >&2
+  exit 1
+fi
+
+MAJOR_VERSION="${FEDORA_VERSION%%-*}"
+BASE="Fedora-Cloud-Base-Generic-${FEDORA_VERSION}"
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+
+download_and_build_arch() {
+  local arch="$1"
+  local url_base="$2"
+  local qcow2_name="${BASE}.${arch}.qcow2"
+  local raw_name="${BASE}.${arch}.raw"
+  local img_name="Fedora-qcow2-${arch}.img"
+  local checksum_file="Fedora-Cloud-${FEDORA_VERSION}-${arch}-CHECKSUM"
+
+  echo "[${arch}] Downloading base qcow2..."
+  wget -q -O "${OUT_DIR}/${qcow2_name}" "${url_base}/${qcow2_name}"
+
+  echo "[${arch}] Downloading checksum file..."
+  wget -q -O "${OUT_DIR}/${checksum_file}" "${url_base}/${checksum_file}"
+  echo "[${arch}] Verifying SHA256 checksum..."
+  local expected_hash actual_hash
+  expected_hash=$(grep "SHA256 (${qcow2_name})" "${OUT_DIR}/${checksum_file}" | awk -F' = ' '{print $2}')
+  actual_hash=$(sha256sum "${OUT_DIR}/${qcow2_name}" | awk '{print $1}')
+  if [[ -z "${expected_hash}" ]]; then
+    echo "[${arch}] WARNING: Could not find checksum for ${qcow2_name} in ${checksum_file}" >&2
+    exit 1
+  fi
+  if [[ "${expected_hash}" != "${actual_hash}" ]]; then
+    echo "[${arch}] CHECKSUM MISMATCH for ${qcow2_name}!" >&2
+    echo "  Expected: ${expected_hash}" >&2
+    echo "  Got:      ${actual_hash}" >&2
+    exit 1
+  fi
+  echo "[${arch}] Checksum OK."
+
+  echo "[${arch}] Creating raw..."
+  qemu-img convert -O raw "${OUT_DIR}/${qcow2_name}" "${OUT_DIR}/${raw_name}"
+
+  echo "[${arch}] Creating raw.gz and raw.xz..."
+  gzip -k "${OUT_DIR}/${raw_name}"
+  xz -k "${OUT_DIR}/${raw_name}"
+
+  echo "[${arch}] Creating qcow2.gz and qcow2.xz..."
+  gzip -k "${OUT_DIR}/${qcow2_name}"
+  xz -k "${OUT_DIR}/${qcow2_name}"
+
+  echo "[${arch}] Renaming qcow2 to ${img_name}..."
+  mv "${OUT_DIR}/${qcow2_name}" "${OUT_DIR}/${img_name}"
+}
+
+# x86_64 and aarch64: primary Fedora mirror
+# s390x: fedora-secondary
+echo "Building Fedora ${FEDORA_VERSION} artifacts for x86_64, aarch64, s390x..."
+download_and_build_arch "x86_64" "https://download.fedoraproject.org/pub/fedora/linux/releases/${MAJOR_VERSION}/Cloud/x86_64/images"
+download_and_build_arch "aarch64" "https://download.fedoraproject.org/pub/fedora/linux/releases/${MAJOR_VERSION}/Cloud/aarch64/images"
+download_and_build_arch "s390x" "https://download.fedoraproject.org/pub/fedora-secondary/releases/${MAJOR_VERSION}/Cloud/s390x/images"
+
+echo "Done. Artifacts in ${OUT_DIR}:"
+ls -la "${OUT_DIR}"

--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -16,7 +16,7 @@ EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR] = f"rhel.9.{S390X}"
 
 
 rhel_os_list = ["rhel-8-10", "rhel-9-6"]
-fedora_os_list = ["fedora-42"]
+fedora_os_list = ["fedora-43"]
 centos_os_list = ["centos-stream-9"]
 
 instance_type_rhel_os_list = [RHEL9_PREFERENCE]

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -168,18 +168,16 @@ class ArchImages:
         BASE_ALPINE_NAME = "alpine-s390x-disk"
         BASE_VERSIONED_ALPINE_NAME = f"alpine-{ALPINE_VERSION}-s390x-disk"
         Cirros = Cirros(
-            # TODO: S390X does not support Cirros; this is a workaround until tests are moved to Fedora
-            RAW_IMG="Fedora-Cloud-Base-Generic-41-1.4.s390x.raw",
-            RAW_IMG_GZ="Fedora-Cloud-Base-Generic-41-1.4.s390x.raw.gz",
-            RAW_IMG_XZ="Fedora-Cloud-Base-Generic-41-1.4.s390x.raw.xz",
-            QCOW2_IMG="Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2",
-            QCOW2_IMG_GZ="Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2.gz",
-            QCOW2_IMG_XZ="Fedora-Cloud-Base-Generic-41-1.4.s390x.qcow2.xz",
+            # S390X does not support Cirros; Alpine is used as a lightweight substitute
+            RAW_IMG_XZ=f"{BASE_VERSIONED_ALPINE_NAME}.raw.xz",
+            QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
+            # DISK_DEMO: unused; kept as Fedora — alpine-container-disk-demo:latest lacks s390x manifest,
+            # though newer versioned builds include s390x
             DISK_DEMO=FEDORA_DISK_DEMO,
-            DIR=f"{BASE_IMAGES_DIR}/fedora-images",
-            DEFAULT_DV_SIZE="10Gi",
-            DEFAULT_MEMORY_SIZE="1Gi",
-            OS_FLAVOR=OS_FLAVOR_FEDORA,
+            DIR=f"{BASE_IMAGES_DIR}/alpine-images",
+            DEFAULT_DV_SIZE="1Gi",
+            DEFAULT_MEMORY_SIZE="128M",
+            OS_FLAVOR=OS_FLAVOR_ALPINE,
         )
 
         Alpine = Alpine(
@@ -201,17 +199,19 @@ class ArchImages:
 
         Fedora = Fedora(
             FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.s390x.qcow2",
-            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41-s390x",
+            FEDORA43_IMG="Fedora-Cloud-Base-Generic-43-1.6.s390x.qcow2",
+            # TODO: Replace with official quay.io/openshift-cnv/qe-cnv-tests-fedora:43-s390x
+            # once PR `#4066` merges and publishes the official Fedora 43 s390x container image.
+            FEDORA_CONTAINER_IMAGE="quay.io/nestor_acuna_blanco/openshift-cnv/fedora:43-s390x",
             DISK_DEMO=FEDORA_DISK_DEMO,
         )
-        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG
-
+        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA43_IMG
         Centos = Centos(CENTOS_STREAM_9_IMG="CentOS-Stream-GenericCloud-9-latest.s390x.qcow2")
         Centos.LATEST_RELEASE_STR = Centos.CENTOS_STREAM_9_IMG
 
         Cdi = Cdi(
             # TODO: S390X does not support Cirros; this is a workaround until tests are moved to Fedora
-            QCOW2_IMG="Fedora-qcow2.img",
+            QCOW2_IMG="Fedora-qcow2-s390x.img",
             DIR=f"{BASE_IMAGES_DIR}/fedora-images",
             DEFAULT_DV_SIZE="10Gi",
         )

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2559,8 +2559,9 @@ def wait_for_vmi_relocation_and_running(initial_node, vm, timeout=TIMEOUT_5MIN):
 
 
 def check_qemu_guest_agent_installed(ssh_exec: Host) -> bool:
-    ssh_exec.sudo = True
-    return ssh_exec.package_manager.exist(package="qemu-guest-agent")
+    """Check if qemu-guest-agent is installed via rpm, bypassing rrmngmnt's `which`-based package manager detection."""
+    rc, _, _ = ssh_exec.run_command(command=shlex.split("rpm -q qemu-guest-agent"))
+    return rc == 0
 
 
 def validate_libvirt_persistent_domain(vm, admin_client):


### PR DESCRIPTION

##### Short description:
As fedora 41 is out of support, moving to newer Fedora. As a first step (less changes) moved cirros workaround from Fedora to alpine, as now with internal-http-server:1.2.0 Fedora/Cirros is replaced with Alpine.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Fedora base/version to 43 and aligned container image references.
  * Switched S390X Cirros defaults to Alpine-derived images, added Alpine disk demo, reduced default disk/memory sizes, and adjusted S390X image naming.

* **New Features**
  * Added a script to build Fedora cloud disk artifacts for multiple architectures.

* **Tests**
  * Updated S390X test configuration to target Fedora 43.

* **Bug Fixes**
  * Improved detection of qemu-guest-agent on test hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->