### PR TITLE
[4.19]Remove test test_create_vm_on_node_without_hpp_pod_and_after_update

### DIFF
--- a/tests/storage/hpp/test_hpp_node_placement.py
+++ b/tests/storage/hpp/test_hpp_node_placement.py
@@ -7,7 +7,6 @@ HPP Node Placement test suite
 import logging
 
 import pytest
-from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from tests.storage.hpp.utils import (
     DV_NAME,
@@ -17,7 +16,7 @@ from tests.storage.hpp.utils import (
     VM_NAME,
     edit_hpp_with_node_selector,
 )
-from utilities.constants import NODE_STR, QUARANTINED, TIMEOUT_1MIN, TIMEOUT_5MIN
+from utilities.constants import NODE_STR
 from utilities.storage import check_disk_count_in_vm
 
 LOGGER = logging.getLogger(__name__)
@@ -63,43 +62,6 @@ def test_create_dv_on_right_node_with_node_placement(
 ):
     # The VM should be created on the node that have the node labels
     assert cirros_vm_for_node_placement_tests.vmi.node.name == worker_node1.name
-
-
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: flaky test, failure only reproduced in full tier2 run; CNV-54589",
-    run=False,
-)
-@pytest.mark.post_upgrade
-@pytest.mark.parametrize(
-    ("updated_hpp_with_node_placement", "cirros_vm_for_node_placement_tests"),
-    [
-        pytest.param(
-            {TYPE: NODE_SELECTOR},
-            {DV_NAME: "dv-5717", VM_NAME: "vm-5717", "wait_running": False},
-            marks=pytest.mark.polarion("CNV-5717"),
-        ),
-    ],
-    indirect=True,
-)
-def test_create_vm_on_node_without_hpp_pod_and_after_update(
-    update_node_labels,
-    updated_hpp_with_node_placement,
-    cirros_vm_for_node_placement_tests,
-):
-    cirros_vm_for_node_placement_tests.vmi.wait_for_status(
-        status=VirtualMachineInstance.Status.SCHEDULING,
-        timeout=TIMEOUT_1MIN,
-        stop_status=VirtualMachineInstance.Status.RUNNING,
-    )
-    assert (
-        cirros_vm_for_node_placement_tests.printable_status
-        == cirros_vm_for_node_placement_tests.Status.WAITING_FOR_VOLUME_BINDING
-    )
-    updated_hpp_with_node_placement.restore()
-    cirros_vm_for_node_placement_tests.vmi.wait_for_status(
-        status=VirtualMachineInstance.Status.RUNNING,
-        timeout=TIMEOUT_5MIN,
-    )
 
 
 @pytest.mark.post_upgrade


### PR DESCRIPTION
##### Short description:
Backport: https://github.com/RedHatQE/openshift-virtualization-tests/pull/3802
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

