### PR TITLE
CherryPicked: [cnv-4.21] Adding ipv6 marker to network metrics tests

### DIFF
--- a/tests/observability/metrics/test_network_metrics.py
+++ b/tests/observability/metrics/test_network_metrics.py
@@ -14,6 +14,7 @@ from tests.observability.metrics.utils import validate_network_traffic_metrics_v
 )
 @pytest.mark.usefixtures("vm_for_test", "linux_vm_for_test_interface_name")
 class TestVmiNetworkMetricsLinux:
+    @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11177")
     @pytest.mark.s390x
     def test_kubevirt_vmi_network_traffic_bytes_total(

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -325,6 +325,7 @@ class TestVmiStatusAddresses:
         "vm_for_test", [pytest.param("vmi-status-addresses", marks=pytest.mark.polarion("CNV-11534"))], indirect=True
     )
     @pytest.mark.s390x
+    @pytest.mark.ipv6
     def test_metric_kubevirt_vmi_status_addresses(
         self,
         prometheus,
@@ -418,6 +419,7 @@ class TestVmVnicInfo:
         ],
         indirect=["vnic_info_from_vm_or_vmi_linux"],
     )
+    @pytest.mark.ipv6
     @pytest.mark.s390x
     def test_metric_kubevirt_vm_vnic_info_linux(
         self, prometheus, running_metric_vm, vnic_info_from_vm_or_vmi_linux, query


### PR DESCRIPTION
Adds @pytest.mark.ipv6 marker to three network metrics tests to enable running them in a single-stack IPv6 cluster test lane.

Original PR: #3963
assisted by: claude code claude-opus-4-6

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-81212
