### PR TITLE
net, network policy: Use fixtures' ports

### DIFF
--- a/tests/network/network_policy/conftest.py
+++ b/tests/network/network_policy/conftest.py
@@ -42,7 +42,7 @@ def allow_all_http_ports(unprivileged_client, namespace_1):
 
 
 @pytest.fixture()
-def allow_single_http_port(unprivileged_client, namespace_1):
+def single_http_port_net_policy(unprivileged_client, namespace_1):
     with ApplyNetworkPolicy(
         name="allow-single-http-port",
         namespace=namespace_1.name,

--- a/tests/network/network_policy/test_network_policy.py
+++ b/tests/network/network_policy/test_network_policy.py
@@ -32,7 +32,6 @@ def test_network_policy_deny_all_http(
                     )
 
 
-@pytest.mark.usefixtures("allow_single_http_port")
 @pytest.mark.order(before="test_network_policy_allow_all_http")
 @pytest.mark.polarion("CNV-2775")
 @pytest.mark.single_nic
@@ -42,6 +41,7 @@ def test_network_policy_allow_single_http_port(
     network_policy_vma,
     network_policy_vmb,
     admin_client,
+    single_http_port_net_policy,
 ):
     pod_ips = network_policy_vma.vmi.get_virt_launcher_pod(privileged_client=admin_client).instance.status.podIPs
     for pod_ip_entry in pod_ips:
@@ -49,7 +49,11 @@ def test_network_policy_allow_single_http_port(
         with subtests.test(msg=f"Testing {dst_ip}"):
             run_ssh_commands(
                 host=network_policy_vmb.ssh_exec,
-                commands=[shlex.split(format_curl_command(ip_address=dst_ip, port=TEST_PORTS[0], head=True))],
+                commands=[
+                    shlex.split(
+                        format_curl_command(ip_address=dst_ip, port=single_http_port_net_policy.ports[0], head=True)
+                    )
+                ],
             )
 
             with pytest.raises(CommandExecFailed):
@@ -59,7 +63,6 @@ def test_network_policy_allow_single_http_port(
                 )
 
 
-@pytest.mark.usefixtures("allow_all_http_ports")
 @pytest.mark.polarion("CNV-2774")
 @pytest.mark.single_nic
 @pytest.mark.s390x
@@ -68,6 +71,7 @@ def test_network_policy_allow_all_http(
     network_policy_vma,
     network_policy_vmb,
     admin_client,
+    allow_all_http_ports,
 ):
     pod_ips = network_policy_vma.vmi.get_virt_launcher_pod(privileged_client=admin_client).instance.status.podIPs
     for pod_ip_entry in pod_ips:
@@ -76,6 +80,7 @@ def test_network_policy_allow_all_http(
             run_ssh_commands(
                 host=network_policy_vmb.ssh_exec,
                 commands=[
-                    shlex.split(format_curl_command(ip_address=dst_ip, port=port, head=True)) for port in TEST_PORTS
+                    shlex.split(format_curl_command(ip_address=dst_ip, port=port, head=True))
+                    for port in allow_all_http_ports.ports
                 ],
             )


### PR DESCRIPTION
Small follow-up requested change https://github.com/RedHatQE/openshift-virtualization-tests/pull/3588/changes#r2753623060

Use the allowed ports provided by the fixtures in network policy object instead of the ports constant to improve test readability, and clearly distinguish between allowed and disallowed ports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated network policy tests: renamed and reworked test fixtures and signatures to remove redundant decorators, tests now consume targeted fixtures and iterate over provided ports. This improves test clarity, reduces duplication, and makes the network policy test suite more reliable and easier to extend and maintain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->