### PR TITLE
WIP: Storage: Refactor test_online_resize test suit.

### DIFF
--- a/tests/storage/online_resize/conftest.py
+++ b/tests/storage/online_resize/conftest.py
@@ -6,28 +6,27 @@ Fixtures for online resize tests
 
 import pytest
 
-from tests.storage.online_resize.utils import (
+from tests.storage.online_resize.constants import (
     SMALLEST_POSSIBLE_EXPAND,
     STORED_FILENAME,
+)
+from tests.storage.online_resize.utils import (
     cksum_file,
     create_rhel_dv_from_data_source,
     expand_pvc,
     wait_for_resize,
 )
 from utilities.constants import OS_FLAVOR_RHEL, Images, StorageClassNames
-from utilities.storage import create_dv, is_snapshot_supported_by_sc
-from utilities.virt import VirtualMachineForTests, running_vm
+from utilities.storage import add_dv_to_vm, create_dv
+from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
 
 
 @pytest.fixture(scope="module")
 def xfail_if_storage_for_online_resize_does_not_support_snapshots(
-    admin_client, storage_class_matrix_online_resize_matrix__module__
+    storage_class_matrix_online_resize_matrix__module__,
 ):
     sc_name = [*storage_class_matrix_online_resize_matrix__module__][0]
-    if not is_snapshot_supported_by_sc(
-        sc_name=sc_name,
-        client=admin_client,
-    ):
+    if not storage_class_matrix_online_resize_matrix__module__[sc_name].get("snapshot"):
         pytest.xfail(f"Storage class for online resize '{sc_name}' doesn't support snapshots")
 
 
@@ -101,3 +100,16 @@ def rhel_vm_after_expand(rhel_dv_for_online_resize, rhel_vm_for_online_resize, r
 @pytest.fixture()
 def running_rhel_vm(rhel_vm_for_online_resize):
     return running_vm(vm=rhel_vm_for_online_resize)
+
+
+@pytest.fixture()
+def running_rhel_vm_with_second_dv(rhel_vm_for_online_resize, second_rhel_dv_for_online_resize):
+    add_dv_to_vm(vm=rhel_vm_for_online_resize, dv_name=second_rhel_dv_for_online_resize.name)
+    running_vm(vm=rhel_vm_for_online_resize)
+    return rhel_vm_for_online_resize
+
+
+@pytest.fixture()
+def rhel_vm_after_expand_and_migrate(rhel_vm_after_expand):
+    migrate_vm_and_verify(vm=rhel_vm_after_expand, check_ssh_connectivity=True)
+    return rhel_vm_after_expand

--- a/tests/storage/online_resize/conftest.py
+++ b/tests/storage/online_resize/conftest.py
@@ -26,7 +26,7 @@ def xfail_if_storage_for_online_resize_does_not_support_snapshots(
     storage_class_matrix_online_resize_matrix__module__,
 ):
     sc_name = [*storage_class_matrix_online_resize_matrix__module__][0]
-    if not storage_class_matrix_online_resize_matrix__module__[sc_name].get("snapshot"):
+    if storage_class_matrix_online_resize_matrix__module__[sc_name].get("snapshot") is not True:
         pytest.xfail(f"Storage class for online resize '{sc_name}' doesn't support snapshots")
 
 

--- a/tests/storage/online_resize/constants.py
+++ b/tests/storage/online_resize/constants.py
@@ -1,0 +1,9 @@
+"""
+Constants for online resize tests
+"""
+
+SMALLEST_POSSIBLE_EXPAND = "1Gi"
+STORED_FILENAME = "random_data_file"
+
+# Increase DV size to 40Gi because source storage size should be larger than the target storage size
+RHEL_DV_SIZE = "40Gi"

--- a/tests/storage/online_resize/constants.py
+++ b/tests/storage/online_resize/constants.py
@@ -5,5 +5,4 @@ Constants for online resize tests
 SMALLEST_POSSIBLE_EXPAND = "1Gi"
 STORED_FILENAME = "random_data_file"
 
-# Increase DV size to 40Gi because source storage size should be larger than the target storage size
 RHEL_DV_SIZE = "40Gi"

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -115,7 +115,7 @@ def test_disk_expand_then_clone_fail(
             wait_timeout=TIMEOUT_1MIN,
             sleep=TIMEOUT_5SEC,
             func=dv.get_condition_message,
-            condition_type=DataVolume.Condition.Type.READY,
+            condition_type=dv.Condition.Type.READY,
         ):
             if (
                 sample

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -80,7 +80,7 @@ def test_simultaneous_disk_expand(
     second_rhel_dv_for_online_resize,
     running_rhel_vm_with_second_dv,
 ):
-    with wait_for_resize(vm=running_rhel_vm_with_second_dv):
+    with wait_for_resize(vm=running_rhel_vm_with_second_dv, devices=("/dev/vda", "/dev/vdc")):
         expand_pvc(dv=rhel_dv_for_online_resize, size_change=SMALLEST_POSSIBLE_EXPAND)
         expand_pvc(dv=second_rhel_dv_for_online_resize, size_change=SMALLEST_POSSIBLE_EXPAND)
 

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -6,21 +6,23 @@ Online resize (PVC expanded while VM running)
 
 import logging
 
+import bitmath
 import pytest
 from ocp_resources.datavolume import DataVolume
 from timeout_sampler import TimeoutSampler
 
-from tests.storage.online_resize.utils import (
+from tests.storage.online_resize.constants import (
     RHEL_DV_SIZE,
     SMALLEST_POSSIBLE_EXPAND,
+)
+from tests.storage.online_resize.utils import (
     check_file_unchanged,
     expand_pvc,
     vm_restore,
     wait_for_resize,
 )
 from utilities.constants import TIMEOUT_1MIN, TIMEOUT_4MIN, TIMEOUT_5SEC
-from utilities.storage import add_dv_to_vm, create_dv, vm_snapshot
-from utilities.virt import migrate_vm_and_verify, running_vm
+from utilities.storage import create_dv, vm_snapshot
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,10 +47,20 @@ def test_sequential_disk_expand(
     rhel_vm_for_online_resize,
     running_rhel_vm,
 ):
-    # Expand PVC and wait for resize 6 times
+    initial_capacity = bitmath.parse_string_unsafe(s=rhel_dv_for_online_resize.pvc.instance.status.capacity.storage)
+    total_expansion = bitmath.parse_string_unsafe(s="0Gi")
+
     for _ in range(6):
         with wait_for_resize(vm=rhel_vm_for_online_resize):
             expand_pvc(dv=rhel_dv_for_online_resize, size_change=SMALLEST_POSSIBLE_EXPAND)
+        total_expansion += bitmath.parse_string_unsafe(s=SMALLEST_POSSIBLE_EXPAND)
+
+    expected_capacity = initial_capacity + total_expansion
+    final_capacity = bitmath.parse_string_unsafe(s=rhel_dv_for_online_resize.pvc.instance.status.capacity.storage)
+
+    assert final_capacity == expected_capacity, (
+        f"PVC capacity mismatch: expected {expected_capacity.best_prefix()}, got {final_capacity.best_prefix()}"
+    )
 
 
 @pytest.mark.polarion("CNV-6794")
@@ -66,11 +78,9 @@ def test_sequential_disk_expand(
 def test_simultaneous_disk_expand(
     rhel_dv_for_online_resize,
     second_rhel_dv_for_online_resize,
-    rhel_vm_for_online_resize,
+    running_rhel_vm_with_second_dv,
 ):
-    add_dv_to_vm(vm=rhel_vm_for_online_resize, dv_name=second_rhel_dv_for_online_resize.name)
-    running_vm(vm=rhel_vm_for_online_resize)
-    with wait_for_resize(vm=rhel_vm_for_online_resize, count=2):
+    with wait_for_resize(vm=running_rhel_vm_with_second_dv, count=2):
         expand_pvc(dv=rhel_dv_for_online_resize, size_change=SMALLEST_POSSIBLE_EXPAND)
         expand_pvc(dv=second_rhel_dv_for_online_resize, size_change=SMALLEST_POSSIBLE_EXPAND)
 
@@ -104,12 +114,13 @@ def test_disk_expand_then_clone_fail(
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_1MIN,
             sleep=TIMEOUT_5SEC,
-            func=lambda: dv.instance.status.conditions,
+            func=lambda: dv.get_condition_message(condition_type=DataVolume.Condition.Type.READY),
         ):
-            if any(
-                "The clone doesn't meet the validation requirements:"
-                " target resources requests storage size is smaller than the source" in condition["message"]
-                for condition in sample
+            if (
+                sample
+                and "The clone doesn't meet the validation requirements:"
+                " target resources requests storage size is smaller than the source"
+                in sample
             ):
                 return
 
@@ -165,12 +176,8 @@ def test_disk_expand_then_clone_success(
     indirect=True,
 )
 @pytest.mark.s390x
-def test_disk_expand_then_migrate(rhel_vm_after_expand, orig_cksum):
-    migrate_vm_and_verify(
-        vm=rhel_vm_after_expand,
-        check_ssh_connectivity=True,
-    )
-    check_file_unchanged(orig_cksum=orig_cksum, vm=rhel_vm_after_expand)
+def test_disk_expand_then_migrate(rhel_vm_after_expand_and_migrate, orig_cksum):
+    check_file_unchanged(orig_cksum=orig_cksum, vm=rhel_vm_after_expand_and_migrate)
 
 
 @pytest.mark.polarion("CNV-6797")

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -114,7 +114,8 @@ def test_disk_expand_then_clone_fail(
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_1MIN,
             sleep=TIMEOUT_5SEC,
-            func=lambda: dv.get_condition_message(condition_type=DataVolume.Condition.Type.READY),
+            func=dv.get_condition_message,
+            condition_type=DataVolume.Condition.Type.READY,
         ):
             if (
                 sample

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -80,7 +80,7 @@ def test_simultaneous_disk_expand(
     second_rhel_dv_for_online_resize,
     running_rhel_vm_with_second_dv,
 ):
-    with wait_for_resize(vm=running_rhel_vm_with_second_dv, count=2):
+    with wait_for_resize(vm=running_rhel_vm_with_second_dv):
         expand_pvc(dv=rhel_dv_for_online_resize, size_change=SMALLEST_POSSIBLE_EXPAND)
         expand_pvc(dv=second_rhel_dv_for_online_resize, size_change=SMALLEST_POSSIBLE_EXPAND)
 

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -13,16 +13,15 @@ from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.storage.online_resize.constants import (
+    RHEL_DV_SIZE,
+    STORED_FILENAME,
+)
 from utilities.constants import TIMEOUT_4MIN
 from utilities.storage import create_dv
 from utilities.virt import running_vm
 
 LOGGER = logging.getLogger(__name__)
-SMALLEST_POSSIBLE_EXPAND = "1Gi"
-STORED_FILENAME = "random_data_file"
-
-# Increase DV size to 40Gi because source storage size should be larger than the target storage size
-RHEL_DV_SIZE = "40Gi"
 
 
 @contextmanager
@@ -102,11 +101,20 @@ def expand_pvc(dv, size_change):
     })
 
 
-def get_resize_count(vm):
-    commands = shlex.split("sudo dmesg | grep -c 'new size' || true")
-    result = run_ssh_commands(host=vm.ssh_exec, commands=commands)[0]
+def get_block_device_size_bytes(vm, device="/dev/vda"):
+    """
+    Get block device size in bytes using lsblk.
 
-    return int(result)
+    Args:
+        vm: VM to run command on
+        device: Block device to check (e.g., /dev/vda)
+
+    Returns:
+        int: Block device size in bytes
+    """
+    commands = shlex.split(f"lsblk -b -d -n -o SIZE {device}")
+    result = run_ssh_commands(host=vm.ssh_exec, commands=commands)[0]
+    return int(result.strip())
 
 
 def check_file_unchanged(orig_cksum, vm):
@@ -118,26 +126,39 @@ def check_file_unchanged(orig_cksum, vm):
 
 @contextmanager
 def wait_for_resize(vm, count=1):
-    starting_count = get_resize_count(vm=vm)
-    desired_count = starting_count + count
+    """
+    Captures block device size before block executes, waits for it to increase after block exits.
+
+    Uses lsblk to verify the block device size increased, which directly reflects the PVC expansion.
+
+    Args:
+        vm: VM to monitor for block device size change
+        count: Expected number of resize operations (used for logging)
+
+    Raises:
+        TimeoutExpiredError: If block device size doesn't increase
+    """
+    starting_size = get_block_device_size_bytes(vm=vm)
     yield
     samples = TimeoutSampler(
         wait_timeout=TIMEOUT_4MIN,
         sleep=5,
-        func=get_resize_count,
+        func=get_block_device_size_bytes,
         vm=vm,
     )
     try:
         for sample in samples:
-            current_resize_count = sample
+            current_size = sample
             LOGGER.info(
-                f"Current resize count is {current_resize_count}. Waiting until resize count is {desired_count}"
+                f"Current block device size: {current_size} bytes. "
+                f"Waiting for size to exceed {starting_size} bytes"
             )
-            if current_resize_count in (desired_count, desired_count + 1):
+            if current_size > starting_size:
+                LOGGER.info(f"Block device expanded from {starting_size} to {current_size} bytes")
                 break
     except TimeoutExpiredError:
-        dmesg = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("dmesg"))[0]
-        LOGGER.error(f"Failed to reach resize count {desired_count}.\ndmesg:\n{dmesg}")
+        lsblk_output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("lsblk -b"))[0]
+        LOGGER.error(f"Block device size did not increase.\nlsblk -b:\n{lsblk_output}")
         raise
 
 

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -127,47 +127,39 @@ def check_file_unchanged(orig_cksum, vm):
 @contextmanager
 def wait_for_resize(vm, count=1):
     """
-    Captures block device sizes before block executes, waits for them to increase after block exits.
+    Captures block device size before block executes, waits for it to increase after block exits.
 
-    Uses lsblk to verify block device sizes increased, which directly reflects PVC expansion.
-    Verifies devices /dev/vda through /dev/vd{a+count-1} based on the count parameter.
+    Uses lsblk to verify the block device size increased, which directly reflects the PVC expansion.
 
     Args:
-        vm: VM to monitor for block device size changes
-        count: Number of block devices to verify (1=/dev/vda, 2=/dev/vda+/dev/vdb, etc.)
+        vm: VM to monitor for block device size change
+        count: Expected number of resize operations (used for logging)
 
     Raises:
-        TimeoutExpiredError: If any block device size doesn't increase
+        TimeoutExpiredError: If block device size doesn't increase
     """
-    devices = [f"/dev/vd{chr(ord('a') + i)}" for i in range(count)]
-    starting_sizes = {device: get_block_device_size_bytes(vm=vm, device=device) for device in devices}
-    LOGGER.info(f"Initial block device sizes: {starting_sizes}")
-
+    starting_size = get_block_device_size_bytes(vm=vm)
     yield
-
-    for device in devices:
-        starting_size = starting_sizes[device]
-        samples = TimeoutSampler(
-            wait_timeout=TIMEOUT_4MIN,
-            sleep=5,
-            func=get_block_device_size_bytes,
-            vm=vm,
-            device=device,
-        )
-        try:
-            for sample in samples:
-                current_size = sample
-                LOGGER.info(
-                    f"Device {device}: current size {current_size} bytes, "
-                    f"waiting for size to exceed {starting_size} bytes"
-                )
-                if current_size > starting_size:
-                    LOGGER.info(f"Device {device} expanded from {starting_size} to {current_size} bytes")
-                    break
-        except TimeoutExpiredError:
-            lsblk_output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("lsblk -b"))[0]
-            LOGGER.error(f"Device {device} size did not increase.\nlsblk -b:\n{lsblk_output}")
-            raise
+    samples = TimeoutSampler(
+        wait_timeout=TIMEOUT_4MIN,
+        sleep=5,
+        func=get_block_device_size_bytes,
+        vm=vm,
+    )
+    try:
+        for sample in samples:
+            current_size = sample
+            LOGGER.info(
+                f"Current block device size: {current_size} bytes. "
+                f"Waiting for size to exceed {starting_size} bytes"
+            )
+            if current_size > starting_size:
+                LOGGER.info(f"Block device expanded from {starting_size} to {current_size} bytes")
+                break
+    except TimeoutExpiredError:
+        lsblk_output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("lsblk -b"))[0]
+        LOGGER.error(f"Block device size did not increase.\nlsblk -b:\n{lsblk_output}")
+        raise
 
 
 @contextmanager

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -151,9 +151,7 @@ def wait_for_resize(vm, devices=("/dev/vda",)):
         try:
             for sample in samples:
                 current_size = sample
-                LOGGER.info(
-                    f"[{device}] Current size: {current_size} bytes. Waiting to exceed {starting_size} bytes"
-                )
+                LOGGER.info(f"[{device}] Current size: {current_size} bytes. Waiting to exceed {starting_size} bytes")
                 if current_size > starting_size:
                     LOGGER.info(f"[{device}] Expanded from {starting_size} to {current_size} bytes")
                     break

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -127,39 +127,47 @@ def check_file_unchanged(orig_cksum, vm):
 @contextmanager
 def wait_for_resize(vm, count=1):
     """
-    Captures block device size before block executes, waits for it to increase after block exits.
+    Captures block device sizes before block executes, waits for them to increase after block exits.
 
-    Uses lsblk to verify the block device size increased, which directly reflects the PVC expansion.
+    Uses lsblk to verify block device sizes increased, which directly reflects PVC expansion.
+    Verifies devices /dev/vda through /dev/vd{a+count-1} based on the count parameter.
 
     Args:
-        vm: VM to monitor for block device size change
-        count: Expected number of resize operations (used for logging)
+        vm: VM to monitor for block device size changes
+        count: Number of block devices to verify (1=/dev/vda, 2=/dev/vda+/dev/vdb, etc.)
 
     Raises:
-        TimeoutExpiredError: If block device size doesn't increase
+        TimeoutExpiredError: If any block device size doesn't increase
     """
-    starting_size = get_block_device_size_bytes(vm=vm)
+    devices = [f"/dev/vd{chr(ord('a') + i)}" for i in range(count)]
+    starting_sizes = {device: get_block_device_size_bytes(vm=vm, device=device) for device in devices}
+    LOGGER.info(f"Initial block device sizes: {starting_sizes}")
+
     yield
-    samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_4MIN,
-        sleep=5,
-        func=get_block_device_size_bytes,
-        vm=vm,
-    )
-    try:
-        for sample in samples:
-            current_size = sample
-            LOGGER.info(
-                f"Current block device size: {current_size} bytes. "
-                f"Waiting for size to exceed {starting_size} bytes"
-            )
-            if current_size > starting_size:
-                LOGGER.info(f"Block device expanded from {starting_size} to {current_size} bytes")
-                break
-    except TimeoutExpiredError:
-        lsblk_output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("lsblk -b"))[0]
-        LOGGER.error(f"Block device size did not increase.\nlsblk -b:\n{lsblk_output}")
-        raise
+
+    for device in devices:
+        starting_size = starting_sizes[device]
+        samples = TimeoutSampler(
+            wait_timeout=TIMEOUT_4MIN,
+            sleep=5,
+            func=get_block_device_size_bytes,
+            vm=vm,
+            device=device,
+        )
+        try:
+            for sample in samples:
+                current_size = sample
+                LOGGER.info(
+                    f"Device {device}: current size {current_size} bytes, "
+                    f"waiting for size to exceed {starting_size} bytes"
+                )
+                if current_size > starting_size:
+                    LOGGER.info(f"Device {device} expanded from {starting_size} to {current_size} bytes")
+                    break
+        except TimeoutExpiredError:
+            lsblk_output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("lsblk -b"))[0]
+            LOGGER.error(f"Device {device} size did not increase.\nlsblk -b:\n{lsblk_output}")
+            raise
 
 
 @contextmanager

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -125,39 +125,42 @@ def check_file_unchanged(orig_cksum, vm):
 
 
 @contextmanager
