### PR TITLE
De-quarantine test_deprecation_audit_logs

### DIFF
--- a/tests/deprecated_api/test_deprecation_audit_logs.py
+++ b/tests/deprecated_api/test_deprecation_audit_logs.py
@@ -4,12 +4,11 @@ from collections import defaultdict
 import pytest
 from packaging.version import Version
 
-from utilities.constants import QUARANTINED
 from utilities.infra import get_node_audit_log_line_dict
 
 LOGGER = logging.getLogger(__name__)
 
-DEPRECATED_API_MAX_VERSION = "1.25"
+DEPRECATED_API_MAX_VERSION = "1.35"
 DEPRECATED_API_LOG_ENTRY = '"k8s.io/deprecated":"true"'
 
 
@@ -109,10 +108,6 @@ def deprecated_apis_calls(audit_logs):
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-6679")
 @pytest.mark.order("last")
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: Timeout after 180s retrieving logs Tracked CNV-76514",
-    run=False,
-)
 def test_deprecated_apis_in_audit_logs(deprecated_apis_calls):
     LOGGER.info(f"Test deprecated API calls, max version for deprecation check: {DEPRECATED_API_MAX_VERSION}")
     if deprecated_apis_calls:


### PR DESCRIPTION
##### Short description:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/3479 implemented a fix that fixes the test.

Behaviour has been validated on `test_cnv_pod_security_violation_audit_logs`, that uses the same fixtures, and passed correctly in the last CI runs for 4.22.

As the correct behaviour is confirmed, this commit is re-enabling it. It also updates the DEPRECATED_API_MAX_VERSION to the k8s version expected for OCP4.22: 1.35.

##### More details:
N/A

##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### jira-ticket:
https://issues.redhat.com/browse/CNV-76514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated deprecation threshold from 1.25 to 1.35 to extend compatibility with higher API versions.
* Enabled full deprecation audit test validation by removing expected-failure condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->