### PR TITLE
tests, net, connectivity: Refactor incorrect NMState dependency comment

### DIFF
--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -99,7 +99,7 @@ def cloud_init_ipv6_network_data(ipv6_primary_interface_cloud_init_data):
 @pytest.mark.gating
 @pytest.mark.single_nic
 @pytest.mark.s390x
-# Not marked as `conformance`; requires NMState
+# conformance candidate
 def test_connectivity_over_pod_network(
     ip_family,
     pod_net_vma,

--- a/tests/network/flat_overlay/test_flat_overlay.py
+++ b/tests/network/flat_overlay/test_flat_overlay.py
@@ -21,7 +21,7 @@ pytestmark = [
 class TestFlatOverlayConnectivity:
     @pytest.mark.gating
     @pytest.mark.polarion("CNV-10158")
-    # Not marked as `conformance`; requires NMState
+    # conformance candidate
     @pytest.mark.dependency(name="test_flat_overlay_basic_ping")
     def test_flat_overlay_basic_ping(self, vma_flat_overlay, vmb_flat_overlay_ip_address):
         assert_ping_successful(

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -86,7 +86,7 @@ def vm_console_connection_ready(running_vm_for_migration):
 @pytest.mark.polarion("CNV-6733")
 @pytest.mark.s390x
 @pytest.mark.single_nic
-# Not marked as `conformance`; requires NMState
+# conformance candidate
 def test_connectivity_after_migration(
     namespace,
     running_vm_static,


### PR DESCRIPTION
##### Short description:
The "requires NMState" comment is misleading because this scenario correctly runs independently of the NMState operator. The test does not use nmstate_dependent_placeholder or any NNCP-creating fixtures; it only uses pod_net_vma/pod_net_vmb (namespace, schedulable_nodes, etc.).

Left unchanged: nmstate and kubemacpool tests still depend on NMState via shared fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked pod network connectivity test as a conformance candidate.
  * Marked flat/overlay network test as a conformance candidate.
  * Marked post-migration masquerade connectivity test as a conformance candidate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->