### PR TITLE
feat: build Fedora images

### DIFF
--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -13,8 +13,8 @@ jobs:
   guest-fedora-amd64:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-      FEDORA_VERSION: 41
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+      FEDORA_VERSION: 43
       CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -34,7 +34,7 @@ jobs:
         run: sudo chmod 0644 /boot/vmlinuz*
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -10,12 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       FEDORA_VERSION: 43
-      CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -35,6 +33,8 @@ jobs:
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
         run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        env:
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -45,11 +45,14 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+          CPU_ARCH: amd64
         run: ./build.sh
       - name: Logging to quay.io
         run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
       - name: Tag & Push image to staging
         env:
+          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
           remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -16,6 +16,7 @@ jobs:
       FEDORA_VERSION: 43
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -24,17 +25,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             qemu-system-x86 \
+            qemu-system-s390x \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
-      - name: Fetch base Fedora image
+      - name: Fetch base Fedora amd64 image
         working-directory: ./containers/fedora
         run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
         env:
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.x86_64.qcow2
+      - name: Fetch base Fedora s390x image
+        working-directory: ./containers/fedora
+        run: wget -q "https://download.fedoraproject.org/pub/fedora-secondary/releases/41/Cloud/s390x/images/${{ env.FEDORA_IMAGE }}"
+        env:
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.s390x.qcow2
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -45,20 +52,31 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.x86_64.qcow2
           CPU_ARCH: amd64
+        run: ./build.sh
+      - name: Create s390x VM
+        working-directory: ./containers/fedora
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
+          ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.s390x.qcow2
+          CPU_ARCH: s390x
         run: ./build.sh
       - name: Logging to quay.io
         run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
       - name: Tag & Push image to staging
         env:
-          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
           remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
-          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          arch_tag_amd64: "${{ env.FEDORA_VERSION }}-amd64"
+          arch_tag_s390x: "${{ env.FEDORA_VERSION }}-s390x"
           remote_tag: "${{ env.FEDORA_VERSION }}-dev"
         run: |
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman push "${remote_repository}":"${arch_tag}"
-          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag}"
+          podman tag "${local_repository}":"${arch_tag_amd64}" "${remote_repository}":"${arch_tag_amd64}"
+          podman tag "${local_repository}":"${arch_tag_s390x}" "${remote_repository}":"${arch_tag_s390x}"
+          podman push "${remote_repository}":"${arch_tag_amd64}"
+          podman push "${remote_repository}":"${arch_tag_s390x}"
+          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag_amd64}" "${remote_repository}":"${arch_tag_s390x}"
           podman manifest push "${remote_repository}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -10,12 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       FEDORA_VERSION: 43
-      CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -35,6 +33,8 @@ jobs:
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
         run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        env:
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -54,11 +54,14 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+          CPU_ARCH: amd64
         run: ./build.sh
       - name: Logging to quay.io
         run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
       - name: Tag & Push image to staging
         env:
+          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
           remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -1,4 +1,9 @@
 name: "Component Builder Publish"
+permissions:
+  contents: read
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
     paths:
@@ -10,31 +15,55 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora:
+  build-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            url_arch: x86_64
+            qemu_package: qemu-system-x86
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images
+          - arch: arm64
+            url_arch: aarch64
+            qemu_package: qemu-system-aarch64
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images
+          - arch: s390x
+            url_arch: s390x
+            qemu_package: qemu-system-s390x
+            fedora_url: https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images
     env:
-      FEDORA_VERSION: 43
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
-        env:
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -54,20 +83,40 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-          CPU_ARCH: amd64
+          FEDORA_IMAGE: "${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2"
         run: ./build.sh
+
       - name: Logging to quay.io
         run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+
       - name: Tag & Push image to staging
         env:
