### PR TITLE
Quarantine: [IUO] xfail test_enable_fg_hco due to feature graduation

### DIFF
--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -7,7 +7,7 @@ from tests.install_upgrade_operators.constants import (
     FEATUREGATES,
     FG_ENABLED,
 )
-from utilities.constants import VALUE_STR
+from utilities.constants import QUARANTINED, VALUE_STR
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 FEATUREGATE_NAME_KEY_STR = "featuregate_name"
@@ -28,6 +28,10 @@ def updated_fg_hco(
         yield
 
 
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: HCO feature gate being replaced with different spec; Tracked in CNV-79304",
+    run=False,
+)
 @pytest.mark.parametrize(
     ("updated_fg_hco", "kubevirt_featuregate_name", "hco_featuregate"),
     [


### PR DESCRIPTION
##### Short description:
The DisableMDevConfiguration in HCO was deprecated in KubeVirt, and the new Enabled field was introduced instead.
Still WIP

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-79304


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked a feature-gate update test as expected to fail and disabled its execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->