### PR TITLE
WIP: [Storage] [CCLM] Post-CCLM validation tests, Windows VM tests

### DIFF
--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -56,6 +56,7 @@ from utilities.constants import (
     SECURITY_CONTEXT,
     TIMEOUT_1MIN,
     TIMEOUT_5SEC,
+    TIMEOUT_30MIN,
     U1_SMALL,
     Images,
 )
@@ -586,3 +587,8 @@ def rhel10_data_source_scope_module(golden_images_namespace):
 @pytest.fixture(scope="class")
 def unique_suffix():
     return shortuuid.ShortUUID().random(length=4).lower()
+
+
+@pytest.fixture(scope="class")
+def dv_wait_timeout(request):
+    return request.param.get("dv_wait_timeout") if hasattr(request, "param") else TIMEOUT_30MIN

--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -18,3 +18,15 @@ HTTP = "http"
 HTTPS = "https"
 
 QUAY_FEDORA_CONTAINER_IMAGE = f"docker://{Images.Fedora.FEDORA_CONTAINER_IMAGE}"
+
+STORAGE_CLASS_A = "storage_class_a"
+STORAGE_CLASS_B = "storage_class_b"
+
+NO_STORAGE_CLASS_FAILURE_MESSAGE = (
+    f"Test failed: {'{storage_class}'} storage class is not deployed. "
+    f"Available storage classes: {'{cluster_storage_classes_names}'}. "
+    "Ensure the correct storage_class is set in the global_config, "
+    "or override it with the pytest params: "
+    f"--tc={STORAGE_CLASS_A}:<storage_class_name> "
+    f"--tc={STORAGE_CLASS_B}:<storage_class_name>"
+)

--- a/tests/storage/cross_cluster_live_migration/conftest.py
+++ b/tests/storage/cross_cluster_live_migration/conftest.py
@@ -490,6 +490,7 @@ def vm_for_cclm_from_template_with_data_source(
         ),
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
+        vm.start()
         yield vm
 
 
@@ -513,6 +514,7 @@ def vm_for_cclm_with_instance_type(
             storage_class=remote_cluster_source_storage_class,
         ),
     ) as vm:
+        vm.start()
         yield vm
 
 
@@ -543,6 +545,7 @@ def vm_for_cclm_from_template_with_dv(
         memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
         data_volume_template={"metadata": dv.res["metadata"], "spec": dv.res["spec"]},
     ) as vm:
+        vm.start()
         yield vm
 
 

--- a/tests/storage/cross_cluster_live_migration/constants.py
+++ b/tests/storage/cross_cluster_live_migration/constants.py
@@ -1,0 +1,2 @@
+TEST_FILE_NAME = "test-file.txt"
+TEST_FILE_CONTENT = "test-content"

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -1,10 +1,21 @@
 import pytest
+from ocp_resources.virtual_machine_restore import VirtualMachineRestore
+from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
+from pytest_testconfig import config as py_config
 
+from tests.storage.constants import STORAGE_CLASS_B
+from tests.storage.cross_cluster_live_migration.constants import (
+    TEST_FILE_CONTENT,
+    TEST_FILE_NAME,
+)
 from tests.storage.cross_cluster_live_migration.utils import (
+    delete_file_in_vm,
     verify_compute_live_migration_after_cclm,
     verify_vms_boot_time_after_migration,
 )
+from tests.storage.utils import check_file_in_vm
 from utilities.constants import TIMEOUT_10MIN
+from utilities.virt import running_vm
 
 TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE = "CCLMvmFromTemplateWithDataSource"
 TESTS_CLASS_NAME_VM_WITH_INSTANCE_TYPE = "CCLMvmWithInstanceType"
@@ -21,26 +32,33 @@ pytestmark = [
 
 
 @pytest.mark.parametrize(
-    "vms_for_cclm",
+    "remote_cluster_source_storage_class, local_cluster_target_storage_class, vms_for_cclm",
     [
         pytest.param(
-            {"vms_fixtures": ["vm_for_cclm_from_template_with_data_source"]},
+            {"source_storage_class": py_config[STORAGE_CLASS_B]},
+            {"target_storage_class": py_config[STORAGE_CLASS_B]},
+            {
+                "vms_fixtures": [
+                    "vm_for_cclm_from_template_with_data_source",
+                    "vm_for_cclm_from_template_with_dv",
+                    "vm_for_cclm_with_instance_type",
+                ]
+            },
         )
     ],
     indirect=True,
 )
-class TestCCLMvmFromTemplateWithDataSource:
+@pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
+class TestCCLMvmFromTemplateWithDataSource: # TODO rename test class 
     @pytest.mark.polarion("CNV-11910")
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"
     )
     def test_migrate_vm_from_remote_to_local_cluster(
         self,
-        mtv_migration,
-        vms_for_cclm,
+        written_file_to_vms_before_cclm,
         vms_boot_time_before_cclm,
-        admin_client,
-        namespace,
+        mtv_migration,
     ):
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
@@ -48,16 +66,85 @@ class TestCCLMvmFromTemplateWithDataSource:
             timeout=TIMEOUT_10MIN,
             stop_condition=mtv_migration.Status.FAILED,
         )