-def wait_for_resize(vm):
+def wait_for_resize(vm, devices=("/dev/vda",)):
     """
-    Captures block device size before block executes, waits for it to increase after block exits.
+    Captures block device sizes before block executes, waits for all to increase after block exits.
 
-    Uses lsblk to verify the block device size increased, which directly reflects the PVC expansion.
+    Uses lsblk to verify block device sizes increased, which directly reflects PVC expansion.
 
     Args:
-        vm: VM to monitor for block device size change
+        vm: VM to monitor for block device size changes
+        devices: Tuple of block devices to monitor (e.g., ("/dev/vda", "/dev/vdc" (Second DV device)))
 
     Raises:
-        TimeoutExpiredError: If block device size doesn't increase
+        TimeoutExpiredError: If any block device size doesn't increase
     """
-    starting_size = get_block_device_size_bytes(vm=vm)
+    starting_sizes = {device: get_block_device_size_bytes(vm=vm, device=device) for device in devices}
     yield
-    samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_4MIN,
-        sleep=5,
-        func=get_block_device_size_bytes,
-        vm=vm,
-    )
-    try:
-        for sample in samples:
-            current_size = sample
-            LOGGER.info(
-                f"Current block device size: {current_size} bytes. Waiting for size to exceed {starting_size} bytes"
-            )
-            if current_size > starting_size:
-                LOGGER.info(f"Block device expanded from {starting_size} to {current_size} bytes")
-                break
-    except TimeoutExpiredError:
-        lsblk_output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("lsblk -b"))[0]
-        LOGGER.error(f"Block device size did not increase.\nlsblk -b:\n{lsblk_output}")
-        raise
+    for device, starting_size in starting_sizes.items():
+        samples = TimeoutSampler(
+            wait_timeout=TIMEOUT_4MIN,
+            sleep=5,
+            func=get_block_device_size_bytes,
+            vm=vm,
+            device=device,
+        )
+        try:
+            for sample in samples:
+                current_size = sample
+                LOGGER.info(
+                    f"[{device}] Current size: {current_size} bytes. Waiting to exceed {starting_size} bytes"
+                )
+                if current_size > starting_size:
+                    LOGGER.info(f"[{device}] Expanded from {starting_size} to {current_size} bytes")
+                    break
+        except TimeoutExpiredError:
+            lsblk_output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("lsblk -b"))[0]
+            LOGGER.error(f"[{device}] Size did not increase.\nlsblk -b:\n{lsblk_output}")
+            raise
 
 
 @contextmanager

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -7,11 +7,15 @@ Utility functions and context managers for online resize tests
 import logging
 import shlex
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import bitmath
 from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+if TYPE_CHECKING:
