### PR TITLE
[IUO] update feature gate defaults for CNV 4.22

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -33,6 +33,7 @@ EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
     "HypervStrictCheck",
     "VideoConfig",
     "HotplugVolumes",
+    "DecentralizedLiveMigration",
 }
 EXPECTED_CDI_HARDCODED_FEATUREGATES = {
     "DataVolumeClaimAdoption",
@@ -46,10 +47,11 @@ HCO_DEFAULT_FEATUREGATES = {
     "alignCPUs": FG_DISABLED,
     "downwardMetrics": FG_DISABLED,
     "enableMultiArchBootImageImport": FG_DISABLED,
-    "decentralizedLiveMigration": FG_DISABLED,
+    "decentralizedLiveMigration": FG_ENABLED,
     "declarativeHotplugVolumes": FG_DISABLED,
     "videoConfig": FG_ENABLED,
     "objectGraph": FG_DISABLED,
+    "incrementalBackup": FG_DISABLED,
 }
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"


### PR DESCRIPTION
##### Short description:
CNV 4.22 changed decentralizedLiveMigration default to enabled, added incrementalBackup gate, and added
DecentralizedLiveMigration to KubeVirt hardcoded gates.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-80649


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decentralized Live Migration is now enabled by default, providing improved virtualization migration capabilities.
  * Incremental Backup feature is now available (disabled by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->