+
+    @pytest.mark.dependency(
+        depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
+    )
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_verify_vms_boot_time_after_migration(self, local_vms_after_cclm_migration, vms_boot_time_before_cclm):
         verify_vms_boot_time_after_migration(
-            client=admin_client, namespace=namespace, vms_list=vms_for_cclm, initial_boot_time=vms_boot_time_before_cclm
+            local_vms=local_vms_after_cclm_migration, initial_boot_time=vms_boot_time_before_cclm
         )
 
     @pytest.mark.dependency(
         depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
     )
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_verify_file_persisted_after_migration(self, local_vms_after_cclm_migration):
+        for vm in local_vms_after_cclm_migration:
+            check_file_in_vm(
+                vm=vm,
+                file_name=TEST_FILE_NAME,
+                file_content=TEST_FILE_CONTENT,
+                username=vm.username,
+                password=vm.password,
+            )
+
+    @pytest.mark.dependency(
+        depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
+    )
     @pytest.mark.polarion("CNV-12038")
-    def test_compute_live_migrate_vms_after_cclm(self, admin_client, namespace, vms_for_cclm):
-        verify_compute_live_migration_after_cclm(client=admin_client, namespace=namespace, vms_list=vms_for_cclm)
+    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
+        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+
+    @pytest.mark.dependency(
+        depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
+    )
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_snapshot_and_restore_vms_after_cclm(self, unprivileged_client, local_vms_after_cclm_migration):
+        for vm in local_vms_after_cclm_migration:
+            # Create snapshot
+            with VirtualMachineSnapshot(
+                name=f"snapshot-{vm.name}",
+                namespace=vm.namespace,
+                vm_name=vm.name,
+                client=unprivileged_client,
+            ) as snapshot:
+                snapshot.wait_snapshot_done()
+
+                # Delete the file and verify deletion
+                delete_file_in_vm(vm=vm, file_name=TEST_FILE_NAME, username=vm.username, password=vm.password)
+
+                # Stop VM and restore from snapshot
+                vm.stop(wait=True)
+                with VirtualMachineRestore(
+                    client=unprivileged_client,
+                    name=f"restore-{vm.name}",
+                    namespace=vm.namespace,
+                    vm_name=vm.name,
+                    snapshot_name=snapshot.name,
+                ) as vm_restore:
+                    vm_restore.wait_restore_done()
+                    running_vm(vm=vm)
+
+                    # Verify file exists after restore
+                    check_file_in_vm(
+                        vm=vm,
+                        file_name=TEST_FILE_NAME,
+                        file_content=TEST_FILE_CONTENT,
+                        username=vm.username,
+                        password=vm.password,
+                    )
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        source_vms_failed_cleanup = {}
+        for vm in vms_for_cclm:
+            try:
+                assert vm.clean_up(), f"Failed to clean up source VM {vm.name}"
+            except Exception as cleanup_exception:
+                source_vms_failed_cleanup[vm.name] = cleanup_exception
+        assert not source_vms_failed_cleanup, f"Failed to clean up source VMs: {source_vms_failed_cleanup}"
 
 
 @pytest.mark.parametrize(
@@ -89,5 +176,5 @@ class TestCCLMvmWithInstanceType:
         depends=[f"{TESTS_CLASS_NAME_VM_WITH_INSTANCE_TYPE}::test_migrate_vm_from_remote_to_local_cluster"]
     )
     @pytest.mark.polarion("CNV-12474")
-    def test_compute_live_migrate_vms_after_cclm(self, admin_client, namespace, vms_for_cclm):
-        verify_compute_live_migration_after_cclm(client=admin_client, namespace=namespace, vms_list=vms_for_cclm)
+    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
+        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -1,6 +1,9 @@
 import pytest
 
-from tests.storage.cross_cluster_live_migration.utils import verify_compute_live_migration_after_cclm
+from tests.storage.cross_cluster_live_migration.utils import (
+    verify_compute_live_migration_after_cclm,
+    verify_vms_boot_time_after_migration,
+)
 from utilities.constants import TIMEOUT_10MIN
 
 TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE = "CCLMvmFromTemplateWithDataSource"
@@ -34,12 +37,19 @@ class TestCCLMvmFromTemplateWithDataSource:
     def test_migrate_vm_from_remote_to_local_cluster(
         self,
         mtv_migration,
+        vms_for_cclm,
+        vms_boot_time_before_cclm,
+        admin_client,
+        namespace,
     ):
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
             status=mtv_migration.Condition.Status.TRUE,
             timeout=TIMEOUT_10MIN,
             stop_condition=mtv_migration.Status.FAILED,
