### PR TITLE
Revert "Webhook validation tests added to cover bug correction"

### DIFF
--- a/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
+++ b/tests/virt/cluster/common_templates/general/test_base_custom_templates.py
@@ -1,26 +1,18 @@
-import copy
 import logging
 
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
-from ocp_resources.data_source import DataSource
-from ocp_resources.resource import ResourceEditor
 from ocp_resources.template import Template
-from pytest_testconfig import config as py_config
 
 from tests.os_params import FEDORA_LATEST
-from utilities.constants import OS_FLAVOR_FEDORA, NamespacesNames
-from utilities.storage import data_volume_template_with_source_ref_dict
+from utilities.constants import NamespacesNames
 from utilities.virt import (
-    VirtualMachineForTests,
     VirtualMachineForTestsFromTemplate,
     add_validation_rule_to_annotation,
     running_vm,
 )
 
 LOGGER = logging.getLogger(__name__)
-
-TEST_ANNOTATION = "my-test-annotation-1"
 
 
 class CustomTemplate(Template):
@@ -61,7 +53,7 @@ class CustomTemplate(Template):
         self.res = template_dict
 
     def get_template_dict_with_added_vm_validation_rule(self, template_dict):
-        modified_template_dict = copy.deepcopy(template_dict)
+        modified_template_dict = template_dict.copy()
         vm_annotation = modified_template_dict["objects"][0]["metadata"]["annotations"]
         add_validation_rule_to_annotation(vm_annotation=vm_annotation, vm_validation_rule=self.vm_validation_rule)
         return modified_template_dict
@@ -86,45 +78,6 @@ def custom_template_from_base_template(request, admin_client, unprivileged_clien
         vm_validation_rule=request.param.get("validation_rule"),
     ) as custom_template:
         yield custom_template
-
-
-@pytest.fixture()
-def vm_with_custom_template_label(
-    unprivileged_client,
-    namespace,
-    golden_images_namespace,
-    custom_template_from_base_template,
-):
-    with VirtualMachineForTests(
-        name="vm-from-custom-template-webhook-validation",
-        namespace=namespace.name,
-        client=unprivileged_client,
-        data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=DataSource(name=OS_FLAVOR_FEDORA, namespace=golden_images_namespace.name),
-            storage_class=py_config["default_storage_class"],
-        ),
-        metadata_labels={
-            f"{VirtualMachineForTests.ApiGroup.VM_KUBEVIRT_IO}/template": custom_template_from_base_template.name,
-            f"{VirtualMachineForTests.ApiGroup.VM_KUBEVIRT_IO}/template.namespace": namespace.name,
-        },
-    ) as vm:
-        yield vm
-
-
-@pytest.fixture()
-def template_removed(custom_template_from_base_template):
-    # vm_with_custom_template_label required for setup order: VM exists before template is removed
-    LOGGER.info("Deleting custom template to test webhook validation with missing parent")
-    custom_template_from_base_template.clean_up()
-    yield
-
-
-@pytest.fixture()
-def existing_vm_annotation_updated(vm_with_custom_template_label, template_removed):
-    ResourceEditor({
-        vm_with_custom_template_label: {"metadata": {"annotations": {"test.annot": TEST_ANNOTATION}}}
-    }).update()
-    yield vm_with_custom_template_label
 
 
 @pytest.mark.parametrize(
@@ -215,22 +168,3 @@ class TestBaseCustomTemplates:
                 cpu_cores=3,
             ) as vm_from_template:
                 pytest.fail(f"VM validation failed on {vm_from_template.name}")
-
-
-@pytest.mark.parametrize(
-    "custom_template_from_base_template",
-    [
-        pytest.param(
-            {
-                "base_template_name": f"fedora-{Template.Workload.DESKTOP}-{Template.Flavor.SMALL}",
-                "new_template_name": "custom-fedora-template-webhook-validation",
-            },
-        )
-    ],
-    indirect=True,
-)
-@pytest.mark.polarion("CNV-13744")
-def test_no_validation_annotation_missing_parent_template(existing_vm_annotation_updated):
-    assert existing_vm_annotation_updated.instance.metadata.annotations.get("test.annot") == TEST_ANNOTATION, (
-        "Annotation update should succeed even when parent template is missing"
-    )

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -274,7 +274,6 @@ class VirtualMachineForTests(VirtualMachine):
         hugepages_page_size=None,
         vm_affinity=None,
         annotations=None,
