### PR TITLE
net, vm import: increase timeout for `Plan` creation

### DIFF
--- a/tests/network/provider_migration/conftest.py
+++ b/tests/network/provider_migration/conftest.py
@@ -244,7 +244,7 @@ def mtv_migration_plan_to_cudn_ns(
         target_power_state="on",
         preserve_static_ips=True,
     ) as plan:
-        plan.wait_for_condition(condition=plan.Condition.READY, status=plan.Condition.Status.TRUE, timeout=60)
+        plan.wait_for_condition(condition=plan.Condition.READY, status=plan.Condition.Status.TRUE, timeout=180)
         yield plan
 
 


### PR DESCRIPTION
Behind the scene during resource creation some images are downloaded to the cluster nodes, in some cases it took ~2min on the local debug environment. The current 60 sec timeout might be not enough.

Log with local debug example on the fresh PSI cluster (see time diff):
```
...
2026-02-18T19:32:57.840391 conftest INFO Executing module fixture: mtv_migration_plan_to_cudn_ns
2026-02-18T19:34:46.327966 conftest INFO Executing module fixture: mtv_migration_to_cudn_ns
...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout configuration for plan migration testing to improve test reliability and reduce timeout-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->