+    from utilities.virt import VirtualMachine
 
 from tests.storage.online_resize.constants import (
     RHEL_DV_SIZE,
@@ -101,7 +105,7 @@ def expand_pvc(dv, size_change):
     })
 
 
-def get_block_device_size_bytes(vm, device="/dev/vda"):
+def get_block_device_size_bytes(vm: "VirtualMachine", device: str = "/dev/vda") -> int:
     """
     Get block device size in bytes using lsblk.
 

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -125,7 +125,7 @@ def check_file_unchanged(orig_cksum, vm):
 
 
 @contextmanager
-def wait_for_resize(vm, count=1):
+def wait_for_resize(vm):
     """
     Captures block device size before block executes, waits for it to increase after block exits.
 
@@ -133,7 +133,6 @@ def wait_for_resize(vm, count=1):
 
     Args:
         vm: VM to monitor for block device size change
-        count: Expected number of resize operations (used for logging)
 
     Raises:
         TimeoutExpiredError: If block device size doesn't increase
@@ -150,8 +149,7 @@ def wait_for_resize(vm, count=1):
         for sample in samples:
             current_size = sample
             LOGGER.info(
-                f"Current block device size: {current_size} bytes. "
-                f"Waiting for size to exceed {starting_size} bytes"
+                f"Current block device size: {current_size} bytes. Waiting for size to exceed {starting_size} bytes"
             )
             if current_size > starting_size:
                 LOGGER.info(f"Block device expanded from {starting_size} to {current_size} bytes")