-        metadata_labels=None,
     ):
         """
         Virtual machine creation
@@ -341,7 +340,6 @@ class VirtualMachineForTests(VirtualMachine):
             priority_class_name (str, optional): The name of the priority class used for the VM
             dry_run (str, default=None): If "All", the resource will be created using the dry_run flag
             additional_labels (dict, optional): Dict of additional labels for VM (e.g. {"vm-label": "best-vm"})
-                              those labels will be placed in structure spec.template.metadata.labels
             generate_unique_name: if True then it will set dynamic name for the vm, False will use the name of vm passed
             node_selector_labels (str, optional): Labels for node selector.
             vm_instance_type (VirtualMachineInstancetype, optional): instance type object for the VM
@@ -357,8 +355,6 @@ class VirtualMachineForTests(VirtualMachine):
             hugepages_page_size (str, optional) defines the size of huge pages,Valid values are 2 Mi and 1 Gi
             vm_affinity (dict, optional): If affinity is specifies, obey all the affinity rules
             annotations (dict, optional): annotations to be added to the VM
-            metadata_labels (dict, optional): Dict of labels for VM (e.g. {"vm.kubevirt.io/template": "custom-fedora"})
-                                    those labels will be placed in a structure metadata.labels
         """
         # Sets VM unique name - replaces "." with "-" in the name to handle valid values.
 
@@ -372,7 +368,6 @@ class VirtualMachineForTests(VirtualMachine):
             node_selector=node_selector,
             node_selector_labels=node_selector_labels,
             yaml_file=yaml_file,
-            label=metadata_labels,
         )
         self.body = body
         self.interfaces = interfaces or []
@@ -1171,7 +1166,6 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         tpm_params=None,
         additional_labels=None,
         vm_affinity=None,
-        label=None,
     ):
         """
         VM creation using common templates.
@@ -1246,7 +1240,6 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
             additional_labels=additional_labels,
             vm_affinity=vm_affinity,
             os_flavor=self.os_flavor,
-            label=label,
         )
         self.data_source = data_source
         self.data_volume_template = data_volume_template


### PR DESCRIPTION
Reverts RedHatQE/openshift-virtualization-tests#3793
Code breaks usage of `VirtualMachineForTestsFromTemplate`

```
>       super().__init__(
            name=name,
            namespace=namespace,
            client=client,
            networks=networks,
            interfaces=interfaces,
            ssh=ssh,
            network_model=network_model,
            network_multiqueue=network_multiqueue,
            cpu_cores=cpu_cores,
            cpu_threads=cpu_threads,
            cpu_model=cpu_model,
            cpu_sockets=cpu_sockets,
            cpu_flags=cpu_flags,
            cpu_placement=cpu_placement,
            cpu_max_sockets=cpu_max_sockets,
            isolate_emulator_thread=isolate_emulator_thread,
            memory_requests=memory_requests,
            memory_guest=memory_guest,
            memory_max_guest=memory_max_guest,
            cloud_init_data=cloud_init_data,
            node_selector=node_selector,
            attached_secret=attached_secret,
            data_volume_template=data_volume_template,
            diskless_vm=diskless_vm,
            run_strategy=run_strategy,
            disk_io_options=disk_options_vm,
            smm_enabled=smm_enabled,
            pvspinlock_enabled=pvspinlock_enabled,
            efi_params=efi_params,
            macs=macs,
            interfaces_types=interfaces_types,
            host_device_name=host_device_name,
            gpu_name=gpu_name,
            iothreads_policy=iothreads_policy,
            dedicated_iothread=dedicated_iothread,
            vhostmd=vhostmd,
            machine_type=machine_type,
            teardown=teardown,
            dry_run=dry_run,
            tpm_params=tpm_params,
            eviction_strategy=eviction_strategy,
            additional_labels=additional_labels,
            vm_affinity=vm_affinity,
            os_flavor=self.os_flavor,
            label=label,
        )
E       TypeError: VirtualMachineForTests.__init__() got an unexpected keyword argument 'label'

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified VM constructor interfaces by removing unused parameters, making the API cleaner and easier to maintain.
  * Cleaned up test infrastructure by removing unnecessary fixtures and setup configurations.
  * Optimized template handling to use more efficient copying approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->