### PR TITLE
fix: use admin client for node object to avoid unprivileged 403 errors

### DIFF
--- a/tests/infrastructure/workload_availability/remediation_fencing/conftest.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing/conftest.py
@@ -49,8 +49,8 @@ def nhc_vm_with_run_strategy_always(namespace, unprivileged_client):
 
 
 @pytest.fixture()
-def vm_node_before_failure(nhc_vm_with_run_strategy_always):
-    return nhc_vm_with_run_strategy_always.vmi.node
+def vm_node_before_failure(admin_client, nhc_vm_with_run_strategy_always):
+    return nhc_vm_with_run_strategy_always.vmi.get_node(privileged_client=admin_client)
 
 
 @pytest.fixture()
@@ -68,11 +68,15 @@ def refreshed_worker_utility_pods(admin_client, workers):
 
 
 @pytest.fixture()
-def performed_node_operation(nhc_vm_with_run_strategy_always, refreshed_worker_utility_pods, node_operation):
+def performed_node_operation(
+    admin_client, nhc_vm_with_run_strategy_always, refreshed_worker_utility_pods, node_operation
+):
     """
     Performs node operations like node start/stop, node kubelet start/stop
     node reboot, node shutdown. After remediation action, utility pods are recreated.
     """
     perform_node_operation(
-        utility_pods=refreshed_worker_utility_pods, node=nhc_vm_with_run_strategy_always.vmi.node, action=node_operation
+        utility_pods=refreshed_worker_utility_pods,
+        node=nhc_vm_with_run_strategy_always.vmi.get_node(privileged_client=admin_client),
+        action=node_operation,
     )

--- a/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
@@ -84,10 +84,10 @@ def stop_kubelet_on_node(utility_pods, node):
     wait_for_node_status(node=node, status=False)
 
 
-def wait_and_verify_vmi_failover(vm):
+def wait_and_verify_vmi_failover(vm, admin_client):
     LOGGER.info(f"Waiting VMI {vm.vmi.name} failover to new node")
     old_uid = vm.vmi.instance.metadata.uid
-    old_node = vm.vmi.node
+    old_node = vm.vmi.get_node(privileged_client=admin_client)
 
     if vm.instance.spec.runStrategy == "Manual":
         vm.vmi.wait_for_status(status="Failed")
@@ -96,7 +96,7 @@ def wait_and_verify_vmi_failover(vm):
     running_vm(vm=vm)
 
     new_uid = vm.vmi.instance.metadata.uid
-    new_node = vm.vmi.node
+    new_node = vm.vmi.get_node(privileged_client=admin_client)
 
     assert old_uid != new_uid, "Old VMI still exists"
     assert old_node.name != new_node.name, "VMI still on old node"
@@ -130,14 +130,15 @@ def wait_node_restored(node):
     ],
     indirect=True,
 )
+@pytest.mark.usefixtures("machine_health_check_reboot")
 def test_ha_vm_container_disk_reboot(
+    admin_client,
     workers_utility_pods,
-    machine_health_check_reboot,
     ha_vm_container_disk,
 ):
-    orig_node = ha_vm_container_disk.vmi.node
+    orig_node = ha_vm_container_disk.vmi.get_node(privileged_client=admin_client)
     stop_kubelet_on_node(utility_pods=workers_utility_pods, node=orig_node)
-    wait_and_verify_vmi_failover(vm=ha_vm_container_disk)
+    wait_and_verify_vmi_failover(vm=ha_vm_container_disk, admin_client=admin_client)
     wait_node_restored(node=orig_node)
 
 
@@ -165,15 +166,16 @@ def test_ha_vm_container_disk_reboot(
     ],
     indirect=True,
 )
+@pytest.mark.usefixtures("machine_health_check_reboot")
 def test_ha_vm_dv_disk_reboot(
+    admin_client,
     workers_utility_pods,
-    machine_health_check_reboot,
     ha_vm_dv_disk,
 ):
-    orig_node = ha_vm_dv_disk.vmi.node
+    orig_node = ha_vm_dv_disk.vmi.get_node(privileged_client=admin_client)
     ha_vm_dv_disk.ssh_exec.run_command(command=["echo", "test", ">>", "ha-test"])
     stop_kubelet_on_node(utility_pods=workers_utility_pods, node=orig_node)
-    wait_and_verify_vmi_failover(vm=ha_vm_container_disk)
+    wait_and_verify_vmi_failover(vm=ha_vm_dv_disk, admin_client=admin_client)
     wait_node_restored(node=orig_node)
     assert "test" in ha_vm_dv_disk.ssh_exec.run_command(["cat", "ha-test"])[1], (
         "Content of file lost during VM failover"


### PR DESCRIPTION
VMs created with unprivileged_client pass that client down to the Node object via vmi.node. Node is cluster-scoped so unprivileged users can't query node status causing 403 Forbidden in wait_for_node_status.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated workload-availability remediation tests to resolve target nodes via an admin client rather than static VM node attributes.
  * Test helpers and fixtures now accept an admin client parameter and propagate it through failover and reboot flows.
  * Added a test utility to derive the node for a VM and added machine-health-check reboot fixtures to relevant tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->