### PR TITLE
auto-retest action:  update regex to match has-conflicts label name

### DIFF
--- a/.github/workflows/auto-retest-needs-rebase.yml
+++ b/.github/workflows/auto-retest-needs-rebase.yml
@@ -71,7 +71,7 @@ jobs:
             echo "Checking PR #$PR_NUM"
 
             # Check if PR has has-conflict, hold, wip, or stale labels
-            SKIP_LABELS=$(gh pr view $PR_NUM --json labels --jq '.labels[].name' | grep -iE "^(has-conflict|hold|wip|stale)$" || true)
+            SKIP_LABELS=$(gh pr view $PR_NUM --json labels --jq '.labels[].name' | grep -iE "^(has-conflicts|hold|wip|stale)$" || true)
 
             if [ -n "$SKIP_LABELS" ]; then
               echo "PR #$PR_NUM has skip label(s): $SKIP_LABELS, skipping retest"


### PR DESCRIPTION
##### Short description:
prs with conflicts had check runs  auto executed on them due to wrong label name

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated retest workflow to use revised label naming convention for improved workflow configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->