### PR TITLE
CherryPicked: [cnv-4.18] Remove redundant observability metric tests already covered by T1

### DIFF
--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -1,7 +1,6 @@
 import pytest
 
 from tests.observability.metrics.constants import (
-    KUBEVIRT_VMI_INFO,
     KUBEVIRT_VMI_MEMORY_DOMAIN_BYTE,
     KUBEVIRT_VMI_MEMORY_SWAP_IN_TRAFFIC_BYTES,
     KUBEVIRT_VMI_MEMORY_SWAP_OUT_TRAFFIC_BYTES,
@@ -9,7 +8,6 @@ from tests.observability.metrics.constants import (
 )
 from tests.observability.metrics.utils import (
     assert_vm_metric_virt_handler_pod,
-    compare_kubevirt_vmi_info_metric_with_vm_info,
     get_vm_metrics,
 )
 from tests.observability.utils import validate_metrics_value
@@ -137,14 +135,3 @@ def test_cnv_installation_with_hco_cr_metrics(
         metric_name=KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS,
         expected_value="1",
     )
-
-
-class TestVMIMetrics:
-    @pytest.mark.polarion("CNV-11400")
-    def test_kubevirt_vmi_info(self, prometheus, single_metric_vm, single_metric_vmi_guest_os_kernel_release_info):
-        compare_kubevirt_vmi_info_metric_with_vm_info(
-            prometheus=prometheus,
-            query=KUBEVIRT_VMI_INFO.format(vm_name=single_metric_vm.name),
-            expected_value="1",
-            values_to_compare=single_metric_vmi_guest_os_kernel_release_info,
-        )

--- a/tests/observability/metrics/test_recording_rules.py
+++ b/tests/observability/metrics/test_recording_rules.py
@@ -1,40 +1,23 @@
 import pytest
 from ocp_resources.resource import Resource
 
-from utilities.constants import KUBEVIRT_VIRT_OPERATOR_UP, VIRT_API, VIRT_CONTROLLER, VIRT_HANDLER, VIRT_OPERATOR
+from utilities.constants import VIRT_CONTROLLER, VIRT_HANDLER, VIRT_OPERATOR
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
 virt_label_dict = {
-    VIRT_API: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_API}",
     VIRT_HANDLER: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_HANDLER}",
     VIRT_OPERATOR: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_OPERATOR}",
-    VIRT_CONTROLLER: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_CONTROLLER} ",
+    VIRT_CONTROLLER: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_CONTROLLER}",
 }
-KUBEVIRT_VIRT_CONTROLLER_READY_STATUS = "kubevirt_virt_controller_ready_status"
-KUBEVIRT_VIRT_OPERATOR_READY_STATUS = "kubevirt_virt_operator_ready_status"
 KUBEVIRT_VIRT_OPERATOR_LEADING_STATUS = "kubevirt_virt_operator_leading_status"
 KUBEVIRT_VIRT_CONTROLLER_LEADING_STATUS = "kubevirt_virt_controller_leading_status"
-KUBEVIRT_VIRT_API_UP = "kubevirt_virt_api_up"
 KUBEVIRT_VIRT_HANDLER_UP = "kubevirt_virt_handler_up"
-KUBEVIRT_VIRT_CONTROLLER_UP = "kubevirt_virt_controller_up"
 
 
 @pytest.mark.parametrize(
     "virt_pod_info_from_prometheus, virt_pod_names_by_label",
     [
-        pytest.param(
-            KUBEVIRT_VIRT_CONTROLLER_READY_STATUS,
-            virt_label_dict[VIRT_CONTROLLER],
-            marks=pytest.mark.polarion("CNV-7110"),
-            id=KUBEVIRT_VIRT_CONTROLLER_READY_STATUS,
-        ),
-        pytest.param(
-            KUBEVIRT_VIRT_OPERATOR_READY_STATUS,
-            virt_label_dict[VIRT_OPERATOR],
-            marks=pytest.mark.polarion("CNV-7111"),
-            id=KUBEVIRT_VIRT_OPERATOR_READY_STATUS,
-        ),
         pytest.param(
             KUBEVIRT_VIRT_OPERATOR_LEADING_STATUS,
             virt_label_dict[VIRT_OPERATOR],
@@ -71,28 +54,10 @@ def test_virt_recording_rules(
     "virt_up_metrics_values, virt_pod_names_by_label",
     [
         pytest.param(
-            KUBEVIRT_VIRT_API_UP,
-            virt_label_dict[VIRT_API],
-            marks=pytest.mark.polarion("CNV-7106"),
-            id=KUBEVIRT_VIRT_API_UP,
-        ),
-        pytest.param(
-            KUBEVIRT_VIRT_OPERATOR_UP,
-            virt_label_dict[VIRT_OPERATOR],
-            marks=pytest.mark.polarion("CNV-7107"),
-            id=KUBEVIRT_VIRT_OPERATOR_UP,
-        ),
-        pytest.param(
             KUBEVIRT_VIRT_HANDLER_UP,
             virt_label_dict[VIRT_HANDLER],
             marks=pytest.mark.polarion("CNV-7108"),
             id=KUBEVIRT_VIRT_HANDLER_UP,
-        ),
-        pytest.param(
-            KUBEVIRT_VIRT_CONTROLLER_UP,
-            virt_label_dict[VIRT_CONTROLLER],
-            marks=pytest.mark.polarion("CNV-7109"),
-            id=KUBEVIRT_VIRT_CONTROLLER_UP,
         ),
     ],
     indirect=True,

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -20,10 +20,8 @@ from tests.observability.metrics.utils import (
     timestamp_to_seconds,
 )
 from tests.observability.utils import validate_metrics_value
-from tests.os_params import FEDORA_LATEST_LABELS
 from utilities.constants import (
     CAPACITY,
-    LIVE_MIGRATE,
     MIGRATION_POLICY_VM_LABEL,
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
@@ -369,35 +367,6 @@ class TestVmResourceLimits:
             expected_value=vm_for_test_with_resource_limits_instance.cpu
             if cnv_vm_resources_limits_matrix__function__ == "cpu"
             else str(int(bitmath.parse_string_unsafe(vm_for_test_with_resource_limits_instance.memory).bytes)),
-        )
-
-
-class TestKubevirtVmiNonEvictable:
-    @pytest.mark.parametrize(
-        "vm_with_rwo_dv",
-        [
-            pytest.param(
-                {
-                    "vm_name": "non-evictable-vm",
-                    "template_labels": FEDORA_LATEST_LABELS,
-                    "ssh": False,
-                    "guest_agent": False,
-                    "eviction_strategy": LIVE_MIGRATE,
-                },
-                marks=pytest.mark.polarion("CNV-7484"),
-            ),
-        ],
-        indirect=True,
-    )
-    def test_kubevirt_vmi_non_evictable(
-        self,
-        prometheus,
-        vm_with_rwo_dv,
-    ):
-        validate_metrics_value(
-            prometheus=prometheus,
-            metric_name="kubevirt_vmi_non_evictable",
-            expected_value="1",
         )
 
 


### PR DESCRIPTION
Remove 9 metric tests (CNV-7484, CNV-11400, CNV-7106, CNV-7107, CNV-7109, CNV-7110, CNV-7111, CNV-8480, CNV-8481) that are indirectly tested in T1 alerts or recording-rules e2e tests upstream. Also removes cascading unused fixtures, utility functions, and imports.

Original pr: #3881

assisted by: claude code

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-80320