+        )
+        verify_vms_boot_time_after_migration(
+            client=admin_client, namespace=namespace, vms_list=vms_for_cclm, initial_boot_time=vms_boot_time_before_cclm
         )
 
     @pytest.mark.dependency(

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -9,16 +9,18 @@ from tests.storage.cross_cluster_live_migration.constants import (
     TEST_FILE_NAME,
 )
 from tests.storage.cross_cluster_live_migration.utils import (
+    assert_vms_are_stopped,
+    assert_vms_cleanup_successful,
     delete_file_in_vm,
     verify_compute_live_migration_after_cclm,
     verify_vms_boot_time_after_migration,
 )
 from tests.storage.utils import check_file_in_vm
-from utilities.constants import TIMEOUT_10MIN
+from utilities.constants import TIMEOUT_10MIN, TIMEOUT_15MIN, TIMEOUT_60MIN
 from utilities.virt import running_vm
 
-TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE = "CCLMvmFromTemplateWithDataSource"
-TESTS_CLASS_NAME_VM_WITH_INSTANCE_TYPE = "CCLMvmWithInstanceType"
+TESTS_CLASS_NAME_SEVERAL_VMS = "TestCCLMSeveralVMs"
+TESTS_CLASS_NAME_WINDOWS_WITH_VTPM = "TestCCLMWindowsWithVTPM"
 
 pytestmark = [
     pytest.mark.cclm,
@@ -49,11 +51,9 @@ pytestmark = [
     indirect=True,
 )
 @pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
-class TestCCLMvmFromTemplateWithDataSource: # TODO rename test class 
-    @pytest.mark.polarion("CNV-11910")
-    @pytest.mark.dependency(
-        name=f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"
-    )
+class TestCCLMSeveralVMs:
+    @pytest.mark.polarion("CNV-11995")
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster")
     def test_migrate_vm_from_remote_to_local_cluster(
         self,
         written_file_to_vms_before_cclm,
@@ -67,19 +67,15 @@ class TestCCLMvmFromTemplateWithDataSource: # TODO rename test class
             stop_condition=mtv_migration.Status.FAILED,
         )
 
-    @pytest.mark.dependency(
-        depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
-    )
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
+    @pytest.mark.polarion("CNV-11910")
     def test_verify_vms_boot_time_after_migration(self, local_vms_after_cclm_migration, vms_boot_time_before_cclm):
         verify_vms_boot_time_after_migration(
             local_vms=local_vms_after_cclm_migration, initial_boot_time=vms_boot_time_before_cclm
         )
 
-    @pytest.mark.dependency(
-        depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
-    )
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
+    @pytest.mark.polarion("CNV-14332")
     def test_verify_file_persisted_after_migration(self, local_vms_after_cclm_migration):
         for vm in local_vms_after_cclm_migration:
             check_file_in_vm(
@@ -90,17 +86,18 @@ class TestCCLMvmFromTemplateWithDataSource: # TODO rename test class
                 password=vm.password,
             )
 
-    @pytest.mark.dependency(
-        depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
-    )
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
+    @pytest.mark.polarion("CNV-14333")
+    def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        assert_vms_are_stopped(vms=vms_for_cclm)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-12038")
     def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
         verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
 
-    @pytest.mark.dependency(
-        depends=[f"{TESTS_CLASS_NAME_VM_FROM_TEMPLATE_WITH_DATA_SOURCE}::test_migrate_vm_from_remote_to_local_cluster"]
-    )
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
+    @pytest.mark.polarion("CNV-11997")
     def test_snapshot_and_restore_vms_after_cclm(self, unprivileged_client, local_vms_after_cclm_migration):
         for vm in local_vms_after_cclm_migration:
             # Create snapshot
@@ -118,11 +115,11 @@ class TestCCLMvmFromTemplateWithDataSource: # TODO rename test class
                 # Stop VM and restore from snapshot
                 vm.stop(wait=True)
                 with VirtualMachineRestore(
-                    client=unprivileged_client,
                     name=f"restore-{vm.name}",
                     namespace=vm.namespace,
                     vm_name=vm.name,
                     snapshot_name=snapshot.name,
+                    client=unprivileged_client,
                 ) as vm_restore:
                     vm_restore.wait_restore_done()
                     running_vm(vm=vm)
@@ -136,32 +133,28 @@ class TestCCLMvmFromTemplateWithDataSource: # TODO rename test class
                         password=vm.password,
                     )
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-14334")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
-        source_vms_failed_cleanup = {}
-        for vm in vms_for_cclm:
-            try:
-                assert vm.clean_up(), f"Failed to clean up source VM {vm.name}"
-            except Exception as cleanup_exception:
-                source_vms_failed_cleanup[vm.name] = cleanup_exception
-        assert not source_vms_failed_cleanup, f"Failed to clean up source VMs: {source_vms_failed_cleanup}"
+        assert_vms_cleanup_successful(vms=vms_for_cclm)
 
 
 @pytest.mark.parametrize(
-    "vms_for_cclm",
+    "remote_cluster_source_storage_class, local_cluster_target_storage_class, dv_wait_timeout, vms_for_cclm",
     [
         pytest.param(
-            {"vms_fixtures": ["vm_for_cclm_with_instance_type"]},
+            {"source_storage_class": py_config[STORAGE_CLASS_B]},
+            {"target_storage_class": py_config[STORAGE_CLASS_B]},
+            {"dv_wait_timeout": TIMEOUT_60MIN},
+            {"vms_fixtures": ["windows_vm_with_vtpm_for_cclm"]},
         ),
     ],
     indirect=True,
 )
-class TestCCLMvmWithInstanceType:
-    @pytest.mark.polarion("CNV-12013")
-    @pytest.mark.dependency(
-        name=f"{TESTS_CLASS_NAME_VM_WITH_INSTANCE_TYPE}::test_migrate_vm_from_remote_to_local_cluster"
-    )
-    def test_migrate_vm_from_remote_to_local_cluster(
+@pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class", "dv_wait_timeout")
+class TestCCLMWindowsWithVTPM:
+    @pytest.mark.polarion("CNV-11999")
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_WINDOWS_WITH_VTPM}::test_migrate_windows_vm_with_vtpm")
+    def test_migrate_windows_vm_with_vtpm(
         self,
         mtv_migration,
     ):
@@ -172,9 +165,41 @@ class TestCCLMvmWithInstanceType:
             stop_condition=mtv_migration.Status.FAILED,
         )
 
