### PR TITLE
[gating][storage] remove test regular user can create vm from cloned dv 4.21

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -888,29 +888,6 @@ def vm_instance_from_template_multi_storage_scope_function(
         yield vm
 
 
-@pytest.fixture()
-def golden_image_vm_instance_from_template_multi_storage_scope_function(
-    request,
-    unprivileged_client,
-    namespace,
-    golden_image_data_source_multi_storage_scope_function,
-    cpu_for_migration,
-):
-    """Calls vm_instance_from_template contextmanager
-
-    Creates a VM from template and starts it (if requested).
-    """
-
-    with vm_instance_from_template(
-        request=request,
-        unprivileged_client=unprivileged_client,
-        namespace=namespace,
-        data_source=golden_image_data_source_multi_storage_scope_function,
-        vm_cpu_model=(cpu_for_migration if request.param.get("set_vm_common_cpu") else None),
-    ) as vm:
-        yield vm
-
-
 """
 Windows-specific fixtures
 """

--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -6,11 +6,10 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import config as py_config
 
-from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS
+from tests.os_params import RHEL_LATEST
 from utilities.artifactory import get_test_artifact_server_url
-from utilities.constants import PVC, QUARANTINED, TIMEOUT_20MIN
+from utilities.constants import PVC, TIMEOUT_20MIN
 from utilities.storage import ErrorMsg, create_dv
-from utilities.virt import wait_for_ssh_connectivity
 
 pytestmark = pytest.mark.post_upgrade
 
@@ -94,42 +93,6 @@ def test_regular_user_cant_delete_dv_from_cloned_dv(
             namespace=golden_image_data_volume_scope_module.namespace,
             client=unprivileged_client,
         ).delete()
-
-
-@pytest.mark.sno
-@pytest.mark.gating
-@pytest.mark.parametrize(
-    "golden_image_data_volume_multi_storage_scope_function,"
-    "golden_image_vm_instance_from_template_multi_storage_scope_function",
-    [
-        pytest.param(
-            {
-                "dv_name": "cnv-4757",
-                "image": LATEST_RHEL_IMAGE,
-                "dv_size": RHEL_IMAGE_SIZE,
-            },
-            {
-                "vm_name": "rhel-vm",
-                "template_labels": RHEL_LATEST_LABELS,
-            },
-            marks=pytest.mark.polarion("CNV-4757"),
-        ),
-    ],
-    indirect=True,
-)
-@pytest.mark.xfail(
-    reason=(
-        f"{QUARANTINED}: Template label selector fails with BadRequestError "
-        "during VM creation from template. Tracked in CNV-75736"
-    ),
-    run=False,
-)
-@pytest.mark.s390x
-def test_regular_user_can_create_vm_from_cloned_dv(
-    golden_image_data_volume_multi_storage_scope_function,
-    golden_image_vm_instance_from_template_multi_storage_scope_function,
-):
-    wait_for_ssh_connectivity(vm=golden_image_vm_instance_from_template_multi_storage_scope_function)
 
 
 @pytest.mark.sno


### PR DESCRIPTION
##### Short description:
Remove redundant test test_regular_user_can_create_vm_from_cloned_dv (CNV-4757).


##### More details:

This test verifies that an unprivileged user can create a VM from a cloned DataVolume . This functionality is already covered by  other tests that create VMs from DataSource in the golden images namespace.

##### What this PR does / why we need it:



##### Which issue(s) this PR fixes:


##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-75736
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
