### PR TITLE
net, udn: Change passt binding plugin to core binding

### DIFF
--- a/libs/net/udn.py
+++ b/libs/net/udn.py
@@ -8,11 +8,15 @@ from libs.vm.spec import Interface, NetBinding, Network
 from utilities.infra import create_ns
 
 UDN_BINDING_DEFAULT_PLUGIN_NAME: Final[str] = "l2bridge"
-UDN_BINDING_PASST_PLUGIN_NAME: Final[str] = "passt"
+UDN_PASST_CORE_BINDING_NAME: Final[str] = "passtBinding"
 
 
 def udn_primary_network(name: str, binding: str) -> tuple[Interface, Network]:
-    return Interface(name=name, binding=NetBinding(name=binding)), Network(name=name, pod={})
+    if binding == UDN_PASST_CORE_BINDING_NAME:
+        interface = Interface(name=name, passtBinding={})
+    else:
+        interface = Interface(name=name, binding=NetBinding(name=binding))
+    return interface, Network(name=name, pod={})
 
 
 def create_udn_namespace(

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -74,6 +74,7 @@ class Interface:
     masquerade: dict[Any, Any] | None = None
     bridge: dict[Any, Any] | None = None
     sriov: dict[Any, Any] | None = None
+    passtBinding: dict[Any, Any] | None = None  # noqa: N815
     binding: NetBinding | None = None
     state: str | None = None
 

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -9,7 +9,7 @@ from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from timeout_sampler import TimeoutExpiredError, retry
 
 from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
-from libs.net.udn import UDN_BINDING_PASST_PLUGIN_NAME
+from libs.net.udn import UDN_PASST_CORE_BINDING_NAME
 from libs.net.vmspec import lookup_primary_network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs.vm_factory import udn_vm
@@ -58,14 +58,14 @@ def passt_running_vm_pair(
             name="vma-passt",
             client=admin_client,
             template_labels=dict((udn_affinity_label,)),
-            binding=UDN_BINDING_PASST_PLUGIN_NAME,
+            binding=UDN_PASST_CORE_BINDING_NAME,
         ) as vm_a,
         udn_vm(
             namespace_name=udn_namespace.name,
             name="vmb-passt",
             client=admin_client,
             template_labels=dict((udn_affinity_label,)),
-            binding=UDN_BINDING_PASST_PLUGIN_NAME,
+            binding=UDN_PASST_CORE_BINDING_NAME,
         ) as vm_b,
     ):
         vm_a.start(wait=False)


### PR DESCRIPTION
As a part of the passt-beta VEP [1] passt is now a core binding instead of a binding plugin.
This commit updates the udn passt tests so that they use VMs with interface that has passtBinding instead of binding:passt

[1] https://github.com/kubevirt/enhancements/blob/main/veps/sig-network/passt/passt-beta.md

##### Special notes for reviewer:
`passtBinding` is the name of the interface binding according to [KubeVirt schema](https://github.com/kubevirt/kubevirt/blob/3e5704a96b730a30e1d1038899130294da6b1c11/staging/src/kubevirt.io/api/core/v1/schema.go#L1524) 
Since this is a camel case and python requires it to be a snake case I have added  noqa at `passtBinding: dict[Any, Any] | None = None  # noqa: N815` following this [example](https://github.com/RedHatQE/openshift-virtualization-tests/blob/580c2ffa2bb2f04daf822b47498e428227c24c76/libs/vm/spec.py#L32) 


##### jira-ticket:
[CNV-76560](https://issues.redhat.com/browse/CNV-76560)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interfaces can now include an optional per-interface passt configuration, and network setup will use that configuration when present.
* **Tests**
  * Test suite updated to validate per-interface passt configuration and ensure expected network behavior when it is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->