### PR TITLE
Webhook validation tests added to cover bug correction

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -341,6 +341,7 @@ class VirtualMachineForTests(VirtualMachine):
             priority_class_name (str, optional): The name of the priority class used for the VM
             dry_run (str, default=None): If "All", the resource will be created using the dry_run flag
             additional_labels (dict, optional): Dict of additional labels for VM (e.g. {"vm-label": "best-vm"})
+                              those labels will be placed in structure spec.template.metadata.labels
             generate_unique_name: if True then it will set dynamic name for the vm, False will use the name of vm passed
             node_selector_labels (str, optional): Labels for node selector.
             vm_instance_type (VirtualMachineInstancetype, optional): instance type object for the VM


### PR DESCRIPTION
Short description:
Add webhook validation test.

More details:
This PR adds test coverage for webhook validation scenario related to custom VM templates.
Improves test coverage for CNV-72405 webhook validation behavior

Additionally, the labels parameter was introduced into the init method of the custom template helper class. This parameter already exists in the parent class, but was not previously exposed in this implementation. The change was required to allow access to metadata.labels, which is needed for template label processing.

What this PR does / why we need it:
Adds regression protection for custom template validation scenarios
Introduces labels parameter to allow accessing template metadata.labels, which is required for correct template selection.

Which issue(s) this PR fixes:
Special notes for reviewer:
The labels argument was added to align the helper class with its parent class interface.
The parameter is required to access template labels and avoid relying solely on template annotations.
Existing test flows were preserved; only helper class location and initialization interface were updated.
Tests were verified locally using common template and webhook validation scenarios.

jira-ticket:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for webhook validation when parent templates are missing; adds a scenario that creates a VM from a data-volume template, removes the parent template, and verifies annotation/validation behavior.
  * Replaced shallow copy with deep copy in test template duplication to avoid unintended mutations during validation checks.

* **New Features**
  * Added label support to virtual machine test utilities, enabling metadata labels when provisioning test VMs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->