-    @pytest.mark.dependency(
-        depends=[f"{TESTS_CLASS_NAME_VM_WITH_INSTANCE_TYPE}::test_migrate_vm_from_remote_to_local_cluster"]
-    )
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_WINDOWS_WITH_VTPM}::test_migrate_windows_vm_with_vtpm"])
     @pytest.mark.polarion("CNV-12474")
-    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
+    def test_compute_live_migrate_windows_vms_after_cclm(self, local_vms_after_cclm_migration):
         verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_WINDOWS_WITH_VTPM}::test_migrate_windows_vm_with_vtpm"])
+    @pytest.mark.polarion("CNV-14335")
+    def test_source_windows_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        assert_vms_are_stopped(vms=vms_for_cclm)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_WINDOWS_WITH_VTPM}::test_migrate_windows_vm_with_vtpm"])
+    @pytest.mark.polarion("CNV-14337")
+    def test_snapshot_and_restore_windows_vms_after_cclm(self, unprivileged_client, local_vms_after_cclm_migration):
+        for vm in local_vms_after_cclm_migration:
+            # Create snapshot
+            with VirtualMachineSnapshot(
+                name=f"snapshot-{vm.name}",
+                namespace=vm.namespace,
+                vm_name=vm.name,
+                client=unprivileged_client,
+            ) as snapshot:
+                snapshot.wait_snapshot_done()
+
+                # Stop VM and restore from snapshot
+                vm.stop(wait=True, timeout=TIMEOUT_15MIN)
+                with VirtualMachineRestore(
+                    name=f"restore-{vm.name}",
+                    namespace=vm.namespace,
+                    vm_name=vm.name,
+                    snapshot_name=snapshot.name,
+                    client=unprivileged_client,
+                ) as vm_restore:
+                    vm_restore.wait_restore_done()
+                    running_vm(vm=vm)
+
+    @pytest.mark.polarion("CNV-14336")
+    def test_source_windows_vms_can_be_deleted(self, vms_for_cclm):
+        assert_vms_cleanup_successful(vms=vms_for_cclm)

