### PR TITLE
storage, ipv6: Adjust gating tests

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -50,6 +50,7 @@ def create_vm_from_clone_dv_template(
         os_flavor=Images.Cirros.OS_FLAVOR,
         client=client,
         memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        ssh=False,
         data_volume_template=data_volume_template_dict(
             target_dv_name=dv_name,
             target_dv_namespace=namespace_name,
@@ -59,7 +60,7 @@ def create_vm_from_clone_dv_template(
             storage_class=storage_class,
         ),
     ) as vm:
-        running_vm(vm=vm, wait_for_interfaces=False)
+        running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 
 
 @pytest.mark.tier3

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -298,9 +298,10 @@ def vm_for_restricted_namespace_cloning_test(
         service_accounts=[restricted_namespace_service_account.name],
         client=unprivileged_client,
         memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        ssh=False,
         data_volume_template=data_volume_clone_settings.res,
     ) as vm:
-        running_vm(vm=vm, wait_for_interfaces=False)
+        running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
         yield vm
 
 


### PR DESCRIPTION
The following storage gating tests use CirrOS VMs:
- test_clone_from_fs_to_block_using_dv_template
- test_create_vm_with_cloned_data_volume_permissions_for_pods_positive

By default, VirtualMachineForTests assumes ssh=true. However, on IPv6 single-stack clusters, SSH remains disabled because guest VMs are not automatically
assigned a masquerade IPv6 address.
Since CirrOS lacks support for the Guest Agent and Cloud-Init, the standard networking fixes cannot be applied.

On this change, we set ssh=false for such VMs,
as SSH connectivity is not a requirement for these test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to streamline VM initialization and testing procedures by modifying SSH connectivity verification behavior during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->