### PR TITLE
Fix flakiness of SR-IOV reboot test

### DIFF
--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -199,7 +199,6 @@ def vm4_interfaces(sriov_vm4):
 def restarted_sriov_vm4(request, sriov_vm4):
     LOGGER.info(f"Reboot number {request.param}")
     sriov_vm4.restart(wait=True)
-    sriov_vm4.wait_for_agent_connected()
     wait_for_vm_interfaces(vmi=sriov_vm4.vmi)
     return sriov_vm4
 

--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -91,6 +91,7 @@ class TestSriovInterfacePersistence:
         restarted_sriov_vm4,
     ):
         # Check only the second interface (SR-IOV interface).
+        lookup_iface_status(vm=restarted_sriov_vm4, iface_name=vm4_interfaces[1].name)
         assert restarted_sriov_vm4.vmi.interfaces[1] == vm4_interfaces[1]
 
 


### PR DESCRIPTION
We observed flakiness of test_sriov_interfaces_post_reboot, where sometimes the interface status report (post reboot) is not yet fully updated, which is accepted and shouldn't fail the test immediately. Therefore the check is now given a grace period to allow completion of the interface status, before checking it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an explicit interface status check before the final SR‑IOV post‑reboot validation to improve reliability and diagnostic clarity without changing the final validation outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->