### PR TITLE
Enhance wait_for_vm_interfaces to detect and log missing interfaces

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -138,12 +138,23 @@ def wait_for_vm_interfaces(vmi: VirtualMachineInstance, timeout: int = TIMEOUT_1
         timeout=timeout,
     )
     LOGGER.info(f"Wait for {vmi.name} network interfaces")
+    expected_names = {
+        iface.name for iface in vmi.instance.spec.domain.devices.interfaces if iface.get("state") != "absent"
+    }
     sampler = TimeoutSampler(wait_timeout=timeout, sleep=1, func=lambda: vmi.instance)
-    for sample in sampler:
-        interfaces = sample.get("status", {}).get("interfaces", [])
-        active_interfaces = [interface for interface in interfaces if interface.get("interfaceName")]
-        if len(active_interfaces) == len(interfaces):
-            return True
+    reported_names = set()
+    try:
+        for sample in sampler:
+            interfaces = sample.get("status", {}).get("interfaces", [])
+            reported_names = {iface.get("name") for iface in interfaces if iface.get("name")}
+            if reported_names == expected_names and all(iface.get("interfaceName") for iface in interfaces):
+                return True
+    except TimeoutExpiredError:
+        LOGGER.error(
+            f"VMI {vmi.name}: expected interfaces: {expected_names}, reported: {reported_names}. "
+            f"Missing (not reported by guest agent): {expected_names - reported_names}."
+        )
+        raise
     return False
 
 


### PR DESCRIPTION
##### Short description:
Previously the function compared interface counts, making it hard  to tell which interface failed to come up after migration. 
##### More details:
with this change , it's easy to identify  which interface was missing. Missing interfaces can happen due to hotplug failures , missing nic maybe during migrations.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM interface validation to accurately match expected interface names against reported interfaces. Enhanced error handling with detailed logging of interface name discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->