### PR TITLE
Add windows.2k3 and windows.xp to VM preferences list

### DIFF
--- a/tests/infrastructure/instance_types/vm_preference_list.py
+++ b/tests/infrastructure/instance_types/vm_preference_list.py
@@ -30,10 +30,12 @@ VM_PREFERENCES_LIST = {
     "windows": [
         "windows.10",
         "windows.11",
+        "windows.2k3",
         "windows.2k16",
         "windows.2k19",
         "windows.2k22",
         "windows.2k25",
+        "windows.xp",
         "windows.7",
         "windows.2k8",
         "windows.2k12",


### PR DESCRIPTION
##### Short description:
Add windows.2k3 and windows.xp to VM preferences list
Assisted-by :Cursor
##### More details:

##### What this PR does / why we need it:
for fixing failed test runs for 4.19 due to missing preferences

##### Which issue(s) this PR fixes:
Jenkins failure for missing preferences
##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Windows virtual machine variant support to include Windows 2003 and Windows XP options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->