### PR TITLE
CherryPicked: [cnv-4.20] Remove redundant observability metric tests already covered by T1

### DIFF
--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -65,16 +65,6 @@ def test_cnv_installation_with_hco_cr_metrics(
 
 
 class TestVMIMetricsLinuxVms:
-    @pytest.mark.polarion("CNV-11400")
-    @pytest.mark.s390x
-    def test_kubevirt_vmi_info(self, prometheus, single_metric_vm, vmi_guest_os_kernel_release_info_linux):
-        compare_kubevirt_vmi_info_metric_with_vm_info(
-            prometheus=prometheus,
-            query=KUBEVIRT_VMI_INFO.format(vm_name=single_metric_vm.name),
-            expected_value="1",
-            values_to_compare=vmi_guest_os_kernel_release_info_linux,
-        )
-
     @pytest.mark.polarion("CNV-11862")
     @pytest.mark.s390x
     def test_metric_kubevirt_vm_info(self, prometheus, single_metric_vm, linux_vm_info_to_compare):

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -9,54 +9,14 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES,
     KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
     KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES,
-    KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE,
-    KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE,
 )
 from tests.observability.metrics.utils import (
     timestamp_to_seconds,
-    wait_for_expected_metric_value_sum,
     wait_for_non_empty_metrics_value,
 )
 from tests.observability.utils import validate_metrics_value
 
 LOGGER = logging.getLogger(__name__)
-
-
-class TestMigrationMetrics:
-    @pytest.mark.polarion("CNV-8480")
-    @pytest.mark.s390x
-    def test_migration_metrics_scheduling(
-        self,
-        admin_client,
-        namespace,
-        prometheus,
-        initial_migration_metrics_values,
-        vm_with_node_selector,
-        vm_with_node_selector_vmim,
-    ):
-        wait_for_expected_metric_value_sum(
-            prometheus=prometheus,
-            metric_name=KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE,
-            expected_value=initial_migration_metrics_values[KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE] + 1,
-            check_times=1,
-        )
-
-    @pytest.mark.polarion("CNV-8481")
-    @pytest.mark.s390x
-    def test_migration_metrics_running(
-        self,
-        prometheus,
-        initial_migration_metrics_values,
-        migration_policy_with_bandwidth,
-        vm_for_migration_metrics_test,
-        vm_migration_metrics_vmim,
-    ):
-        wait_for_expected_metric_value_sum(
-            prometheus=prometheus,
-            metric_name=KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE,
-            expected_value=initial_migration_metrics_values[KUBEVIRT_VMI_MIGRATIONS_IN_RUNNING_PHASE] + 1,
-            check_times=1,
-        )
 
 
 class TestKubevirtVmiMigrationMetrics:

--- a/tests/observability/metrics/test_recording_rules.py
+++ b/tests/observability/metrics/test_recording_rules.py
@@ -1,40 +1,23 @@
 import pytest
 from ocp_resources.resource import Resource
 
-from utilities.constants import KUBEVIRT_VIRT_OPERATOR_UP, VIRT_API, VIRT_CONTROLLER, VIRT_HANDLER, VIRT_OPERATOR
+from utilities.constants import VIRT_CONTROLLER, VIRT_HANDLER, VIRT_OPERATOR
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
 virt_label_dict = {
-    VIRT_API: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_API}",
     VIRT_HANDLER: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_HANDLER}",
     VIRT_OPERATOR: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_OPERATOR}",
-    VIRT_CONTROLLER: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_CONTROLLER} ",
+    VIRT_CONTROLLER: f"{Resource.ApiGroup.KUBEVIRT_IO}={VIRT_CONTROLLER}",
 }
-KUBEVIRT_VIRT_CONTROLLER_READY_STATUS = "kubevirt_virt_controller_ready_status"
-KUBEVIRT_VIRT_OPERATOR_READY_STATUS = "kubevirt_virt_operator_ready_status"
 KUBEVIRT_VIRT_OPERATOR_LEADING_STATUS = "kubevirt_virt_operator_leading_status"
 KUBEVIRT_VIRT_CONTROLLER_LEADING_STATUS = "kubevirt_virt_controller_leading_status"
-KUBEVIRT_VIRT_API_UP = "kubevirt_virt_api_up"
 KUBEVIRT_VIRT_HANDLER_UP = "kubevirt_virt_handler_up"
