### PR TITLE
Quarantine: [storage] test_virtctl_image_upload_pvc

### DIFF
--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -14,6 +14,7 @@ from ocp_resources.route import Route
 from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import config as py_config
 
+from libs.net.cluster import is_ipv6_single_stack_cluster
 from tests.storage.cdi_upload.utils import get_storage_profile_minimum_supported_pvc_size
 from tests.storage.utils import assert_use_populator, create_windows_vm_validate_guest_agent_info
 from utilities.constants import CDI_UPLOADPROXY, QUARANTINED, TIMEOUT_1MIN, Images
@@ -245,6 +246,10 @@ def test_virtctl_image_upload_pvc(download_image, namespace, storage_class_name_
     """
     Check that virtctl can create a new PVC and upload an image to it
     """
+    if is_ipv6_single_stack_cluster():
+        pytest.xfail(
+            reason=f"{QUARANTINED}: virtctl image-upload PVC fails on IPv6 single-stack cluster; tracked in CNV-81258"
+        )
     pvc_name = "cnv-3728"
     with virtctl_upload_dv(
         client=namespace.client,


### PR DESCRIPTION
The test is failing on IPv6 single stack clusters due to virtctl image-upload dialing IPv4 route

Tracked in https://issues.redhat.com/browse/CNV-81258


##### jira-ticket: https://issues.redhat.com/browse/CNV-80606
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated image upload tests to mark as expected-to-fail on IPv6 single‑stack cluster configurations to avoid false negatives.
  * Applied the pre-check to both existing-image and PVC image upload scenarios with quarantine reason CNV-81258.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->