### PR DESCRIPTION
##### Short description:
This PR comes from changing some test into https://github.com/RedHatQE/openshift-virtualization-tests/pull/2300. Was decided to refactor all `tests/storage/online_resize` test suit. 
**Please read carefully "What this PR does" section**
##### More details:
jira: https://issues.redhat.com/browse/CNV-71565
##### What this PR does / why we need it:
This PR changes different parts into the code for `online_resize` test described below:

- Handle TimeOut error by using `get_condition_message` from the wrapper. 
- Seems there is repeated code affecting test logic. Need to do some research in test workflow to consider if code is repeated and if does make sense to keep this code as it is now or refactor it. **This was already removed**
- Add verification in` test _ test_sequential_disk_expand_ `as the test was not verifying nothing. 
- Create` /online_resize/constants.py `and move variables as needed. 
- Modify test `test_simultaneous_disk_expand` to add fixtures for this test.
- Refactor `checksum_file` function to modify the command to run via ssh into vm to return checksum, this might clean up the code. **Leave it as it is as current code works.**
- Refactor function` wait_for_resize` to explain the logic, adding docstring explaining it.
- Change` xfail_if_storage_for_online_resize_does_not_support_snapshots` function to get information from matrix dictionary. 
- Refactor function` get_resize_count` to be more customer kind of check PVC expansion. 
- Move `migrate_vm_and_verify` from test `test_disk_expand_then_migrate` to a fixture.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
For more details of the changes, there are links into jira ticket to the PR reviews comments.

Assisted by Cursor AI
##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fixtures to exercise VM migration during online disk resize and to attach a second disk for simultaneous operations.
  * Switched to data-driven snapshot capability checks and added broader migration/expand workflows.
  * Improved readiness polling for disks and VMs and adjusted tests for sequential, simultaneous, clone and migrate scenarios.

* **Refactor**
  * Moved online-resize constants into a dedicated module.
  * Replaced dmesg-based detection with direct block-device size monitoring for resize verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->