### PR TITLE
workflows: Skip auto-retest for PRs with stale label

### DIFF
--- a/.github/workflows/auto-retest-needs-rebase.yml
+++ b/.github/workflows/auto-retest-needs-rebase.yml
@@ -70,8 +70,8 @@ jobs:
             echo "================================================"
             echo "Checking PR #$PR_NUM"
 
-            # Check if PR has has-conflict, hold, or wip labels
-            SKIP_LABELS=$(gh pr view $PR_NUM --json labels --jq '.labels[].name' | grep -E "^(has-conflict|hold|wip)$" || true)
+            # Check if PR has has-conflict, hold, wip, or stale labels
+            SKIP_LABELS=$(gh pr view $PR_NUM --json labels --jq '.labels[].name' | grep -iE "^(has-conflict|hold|wip|stale)$" || true)
 
             if [ -n "$SKIP_LABELS" ]; then
               echo "PR #$PR_NUM has skip label(s): $SKIP_LABELS, skipping retest"


### PR DESCRIPTION
## Summary

The auto-retest workflow now skips PRs that have a `stale` label (case-insensitive). Previously only `has-conflict`, `hold`, and `wip` labels were checked.

The grep is now case-insensitive (`-iE`), so it matches `Stale`, `STALE`, `stale`, etc. for all skip labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated retest workflow to skip pull requests labeled with stale, in addition to existing labels (has-conflict, hold, wip). Label matching is now case-insensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->