### PR TITLE
[IUO] use full API version (group/version) for HCO resource

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -614,7 +614,7 @@ def get_hyperconverged_resource(client, hco_ns_name):
         namespace=hco_ns_name,
         name=hco_name,
     )
-    hco.api_version = hco.ApiVersion.V1BETA1
+    hco.api_version = f"{hco.ApiGroup.HCO_KUBEVIRT_IO}/{hco.ApiVersion.V1BETA1}"
     if hco.exists:
         return hco
     raise ResourceNotFoundError(f"Hyperconverged: {hco_name} not found in {hco_ns_name}")


### PR DESCRIPTION
##### Short description:
Setting hco.api_version to just "v1beta1" instead of "hco.kubevirt.io/v1beta1" causes failures in ResourceEditor

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HyperConverged resource lookup to use correct API version formatting, ensuring proper resource identification and discovery during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->