### PR TITLE
 Quarantine: [IUO] test_common_template_modify_spec causes leftovers

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -16,6 +16,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
 )
 from utilities.constants import (
     DATA_IMPORT_CRON_ENABLE,
+    QUARANTINED,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
     WILDCARD_CRON_EXPRESSION,
 )
@@ -159,7 +160,16 @@ class TestModifyCommonTemplateSpec:
             pytest.param(
                 {"num_templates": 1, "update_dict": UPDATE_STORAGE_CLASS_IN_SPEC},
                 UPDATE_STORAGE_CLASS_IN_SPEC,
-                marks=pytest.mark.polarion("CNV-8740"),
+                marks=(
+                    pytest.mark.polarion("CNV-8740"),
+                    pytest.mark.xfail(
+                        reason=(
+                            f"{QUARANTINED}: VolumeSnapshot source causes DV leftover when applying "
+                            f"non-existent storage class. DV is in pending not cleaned up; Tracked in CNV-80607"
+                        ),
+                        run=False,
+                    ),
+                ),
             ),
         ],
         indirect=["updated_common_template"],


### PR DESCRIPTION
##### Short description:
Volumesnapshot golden image causes leftover.
Might be storage/automation bug.

##### More details:
See https://issues.redhat.com/browse/CNV-80607
##### What this PR does / why we need it:
Since its failing our health-checks in scheduled runs, its better to qurantine until its being figured out.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked a storage-class-related test scenario as expected to fail and excluded it from execution, preventing a known intermittent failure from affecting results.
  * This preserves overall test flow, improves accuracy of test outcomes, and documents the known issue without disrupting CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->