### PR TITLE
Remove duplicated T2 must-gather tests covered by T1 upstream

### DIFF
--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from ocp_resources.image_image_openshift_io import Image
 from ocp_resources.image_stream import ImageStream
@@ -32,11 +34,6 @@ class TestImageGathering:
                 ImageStream,
                 marks=(pytest.mark.polarion("CNV-9235")),
             ),
-            pytest.param(
-                f"namespaces/{NamespacesNames.OPENSHIFT}/imagestreamtags/{{name}}.yaml",
-                ImageStreamTag,
-                marks=(pytest.mark.polarion("CNV-9236")),
-            ),
         ],
     )
     def test_image_gather(self, admin_client, gathered_images, resource, resource_path):
@@ -45,6 +42,22 @@ class TestImageGathering:
             resource_type=resource,
             temp_dir=gathered_images,
             resource_path=resource_path,
+            checks=VALIDATE_UID_NAME,
+            filter_resource="redhat",
+        )
+
+    @pytest.mark.polarion("CNV-9236")
+    def test_image_stream_tag_gather(self, admin_client, gathered_images):
+        resource_path = f"namespaces/{NamespacesNames.OPENSHIFT}/imagestreamtags"
+        istag_dir = os.path.join(gathered_images, resource_path)
+        assert len(os.listdir(istag_dir)) == len(
+            list(ImageStreamTag.get(client=admin_client, namespace=NamespacesNames.OPENSHIFT))
+        ), "ImageStreamTag count mismatch between must-gather and cluster"
+        check_list_of_resources(
+            client=admin_client,
+            resource_type=ImageStreamTag,
+            temp_dir=gathered_images,
+            resource_path=f"{resource_path}/{{name}}.yaml",
             checks=VALIDATE_UID_NAME,
             filter_resource="redhat",
         )

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -4,7 +4,6 @@ import re
 
 import pytest
 from ocp_resources.network_attachment_definition import NetworkAttachmentDefinition
-from ocp_resources.virtual_machine import VirtualMachine
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import FILE_SUFFIX, SECTION_TITLE
@@ -69,13 +68,6 @@ class TestMustGatherClusterWithVMs:
                 VALIDATE_FIELDS,
                 marks=(pytest.mark.polarion("CNV-2720")),
                 id="test_network_attachment_definitions_resources",
-            ),
-            pytest.param(
-                VirtualMachine,
-                f"namespaces/{{namespace}}/{VirtualMachine.ApiGroup.KUBEVIRT_IO}/virtualmachines/custom/{{name}}.yaml",
-                VALIDATE_FIELDS,
-                marks=(pytest.mark.polarion("CNV-3043")),
-                id="test_virtualmachine_resources",
             ),
         ],
         indirect=["resource_type"],


### PR DESCRIPTION

##### Short description:
Remove T2 tests that duplicate validation already performed by T1 tests in the upstream kubevirt/must-gather repo and duplicate tests.

T1 cluster-scoped-resources validation (lines 101-161) checks that each expected resource directory exists, opens the YAML file, fetches the same resource from the cluster, and does reflect.DeepEqual on the full spec. Our T2 tests only compared selected fields (uid/name or uid/name/spec), so T1 is strictly stricter.

- CNV-3042 (NetworkAddonsConfig): T1 validates networkaddonsconfigs at cluster-scoped-resources/ with full spec DeepEqual. https://github.com/kubevirt/must-gather/blob/main/tests/validate_must_gather_test.go#L104
- CNV-3373 (CDIConfig): T1 validates cdiconfigs at cluster-scoped-resources/ with full spec DeepEqual. https://github.com/kubevirt/must-gather/blob/main/tests/validate_must_gather_test.go#L102

T1 VM validation (lines 263-282) iterates VMs per namespace, builds the path at kubevirt.io/virtualmachines/{type}/{name}.yaml, then calls validateVmFile (lines 389-406) which does reflect.DeepEqual on the full spec. Our T2 test only compared uid/name/spec fields.

- CNV-3043 (VirtualMachine): T1 validates VM YAMLs with full spec DeepEqual via validateVmFile. https://github.com/kubevirt/must-gather/blob/main/tests/validate_must_gather_test.go#L263-L282 https://github.com/kubevirt/must-gather/blob/main/tests/validate_must_gather_test.go#L389-L406

- CNV-2939 (ImageStreamTag count): Not a T1 duplicate. Consolidation within our test suite — CNV-9236 in test_must_gather_images.py already validates ImageStreamTag uid/name. The count validation from CNV-2939 is merged into CNV-9236, so no coverage is lost.

Additional changes:
- Add pytest.mark.dependency between test_no_new_cnv_crds (CNV-8508) and test_crd_resources (CNV-2724), since an outdated CRD list means test_crd_resources validates an incomplete set.
- Clean up unused imports (CDIConfig, NetworkAddonsConfig, ImageStreamTag, VirtualMachine).

assisted by: claude code claude-opus-4-6
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-35404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restructured must-gather test suite with improved test organization and dependencies for better validation ordering.
  * Consolidated image stream tag testing into a dedicated test method.
  * Removed obsolete resource validation tests for network add-ons, storage configurations, and virtual machine resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->