### PR TITLE
Fix tekton test image extraction to use Konflux mirrors

### DIFF
--- a/tests/infrastructure/tekton/conftest.py
+++ b/tests/infrastructure/tekton/conftest.py
@@ -25,7 +25,6 @@ from tests.infrastructure.tekton.utils import (
 )
 from utilities.artifactory import get_artifactory_config_map, get_artifactory_secret
 from utilities.constants import (
-    BREW_REGISTERY_SOURCE,
     OS_FLAVOR_FEDORA,
     TEKTON_AVAILABLE_PIPELINEREF,
     TEKTON_AVAILABLE_TASKS,
@@ -115,12 +114,20 @@ def csv_instance(csv_scope_session):
 
 
 @pytest.fixture(scope="session")
-def extracted_tekton_test_image(csv_instance):
-    annotation = csv_instance.metadata.annotations.get("test-images-nvrs", "")
-    for image in annotation.split(","):
-        if KUBEVIRT_TEKTON_AVAILABLE_TASKS_TEST in image:
-            return f"{BREW_REGISTERY_SOURCE}/rh-osbs/container-native-virtualization-{image.strip()}"
-    raise ValueError("Tekton test image not found in CSV annotations.")
+def tekton_test_image_name_and_digest(csv_scope_session):
+    test_images_nvrs = csv_scope_session.instance.metadata.annotations.get("test-images-nvrs")
+    for test_image in test_images_nvrs.split(","):
+        if KUBEVIRT_TEKTON_AVAILABLE_TASKS_TEST in test_image:
+            return test_image.strip()
+    raise ValueError(
+        f"{KUBEVIRT_TEKTON_AVAILABLE_TASKS_TEST} not found in CSV 'test-images-nvrs' annotation: {test_images_nvrs}"
+    )
+
+
+@pytest.fixture(scope="session")
+def tekton_test_image(tekton_test_image_name_and_digest, cnv_current_version):
+    major, minor = cnv_current_version.split(".")[:2]
+    return f"quay.io/openshift-virtualization/konflux-builds/v{major}-{minor}/{tekton_test_image_name_and_digest}"
 
 
 @pytest.fixture(scope="session")
@@ -132,11 +139,11 @@ def extracted_virtio_image_container(csv_instance):
 
 
 @pytest.fixture(scope="session")
-def extracted_kubevirt_tekton_resources(tekton_manifests_dir, extracted_tekton_test_image, generated_pulled_secret):
+def extracted_kubevirt_tekton_resources(tekton_manifests_dir, tekton_test_image, generated_pulled_secret):
     run_command(
         command=shlex.split(
             f"oc image extract --registry-config={generated_pulled_secret} "
-            f"--path release/*:{tekton_manifests_dir} {extracted_tekton_test_image}"
+            f"--path release/*:{tekton_manifests_dir} {tekton_test_image}"
         )
     )
 


### PR DESCRIPTION
##### Short description:
tekton test image kubevirt-tekton-tasks-tests was previously pulled from Brew. With the move to Konflux builds, the Brew path no longer hosts these images causing Tekton pipeline tests to fail during image extraction. These image carry pipeline definitions.

##### More details:
we don't ship test-nvrs so they can never be part of external registry. Accessing them through konflux is only solution as discussed by CI team.
##### What this PR does / why we need it:
small PR change to point to right konflux builds dynamically from ImageDigestMirrorSet resources on the cluster

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
this will fix all tier3 lanes
##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored Tekton test setup to first derive image name and digest, then assemble a full image reference for extraction.
  * Switched resource extraction to use the new image reference for more reliable pulls.
  * Added stricter error handling and clearer diagnostics when CSV annotations or image discovery are missing.
  * Replaced the prior image-extraction flow with the new two-step construction for improved test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->