### PR TITLE
Add webhook health precheck to cluster sanity checks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -241,6 +241,11 @@ def pytest_addoption(parser):
         help="Skip cluster_sanity check",
         action="store_true",
     )
+    cluster_sanity_group.addoption(
+        "--cluster-sanity-skip-webhook-check",
+        help="Skip webhook check in cluster_sanity fixture",
+        action="store_true",
+    )
     # Log collector group
     data_collector_group.addoption(
         "--data-collector",

--- a/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
+++ b/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
@@ -13,7 +13,12 @@ from timeout_sampler import TimeoutSampler
 
 from utilities.constants import KUBELET_READY_CONDITION, TIMEOUT_1MIN, TIMEOUT_5MIN, TIMEOUT_5SEC, TIMEOUT_10MIN
 from utilities.hco import get_installed_hco_csv, wait_for_hco_conditions
-from utilities.infra import storage_sanity_check, wait_for_pods_running
+from utilities.infra import (
+    check_vm_creation_capability,
+    check_webhook_endpoints_health,
+    storage_sanity_check,
+    wait_for_pods_running,
+)
 from utilities.operator import wait_for_cluster_operator_stabilize
 from utilities.storage import get_data_sources_managed_by_data_import_cron
 
@@ -174,3 +179,18 @@ def test_common_node_cpu_model(cluster_node_cpus, cluster_common_node_cpu, clust
     assert cluster_common_node_cpu and cluster_common_modern_node_cpu, (
         f"This is a heterogeneous cluster with no common cpus: {cluster_node_cpus}"
     )
+
+
+@pytest.mark.cluster_health_check
+def test_webhook_endpoints_health(admin_client, hco_namespace):
+    """
+    Test that all webhook services in the HCO namespace have available endpoints and
+    each webhook service has at least one ready endpoint address.
+    """
+    check_webhook_endpoints_health(admin_client=admin_client, namespace=hco_namespace)
+
+
+@pytest.mark.cluster_health_check
+def test_vm_creation_capability(admin_client):
+    """Test VM creation capability by performing a dry-run VM creation."""
+    check_vm_creation_capability(admin_client=admin_client, namespace="default")

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -34,9 +34,11 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.console_cli_download import ConsoleCLIDownload
 from ocp_resources.daemonset import DaemonSet
 from ocp_resources.deployment import Deployment
+from ocp_resources.endpoints import Endpoints
 from ocp_resources.exceptions import ResourceTeardownError
 from ocp_resources.hyperconverged import HyperConverged
 from ocp_resources.infrastructure import Infrastructure
+from ocp_resources.mutating_webhook_config import MutatingWebhookConfiguration
 from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
 from ocp_resources.package_manifest import PackageManifest
@@ -46,6 +48,8 @@ from ocp_resources.project_request import ProjectRequest
 from ocp_resources.resource import Resource, ResourceEditor, get_client
 from ocp_resources.secret import Secret
 from ocp_resources.subscription import Subscription
+from ocp_resources.validating_webhook_config import ValidatingWebhookConfiguration
+from ocp_resources.virtual_machine import VirtualMachine
 from ocp_utilities.exceptions import NodeNotReadyError, NodeUnschedulableError
 from ocp_utilities.infra import (
     assert_nodes_in_healthy_condition,
@@ -619,6 +623,7 @@ def cluster_sanity(
     skip_cluster_sanity_check = "--cluster-sanity-skip-check"
     skip_storage_classes_check = "--cluster-sanity-skip-storage-check"
     skip_nodes_check = "--cluster-sanity-skip-nodes-check"
+    skip_webhook_check = "--cluster-sanity-skip-webhook-check"
     exceptions_filename = "cluster_sanity_failure.txt"
     try:
         if request.session.config.getoption(skip_cluster_sanity_check):
@@ -662,6 +667,15 @@ def cluster_sanity(
                 raise ClusterSanityError(
                     err_str=f"Timed out waiting for all pods in namespace {hco_namespace.name} to get to running state."
                 )
+
+        # Check webhook endpoints only if --cluster-sanity-skip-webhook-check not passed to pytest.
+        if request.session.config.getoption(skip_webhook_check):
+            LOGGER.warning(f"Skipping webhook health check, got {skip_webhook_check}")
+        else:
+            LOGGER.info(f"Check webhook endpoints health. (To skip webhook check pass {skip_webhook_check} to pytest)")
+            check_webhook_endpoints_health(admin_client=admin_client, namespace=hco_namespace)
+            check_vm_creation_capability(admin_client=admin_client, namespace="default")
+
         # Wait for hco to be healthy
         wait_for_hco_conditions(
             admin_client=admin_client,
@@ -673,6 +687,159 @@ def cluster_sanity(
             message=str(ex),
             junitxml_property=junitxml_property,
         )
+
+
+def _discover_webhook_services(admin_client: DynamicClient, namespace: Namespace) -> set[str]:
+    """
+    Discover all webhook services in the HCO namespace.
+
+    Scans all MutatingWebhookConfiguration and ValidatingWebhookConfiguration resources
+    and extracts service names that point to the namespace.
+
+    Args:
+        admin_client: Kubernetes dynamic client with admin privileges for cluster operations.
+        namespace: Namespace resource.
+
+    Returns:
+        Set of service names that are referenced by webhook configurations in the namespace.
+    """
+    webhook_services: set[str] = set()
+
+    for webhook_kind in [MutatingWebhookConfiguration, ValidatingWebhookConfiguration]:
+        LOGGER.info(f"Scanning {webhook_kind.kind} resources for webhook services")
+        for webhook in webhook_kind.get(client=admin_client):
+            webhook_items = webhook.instance.webhooks or []
+            if not webhook_items:
+                LOGGER.warning(f"Webhook configuration {webhook.name} has no webhooks")
+                continue
+
+            for webhook_item in webhook_items:
+                service_config = webhook_item.get("clientConfig", {}).get("service")
+                if not service_config:
+                    continue
+
+                if service_config["namespace"] == namespace.name:
+                    webhook_services.add(service_config["name"])
+
+    return webhook_services
+
+
+def check_webhook_endpoints_health(admin_client: DynamicClient, namespace: Namespace) -> None:
+    """
+    Check that all webhook services in the HCO namespace have available endpoints.
+
+    Args:
+        admin_client: Kubernetes dynamic client with admin privileges for cluster operations.
+        namespace: Namespace resource.
+
+    Raises:
+        ClusterSanityError: When any webhook service has no ready endpoint addresses.
+    """
+    LOGGER.info(f"Checking webhook endpoints health for services in namespace: {namespace.name}")
+
+    webhook_services = _discover_webhook_services(admin_client=admin_client, namespace=namespace)
+
+    if not webhook_services:
+        LOGGER.warning(f"No webhook services discovered in namespace {namespace.name}")
+        return
+
+    services_without_endpoints = []
+
+    for service_name in sorted(webhook_services):
+        LOGGER.info(f"Checking endpoints for service: {service_name}")
+        try:
+            endpoint = Endpoints(
+                name=service_name,
+                namespace=namespace.name,
+                client=admin_client,
+                ensure_exists=True,
+            )
+
+            subsets = endpoint.instance.subsets
+            if not subsets:
+                LOGGER.error(f"No subsets found in endpoints for service: {service_name}")
+                services_without_endpoints.append(service_name)
+                continue
+
+            for subset in subsets:
+                if addresses := getattr(subset, "addresses", None):
+                    LOGGER.info(f"Service {service_name} has {len(addresses)} ready endpoint address(es)")
+                    break
+            else:
+                LOGGER.error(f"No ready addresses found in endpoints for service: {service_name}")
+                services_without_endpoints.append(service_name)
+
+        except ResourceNotFoundError:
+            LOGGER.error(f"Endpoints resource not found for service: {service_name}")
+            services_without_endpoints.append(service_name)
+
+        except ApiException as ex:
+            LOGGER.error(f"API error checking endpoints for service {service_name}: {ex}")
+            services_without_endpoints.append(service_name)
+
+    if services_without_endpoints:
+        raise ClusterSanityError(
+            err_str=f"Webhook services have no available endpoints: {', '.join(services_without_endpoints)}. "
+            "Check that the corresponding pods are running."
+        )
+
+    LOGGER.info("All discovered webhook services have available endpoints")
+
+
+def check_vm_creation_capability(admin_client: DynamicClient, namespace: str) -> None:
+    """
+    Verify VM creation capability by performing a dry-run VM creation.
+
+    Args:
+        admin_client: Kubernetes dynamic client with admin privileges for cluster operations.
+        namespace: str
+
+    Raises:
+        ClusterSanityError: When dry-run VM creation fails.
+    """
+    LOGGER.info(f"Checking VM creation capability via dry-run in namespace: {namespace}")
+
+    try:
+        vm = VirtualMachine(
+            name="sanity-check-dry-run-vm",
+            namespace=namespace,
+            client=admin_client,
+            body={
+                "spec": {
+                    "running": False,
+                    "template": {
+                        "spec": {
+                            "domain": {
+                                "devices": {},
+                                "resources": {
+                                    "requests": {
+                                        "memory": "64Mi",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            dry_run=True,
+        )
+        vm.create()
+        LOGGER.info("Dry-run VM creation succeeded")
+
+    except ApiException as ex:
+        raise ClusterSanityError(
+            err_str=f"Dry-run VM creation failed: {ex}. This may indicate webhook or API server issues."
+        ) from ex
+
+    except (ConnectionError, TimeoutError) as ex:
+        raise ClusterSanityError(
+            err_str=f"Connection error during dry-run VM creation: {ex}. Check cluster connectivity and webhook health."
+        ) from ex
+
+    except Exception as ex:
+        raise ClusterSanityError(
+            err_str=f"Unexpected error during dry-run VM creation: {ex}. Check cluster state and webhook configuration."
+        ) from ex
 
 
 class ResourceMismatch(Exception):


### PR DESCRIPTION
## Summary
- Add webhook health check functions to verify all webhook services in the HCO namespace have available endpoints
- Add dry-run VM creation test to validate API and webhook functionality
- Add `--cluster-sanity-skip-webhook-check` pytest option to skip webhook checks when needed
- Add `test_webhook_endpoints_health` and `test_vm_creation_capability` tests to cluster_health_check suite

## Changes
- **utilities/infra.py**: Added webhook health check functions (`check_webhook_endpoints_health`, `check_vm_creation_capability`, `_discover_webhook_services`)
- **conftest.py**: Added `--cluster-sanity-skip-webhook-check` option
- **tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py**: Added webhook health tests

## Test plan
- [ ] Run `pytest tests/after_cluster_deploy_sanity/ -m cluster_health_check` to verify webhook tests

Backport of #3573 and #3690