### PR TITLE
Adding ipv6 marker to network metrics tests

### DIFF
--- a/tests/observability/metrics/test_network_metrics.py
+++ b/tests/observability/metrics/test_network_metrics.py
@@ -14,6 +14,7 @@ from tests.observability.metrics.utils import validate_network_traffic_metrics_v
 )
 @pytest.mark.usefixtures("vm_for_test", "linux_vm_for_test_interface_name")
 class TestVmiNetworkMetricsLinux:
+    @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11177")
     @pytest.mark.s390x
     def test_kubevirt_vmi_network_traffic_bytes_total(

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -327,6 +327,7 @@ class TestVmiStatusAddresses:
         "vm_for_test", [pytest.param("vmi-status-addresses", marks=pytest.mark.polarion("CNV-11534"))], indirect=True
     )
     @pytest.mark.s390x
+    @pytest.mark.ipv6
     def test_metric_kubevirt_vmi_status_addresses(
         self,
         prometheus,
@@ -420,6 +421,7 @@ class TestVmVnicInfo:
         ],
         indirect=["vnic_info_from_vm_or_vmi_linux"],
     )
+    @pytest.mark.ipv6
     @pytest.mark.s390x
     def test_metric_kubevirt_vm_vnic_info_linux(
         self, prometheus, running_metric_vm, vnic_info_from_vm_or_vmi_linux, query


### PR DESCRIPTION
##### Short description:
There will be a lane for running tests with single stack ipv6 cluster, for this effort in this PR I'm adding ipv6 marker to network metrics tests for the lane.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-80537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added IPv6 markers to network and VM metrics tests to enable IPv6-specific test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->