### PR TITLE
[IUO]Add --keep-upgrade-test-resources flag to preserve upgrade fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -171,6 +171,11 @@ def pytest_addoption(parser):
         help="Runs cnv install tests",
         action="store_true",
     )
+    install_upgrade_group.addoption(
+        "--keep-upgrade-test-resources",
+        help="Keep upgrade test resources (VMs, DVs, namespaces) after the session ends",
+        action="store_true",
+    )
     # Matrix addoption
     matrix_group.addoption("--storage-class-matrix", help="Storage class matrix to use")
     matrix_group.addoption("--bridge-device-matrix", help="Bridge device matrix to use")
@@ -466,6 +471,11 @@ def filter_upgrade_tests(
             upgrade_tests=upgrade_tests,
         )
         return upgrade_tests, [*non_upgrade_tests, *discard]
+
+    # When --keep-upgrade-test-resources is set without --upgrade/--upgrade_custom,
+    # keep upgrade tests to allow running before_upgrade fixtures without the full upgrade pipeline.
+    if config.getoption("keep_upgrade_test_resources"):
+        return items, []
 
     # If no upgrade marker in config, discard all upgrade tests.
     return non_upgrade_tests, upgrade_tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1776,11 +1776,12 @@ def determine_upgrade_stream(current_version, target_version):
 
 
 @pytest.fixture(scope="session")
-def upgrade_namespace_scope_session(admin_client, unprivileged_client):
+def upgrade_namespace_scope_session(admin_client, unprivileged_client, keep_upgrade_test_resources):
     yield from create_ns(
         unprivileged_client=unprivileged_client,
         admin_client=admin_client,
         name="test-upgrade-namespace",
+        teardown=not keep_upgrade_test_resources,
     )
 
 
@@ -2462,6 +2463,11 @@ def upgrade_skip_default_sc_setup(pytestconfig):
 
 
 @pytest.fixture(scope="session")
+def keep_upgrade_test_resources(pytestconfig):
+    return pytestconfig.option.keep_upgrade_test_resources
+
+
+@pytest.fixture(scope="session")
 def updated_default_storage_class_ocs_virt(
     admin_client,
     upgrade_skip_default_sc_setup,
@@ -2511,6 +2517,7 @@ def dvs_for_upgrade(
     worker_node1,
     rhel_latest_os_params,
     updated_default_storage_class_ocs_virt,
+    keep_upgrade_test_resources,
 ):
     golden_images_namespace_name = py_config["golden_images_namespace"]
     dvs_list = []
@@ -2532,19 +2539,21 @@ def dvs_for_upgrade(
             bind_immediate_annotation=True,
             api_name="storage",
         )
-        dv.create()
+        if not dv.exists:
+            dv.create()
         dvs_list.append(dv)
     for dv in dvs_list:
         dv.wait_for_dv_success()
 
     yield dvs_list
 
-    for dv in dvs_list:
-        dv.clean_up()
-    utilities.artifactory.cleanup_artifactory_secret_and_config_map(
-        artifactory_secret=artifactory_secret,
-        artifactory_config_map=artifactory_config_map,
-    )
+    if not keep_upgrade_test_resources:
+        for dv in dvs_list:
+            dv.clean_up()
+        utilities.artifactory.cleanup_artifactory_secret_and_config_map(
+            artifactory_secret=artifactory_secret,
+            artifactory_config_map=artifactory_config_map,
+        )
 
 
 @pytest.fixture(scope="class")

--- a/tests/virt/upgrade/utils.py
+++ b/tests/virt/upgrade/utils.py
@@ -182,8 +182,9 @@ def vm_from_template(
     node_selector=None,
     vm_affinity=None,
     gpu_name=None,
+    teardown=True,
 ):
-    with VirtualMachineForTestsFromTemplate(
+    vm = VirtualMachineForTestsFromTemplate(
         name=vm_name,
         namespace=namespace,
         client=client,
@@ -197,5 +198,12 @@ def vm_from_template(
         node_selector=node_selector,
         vm_affinity=vm_affinity,
         gpu_name=gpu_name,
-    ) as vm:
+        teardown=teardown,
+    )
+    if not vm.exists:
+        vm.deploy()
+    try:
         yield vm
+    finally:
+        if teardown:
+            vm.clean_up()


### PR DESCRIPTION
Add a new pytest CLI option `--keep-upgrade-test-resources` that prevents teardown of upgrade test resources (VMs, DVs, DataSources, namespaces, MigrationPolicies, cluster instancetypes/preferences) when the pytest session ends. This allows running only before_upgrade tests and keeping the created resources alive in the cluster for manual inspection or subsequent test runs.

##### Short description:
When --keep-upgrade-test-resources is passed without --upgrade, the filter_upgrade_tests logic is bypassed so that upgrade-marked tests can be selected via -k "before_upgrade" without requiring the full upgrade pipeline (--upgrade cnv --cnv-version X).

All resource-creating fixtures are made idempotent: they check if the resource already exists before deploying, preventing 409 Conflict errors on repeated runs.

##### More details:
Changes:
- conftest.py: Add --keep-upgrade-test-resources option and bypass in filter_upgrade_tests
- tests/conftest.py: Add keep_upgrade_test_resources fixture, condition teardown in upgrade_namespace_scope_session and dvs_for_upgrade
- tests/virt/upgrade/conftest.py: Condition teardown and add exists checks in all resource-creating fixtures (datasources_for_upgrade, vms_for_upgrade, vm_cluster_preference_for_upgrade, vm_cluster_instancetype_for_upgrade, vm_with_instancetypes_for_upgrade, manual_run_strategy_vm, always_run_strategy_vm, windows_vm, run_strategy_golden_image_data_source, post_copy_migration_policy_for_upgrade, vm_for_post_copy_upgrade)
- tests/virt/upgrade/utils.py: Add teardown parameter to vm_from_template and make it idempotent with exists check

##### What this PR does / why we need it:
Needed for manual testing on upgrades

manual usage: 

```
uv run pytest tests/virt/upgrade/ -k "before_upgrade" --keep-upgrade-test-resources --tc-file=tests/global_config.py --storage-class-matrix=<your-sc> -s
```

##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
N/A