### PR TITLE
Add tier2 tests for Live Update NAD Reference feature (CNV-72329)

### DIFF
--- a/tests/network/test_live_update_nad_reference.py
+++ b/tests/network/test_live_update_nad_reference.py
@@ -16,20 +16,16 @@ import threading
 import time
 
 import pytest
-from ocp_resources.network_attachment_definition import NetworkAttachmentDefinition
-from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import TIMEOUT_3MIN, TIMEOUT_5MIN, TIMEOUT_10MIN
+from utilities.constants import TIMEOUT_3MIN, TIMEOUT_5MIN
 from utilities.network import (
-    assert_ping_successful,
     get_vmi_ip_v4_by_name,
     network_nad,
 )
 from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
-    migrate_vm_and_verify,
     running_vm,
     wait_for_vm_interfaces,
 )
@@ -226,8 +222,7 @@ def wait_for_migration_complete(vm, timeout=TIMEOUT_5MIN):
             wait_timeout=timeout,
             sleep=5,
             func=lambda: (
-                vm.vmi.instance.status.migrationState is not None
-                and vm.vmi.instance.status.migrationState.completed
+                vm.vmi.instance.status.migrationState is not None and vm.vmi.instance.status.migrationState.completed
             ),
         ):
             if sample:
@@ -428,9 +423,7 @@ class TestLiveUpdateNADReference:
             assert new_ip, "VM must have IP on target NAD after swap"
 
             # Verify VM is running
-            assert vm.vmi.instance.status.phase == "Running", (
-                "VM should be running after NAD swap"
-            )
+            assert vm.vmi.instance.status.phase == "Running", "VM should be running after NAD swap"
 
     def test_ts_cnv72329_009_vlan_change_via_nad_update(
         self,
@@ -481,9 +474,7 @@ class TestLiveUpdateNADReference:
         assert vlan_200_ip, "VM must have IP on VLAN 200 after NAD update"
 
         # Verify VM is running
-        assert vm.vmi.instance.status.phase == "Running", (
-            "VM should be running after VLAN change"
-        )
+        assert vm.vmi.instance.status.phase == "Running", "VM should be running after VLAN change"
 
     def test_ts_cnv72329_010_vm_remains_functional_after_failed_nad_update(
         self,
@@ -537,14 +528,10 @@ class TestLiveUpdateNADReference:
                 LOGGER.info(f"NAD update rejected as expected: {e}")
 
             # Verify VM is still running
-            assert vm.vmi.instance.status.phase == "Running", (
-                "VM should remain running after failed NAD update"
-            )
+            assert vm.vmi.instance.status.phase == "Running", "VM should remain running after failed NAD update"
 
             # Verify original connectivity preserved
             current_ip = get_vmi_ip_v4_by_name(vm=vm, name=source_nad_scope_class.name)
             LOGGER.info(f"VM IP after failed update: {current_ip}")
             assert current_ip, "VM must retain connectivity on original NAD"
-            assert current_ip == initial_ip, (
-                "VM IP should be unchanged after failed NAD update"
-            )
+            assert current_ip == initial_ip, "VM IP should be unchanged after failed NAD update"


### PR DESCRIPTION
## Summary
- Add end-to-end tests for the Live Update NAD Reference feature
- Tests validate changing NetworkAttachmentDefinition reference on running VMs through live migration

## Test Coverage
- TCP connection survives NAD reference change
- Complete NAD swap workflow (source → target NAD)
- VLAN change via NAD update
- VM remains functional after failed NAD update (negative test)

## References
- Jira: CNV-72329
- PR: https://github.com/kubevirt/kubevirt/pull/16412

## Test plan
- [ ] Run tests on multi-node cluster with shared storage
- [ ] Verify LiveUpdateNADRefEnabled feature gate is enabled
- [ ] Test with multiple NAD configurations (bridge, VLAN)
- [ ] Validate network connectivity preserved across migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for Live Update NAD Reference functionality, including scenarios for connection persistence during network updates, complete network adapter swap workflows, network isolation changes, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->