### PR TITLE
Fix client warning on test_vhostmd.py

### DIFF
--- a/tests/infrastructure/vhostmd/test_vhostmd.py
+++ b/tests/infrastructure/vhostmd/test_vhostmd.py
@@ -47,11 +47,12 @@ def download_and_install_vm_dump_metrics(vm, rpm_file_name):
 
 
 @pytest.fixture(scope="module")
-def enabled_downward_metrics_hco_featuregate(hyperconverged_resource_scope_module):
+def enabled_downward_metrics_hco_featuregate(admin_client, hyperconverged_resource_scope_module):
     with ResourceEditorValidateHCOReconcile(
         patches={hyperconverged_resource_scope_module: {"spec": {"featureGates": {"downwardMetrics": True}}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,
+        admin_client=admin_client,
     ):
         yield
 


### PR DESCRIPTION
##### Short description:
Fix client warning on test_vhostmd.py

##### More details:
The warning comes from the enabled_downward_metrics_hco_featuregate fixture. ResourceEditorValidateHCOReconcile creates backup Resource instances internally and needs the admin_client parameter.

##### What this PR does / why we need it:
Fix deprecation warning showing

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-68519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to support admin-scoped validation testing with enhanced reconciliation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->