-          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-          remote_tag: "${{ env.FEDORA_VERSION }}-dev"
         run: |
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman push "${remote_repository}":"${arch_tag}"
-          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag}"
-          podman manifest push "${remote_repository}":"${remote_tag}" --all --format=v2s2
+          podman tag "${local_repository}":"${arch_tag}" "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
+          podman push "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
+
+  create-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: build-images
+    env:
+      # List of architectures must match the matrix in build-images job
+      ARCHITECTURES: "amd64 arm64 s390x"
+    steps:
+      - name: Logging to quay.io
+        run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+
+      - name: Create and push manifest
+        run: |
+          remote_tag="${{ env.FEDORA_VERSION }}-dev"
+          # Build the list of arch-specific image references
+          ARCH_IMAGES=""
+          for arch in ${{ env.ARCHITECTURES }}; do
+            ARCH_IMAGES="${ARCH_IMAGES} ${{ env.REMOTE_REPOSITORY }}:${{ env.FEDORA_VERSION }}-${arch}"
+          done
+          # Create and push the multi-arch manifest
+          podman manifest create --log-level=debug "${{ env.REMOTE_REPOSITORY }}":"${remote_tag}" ${ARCH_IMAGES}
+          podman manifest push "${{ env.REMOTE_REPOSITORY }}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -51,12 +51,12 @@ jobs:
         run: |
           mkdir -p artifacts
           podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image.tar"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-container-image
-          path: artifacts/fedora-image.tar
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
           retention-days: 5
           compression-level: 0

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -60,3 +60,55 @@ jobs:
           path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
           retention-days: 5
           compression-level: 0
+  guest-fedora-s390x:
+    runs-on: ubuntu-latest
+    env:
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.s390x.qcow2
+      FEDORA_VERSION: 43
+      CPU_ARCH: s390x
+      FULL_EMULATION: "true"
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install dependencies for VM build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            qemu-system-s390x \
+            libvirt-daemon-system \
+            virtinst cloud-image-utils \
+            libguestfs-tools
+      - name: Tweak hosted runner to enable 'virt-sysprep'
+        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
+        run: sudo chmod 0644 /boot/vmlinuz*
+      - name: Fetch base Fedora image
+        working-directory: ./containers/fedora
+        run: wget -q "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images/${{ env.FEDORA_IMAGE }}"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.11.2"
+      - name: Create VM
+        working-directory: ./containers/fedora
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          NO_SECRETS: "true"
+        run: ./build.sh
+      - name: Save container image as tarball
+        env:
+          local_repository: "localhost/fedora"
+          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+        run: |
+          mkdir -p artifacts
+          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
+      - name: Upload container image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
+          retention-days: 5
+          compression-level: 0

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -11,8 +11,8 @@ jobs:
   guest-fedora-amd64:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-      FEDORA_VERSION: 41
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+      FEDORA_VERSION: 43
       CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -32,7 +32,7 @@ jobs:
         run: sudo chmod 0644 /boot/vmlinuz*
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -7,32 +7,60 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
+
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            url_arch: x86_64
+            qemu_package: qemu-system-x86
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images
+          - arch: arm64
+            url_arch: aarch64
+            qemu_package: qemu-system-aarch64
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images
+          - arch: s390x
+            url_arch: s390x
+            qemu_package: qemu-system-s390x
+            fedora_url: https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
-      FEDORA_VERSION: 43
-      CPU_ARCH: amd64
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -42,17 +70,19 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
           NO_SECRETS: "true"
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2
         run: ./build.sh
+
       - name: Save container image as tarball
         env:
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
         run: |
           mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          podman tag "${local_repository}":"${arch_tag}" "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
           echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
+
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Open for discussion, since Fedora41 is no longer available, and we would need to change to 43 once the the distribution is tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Fedora VM image builds to support multiple architectures (amd64, arm64, s390x) via a single matrix-driven workflow.
  * Enhanced container publishing by pushing arch-specific images and then generating a multi-architecture manifest for staging tags.
* **Chores**
  * Updated the build-to-publish pipeline to use a dedicated manifest-creation step after the matrix builds.
  * Made container image artifacts architecture-specific for clearer per-arch distribution and tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->