### PR TITLE
WIP: [gating] [4.21] add must gather test_data_import_cron_garbage_collection

### DIFF
--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -8,7 +8,7 @@ from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS
 from utilities.artifactory import get_test_artifact_server_url
-from utilities.constants import PVC, QUARANTINED, TIMEOUT_20MIN
+from utilities.constants import PVC, TIMEOUT_20MIN
 from utilities.storage import ErrorMsg, create_dv
 from utilities.virt import wait_for_ssh_connectivity
 
@@ -117,13 +117,13 @@ def test_regular_user_cant_delete_dv_from_cloned_dv(
     ],
     indirect=True,
 )
-@pytest.mark.xfail(
-    reason=(
-        f"{QUARANTINED}: Template label selector fails with BadRequestError "
-        "during VM creation from template. Tracked in CNV-75736"
-    ),
-    run=False,
-)
+# @pytest.mark.xfail(
+#     reason=(
+#         f"{QUARANTINED}: Template label selector fails with BadRequestError "
+#         "during VM creation from template. Tracked in CNV-75736"
+#     ),
+#     run=False,
+# )
 @pytest.mark.s390x
 def test_regular_user_can_create_vm_from_cloned_dv(
     golden_image_data_volume_multi_storage_scope_function,


### PR DESCRIPTION
##### Short description:
Add automatic must-gather collection on failure for test_data_import_cron_garbage_collection


##### More details:
Added a pytest fixture that automatically collects CNV must-gather logs when the DataImportCron garbage collection test fails, regardless of the --data-collector flag.

##### What this PR does / why we need it:
Adds collect_must_gather_on_failure fixture to tests/storage/test_data_import_cron.py
Applies the fixture to test_data_import_cron_garbage_collection test
When the test fails, must-gather is automatically collected to data-import-cron-must-gather/ directory
This helps debug intermittent storage-related failures without requiring manual log collection or the --data-collector flag


##### Which issue(s) this PR fixes:
Improves debugging capability for flaky DataImportCron garbage collection test failures


##### Special notes for reviewer:
The fixture uses request.session.testsfailed to detect test failure (same pattern as tests/install_upgrade_operators/must_gather/conftest.py)
Must-gather is only collected on failure, not on every run
Uses existing must_gather_image_url fixture from tests/conftest.py


##### jira-ticket:
https://issues.redhat.com/browse/CNV-75955
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
