### PR TITLE
update python-rrmngmnt version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1268,16 +1268,16 @@ wheels = [
 
 [[package]]
 name = "python-rrmngmnt"
-version = "0.2.0"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "netaddr" },
     { name = "paramiko" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/ee/0cf3a56fe4ea93cb00d90134f9978f85c9d30797007f19b7747cf15c561d/python_rrmngmnt-0.2.0.tar.gz", hash = "sha256:6600a686df8b4d0dd4c420968f385d75bb15a8768f54daee9cd64cc54e2f3c37", size = 116373, upload-time = "2025-05-05T07:58:05.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/ba/c6625d8754f9f963f854fdd7b731d174ae23bf663da0e7dc4bdcc1ba0ca8/python_rrmngmnt-0.2.2.tar.gz", hash = "sha256:5f8e61ca33cffc9084eadf69a83f05d59f7a5a2fd349cc5cc664698c0c672b39", size = 152757, upload-time = "2026-02-11T07:03:10.616Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/aa/19cdc70f6f427234f4bfbc9ea91845eaf42854cf2e66d025f6c2eb7dde8f/python_rrmngmnt-0.2.0-py3-none-any.whl", hash = "sha256:f6e84c927474408958fd85dc06754caacbd950db7341511440b8dccf1168a67f", size = 49911, upload-time = "2025-05-05T07:58:04.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4c/1296147b5c157c79a83ddb9d8e76a0f96c8dfc086d25de1b7ed104511efd/python_rrmngmnt-0.2.2-py3-none-any.whl", hash = "sha256:353c5cf03c46ba27c7a70065e0417816115212af722d03a7cea49bb3eb3432ae", size = 50073, upload-time = "2026-02-11T07:03:08.915Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cherry-pick of #3818

The new python-rrmngmnt version contains fixes for ssh connectivity (see https://github.com/rhevm-qe-automation/python-rrmngmnt/pull/159)