### PR TITLE
virt: Enable ssh on VMs on IPv6 only clusters

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,7 @@ from _pytest.nodes import Collector, Node
 from _pytest.reports import CollectReport, TestReport
 from _pytest.runner import CallInfo
 from kubernetes.dynamic.exceptions import ConflictError
+from ocp_resources.network_config_openshift_io import Network
 from pyhelper_utils.shell import run_command
 from pytest import Item
 from pytest_testconfig import config as py_config
@@ -810,6 +811,9 @@ def pytest_sessionstart(session):
     if not skip_if_pytest_flags_exists(pytest_config=session.config):
         admin_client = utilities.cluster.cache_admin_client()
         py_config["version_explorer_url"] = get_cnv_version_explorer_url(pytest_config=session.config)
+        py_config["cluster_service_network"] = Network(
+            client=admin_client, name="cluster"
+        ).instance.status.serviceNetwork
         if not session.config.getoption("--skip-artifactory-check"):
             py_config["server_url"] = py_config["server_url"] or get_artifactory_server_url(
                 cluster_host_url=admin_client.configuration.host, session=session

--- a/libs/net/cluster.py
+++ b/libs/net/cluster.py
@@ -1,0 +1,21 @@
+import ipaddress
+import logging
+from functools import cache
+
+from pytest_testconfig import py_config
+
+LOGGER = logging.getLogger(__name__)
+
+
+@cache
+def is_ipv6_single_stack_cluster() -> bool:
+    ipv4_supported = cluster_ip_family_supported(ip_family=4)
+    ipv6_supported = cluster_ip_family_supported(ip_family=6)
+
+    is_ipv6_only = ipv6_supported and not ipv4_supported
+    LOGGER.info(f"Cluster network detection: IPv4={ipv4_supported}, IPv6={ipv6_supported}, IPv6-only={is_ipv6_only}")
+    return is_ipv6_only
+
+
+def cluster_ip_family_supported(ip_family: int) -> bool:
+    return any(ipaddress.ip_network(ip).version == ip_family for ip in py_config.get("cluster_service_network"))


### PR DESCRIPTION
Masquerade IP is not auto-assigned on guest VMs which
are created on IPv6 single-stack clusters. This leads
to ssh failure to guest VM when running on such clusters.

The following changes are necessary for enabling ssh to guest VM:
- Configure masquerade IP on each VM in cloud init to enable ssh to
  guest VM
- In case VM uses ssh, wait for agent connected
- Fetch ssh error exception and retry in sampler when waiting for
  cloud-init to complete in `wait_for_cloud_init_complete`

Note:
VMs with OS which don't support cloud-init guest agents like Cirros and ssh is not necessary for test - will be handled in a follow-up

##### jira-ticket: https://issues.redhat.com/browse/CNV-75766
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of IPv6 single‑stack (IPv6‑only) clusters during test startup.
  * VM startup injects default IPv6 cloud‑init network config when needed and merges generated network/user data into VM cloud‑init.

* **Bug Fixes / Improvements**
  * Improved SSH and run‑command handling via proper cloud‑init structures for IPv6 environments.
  * Startup wait logic adjusted to skip unnecessary cloud‑init waits on IPv6 single‑stack clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->