### PR TITLE
Revert "Add windows.2k3 and windows.xp to VM preferences list (#3961)"

### DIFF
--- a/tests/infrastructure/instance_types/vm_preference_list.py
+++ b/tests/infrastructure/instance_types/vm_preference_list.py
@@ -30,12 +30,10 @@ VM_PREFERENCES_LIST = {
     "windows": [
         "windows.10",
         "windows.11",
-        "windows.2k3",
         "windows.2k16",
         "windows.2k19",
         "windows.2k22",
         "windows.2k25",
-        "windows.xp",
         "windows.7",
         "windows.2k8",
         "windows.2k12",


### PR DESCRIPTION
##### Short description:
Due to incorrect version of common-instancetypes picked in CNV-v4.19.19.rhel9-6  , incorrect preferences got picked. Reverting back changes. New builds picked the right upstream version and are in sync with upstream code https://github.com/kubevirt/common-instancetypes/tree/release-1.3/VirtualMachineClusterInstancetypes
Refer : https://issues.redhat.com/browse/CNV-81000
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-81000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed preferences for legacy Windows operating systems (Windows 2003 and Windows XP) from instance type configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->