### PR TITLE
Silence paramiko PytestUnhandledThreadExceptionWarning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -18,7 +18,7 @@ addopts =
 
 # Remove once https://github.com/paramiko/paramiko/issues/2568 is resolved
 filterwarnings =
-    ignore::pytest.PytestUnhandledThreadExceptionWarning
+    ignore:(?s).*paramiko.*:pytest.PytestUnhandledThreadExceptionWarning
 
 markers =
     # General


### PR DESCRIPTION
Suppress `PytestUnhandledThreadExceptionWarning` caused by paramiko's `ProxyCommand.close()` trying to kill an already-dead process.

Upstream bug: https://github.com/paramiko/paramiko/issues/2568

This filter targets only paramiko-related thread exceptions using `(?s)` dotall flag to match the multiline traceback message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to suppress a specific warning during test runs, improving test output clarity.
  * Added an inline note marking the suppression for future removal once the upstream issue is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->