### PR TITLE
Guard cnv_current_version against missing csv spec.version

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -956,7 +956,10 @@ def cnv_current_version(installing_cnv, csv_scope_session):
     if installing_cnv:
         return CNV_NOT_INSTALLED
     if csv_scope_session:
-        return csv_scope_session.instance.spec.version
+        version = csv_scope_session.instance.spec.version
+        if not version:
+            raise ValueError("CSV spec.version is missing (field is optional in schema).")
+        return version
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
##### Short description:
spec.version is not a required field in the ClusterServiceVersion schema. If absent, the fixture silently returns None causing unexpected behavior in multiple downstream tests.
##### More details:

##### What this PR does / why we need it:
identified during verifying https://github.com/RedHatQE/openshift-virtualization-tests/pull/3984 that we always assume csv has .spec.version , although it exist but since it's optional if it's not there , We should fail early and at right place

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to ensure CSV specification version information is properly defined, raising an error if the required version field is missing rather than silently accepting empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->