### PR TITLE
Fix IPv6 address parsing in test_metric_kubevirt_vmi_status_addresses

### DIFF
--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -1,6 +1,6 @@
 import logging
-import re
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 import bitmath
 import pytest
@@ -336,10 +336,8 @@ class TestVmiStatusAddresses:
         kubevirt_vmi_status_addresses_ip_labels_values,
         vm_virt_controller_ip_address,
     ):
-        instance_match = re.match(
-            r"\[?(?P<address>[^]]+)\]?:\d+$", kubevirt_vmi_status_addresses_ip_labels_values.get("instance")
-        )
-        instance_value = instance_match.group("address")
+        instance_value = urlparse(f"//{kubevirt_vmi_status_addresses_ip_labels_values.get('instance')}").hostname
+
         address_value = kubevirt_vmi_status_addresses_ip_labels_values.get("address")
         vm_ip_address = vm_for_test.vmi.interface_ip(interface="eth0")
         assert instance_value == vm_virt_controller_ip_address, (


### PR DESCRIPTION
##### Short description:
The test used .split(":")[0] to extract the IP from the Prometheus instance label (e.g. "10.0.0.1:8443"). On IPv6 clusters the instance label uses bracket notation "[fd02:0:0:1::4d]:8443", so splitting on the first colon produced "[fd02" instead of the full address.

Use .rsplit(":", 1)[0].strip("[]") to correctly handle both IPv4 and IPv6 formats by splitting on the last colon (port separator) and stripping brackets.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://issues.redhat.com/browse/CNV-81455


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics address parsing so observability tests reliably extract hostnames from IPv6 and bracketed address formats. This reduces false positives in instance identification and improves stability and accuracy of metrics-related tests and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->