### PR TITLE
fix: Remove s390x markers for the unsupported storage tests.

### DIFF
--- a/tests/storage/checkups/test_checkups_negative.py
+++ b/tests/storage/checkups/test_checkups_negative.py
@@ -39,7 +39,6 @@ class TestCheckupNegative:
         )
 
     @pytest.mark.polarion("CNV-10705")
-    @pytest.mark.s390x
     def test_additional_default_storage_class(
         self,
         updated_two_default_storage_classes,
@@ -58,7 +57,6 @@ class TestCheckupNegative:
         )
 
     @pytest.mark.polarion("CNV-10706")
-    @pytest.mark.s390x
     def test_unknown_provisioner(
         self,
         storage_class_with_unknown_provisioner,
@@ -76,7 +74,6 @@ class TestCheckupNegative:
         )
 
     @pytest.mark.polarion("CNV-10711")
-    @pytest.mark.s390x
     def test_golden_image_data_source_not_ready(
         self,
         broken_data_import_cron,


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:
The checkup_job creates a VirtualMachine with TPM enabled. TPM is not supported on s390x, causing the VirtualMachine to fail and all related tests to fail.Remove the s390x markers from the unsupported tests.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed platform-specific test markers to simplify test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->