### PR TITLE
net, stability: de-quarantine localnet scenarios

### DIFF
--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -6,7 +6,6 @@ from tests.network.localnet.liblocalnet import (
     LINK_STATE_UP,
     LOCALNET_OVS_BRIDGE_INTERFACE,
 )
-from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 
@@ -14,10 +13,6 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")
 @pytest.mark.polarion("CNV-11905")
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: fails in CI due to cluster issue; tracked in CNV-71535",
-    run=False,
-)
 def test_connectivity_over_migration_between_ovs_bridge_localnet_vms(
     localnet_ovs_bridge_server, localnet_ovs_bridge_client
 ):
@@ -28,10 +23,6 @@ def test_connectivity_over_migration_between_ovs_bridge_localnet_vms(
 @pytest.mark.ipv4
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")
 @pytest.mark.polarion("CNV-12006")
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: fails in CI due to cluster issue; tracked in CNV-71535",
-    run=False,
-)
 def test_connectivity_after_interface_state_change_in_ovs_bridge_localnet_vms(
     ovs_bridge_localnet_running_vms_one_with_interface_down,
 ):


### PR DESCRIPTION
DevOps is not using a broken cluster in recent launches, so we can de-quarantine related test scenarios.

jira-ticket: https://issues.redhat.com/browse/CNV-73391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled previously skipped tests to run normally, removing test skip markers that were marking them for known issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->