### PR TITLE
[network] Mark flat-overlay jumbo tests as special_infra to avoid failures in unsupported clusters

### DIFF
--- a/tests/network/flat_overlay/test_flat_overlay.py
+++ b/tests/network/flat_overlay/test_flat_overlay.py
@@ -93,6 +93,7 @@ class TestFlatOverlayConnectivity:
 
 
 @pytest.mark.jumbo_frame
+@pytest.mark.special_infra
 class TestFlatOverlayJumboConnectivity:
     @pytest.mark.polarion("CNV-10162")
     @pytest.mark.s390x


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure: added a new pytest marker to tag a public test class for special infra handling, ensuring selected connectivity tests are marked for targeted runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->