### PR TITLE
[VIRT] Collect VNC screenshot on post-migration verification timeout

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1896,6 +1896,7 @@ def verify_vm_migrated(
         if check_ssh_connectivity:
             wait_for_ssh_connectivity(vm=vm)
     except TimeoutExpiredError:
+        LOGGER.error(f"VM {vm.name} unresponsive after migration; getting VNC screenshot")
         collect_vnc_screenshot_for_vms(vm_name=vm.name, vm_namespace=vm.namespace)
         raise
 


### PR DESCRIPTION
Add VNC screenshot collection when VM non-responsive after migration.

Signed-off-by: dshchedr@redhat.com
Assisted-by: Claude

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM migration timeout handling: related waits are now handled together so that if a timeout occurs an error is logged and a VNC snapshot is captured to aid troubleshooting; the error is then propagated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->