### PR TITLE
fix: use admin client for node object to avoid unprivileged 403 errors

### DIFF
--- a/tests/infrastructure/utils.py
+++ b/tests/infrastructure/utils.py
@@ -3,10 +3,17 @@ import logging
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
 from ocp_resources.kubelet_config import KubeletConfig
+from ocp_resources.node import Node
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from utilities.exceptions import ResourceMissingFieldError, ResourceValueError
 
 LOGGER = logging.getLogger(__name__)
+
+
+def node_for_vmi(admin_client: DynamicClient, vmi: VirtualMachineInstance) -> Node:
+    """Return the node running the given VMI, using admin client for cluster-scoped access."""
+    return Node(client=admin_client, name=vmi.instance.status.nodeName)
 
 
 def verify_tekton_operator_installed(client: DynamicClient) -> None:

--- a/tests/infrastructure/workload_availability/remediation_fencing/conftest.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing/conftest.py
@@ -5,6 +5,7 @@ Node Health Check common use cases
 import pytest
 from ocp_resources.virtual_machine import VirtualMachine
 
+from tests.infrastructure.utils import node_for_vmi
 from tests.infrastructure.workload_availability.remediation_fencing.constants import (
     NODE_HEALTH_DETECTION_OPERATOR,
     REMEDIATION_OPERATOR_NAMESPACE,
@@ -49,8 +50,8 @@ def nhc_vm_with_run_strategy_always(namespace, unprivileged_client):
 
 
 @pytest.fixture()
-def vm_node_before_failure(nhc_vm_with_run_strategy_always):
-    return nhc_vm_with_run_strategy_always.vmi.node
+def vm_node_before_failure(admin_client, nhc_vm_with_run_strategy_always):
+    return node_for_vmi(admin_client=admin_client, vmi=nhc_vm_with_run_strategy_always.vmi)
 
 
 @pytest.fixture()
@@ -68,11 +69,15 @@ def refreshed_worker_utility_pods(admin_client, workers):
 
 
 @pytest.fixture()
-def performed_node_operation(nhc_vm_with_run_strategy_always, refreshed_worker_utility_pods, node_operation):
+def performed_node_operation(
+    admin_client, nhc_vm_with_run_strategy_always, refreshed_worker_utility_pods, node_operation
+):
     """
     Performs node operations like node start/stop, node kubelet start/stop
     node reboot, node shutdown. After remediation action, utility pods are recreated.
     """
     perform_node_operation(
-        utility_pods=refreshed_worker_utility_pods, node=nhc_vm_with_run_strategy_always.vmi.node, action=node_operation
+        utility_pods=refreshed_worker_utility_pods,
+        node=node_for_vmi(admin_client=admin_client, vmi=nhc_vm_with_run_strategy_always.vmi),
+        action=node_operation,
     )


### PR DESCRIPTION
VMs created with unprivileged_client pass that client down to the Node object via vmi.node. Node is cluster-scoped so unprivileged users can't query node status causing 403 Forbidden in wait_for_node_status.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