-KUBEVIRT_VIRT_CONTROLLER_UP = "kubevirt_virt_controller_up"
 
 
 @pytest.mark.parametrize(
     "virt_pod_info_from_prometheus, virt_pod_names_by_label",
     [
-        pytest.param(
-            KUBEVIRT_VIRT_CONTROLLER_READY_STATUS,
-            virt_label_dict[VIRT_CONTROLLER],
-            marks=pytest.mark.polarion("CNV-7110"),
-            id=KUBEVIRT_VIRT_CONTROLLER_READY_STATUS,
-        ),
-        pytest.param(
-            KUBEVIRT_VIRT_OPERATOR_READY_STATUS,
-            virt_label_dict[VIRT_OPERATOR],
-            marks=pytest.mark.polarion("CNV-7111"),
-            id=KUBEVIRT_VIRT_OPERATOR_READY_STATUS,
-        ),
         pytest.param(
             KUBEVIRT_VIRT_OPERATOR_LEADING_STATUS,
             virt_label_dict[VIRT_OPERATOR],
@@ -72,28 +55,10 @@ def test_virt_recording_rules(
     "virt_up_metrics_values, virt_pod_names_by_label",
     [
         pytest.param(
-            KUBEVIRT_VIRT_API_UP,
-            virt_label_dict[VIRT_API],
-            marks=pytest.mark.polarion("CNV-7106"),
-            id=KUBEVIRT_VIRT_API_UP,
-        ),
-        pytest.param(
-            KUBEVIRT_VIRT_OPERATOR_UP,
-            virt_label_dict[VIRT_OPERATOR],
-            marks=pytest.mark.polarion("CNV-7107"),
-            id=KUBEVIRT_VIRT_OPERATOR_UP,
-        ),
-        pytest.param(
             KUBEVIRT_VIRT_HANDLER_UP,
             virt_label_dict[VIRT_HANDLER],
             marks=pytest.mark.polarion("CNV-7108"),
             id=KUBEVIRT_VIRT_HANDLER_UP,
-        ),
-        pytest.param(
-            KUBEVIRT_VIRT_CONTROLLER_UP,
-            virt_label_dict[VIRT_CONTROLLER],
-            marks=pytest.mark.polarion("CNV-7109"),
-            id=KUBEVIRT_VIRT_CONTROLLER_UP,
         ),
     ],
     indirect=True,

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -24,10 +24,8 @@ from tests.observability.metrics.utils import (
     validate_vnic_info,
 )
 from tests.observability.utils import validate_metrics_value
-from tests.os_params import FEDORA_LATEST_LABELS
 from utilities.constants import (
     CAPACITY,
-    LIVE_MIGRATE,
     MIGRATION_POLICY_VM_LABEL,
     QUARANTINED,
     TIMEOUT_2MIN,
@@ -371,36 +369,6 @@ class TestVmResourceLimits:
             expected_value=vm_for_test_with_resource_limits_instance.cpu
             if cnv_vm_resources_limits_matrix__function__ == "cpu"
             else str(int(bitmath.parse_string_unsafe(vm_for_test_with_resource_limits_instance.memory).bytes)),
-        )
-
-
-class TestKubevirtVmiNonEvictable:
-    @pytest.mark.parametrize(
-        "vm_with_rwo_dv",
-        [
-            pytest.param(
-                {
-                    "vm_name": "non-evictable-vm",
-                    "template_labels": FEDORA_LATEST_LABELS,
-                    "ssh": False,
-                    "guest_agent": False,
-                    "eviction_strategy": LIVE_MIGRATE,
-                },
-                marks=pytest.mark.polarion("CNV-7484"),
-            ),
-        ],
-        indirect=True,
-    )
-    @pytest.mark.s390x
-    def test_kubevirt_vmi_non_evictable(
-        self,
-        prometheus,
-        vm_with_rwo_dv,
-    ):
-        validate_metrics_value(
-            prometheus=prometheus,
-            metric_name="kubevirt_vmi_non_evictable",
-            expected_value="1",
         )
 
 

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -385,53 +385,6 @@ def validate_network_traffic_metrics_value(
         raise
 
 
-def get_metric_sum_value(prometheus: Prometheus, metric: str) -> int:
-    metrics = prometheus.query(query=metric)
-    metrics_result = metrics["data"].get("result", [])
-    if metrics_result:
-        return sum(int(metric_metrics_result["value"][1]) for metric_metrics_result in metrics_result)
-    LOGGER.warning(f"For Query {metric}, empty results found.")
-    return 0
-
-
-def wait_for_expected_metric_value_sum(
-    prometheus: Prometheus,
-    metric_name: str,
-    expected_value: int,
-    check_times: int = 3,
-    timeout: int = TIMEOUT_4MIN,
-) -> None:
-    sampler = TimeoutSampler(
-        wait_timeout=timeout,
-        sleep=TIMEOUT_15SEC,
-        func=get_metric_sum_value,
-        prometheus=prometheus,
-        metric=metric_name,
-    )
-    sample = None
-    current_check = 0
-    comparison_values_log = {}
-    try:
-        for sample in sampler:
-            if sample:
-                comparison_values_log[datetime.now()] = (
-                    f"metric: {metric_name} value is: {sample}, the expected value is {expected_value}"
-                )
-            if sample == expected_value:
-                current_check += 1
-                if current_check >= check_times:
-                    return
-            else:
-                current_check = 0
-
-    except TimeoutExpiredError:
-        LOGGER.error(
-            f"Metric: {metric_name}, metrics value: {sample}, expected: {expected_value}, "
-            f"comparison log: {comparison_values_log}"
-        )
-        raise
-
-
 def metric_result_output_dict_by_mountpoint(
     prometheus: Prometheus, capacity_or_used: str, vm_name: str
 ) -> dict[str, str]:


### PR DESCRIPTION
##### Short description:
Remove 9 redundant observability metric tests (CNV-7484, CNV-11400, CNV-7106, CNV-7107, CNV-7109, CNV-7110, CNV-7111, CNV-8480, CNV-8481) and their associated fixtures, utility functions, and imports.

Original pr: #3881

assisted by: claude code claude-opus-4-6
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-80322