### PR TITLE
update python-rrmngmnt version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1558,6 +1558,9 @@ dependencies = [
     { name = "suds" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/38/0c0ccaafbb8594cf50af8d2376a5afee9e7279b7715a928558e7b52eb6f6/pylero-0.1.1.tar.gz", hash = "sha256:de0ccd37da69e50993fe403eca5d093d70c57319640d6af6403ab9a3496ae16c", size = 309121, upload-time = "2025-05-30T13:38:52.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/79/4a7ff895325f7226f846cf4e274be9bbeedcd2d9804027c5025e72134ff4/pylero-0.1.1-py3-none-any.whl", hash = "sha256:ada04668e36adaaed950e213699f8442466994142c127a3f07b5e4d19fc9709f", size = 101338, upload-time = "2025-12-19T15:11:28.422Z" },
+]
 
 [[package]]
 name = "pynacl"
@@ -1826,16 +1829,16 @@ wheels = [
 
 [[package]]
 name = "python-rrmngmnt"
-version = "0.2.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "netaddr" },
     { name = "paramiko" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/ee/0cf3a56fe4ea93cb00d90134f9978f85c9d30797007f19b7747cf15c561d/python_rrmngmnt-0.2.0.tar.gz", hash = "sha256:6600a686df8b4d0dd4c420968f385d75bb15a8768f54daee9cd64cc54e2f3c37", size = 116373, upload-time = "2025-05-05T07:58:05.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/ba/c6625d8754f9f963f854fdd7b731d174ae23bf663da0e7dc4bdcc1ba0ca8/python_rrmngmnt-0.2.2.tar.gz", hash = "sha256:5f8e61ca33cffc9084eadf69a83f05d59f7a5a2fd349cc5cc664698c0c672b39", size = 152757, upload-time = "2026-02-11T07:03:10.616Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/aa/19cdc70f6f427234f4bfbc9ea91845eaf42854cf2e66d025f6c2eb7dde8f/python_rrmngmnt-0.2.0-py3-none-any.whl", hash = "sha256:f6e84c927474408958fd85dc06754caacbd950db7341511440b8dccf1168a67f", size = 49911, upload-time = "2025-05-05T07:58:04.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4c/1296147b5c157c79a83ddb9d8e76a0f96c8dfc086d25de1b7ed104511efd/python_rrmngmnt-0.2.2-py3-none-any.whl", hash = "sha256:353c5cf03c46ba27c7a70065e0417816115212af722d03a7cea49bb3eb3432ae", size = 50073, upload-time = "2026-02-11T07:03:08.915Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cherry-pick of #3818

The new python-rrmngmnt version contains fixes for ssh connectivity (see https://github.com/rhevm-qe-automation/python-rrmngmnt/pull/159)