--- a/tests/storage/cross_cluster_live_migration/utils.py
+++ b/tests/storage/cross_cluster_live_migration/utils.py
@@ -156,6 +156,25 @@ def verify_vms_boot_time_after_migration(
     assert not rebooted_vms, f"Boot time changed for VMs:\n {rebooted_vms}"
 
 
+def assert_vms_are_stopped(vms: list[VirtualMachineForTests]) -> None:
+    not_stopped_vms = {}
+    for vm in vms:
+        vm_status = vm.printable_status
+        if vm_status != vm.Status.STOPPED:
+            not_stopped_vms[vm.name] = vm_status
+    assert not not_stopped_vms, f"Source VMs are not stopped: {not_stopped_vms}"
+
+
+def assert_vms_cleanup_successful(vms: list[VirtualMachineForTests]) -> None:
+    vms_failed_cleanup = {}
+    for vm in vms:
+        try:
+            assert vm.clean_up(), f"Failed to clean up source VM {vm.name}"
+        except Exception as cleanup_exception:
+            vms_failed_cleanup[vm.name] = cleanup_exception
+    assert not vms_failed_cleanup, f"Failed to clean up source VMs: {vms_failed_cleanup}"
+
+
 def delete_file_in_vm(
     vm: VirtualMachineForTests, file_name: str, username: str | None = None, password: str | None = None
 ) -> None:

--- a/tests/storage/cross_cluster_live_migration/utils.py
+++ b/tests/storage/cross_cluster_live_migration/utils.py
@@ -1,3 +1,5 @@
+import logging
+import re
 from typing import Generator
 
 from kubernetes.dynamic import DynamicClient
@@ -6,10 +8,17 @@ from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.namespace import Namespace
 from ocp_resources.network_attachment_definition import NetworkAttachmentDefinition
 
+from utilities import console
 from utilities.constants import VIRT_HANDLER
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import get_daemonset_by_name
-from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, wait_for_virt_handler_pods_network_updated
+from utilities.virt import (
+    VirtualMachineForTests,
+    migrate_vm_and_verify,
+    wait_for_virt_handler_pods_network_updated,
+)
+
+LOGGER = logging.getLogger(__name__)
 
 
 def enable_feature_gate_and_configure_hco_live_migration_network(
@@ -95,3 +104,70 @@ def verify_compute_live_migration_after_cclm(
         except Exception as migration_exception:
             vms_failed_migration[local_vm.name] = migration_exception
     assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"
+
+
+def get_vm_boot_time_via_console(
+    vm: VirtualMachineForTests, kubeconfig: str | None = None, username: str | None = None, password: str | None = None
+) -> str:
+    """
+    Returns the boot time string, e.g., "system boot  2026-01-08 11:17"
+    """
+    with console.Console(vm=vm, kubeconfig=kubeconfig, username=username, password=password) as vm_console:
+        vm_console.sendline("who -b")
+
+        # Wait for the prompt to return
+        vm_console.expect([r"#", r"\$"])
+        raw_output = vm_console.before
+
+        # Decode if bytes
+        if isinstance(raw_output, bytes):
+            output = raw_output.decode("utf-8", errors="ignore")
+        else:
+            output = str(raw_output)
+
+        # Remove ANSI escape sequences and control characters
+        output = re.sub(r"\x1b\[\?[0-9]+[hl]", "", output)  # Remove bracketed paste mode
+        output = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", output)  # Remove ANSI sequences
+        output = output.replace("\r", "")  # Remove carriage returns
+
+        lines = output.strip().split("\n")
+        for line in lines:
+            if "system boot" in line:
+                # Extract and return just the date/time part
+                # Format: "         system boot  2026-01-08 11:17"
+                boot_info = line.strip()
+                # Remove extra spaces
+                boot_info = re.sub(r"\s+", " ", boot_info)
+                LOGGER.info(f"Boot time: {boot_info}")
+                return boot_info
+
+        raise ValueError(f"Could not determine boot time from output: {raw_output}")
+
+
+def verify_vms_boot_time_after_migration(
+    client: DynamicClient,
+    namespace: Namespace,
+    vms_list: list[VirtualMachineForTests],
+    initial_boot_time: dict[str, str],
+) -> None:
+    """
+    Verify that VMs have not rebooted after storage migration.
+
+    Args:
+        vms_list: List of VMs to check
+        initial_boot_time: Dictionary mapping VM names to their initial boot times
+
+    Raises:
+        AssertionError: If any VM has rebooted (boot time changed)
+    """
+    rebooted_vms = {}
+    for vm in vms_list:
+        local_vm = VirtualMachineForTests(
+            name=vm.name, namespace=namespace.name, client=client, generate_unique_name=False
+        )
+        # local_vm.username = vm.username
+        # local_vm.password = vm.password
+        current_boot_time = get_vm_boot_time_via_console(vm=local_vm, username=vm.username, password=vm.password)
+        if initial_boot_time[local_vm.name] != current_boot_time:
+            rebooted_vms[local_vm.name] = {"initial": initial_boot_time[local_vm.name], "current": current_boot_time}
+    assert not rebooted_vms, f"Boot time changed for VMs:\n {rebooted_vms}"

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -21,16 +21,14 @@ from tests.storage.storage_migration.constants import (
 )
 from tests.storage.storage_migration.utils import (
     build_namespaces_spec_for_storage_migration,
-    get_storage_class_for_storage_migration,
     wait_for_storage_migration_completed,
 )
-from tests.storage.utils import create_windows_directory
+from tests.storage.utils import create_windows_directory, get_storage_class_for_storage_migration
 from utilities.artifactory import get_http_image_url
 from utilities.constants import (
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_RHEL,
     OS_FLAVOR_WINDOWS,
-    TIMEOUT_30MIN,
     U1_SMALL,
     Images,
 )
@@ -222,11 +220,6 @@ def vms_for_storage_class_migration(request):
     """
     vms = [request.getfixturevalue(argname=vm_fixture) for vm_fixture in request.param["vms_fixtures"]]
     yield vms
-
-
-@pytest.fixture(scope="class")
-def dv_wait_timeout(request):
-    return request.param.get("dv_wait_timeout") if hasattr(request, "param") else TIMEOUT_30MIN
 
 
 @pytest.fixture(scope="class")

--- a/tests/storage/storage_migration/constants.py
+++ b/tests/storage/storage_migration/constants.py
@@ -4,17 +4,5 @@ WINDOWS_TEST_DIRECTORY_PATH = r"C:\Users\TestFolder"
 WINDOWS_FILE_BEFORE_STORAGE_MIGRATION = f"{FILE_BEFORE_STORAGE_MIGRATION}.txt"
 WINDOWS_FILE_WITH_PATH = f"{WINDOWS_TEST_DIRECTORY_PATH}\\{WINDOWS_FILE_BEFORE_STORAGE_MIGRATION}"
 
-STORAGE_CLASS_A = "storage_class_a"
-STORAGE_CLASS_B = "storage_class_b"
-
-NO_STORAGE_CLASS_FAILURE_MESSAGE = (
-    f"Test failed: {'{storage_class}'} storage class is not deployed. "
-    f"Available storage classes: {'{cluster_storage_classes_names}'}. "
-    "Ensure the correct storage_class is set in the global_config, "
-    "or override it with the pytest params: "
-    f"--tc={STORAGE_CLASS_A}:<storage_class_name> "
-    f"--tc={STORAGE_CLASS_B}:<storage_class_name>"
-)
-
 HOTPLUGGED_DEVICE = "/dev/sda"
 MOUNT_HOTPLUGGED_DEVICE_PATH = "/mnt/hotplug"

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -2,11 +2,10 @@ import pytest
 from pytest_testconfig import config as py_config
 
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS
+from tests.storage.constants import STORAGE_CLASS_A, STORAGE_CLASS_B
 from tests.storage.storage_migration.constants import (
     CONTENT,
     FILE_BEFORE_STORAGE_MIGRATION,
-    STORAGE_CLASS_A,
-    STORAGE_CLASS_B,
     WINDOWS_FILE_WITH_PATH,
 )
 from tests.storage.storage_migration.utils import (

--- a/tests/storage/storage_migration/utils.py
+++ b/tests/storage/storage_migration/utils.py
@@ -1,6 +1,5 @@
 import shlex
 
-import pytest
 from ocp_resources.multi_namespace_virtual_machine_storage_migration import MultiNamespaceVirtualMachineStorageMigration
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pyhelper_utils.shell import run_ssh_commands
@@ -10,22 +9,11 @@ from tests.storage.storage_migration.constants import (
     CONTENT,
     FILE_BEFORE_STORAGE_MIGRATION,
     MOUNT_HOTPLUGGED_DEVICE_PATH,
-    NO_STORAGE_CLASS_FAILURE_MESSAGE,
 )
-from utilities import console
-from utilities.constants import LS_COMMAND, TIMEOUT_10MIN, TIMEOUT_10SEC, TIMEOUT_20SEC
+from tests.storage.utils import check_file_in_vm
+from utilities.constants import TIMEOUT_10MIN, TIMEOUT_10SEC
 from utilities.exceptions import StorageMigrationError
 from utilities.virt import VirtualMachineForTests, get_vm_boot_time
-
-
-def check_file_in_vm(vm: VirtualMachineForTests, file_name: str, file_content: str) -> None:
-    if not vm.ready:
-        vm.start(wait=True)
-    with console.Console(vm=vm) as vm_console:
-        vm_console.sendline(LS_COMMAND)
-        vm_console.expect(file_name, timeout=TIMEOUT_20SEC)
-        vm_console.sendline(f"cat {file_name}")
-        vm_console.expect(file_content, timeout=TIMEOUT_20SEC)
 
 
 def verify_vms_boot_time_after_storage_migration(
@@ -84,17 +72,6 @@ def verify_storage_migration_succeeded(
             file_content=CONTENT,
         )
         verify_vm_storage_class_updated(vm=vm, target_storage_class=target_storage_class)
-
-
-def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_classes_names: list[str]) -> str:
-    if storage_class in cluster_storage_classes_names:
-        return storage_class
-    else:
-        pytest.fail(
-            NO_STORAGE_CLASS_FAILURE_MESSAGE.format(
-                storage_class=storage_class, cluster_storage_classes_names=cluster_storage_classes_names
-            )
-        )
 
 
 def verify_file_in_hotplugged_disk(vm: VirtualMachineForTests, file_name: str, file_content: str) -> None:

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -531,9 +531,9 @@ def check_file_in_vm(
         vm.start(wait=True)
     with console.Console(vm=vm, username=username, password=password) as vm_console:
         vm_console.sendline(LS_COMMAND)
-        vm_console.expect(file_name, timeout=TIMEOUT_20SEC)
+        vm_console.expect(pattern=file_name, timeout=TIMEOUT_20SEC)
         vm_console.sendline(f"cat {file_name}")
-        vm_console.expect(file_content, timeout=TIMEOUT_20SEC)
+        vm_console.expect(pattern=file_content, timeout=TIMEOUT_20SEC)
 
 
 def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_classes_names: list[str]) -> str:

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -4,6 +4,7 @@ import shlex
 from contextlib import contextmanager
 from typing import Generator
 
+import pytest
 import requests
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cdi import CDI
@@ -25,6 +26,8 @@ from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.storage.constants import NO_STORAGE_CLASS_FAILURE_MESSAGE
+from utilities import console
 from utilities.artifactory import (
     cleanup_artifactory_secret_and_config_map,
     get_artifactory_config_map,
@@ -33,7 +36,9 @@ from utilities.artifactory import (
 )
 from utilities.constants import (
     CDI_UPLOADPROXY,
+    LS_COMMAND,
     TIMEOUT_2MIN,
+    TIMEOUT_20SEC,
     TIMEOUT_30MIN,
     Images,
 )
@@ -503,3 +508,41 @@ def assert_disk_bus(vm: VirtualMachineForTests, volume: DataVolume, expected_bus
     assert disk is not None, f"Disk {volume.name} not found in VM {vm.name}"
     actual_bus = disk.get("disk", {}).get("bus")
     assert actual_bus == expected_bus, f"Disk {volume.name} has bus '{actual_bus}' but expected '{expected_bus}'"
+
+
+def check_file_in_vm(
+    vm: VirtualMachineForTests,
+    file_name: str,
+    file_content: str,
+    username: str | None = None,
+    password: str | None = None,
+) -> None:
+    """
+    Check that a file exists in a VM with expected content.
+
+    Args:
+        vm: VirtualMachine instance
+        file_name: Name of the file to check
+        file_content: Expected content in the file
+        username: Optional username for console login (defaults to vm.username)
+        password: Optional password for console login (defaults to vm.password)
+    """
+    if not vm.ready:
+        vm.start(wait=True)
+    with console.Console(vm=vm, username=username, password=password) as vm_console:
+        vm_console.sendline(LS_COMMAND)
+        vm_console.expect(file_name, timeout=TIMEOUT_20SEC)
+        vm_console.sendline(f"cat {file_name}")
+        vm_console.expect(file_content, timeout=TIMEOUT_20SEC)
+
+
+def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_classes_names: list[str]) -> str:
+    if storage_class in cluster_storage_classes_names:
+        return storage_class
+    else:
+        pytest.fail(
+            NO_STORAGE_CLASS_FAILURE_MESSAGE.format(
+                storage_class=storage_class, cluster_storage_classes_names=cluster_storage_classes_names
+            )
+        )
+        

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -545,4 +545,3 @@ def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_
                 storage_class=storage_class, cluster_storage_classes_names=cluster_storage_classes_names
             )
         )
-        

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -539,9 +539,9 @@ def check_file_in_vm(
 def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_classes_names: list[str]) -> str:
     if storage_class in cluster_storage_classes_names:
         return storage_class
-    else:
-        pytest.fail(
-            NO_STORAGE_CLASS_FAILURE_MESSAGE.format(
-                storage_class=storage_class, cluster_storage_classes_names=cluster_storage_classes_names
-            )
+
+    pytest.fail(
+        NO_STORAGE_CLASS_FAILURE_MESSAGE.format(
+            storage_class=storage_class, cluster_storage_classes_names=cluster_storage_classes_names
         )
+    )

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -527,9 +527,12 @@ def check_file_in_vm(
         username: Optional username for console login (defaults to vm.username)
         password: Optional password for console login (defaults to vm.password)
     """
+    LOGGER.info(f"Verifying file {file_name} exists in VM {vm.name}")
     if not vm.ready:
+        LOGGER.info(f"Starting VM {vm.name}")
         vm.start(wait=True)
     with console.Console(vm=vm, username=username, password=password) as vm_console:
+        LOGGER.info(f"Checking file contents for {file_name} in VM {vm.name}")
         vm_console.sendline(LS_COMMAND)
         vm_console.expect(pattern=file_name, timeout=TIMEOUT_20SEC)
         vm_console.sendline(f"cat {file_name}")

--- a/utilities/artifactory.py
+++ b/utilities/artifactory.py
@@ -3,6 +3,7 @@ import os
 import ssl
 
 import requests
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
@@ -84,6 +85,7 @@ def get_artifactory_header() -> dict[str, str]:
 
 def get_artifactory_secret(
     namespace: str,
+    client: DynamicClient | None = None,
 ) -> Secret:
     """
     Create or retrieve an Artifactory authentication secret in the specified namespace.
@@ -94,6 +96,7 @@ def get_artifactory_secret(
 
     Args:
         namespace (str): The Kubernetes namespace where the secret should be created or retrieved.
+        client (DynamicClient | None): Optional Kubernetes client. If None, uses the default client.
 
     Returns:
         Secret: The Artifactory Secret resource object.
@@ -104,6 +107,7 @@ def get_artifactory_secret(
     artifactory_secret = Secret(
         name=ARTIFACTORY_SECRET_NAME,
         namespace=namespace,
+        client=client,
         accesskeyid=base64_encode_str(os.environ["ARTIFACTORY_USER"]),
         secretkey=base64_encode_str(os.environ["ARTIFACTORY_TOKEN"]),
     )
@@ -114,6 +118,7 @@ def get_artifactory_secret(
 
 def get_artifactory_config_map(
     namespace: str,
+    client: DynamicClient | None = None,
 ) -> ConfigMap:
     """
     Create or retrieve an Artifactory TLS certificate ConfigMap in the specified namespace.
@@ -125,6 +130,7 @@ def get_artifactory_config_map(
 
     Args:
         namespace (str): The Kubernetes namespace where the ConfigMap should be created or retrieved.
+        client (DynamicClient | None): Optional Kubernetes client. If None, uses the default client.
 
     Returns:
         ConfigMap: The Artifactory ConfigMap resource object containing the TLS certificate.
@@ -136,6 +142,7 @@ def get_artifactory_config_map(
     artifactory_cm = ConfigMap(
         name="artifactory-configmap",
         namespace=namespace,
+        client=client,
         data={"tlsregistry.crt": ssl.get_server_certificate(addr=(py_config["server_url"], 443))},
     )
     if not artifactory_cm.exists:

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -624,7 +624,13 @@ def get_hyperconverged_cdi(admin_client):
         return cdi
 
 
-def write_file(vm, filename, content, stop_vm=True, kubeconfig=None):
+def write_file(
+    vm: virt_util.VirtualMachineForTests,
+    filename: str,
+    content: str,
+    stop_vm: bool = True,
+    kubeconfig: str | None = None,
+) -> None:
     """
     Start VM if not running, write a file in the VM and stop the VM.
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -624,11 +624,21 @@ def get_hyperconverged_cdi(admin_client):
         return cdi
 
 
-def write_file(vm, filename, content, stop_vm=True):
-    """Start VM if not running, write a file in the VM and stop the VM"""
+def write_file(vm, filename, content, stop_vm=True, kubeconfig=None):
+    """
+    Start VM if not running, write a file in the VM and stop the VM.
+
+    Args:
+        vm: VirtualMachine instance
+        filename: Path to the file to write in the VM
+        content: Content to write to the file
+        stop_vm: Whether to stop the VM after writing the file
+        kubeconfig: Optional path to kubeconfig file for remote cluster access
+    """
     if not vm.ready:
         vm.start(wait=True)
-    with console.Console(vm=vm) as vm_console:
+    # Pass the kubeconfig to Console for remote cluster support
+    with console.Console(vm=vm, kubeconfig=kubeconfig) as vm_console:
         vm_console.sendline(f"echo '{content}' >> {filename}")
     if stop_vm:
         vm.stop(wait=True)

--- a/utilities/unittests/test_artifactory.py
+++ b/utilities/unittests/test_artifactory.py
@@ -290,6 +290,7 @@ class TestGetArtifactorySecret:
             mock_secret_class.assert_called_once_with(
                 name=ARTIFACTORY_SECRET_NAME,
                 namespace="test-namespace",
+                client=None,
                 accesskeyid="base64_test-user",
                 secretkey="base64_test-token",
             )
@@ -393,6 +394,7 @@ class TestGetArtifactoryConfigMap:
         mock_cm_class.assert_called_once_with(
             name="artifactory-configmap",
             namespace="test-namespace",
+            client=None,
             data={"tlsregistry.crt": mock_cert},
         )
 

--- a/utilities/unittests/test_console.py
+++ b/utilities/unittests/test_console.py
@@ -109,13 +109,6 @@ class TestConsole:
         # Should include --kubeconfig flag
         assert console.cmd == "virtctl console test-vm -n test-namespace --kubeconfig /path/to/kubeconfig"
 
-        # Test with kubeconfig but without namespace
-        mock_vm.namespace = None
-        with patch("console.VIRTCTL", "virtctl"):
-            console = Console(vm=mock_vm, kubeconfig="/path/to/custom.kubeconfig")
-
-        assert console.cmd == "virtctl console test-vm --kubeconfig /path/to/custom.kubeconfig"
-
     @patch("console.pexpect.spawn")
     def test_console_enter(self, mock_spawn, mock_vm_no_namespace):
         """Test __enter__ method"""

--- a/utilities/unittests/test_console.py
+++ b/utilities/unittests/test_console.py
@@ -98,6 +98,24 @@ class TestConsole:
 
         assert console.cmd == "virtctl console test-vm"
 
+    def test_console_generate_cmd_with_kubeconfig(self, mock_vm):
+        """Test _generate_cmd method with kubeconfig parameter"""
+        mock_vm.username = "user"
+        mock_vm.password = "pass"
+
+        with patch("console.VIRTCTL", "virtctl"):
+            console = Console(vm=mock_vm, kubeconfig="/path/to/kubeconfig")
+
+        # Should include --kubeconfig flag
+        assert console.cmd == "virtctl console test-vm -n test-namespace --kubeconfig /path/to/kubeconfig"
+
+        # Test with kubeconfig but without namespace
+        mock_vm.namespace = None
+        with patch("console.VIRTCTL", "virtctl"):
+            console = Console(vm=mock_vm, kubeconfig="/path/to/custom.kubeconfig")
+
+        assert console.cmd == "virtctl console test-vm --kubeconfig /path/to/custom.kubeconfig"
+
     @patch("console.pexpect.spawn")
     def test_console_enter(self, mock_spawn, mock_vm_no_namespace):
         """Test __enter__ method"""

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1551,8 +1551,16 @@ def wait_for_ssh_connectivity(
             return
 
 
-def wait_for_console(vm):
-    with Console(vm=vm, timeout=TIMEOUT_25MIN):
+def wait_for_console(vm, kubeconfig=None):
+    """
+    Wait for VM console to be accessible.
+
+    Args:
+        vm: VirtualMachine instance
+        kubeconfig: Optional path to kubeconfig file for remote cluster access
+    """
+    # Pass the kubeconfig to Console for remote cluster support
+    with Console(vm=vm, timeout=TIMEOUT_25MIN, kubeconfig=kubeconfig):
         LOGGER.info(f"Successfully connected to {vm.name} console")
 
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1551,16 +1551,8 @@ def wait_for_ssh_connectivity(
             return
 
 
-def wait_for_console(vm, kubeconfig=None):
-    """
-    Wait for VM console to be accessible.
-
-    Args:
-        vm: VirtualMachine instance
-        kubeconfig: Optional path to kubeconfig file for remote cluster access
-    """
-    # Pass the kubeconfig to Console for remote cluster support
-    with Console(vm=vm, timeout=TIMEOUT_25MIN, kubeconfig=kubeconfig):
+def wait_for_console(vm):
+    with Console(vm=vm, timeout=TIMEOUT_25MIN):
         LOGGER.info(f"Successfully connected to {vm.name} console")
 
 


### PR DESCRIPTION
##### Short description:
- Add post-CCLM validation tests
- Add Windows VM tests

##### More details:
- CCLM multiple VMs
- Make storage class configurable 
- Check boot time before and after CCLM for Fedora and RHEL VMs
- Allow connection to the VM Console in the remote cluster with the kubeconfig

Jira: https://issues.redhat.com/browse/CNV-60016

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Assisted by Claude AI and Cursor AI

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded cross-cluster live-migration coverage: multi‑VM and Windows VTPM flows, snapshots/restores, file persistence checks, boot-time verification, and fixtures for remote cluster provisioning and mapping.

* **Refactor**
  * Consolidated VM and storage helpers into shared utilities; added boot-time and lifecycle helpers; console and storage helpers now accept an optional kubeconfig for remote operations.

* **Chores**
  * Adjusted timeout fixture handling and reorganized storage-class constants and imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->