### PR TITLE
WIP: Virt: Replace get_client() usage in utilities/virt.py (fedora_vm_body func part)

### DIFF
--- a/tests/chaos/utils.py
+++ b/tests/chaos/utils.py
@@ -298,7 +298,7 @@ def create_vm_with_nginx_service(chaos_namespace, admin_client, utility_pods, no
     with VirtualMachineForTests(
         namespace=chaos_namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=admin_client,
         node_selector_labels=node_selector_label,
         additional_labels=MIGRATION_POLICY_VM_LABEL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1650,6 +1650,7 @@ def upgrade_bridge_marker_nad(admin_client, bridge_on_one_node, kmp_enabled_name
 
 @pytest.fixture(scope="session")
 def running_vm_upgrade_a(
+    admin_client,
     unprivileged_client,
     upgrade_bridge_marker_nad,
     kmp_enabled_namespace,
@@ -1663,7 +1664,7 @@ def running_vm_upgrade_a(
         interfaces=[upgrade_bridge_marker_nad.name],
         client=unprivileged_client,
         cloud_init_data=cloud_init(ip_address="10.200.100.1"),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         eviction_strategy=ES_NONE,
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)
@@ -1672,6 +1673,7 @@ def running_vm_upgrade_a(
 
 @pytest.fixture(scope="session")
 def running_vm_upgrade_b(
+    admin_client,
     unprivileged_client,
     upgrade_bridge_marker_nad,
     kmp_enabled_namespace,
@@ -1685,7 +1687,7 @@ def running_vm_upgrade_b(
         interfaces=[upgrade_bridge_marker_nad.name],
         client=unprivileged_client,
         cloud_init_data=cloud_init(ip_address="10.200.100.2"),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         eviction_strategy=ES_NONE,
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)
@@ -2203,12 +2205,12 @@ def kmp_deployment(admin_client, hco_namespace):
 
 
 @pytest.fixture(scope="class")
-def running_metric_vm(namespace, unprivileged_client):
+def running_metric_vm(admin_client, namespace, unprivileged_client):
     name = "running-metrics-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         network_model=VIRTIO,
     ) as vm:
@@ -2342,12 +2344,12 @@ def storage_class_with_block_volume_mode(available_storage_classes_names):
 
 
 @pytest.fixture(scope="class")
-def vm_for_test(request, namespace, unprivileged_client):
+def vm_for_test(request, admin_client, namespace, unprivileged_client):
     vm_name = request.param
     with VirtualMachineForTests(
         client=unprivileged_client,
         name=vm_name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         namespace=namespace.name,
     ) as vm:
         running_vm(vm=vm)
@@ -2528,12 +2530,12 @@ def dvs_for_upgrade(
 
 
 @pytest.fixture(scope="class")
-def vm_for_migration_test(request, namespace, unprivileged_client, cpu_for_migration):
+def vm_for_migration_test(request, admin_client, namespace, unprivileged_client, cpu_for_migration):
     vm_name = request.param
     with VirtualMachineForTests(
         client=unprivileged_client,
         name=vm_name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
         namespace=namespace.name,
     ) as vm:

--- a/tests/infrastructure/workload_availability/remediation_fencing/conftest.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing/conftest.py
@@ -35,13 +35,13 @@ def checkup_nodehealthcheck_operator_deployment(admin_client):
 
 
 @pytest.fixture()
-def nhc_vm_with_run_strategy_always(namespace, unprivileged_client):
+def nhc_vm_with_run_strategy_always(admin_client, namespace, unprivileged_client):
     name = "nhc-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:
         running_vm(vm=vm)

--- a/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
@@ -48,13 +48,13 @@ def machine_health_check_reboot(admin_client, worker_machine1):
 
 
 @pytest.fixture()
-def ha_vm_container_disk(request, unprivileged_client, namespace):
+def ha_vm_container_disk(request, admin_client, unprivileged_client, namespace):
     run_strategy = request.param["run_strategy"]
     name = f"ha-vm-container-disk-{run_strategy}".lower()
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         run_strategy=run_strategy,
     ) as vm:

--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -199,6 +199,7 @@ def must_gather_vm(
     must_gather_bridge,
     must_gather_nad,
     unprivileged_client,
+    admin_client,
 ):
     name = f"{MUST_GATHER_VM_NAME_PREFIX}-2"
     networks = {must_gather_bridge.bridge_name: must_gather_bridge.bridge_name}
@@ -209,7 +210,7 @@ def must_gather_vm(
         name=name,
         networks=networks,
         interfaces=sorted(networks.keys()),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -221,6 +222,7 @@ def must_gather_vm_scope_class(
     must_gather_bridge,
     must_gather_nad,
     unprivileged_client,
+    admin_client,
 ):
     name = f"{MUST_GATHER_VM_NAME_PREFIX}-enabled-guest-console-log"
     networks = {must_gather_bridge.bridge_name: must_gather_bridge.bridge_name}
@@ -231,7 +233,7 @@ def must_gather_vm_scope_class(
         name=name,
         networks=networks,
         interfaces=sorted(networks.keys()),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -427,10 +429,12 @@ def must_gather_vms_alternate_namespace_base_path(collected_vm_details_must_gath
 
 @pytest.fixture(scope="class")
 def must_gather_vms_from_alternate_namespace(
+    admin_client,
     must_gather_alternate_namespace,
     unprivileged_client,
 ):
     vms_list = create_vms(
+        admin_client=admin_client,
         name_prefix=MUST_GATHER_VM_NAME_PREFIX,
         namespace_name=must_gather_alternate_namespace.name,
         vm_count=5,
@@ -460,12 +464,12 @@ def must_gather_stopped_vms(must_gather_vms_from_alternate_namespace):
 
 
 @pytest.fixture(scope="class")
-def must_gather_long_name_vm(node_gather_unprivileged_namespace, unprivileged_client):
+def must_gather_long_name_vm(admin_client, node_gather_unprivileged_namespace, unprivileged_client):
     with VirtualMachineForTests(
         client=unprivileged_client,
         namespace=node_gather_unprivileged_namespace.name,
         name=LONG_VM_NAME,
-        body=fedora_vm_body(name=LONG_VM_NAME),
+        body=fedora_vm_body(name=LONG_VM_NAME, admin_client=admin_client),
         generate_unique_name=False,
     ) as vm:
         running_vm(vm=vm)
@@ -555,12 +559,12 @@ def nftables_ruleset_from_utility_pods(workers_utility_pods):
 
 
 @pytest.fixture(scope="class")
-def multiple_disks_vm(namespace, unprivileged_client, data_volume_scope_class):
+def multiple_disks_vm(admin_client, namespace, unprivileged_client, data_volume_scope_class):
     vm_name = "must-gather-multiple-disks-vm"
     with VirtualMachineForTests(
         client=unprivileged_client,
         name=vm_name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         namespace=namespace.name,
     ) as vm:
         add_dv_to_vm(vm=vm, dv_name=data_volume_scope_class.name)

--- a/tests/install_upgrade_operators/node_component/conftest.py
+++ b/tests/install_upgrade_operators/node_component/conftest.py
@@ -257,13 +257,14 @@ def vm_placement_vm_work3(
     namespace,
     unprivileged_client,
     nodes_labeled,
+    admin_client,
 ):
     name = "vm-placement-sanity-tests-vm"
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
         node_selector=get_node_selector_dict(node_selector=nodes_labeled["work3"][0]),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         teardown=False,
     ) as vm:

--- a/tests/install_upgrade_operators/node_component/test_hco_vm.py
+++ b/tests/install_upgrade_operators/node_component/test_hco_vm.py
@@ -23,12 +23,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture()
-def hco_vm(unprivileged_client, namespace):
+def hco_vm(admin_client, unprivileged_client, namespace):
     name = "hco-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
@@ -144,12 +144,12 @@ def hco_uninstall_strategy_remove_workloads(
 
 
 @pytest.fixture(scope="class")
-def hco_fedora_vm(unprivileged_client, namespace):
+def hco_fedora_vm(admin_client, unprivileged_client, namespace):
     name = "cascade-delete-fedora-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
@@ -21,12 +21,12 @@ def set_uninstall_strategy_remove_workloads(hyperconverged_resource_scope_functi
 
 
 @pytest.fixture()
-def remove_kubevirt_vm(unprivileged_client, namespace):
+def remove_kubevirt_vm(admin_client, unprivileged_client, namespace):
     name = "remove-kubevirt-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         vm.start()

--- a/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
+++ b/tests/install_upgrade_operators/security/scc/test_unprivileged_client_virt_launcher.py
@@ -11,13 +11,14 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64, pytest.mark.s390x]
 def developer_vm(
     unprivileged_client,
     namespace,
+    admin_client,
 ):
     name = "unprivileged-client-test-vm"
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="unprivileged-client-test-vm",
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         vm.start()
         vm.vmi.wait_until_running()

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -35,12 +35,12 @@ def assert_kubevirt_cpu_model(kubevirt_resource, hco_resource):
     )
 
 
-def create_vm(client, namespace):
+def create_vm(admin_client, client, namespace):
     name = "fedora-vm-for-test"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:
@@ -63,13 +63,13 @@ def updated_vmi_cpu_model(nodes_cpu_architecture, cluster_common_node_cpu):
 
 
 @pytest.fixture(scope="module")
-def fedora_vm_scope_module(unprivileged_client, namespace):
-    yield from create_vm(client=unprivileged_client, namespace=namespace)
+def fedora_vm_scope_module(admin_client, unprivileged_client, namespace):
+    yield from create_vm(admin_client=admin_client, client=unprivileged_client, namespace=namespace)
 
 
 @pytest.fixture()
-def fedora_vm_scope_function(unprivileged_client, namespace):
-    yield from create_vm(client=unprivileged_client, namespace=namespace)
+def fedora_vm_scope_function(admin_client, unprivileged_client, namespace):
+    yield from create_vm(admin_client=admin_client, client=unprivileged_client, namespace=namespace)
 
 
 @pytest.fixture()

--- a/tests/network/bond/test_bond_modes.py
+++ b/tests/network/bond/test_bond_modes.py
@@ -43,7 +43,7 @@ def assert_bond_validation(utility_pods, bond):
 
 
 @contextmanager
-def create_vm(namespace, nad, node_selector, unprivileged_client):
+def create_vm(admin_client, namespace, nad, node_selector, unprivileged_client):
     name = "bond-vm"
     networks = OrderedDict()
     networks[nad.name] = nad.name
@@ -51,7 +51,7 @@ def create_vm(namespace, nad, node_selector, unprivileged_client):
     with VirtualMachineForTests(
         namespace=namespace,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=node_selector,
@@ -122,6 +122,7 @@ def matrix_bond_modes_bridge(
 
 @pytest.fixture()
 def bond_modes_vm(
+    admin_client,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -133,6 +134,7 @@ def bond_modes_vm(
         nad=bond_modes_nad,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         unprivileged_client=unprivileged_client,
+        admin_client=admin_client,
     ) as vm:
         yield vm
 
@@ -179,6 +181,7 @@ def active_backup_bond_with_fail_over_mac(
 
 @pytest.fixture()
 def vm_with_fail_over_mac_bond(
+    admin_client,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -191,6 +194,7 @@ def vm_with_fail_over_mac_bond(
         nad=bond_modes_nad,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         unprivileged_client=unprivileged_client,
+        admin_client=admin_client,
     ) as vm:
         yield vm
 

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -132,6 +132,7 @@ def ovs_linux_bridge_on_bond_worker_2(
 
 @pytest.fixture(scope="class")
 def ovs_linux_bond_bridge_attached_vma(
+    admin_client,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -148,7 +149,7 @@ def ovs_linux_bond_bridge_attached_vma(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -161,6 +162,7 @@ def ovs_linux_bond_bridge_attached_vma(
 
 @pytest.fixture(scope="class")
 def ovs_linux_bond_bridge_attached_vmb(
+    admin_client,
     worker_node2,
     namespace,
     unprivileged_client,
@@ -178,7 +180,7 @@ def ovs_linux_bond_bridge_attached_vmb(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),

--- a/tests/network/connectivity/conftest.py
+++ b/tests/network/connectivity/conftest.py
@@ -261,6 +261,7 @@ def nad_ovs_bridge_vlan_3(
 
 @pytest.fixture(scope="class")
 def vm_linux_bridge_attached_vma_source(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     worker_node1,
@@ -287,6 +288,7 @@ def vm_linux_bridge_attached_vma_source(
     )
 
     yield from create_running_vm(
+        admin_client=admin_client,
         name=f"vma-{LINUX_BRIDGE}",
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         network_names=network_names,
@@ -298,6 +300,7 @@ def vm_linux_bridge_attached_vma_source(
 
 @pytest.fixture(scope="class")
 def vm_ovs_bridge_attached_vma_source(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     worker_node1,
@@ -324,6 +327,7 @@ def vm_ovs_bridge_attached_vma_source(
     )
 
     yield from create_running_vm(
+        admin_client=admin_client,
         name=f"vma-{OVS_BRIDGE}",
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         network_names=network_names,
@@ -335,6 +339,7 @@ def vm_ovs_bridge_attached_vma_source(
 
 @pytest.fixture(scope="class")
 def vm_linux_bridge_attached_vmb_destination(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     worker_node2,
@@ -361,6 +366,7 @@ def vm_linux_bridge_attached_vmb_destination(
     )
 
     yield from create_running_vm(
+        admin_client=admin_client,
         name=f"vmb-{LINUX_BRIDGE}",
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         network_names=network_names,
@@ -372,6 +378,7 @@ def vm_linux_bridge_attached_vmb_destination(
 
 @pytest.fixture(scope="class")
 def vm_ovs_bridge_attached_vmb_destination(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     worker_node2,
@@ -398,6 +405,7 @@ def vm_ovs_bridge_attached_vmb_destination(
     )
 
     yield from create_running_vm(
+        admin_client=admin_client,
         name=f"vmb-{OVS_BRIDGE}",
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         network_names=network_names,

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -15,6 +15,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, vm_console_ru
 
 @pytest.fixture()
 def pod_net_vma(
+    admin_client,
     namespace,
     unprivileged_client,
     nic_models_matrix__module__,
@@ -29,7 +30,7 @@ def pod_net_vma(
         node_selector=get_node_selector_dict(node_selector=node_selector),
         client=unprivileged_client,
         network_model=nic_models_matrix__module__,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cloud_init_data=cloud_init_ipv6_network_data,
     ) as vm:
         vm.start(wait=True)
@@ -38,6 +39,7 @@ def pod_net_vma(
 
 @pytest.fixture()
 def pod_net_vmb(
+    admin_client,
     namespace,
     unprivileged_client,
     nic_models_matrix__module__,
@@ -52,7 +54,7 @@ def pod_net_vmb(
         node_selector=get_node_selector_dict(node_selector=node_selector),
         client=unprivileged_client,
         network_model=nic_models_matrix__module__,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cloud_init_data=cloud_init_ipv6_network_data,
     ) as vm:
         vm.start(wait=True)

--- a/tests/network/connectivity/utils.py
+++ b/tests/network/connectivity/utils.py
@@ -5,6 +5,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 
 def create_running_vm(
+    admin_client,
     name,
     node_selector,
     network_names,
@@ -20,7 +21,7 @@ def create_running_vm(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=node_selector,

--- a/tests/network/dry_run/test_dry_run_kubemacpool.py
+++ b/tests/network/dry_run/test_dry_run_kubemacpool.py
@@ -17,14 +17,14 @@ MAC_ADDRESS = "macAddress"
 
 
 @contextmanager
-def create_dry_run_vm(name, namespace, networks, unprivileged_client, macs=None):
+def create_dry_run_vm(admin_client, name, namespace, networks, unprivileged_client, macs=None):
     vm = VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
         networks=networks,
         interfaces=sorted(networks.keys()),
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         macs=macs,
         dry_run="All",
     )
@@ -59,12 +59,13 @@ def linux_bridge_network_nad(admin_client, namespace, bridge_on_all_nodes):
 
 
 @pytest.fixture()
-def dry_run_vma(unprivileged_client, namespace, linux_bridge_network_nad):
+def dry_run_vma(admin_client, unprivileged_client, namespace, linux_bridge_network_nad):
     with create_dry_run_vm(
         name="dry-run-vma",
         namespace=namespace,
         networks={linux_bridge_network_nad.name: linux_bridge_network_nad.name},
         unprivileged_client=unprivileged_client,
+        admin_client=admin_client,
     ) as vm:
         yield vm.create()
 
@@ -79,6 +80,7 @@ def dry_run_vma_mac_address(dry_run_vma):
 
 @pytest.fixture()
 def vm_with_mac_address(
+    admin_client,
     unprivileged_client,
     namespace,
     linux_bridge_network_nad,
@@ -93,7 +95,7 @@ def vm_with_mac_address(
         networks=networks,
         interfaces=sorted(networks.keys()),
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         macs={linux_bridge_network_nad.name: dry_run_vma_mac_address},
     ) as vm:
         yield vm
@@ -101,6 +103,7 @@ def vm_with_mac_address(
 
 @pytest.fixture()
 def dry_run_vm_with_mac_address(
+    admin_client,
     unprivileged_client,
     namespace,
     linux_bridge_network_nad,
@@ -114,6 +117,7 @@ def dry_run_vm_with_mac_address(
         namespace=namespace,
         networks={linux_bridge_network_nad.name: linux_bridge_network_nad.name},
         unprivileged_client=unprivileged_client,
+        admin_client=admin_client,
         macs={linux_bridge_network_nad.name: allocated_mac_address},
     )
 

--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -138,12 +138,14 @@ def flat_overlay_jumbo_frame_nad(admin_client, namespace, cluster_hardware_mtu):
 
 @pytest.fixture(scope="class")
 def vma_flat_overlay(
+    admin_client,
     unprivileged_client,
     worker_node1,
     index_number,
     flat_overlay_vma_vmb_nad,
 ):
     yield from create_flat_overlay_vm(
+        admin_client=admin_client,
         vm_name=f"vma-{FLAT_L2_STR}",
         namespace_name=flat_overlay_vma_vmb_nad.namespace,
         nad_name=flat_overlay_vma_vmb_nad.name,
@@ -155,12 +157,14 @@ def vma_flat_overlay(
 
 @pytest.fixture(scope="class")
 def vmb_flat_overlay(
+    admin_client,
     unprivileged_client,
     worker_node1,
     index_number,
     flat_overlay_vma_vmb_nad,
 ):
     yield from create_flat_overlay_vm(
+        admin_client=admin_client,
         vm_name=f"vmb-{FLAT_L2_STR}",
         namespace_name=flat_overlay_vma_vmb_nad.namespace,
         nad_name=flat_overlay_vma_vmb_nad.name,
@@ -172,12 +176,14 @@ def vmb_flat_overlay(
 
 @pytest.fixture(scope="class")
 def vmc_flat_overlay(
+    admin_client,
     unprivileged_client,
     index_number,
     flat_overlay_vmc_vmd_nad,
 ):
     # This VM doesn't have a node selector since it will be migrated in a later step.
     yield from create_flat_overlay_vm(
+        admin_client=admin_client,
         vm_name=f"vmc-{FLAT_L2_STR}",
         namespace_name=flat_overlay_vmc_vmd_nad.namespace,
         nad_name=flat_overlay_vmc_vmd_nad.name,
@@ -188,12 +194,14 @@ def vmc_flat_overlay(
 
 @pytest.fixture(scope="class")
 def vmd_flat_overlay(
+    admin_client,
     unprivileged_client,
     worker_node1,
     index_number,
     flat_overlay_vmc_vmd_nad,
 ):
     yield from create_flat_overlay_vm(
+        admin_client=admin_client,
         vm_name=f"vmd-{FLAT_L2_STR}",
         namespace_name=flat_overlay_vmc_vmd_nad.namespace,
         nad_name=flat_overlay_vmc_vmd_nad.name,
@@ -205,12 +213,14 @@ def vmd_flat_overlay(
 
 @pytest.fixture(scope="class")
 def vme_flat_overlay(
+    admin_client,
     unprivileged_client,
     worker_node3,
     index_number,
     flat_overlay_vme_nad,
 ):
     yield from create_flat_overlay_vm(
+        admin_client=admin_client,
         vm_name=f"vme-{FLAT_L2_STR}",
         namespace_name=flat_overlay_vme_nad.namespace,
         nad_name=flat_overlay_vme_nad.name,
@@ -222,12 +232,14 @@ def vme_flat_overlay(
 
 @pytest.fixture(scope="class")
 def vma_jumbo_flat_l2(
+    admin_client,
     unprivileged_client,
     worker_node1,
     index_number,
     flat_overlay_jumbo_frame_nad,
 ):
     yield from create_flat_overlay_vm(
+        admin_client=admin_client,
         vm_name=f"vma-jumbo-{FLAT_L2_STR}",
         namespace_name=flat_overlay_jumbo_frame_nad.namespace,
         nad_name=flat_overlay_jumbo_frame_nad.name,
@@ -239,12 +251,14 @@ def vma_jumbo_flat_l2(
 
 @pytest.fixture(scope="class")
 def vmb_jumbo_flat_l2(
+    admin_client,
     unprivileged_client,
     worker_node2,
     index_number,
     flat_overlay_jumbo_frame_nad,
 ):
     yield from create_flat_overlay_vm(
+        admin_client=admin_client,
         vm_name=f"vmb-jumbo-{FLAT_L2_STR}",
         namespace_name=flat_overlay_jumbo_frame_nad.namespace,
         nad_name=flat_overlay_jumbo_frame_nad.name,

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -24,6 +24,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def create_flat_overlay_vm(
+    admin_client,
     vm_name,
     namespace_name,
     nad_name,
@@ -44,7 +45,7 @@ def create_flat_overlay_vm(
         networks=networks,
         interfaces=networks.keys(),
         client=unprivileged_client,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         cloud_init_data=cloud_init_data,
         node_selector=get_node_selector_dict(node_selector=worker_node_hostname),
     ) as vm:

--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -20,7 +20,7 @@ BRIDGEMARKER3 = "bridgemarker3"
 
 
 @contextmanager
-def create_bridge_attached_vm_for_bridge_marker(namespace, bridge_marker_bridge_network):
+def create_bridge_attached_vm_for_bridge_marker(admin_client, namespace, bridge_marker_bridge_network):
     networks = {bridge_marker_bridge_network.name: bridge_marker_bridge_network.name}
     name = _get_name(suffix="bridge-vm")
     with VirtualMachineForTests(
@@ -28,7 +28,7 @@ def create_bridge_attached_vm_for_bridge_marker(namespace, bridge_marker_bridge_
         name=name,
         networks=networks,
         interfaces=sorted(networks.keys()),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         yield vm
 
@@ -69,18 +69,18 @@ def bridge_networks(admin_client, namespace):
 
 
 @pytest.fixture()
-def bridge_attached_vmi_for_bridge_marker_no_device(namespace, bridge_marker_bridge_network):
+def bridge_attached_vmi_for_bridge_marker_no_device(admin_client, namespace, bridge_marker_bridge_network):
     with create_bridge_attached_vm_for_bridge_marker(
-        namespace=namespace, bridge_marker_bridge_network=bridge_marker_bridge_network
+        admin_client=admin_client, namespace=namespace, bridge_marker_bridge_network=bridge_marker_bridge_network
     ) as vm:
         vm.start()
         yield vm.vmi
 
 
 @pytest.fixture()
-def bridge_attached_vmi_for_bridge_marker_device_exists(namespace, bridge_marker_bridge_network):
+def bridge_attached_vmi_for_bridge_marker_device_exists(admin_client, namespace, bridge_marker_bridge_network):
     with create_bridge_attached_vm_for_bridge_marker(
-        namespace=namespace, bridge_marker_bridge_network=bridge_marker_bridge_network
+        admin_client=admin_client, namespace=namespace, bridge_marker_bridge_network=bridge_marker_bridge_network
     ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()
@@ -88,7 +88,7 @@ def bridge_attached_vmi_for_bridge_marker_device_exists(namespace, bridge_marker
 
 
 @pytest.fixture()
-def multi_bridge_attached_vmi(namespace, bridge_networks, unprivileged_client):
+def multi_bridge_attached_vmi(admin_client, namespace, bridge_networks, unprivileged_client):
     networks = {b.name: b.name for b in bridge_networks}
     name = _get_name(suffix="multi-bridge-vm")
     with VirtualMachineForTests(
@@ -97,7 +97,7 @@ def multi_bridge_attached_vmi(namespace, bridge_networks, unprivileged_client):
         networks=networks,
         interfaces=sorted(networks.keys()),
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         vm.start()
         yield vm.vmi

--- a/tests/network/general/test_cnv_tuning_regression.py
+++ b/tests/network/general/test_cnv_tuning_regression.py
@@ -33,7 +33,7 @@ def linux_bridge_device(nmstate_dependent_placeholder, admin_client, worker_node
 
 
 @pytest.fixture()
-def cnv_tuning_vm(unprivileged_client, worker_node1, linux_bridge_nad, linux_bridge_device):
+def cnv_tuning_vm(admin_client, unprivileged_client, worker_node1, linux_bridge_nad, linux_bridge_device):
     name = "tuning-vma"
     networks = {"net1": linux_bridge_nad.name}
     network_data_data = {
@@ -46,7 +46,7 @@ def cnv_tuning_vm(unprivileged_client, worker_node1, linux_bridge_nad, linux_bri
         networks=networks,
         interfaces=sorted(networks.keys()),
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         cloud_init_data=compose_cloud_init_data_dict(
             network_data=network_data_data,

--- a/tests/network/general/test_network_naming.py
+++ b/tests/network/general/test_network_naming.py
@@ -14,7 +14,7 @@ def invalid_network_names():
 @pytest.mark.polarion("CNV-8304")
 @pytest.mark.single_nic
 @pytest.mark.s390x
-def test_vm_with_illegal_network_name(namespace, unprivileged_client, invalid_network_names):
+def test_vm_with_illegal_network_name(admin_client, namespace, unprivileged_client, invalid_network_names):
     vm_name = "unsupported-network-name-vm"
 
     with pytest.raises(
@@ -24,7 +24,7 @@ def test_vm_with_illegal_network_name(namespace, unprivileged_client, invalid_ne
         with VirtualMachineForTests(
             namespace=namespace.name,
             name=vm_name,
-            body=fedora_vm_body(name=vm_name),
+            body=fedora_vm_body(name=vm_name, admin_client=admin_client),
             client=unprivileged_client,
             **invalid_network_names,
         ):

--- a/tests/network/jumbo_frame/conftest.py
+++ b/tests/network/jumbo_frame/conftest.py
@@ -15,12 +15,14 @@ from utilities.network import network_device, network_nad
 
 @pytest.fixture(scope="class")
 def running_vma_jumbo_primary_interface_worker_1(
+    admin_client,
     worker_node1,
     namespace,
     index_number,
     unprivileged_client,
 ):
     with create_vm_for_jumbo_test(
+        admin_client=admin_client,
         index=next(index_number),
         namespace_name=namespace.name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -33,12 +35,14 @@ def running_vma_jumbo_primary_interface_worker_1(
 
 @pytest.fixture(scope="class")
 def running_vmb_jumbo_primary_interface_worker_2(
+    admin_client,
     worker_node2,
     namespace,
     index_number,
     unprivileged_client,
 ):
     with create_vm_for_jumbo_test(
+        admin_client=admin_client,
         index=next(index_number),
         namespace_name=namespace.name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
@@ -51,12 +55,14 @@ def running_vmb_jumbo_primary_interface_worker_2(
 
 @pytest.fixture()
 def running_vmc_jumbo_primary_interface_worker_1(
+    admin_client,
     worker_node1,
     namespace,
     index_number,
     unprivileged_client,
 ):
     with create_vm_for_jumbo_test(
+        admin_client=admin_client,
         index=next(index_number),
         namespace_name=namespace.name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -69,6 +75,7 @@ def running_vmc_jumbo_primary_interface_worker_1(
 
 @pytest.fixture()
 def running_vmd_jumbo_primary_interface_and_secondary_interface(
+    admin_client,
     index_number,
     namespace,
     unprivileged_client,
@@ -77,6 +84,7 @@ def running_vmd_jumbo_primary_interface_and_secondary_interface(
     index = next(index_number)
     cloud_init_data = cloud_init_data_for_secondary_traffic(index=index)
     with create_vm_for_jumbo_test(
+        admin_client=admin_client,
         index=index,
         namespace_name=namespace.name,
         client=unprivileged_client,
@@ -90,6 +98,7 @@ def running_vmd_jumbo_primary_interface_and_secondary_interface(
 
 @pytest.fixture()
 def running_vme_jumbo_primary_interface_and_secondary_interface(
+    admin_client,
     index_number,
     namespace,
     unprivileged_client,
@@ -98,6 +107,7 @@ def running_vme_jumbo_primary_interface_and_secondary_interface(
     index = next(index_number)
     cloud_init_data = cloud_init_data_for_secondary_traffic(index=index)
     with create_vm_for_jumbo_test(
+        admin_client=admin_client,
         index=index,
         namespace_name=namespace.name,
         client=unprivileged_client,

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -147,6 +147,7 @@ def br1bond_nad(
 
 @pytest.fixture(scope="class")
 def bond_bridge_attached_vma(
+    admin_client,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -164,7 +165,7 @@ def bond_bridge_attached_vma(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -177,6 +178,7 @@ def bond_bridge_attached_vma(
 
 @pytest.fixture(scope="class")
 def bond_bridge_attached_vmb(
+    admin_client,
     worker_node2,
     namespace,
     unprivileged_client,
@@ -194,7 +196,7 @@ def bond_bridge_attached_vmb(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -98,7 +98,7 @@ def br1test_bridge_nad(
 
 
 @pytest.fixture(scope="class")
-def bridge_attached_vma(worker_node1, namespace, unprivileged_client, br1test_bridge_nad):
+def bridge_attached_vma(admin_client, worker_node1, namespace, unprivileged_client, br1test_bridge_nad):
     name = "vma"
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
@@ -110,7 +110,7 @@ def bridge_attached_vma(worker_node1, namespace, unprivileged_client, br1test_br
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -123,7 +123,7 @@ def bridge_attached_vma(worker_node1, namespace, unprivileged_client, br1test_br
 
 
 @pytest.fixture(scope="class")
-def bridge_attached_vmb(worker_node2, namespace, unprivileged_client, br1test_bridge_nad):
+def bridge_attached_vmb(admin_client, worker_node2, namespace, unprivileged_client, br1test_bridge_nad):
     name = "vmb"
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
@@ -135,7 +135,7 @@ def bridge_attached_vmb(worker_node2, namespace, unprivileged_client, br1test_br
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),

--- a/tests/network/jumbo_frame/utils.py
+++ b/tests/network/jumbo_frame/utils.py
@@ -7,6 +7,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 @contextmanager
 def create_vm_for_jumbo_test(
+    admin_client,
     index,
     namespace_name,
     client,
@@ -19,7 +20,7 @@ def create_vm_for_jumbo_test(
     with VirtualMachineForTests(
         namespace=namespace_name,
         name=vm_name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         node_selector=node_selector,
         cloud_init_data=cloud_init_data,
         networks=networks,

--- a/tests/network/kubemacpool/conftest.py
+++ b/tests/network/kubemacpool/conftest.py
@@ -197,6 +197,7 @@ def all_nads(
 
 @pytest.fixture(scope="class")
 def vm_a(
+    admin_client,
     namespace,
     all_nads,
     worker_node1,
@@ -208,6 +209,7 @@ def vm_a(
         mac_pool=mac_pool, all_nads=all_nads, end_ip_octet=1, mac_uid="1"
     )
     yield from kmp_utils.create_vm(
+        admin_client=admin_client,
         name="vm-fedora-a",
         iface_config=requested_network_config,
         namespace=namespace,
@@ -219,6 +221,7 @@ def vm_a(
 
 @pytest.fixture(scope="class")
 def vm_b(
+    admin_client,
     namespace,
     all_nads,
     worker_node2,
@@ -230,6 +233,7 @@ def vm_b(
         mac_pool=mac_pool, all_nads=all_nads, end_ip_octet=2, mac_uid="2"
     )
     yield from kmp_utils.create_vm(
+        admin_client=admin_client,
         name="vm-fedora-b",
         iface_config=requested_network_config,
         namespace=namespace,
@@ -278,7 +282,7 @@ def disabled_ns_vm(admin_client, disabled_ns, disabled_ns_nad, mac_pool):
         name=name,
         networks=networks,
         interfaces=networks.keys(),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=admin_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
@@ -297,7 +301,7 @@ def enabled_ns_vm(admin_client, kmp_enabled_ns, enabled_ns_nad, mac_pool):
         name=name,
         networks=networks,
         interfaces=networks.keys(),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=admin_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
@@ -316,7 +320,7 @@ def no_label_ns_vm(admin_client, no_label_ns, no_label_ns_nad, mac_pool):
         name=name,
         networks=networks,
         interfaces=networks.keys(),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=admin_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)

--- a/tests/network/kubemacpool/utils.py
+++ b/tests/network/kubemacpool/utils.py
@@ -2,6 +2,8 @@ import logging
 from collections import namedtuple
 from ipaddress import ip_interface
 
+from kubernetes.dynamic import DynamicClient
+
 from tests.network.libs.ip import random_ipv4_address
 from utilities.network import cloud_init_network_data, get_vmi_mac_address_by_iface_name
 from utilities.virt import (
@@ -49,7 +51,7 @@ def vm_network_config(mac_pool, all_nads, end_ip_octet, mac_uid):
     }
 
 
-def create_vm(name, namespace, iface_config, node_selector, client, mac_pool):
+def create_vm(admin_client, name, namespace, iface_config, node_selector, client, mac_pool):
     network_data_data = {}
     _data = {
         iface: {"addresses": [f"{iface_config[iface].ip_address}/24"]}
@@ -74,6 +76,7 @@ def create_vm(name, namespace, iface_config, node_selector, client, mac_pool):
         node_selector=node_selector,
         client=client,
         cloud_init_data=cloud_init_data,
+        admin_client=admin_client,
     ) as vm:
         mac_pool.append_macs(vm=vm)
         yield vm
@@ -87,9 +90,11 @@ class VirtualMachineWithMultipleAttachments(VirtualMachineForTests):
         namespace,
         iface_config,
         node_selector,
+        admin_client: DynamicClient,
         client=None,
         cloud_init_data=None,
     ):
+        self.admin_client = admin_client
         self.iface_config = iface_config
 
         networks = {}
@@ -132,7 +137,7 @@ class VirtualMachineWithMultipleAttachments(VirtualMachineForTests):
         return self.iface_config["eth4"]
 
     def to_dict(self):
-        self.body = fedora_vm_body(name=self.name)
+        self.body = fedora_vm_body(name=self.name, admin_client=self.admin_client)
         super().to_dict()
         for mac, iface in zip(
             self.iface_config.values(),

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -167,7 +167,7 @@ def l2_bridge_all_nads(dhcp_nad, custom_eth_type_llpd_nad, mpls_nad, dot1q_nad):
 
 @pytest.fixture(scope="class")
 def l2_bridge_running_vm_a(
-    namespace, worker_node1, l2_bridge_all_nads, dhcp_nad, unprivileged_client, l2_bridge_running_vm_b
+    admin_client, namespace, worker_node1, l2_bridge_all_nads, dhcp_nad, unprivileged_client, l2_bridge_running_vm_b
 ):
     dhcpd_data = DHCP_SERVER_CONF_FILE.format(
         DHCP_IP_SUBNET=DHCP_IP_SUBNET,
@@ -190,6 +190,7 @@ def l2_bridge_running_vm_a(
         random_ipv4_address(net_seed=4, host_address=1),
     ]
     with bridge_attached_vm(
+        admin_client=admin_client,
         name="vm-fedora-1",
         namespace=namespace.name,
         interfaces=l2_bridge_all_nads,
@@ -209,7 +210,7 @@ def l2_bridge_running_vm_a(
 
 
 @pytest.fixture(scope="class")
-def l2_bridge_running_vm_b(namespace, worker_node2, l2_bridge_all_nads, unprivileged_client):
+def l2_bridge_running_vm_b(admin_client, namespace, worker_node2, l2_bridge_all_nads, unprivileged_client):
     interface_ip_addresses = [
         random_ipv4_address(net_seed=0, host_address=2),
         random_ipv4_address(net_seed=2, host_address=2),
@@ -217,6 +218,7 @@ def l2_bridge_running_vm_b(namespace, worker_node2, l2_bridge_all_nads, unprivil
         random_ipv4_address(net_seed=4, host_address=2),
     ]
     with bridge_attached_vm(
+        admin_client=admin_client,
         name="vm-fedora-2",
         namespace=namespace.name,
         interfaces=l2_bridge_all_nads,

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -77,6 +77,7 @@ def create_vm_with_secondary_interface_on_setup(
     bridge_nad,
     vm_name,
     ipv4_address_suffix,
+    admin_client,
 ):
     networks = {bridge_nad.name: bridge_nad.name}
     cloud_init_data = compose_cloud_init_data_dict(
@@ -101,7 +102,7 @@ def create_vm_with_secondary_interface_on_setup(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=vm_name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         cloud_init_data=cloud_init_data,
@@ -245,6 +246,7 @@ def create_vm_for_hot_plug(
     namespace_name,
     vm_name,
     client,
+    admin_client,
 ):
     cloud_init_data = {"userData": {}}
     update_cloud_init_extra_user_data(
@@ -255,7 +257,7 @@ def create_vm_for_hot_plug(
     with VirtualMachineForTests(
         namespace=namespace_name,
         name=vm_name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         client=client,
         cloud_init_data=cloud_init_data,
     ) as vm:
@@ -318,11 +320,13 @@ def create_vm_with_hot_plugged_sriov_interface(
     sriov_network_for_hot_plug,
     ipv4_address,
     client,
+    admin_client,
 ):
     with create_vm_for_hot_plug(
         namespace_name=namespace_name,
         vm_name=vm_name,
         client=client,
+        admin_client=admin_client,
     ) as vm:
         hot_plug_interface_and_set_address(
             vm=vm,
@@ -372,6 +376,7 @@ def bridge_attached_vm(
     mpls_dest_tag,
     mpls_route_next_hop,
     mpls_local_ip,
+    admin_client,
     cloud_init_extra_user_data=None,
     client=None,
     node_selector=None,
@@ -396,6 +401,7 @@ def bridge_attached_vm(
         mpls_dest_ip=mpls_dest_ip,
         mpls_dest_tag=mpls_dest_tag,
         mpls_route_next_hop=mpls_route_next_hop,
+        admin_client=admin_client,
         client=client,
         cloud_init_data=cloud_init_data,
         node_selector=node_selector,
@@ -466,10 +472,12 @@ class VirtualMachineAttachedToBridge(VirtualMachineForTests):
         mpls_dest_ip: str,
         mpls_dest_tag: int,
         mpls_route_next_hop: str,
+        admin_client: DynamicClient,
         client: DynamicClient | None = None,
         cloud_init_data: dict[str, dict] | None = None,
         node_selector: dict[str, str] | None = None,
     ):
+        self.admin_client = admin_client
         self.cloud_init_data = cloud_init_data
         self.mpls_local_tag = mpls_local_tag
         self.ip_addresses = ip_addresses
@@ -493,5 +501,5 @@ class VirtualMachineAttachedToBridge(VirtualMachineForTests):
         )
 
     def to_dict(self) -> None:
-        self.body = fedora_vm_body(name=self.name)
+        self.body = fedora_vm_body(name=self.name, admin_client=self.admin_client)
         super().to_dict()  # type: ignore[no-untyped-call]

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -35,9 +35,10 @@ SECONDARY_SETUP_INTERFACE_NAME = "eth1"
 
 
 @pytest.fixture(scope="class")
-def running_vm_for_nic_hot_plug(namespace, unprivileged_client):
+def running_vm_for_nic_hot_plug(admin_client, namespace, unprivileged_client):
     vm_name = f"{HOT_PLUG_STR}-test-vm"
     with create_vm_for_hot_plug(
+        admin_client=admin_client,
         namespace_name=namespace.name,
         vm_name=vm_name,
         client=unprivileged_client,
@@ -99,6 +100,7 @@ def multiple_hot_plugged_interfaces(running_vm_for_nic_hot_plug, network_attachm
 
 @pytest.fixture(scope="module")
 def running_utility_vm_for_connectivity_check(
+    admin_client,
     namespace,
     unprivileged_client,
     network_attachment_definition_for_hot_plug,
@@ -107,6 +109,7 @@ def running_utility_vm_for_connectivity_check(
     # The VM that is created with a secondary interface can utilize the same net-attach-def (and node bridge
     # interface) which is used by the VM with hot-plugged interface.
     yield from create_vm_with_secondary_interface_on_setup(
+        admin_client=admin_client,
         namespace=namespace,
         client=unprivileged_client,
         bridge_nad=network_attachment_definition_for_hot_plug,
@@ -126,12 +129,14 @@ def hot_plugged_interface_with_address(running_vm_for_nic_hot_plug, index_number
 
 @pytest.fixture(scope="class")
 def running_vm_with_secondary_and_hot_plugged_interfaces(
+    admin_client,
     namespace,
     unprivileged_client,
     network_attachment_definition_for_hot_plug,
     index_number,
 ):
     yield from create_vm_with_secondary_interface_on_setup(
+        admin_client=admin_client,
         namespace=namespace,
         client=unprivileged_client,
         bridge_nad=network_attachment_definition_for_hot_plug,
@@ -166,9 +171,10 @@ def hot_plugged_second_interface_with_address(
 
 
 @pytest.fixture()
-def running_vm_for_jumbo_nic_hot_plug(namespace, unprivileged_client):
+def running_vm_for_jumbo_nic_hot_plug(admin_client, namespace, unprivileged_client):
     vm_name = f"jumbo-{HOT_PLUG_STR}-test-vm"
     with create_vm_for_hot_plug(
+        admin_client=admin_client,
         namespace_name=namespace.name,
         vm_name=vm_name,
         client=unprivileged_client,
@@ -276,8 +282,9 @@ def flat_overlay_network_attachment_definition_for_hot_plug(
 
 
 @pytest.fixture()
-def vm_for_hot_plug_and_kmp(namespace, unprivileged_client):
+def vm_for_hot_plug_and_kmp(admin_client, namespace, unprivileged_client):
     with create_vm_for_hot_plug(
+        admin_client=admin_client,
         namespace_name=namespace.name,
         vm_name=f"{HOT_PLUG_STR}-kmp-release-vm",
         client=unprivileged_client,
@@ -396,12 +403,14 @@ def hot_unplug_secondary_interface_from_setup(
 
 @pytest.fixture()
 def vm1_with_hot_plugged_sriov_interface(
+    admin_client,
     namespace,
     unprivileged_client,
     sriov_network_for_hot_plug,
     index_number,
 ):
     yield from create_vm_with_hot_plugged_sriov_interface(
+        admin_client=admin_client,
         namespace_name=namespace.name,
         vm_name=f"{SRIOV}-{HOT_PLUG_STR}-vm1",
         sriov_network_for_hot_plug=sriov_network_for_hot_plug,
@@ -412,12 +421,14 @@ def vm1_with_hot_plugged_sriov_interface(
 
 @pytest.fixture()
 def vm2_with_hot_plugged_sriov_interface(
+    admin_client,
     namespace,
     unprivileged_client,
     sriov_network_for_hot_plug,
     index_number,
 ):
     yield from create_vm_with_hot_plugged_sriov_interface(
+        admin_client=admin_client,
         namespace_name=namespace.name,
         vm_name=f"{SRIOV}-{HOT_PLUG_STR}-vm2",
         sriov_network_for_hot_plug=sriov_network_for_hot_plug,

--- a/tests/network/macspoof/conftest.py
+++ b/tests/network/macspoof/conftest.py
@@ -107,6 +107,7 @@ def linux_macspoof_nad(
 
 @pytest.fixture(scope="class")
 def linux_bridge_attached_vma(
+    admin_client,
     worker_node1,
     unprivileged_client,
     linux_macspoof_nad,
@@ -122,7 +123,7 @@ def linux_bridge_attached_vma(
     with VirtualMachineForTests(
         namespace=linux_macspoof_nad.namespace,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -135,6 +136,7 @@ def linux_bridge_attached_vma(
 
 @pytest.fixture(scope="class")
 def linux_bridge_attached_vmb(
+    admin_client,
     worker_node2,
     unprivileged_client,
     linux_macspoof_nad,
@@ -150,7 +152,7 @@ def linux_bridge_attached_vmb(
     with VirtualMachineForTests(
         namespace=linux_macspoof_nad.namespace,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -18,6 +18,7 @@ LOGGER = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def running_vm_static(
+    admin_client,
     unprivileged_client,
     namespace,
 ):
@@ -25,7 +26,7 @@ def running_vm_static(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         vm.start(wait=True)
@@ -35,6 +36,7 @@ def running_vm_static(
 
 @pytest.fixture(scope="module")
 def running_vm_for_migration(
+    admin_client,
     unprivileged_client,
     cpu_for_migration,
     namespace,
@@ -43,7 +45,7 @@ def running_vm_for_migration(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         cpu_model=cpu_for_migration,
     ) as vm:

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -112,6 +112,7 @@ def br1test_nad(admin_client, namespace, bridge_worker_1, bridge_worker_2):
 
 @pytest.fixture(scope="module")
 def vma(
+    admin_client,
     namespace,
     unprivileged_client,
     cpu_for_migration,
@@ -131,7 +132,7 @@ def vma(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=sorted(networks.keys()),
         client=unprivileged_client,
@@ -144,6 +145,7 @@ def vma(
 
 @pytest.fixture(scope="module")
 def vmb(
+    admin_client,
     namespace,
     unprivileged_client,
     cpu_for_migration,
@@ -163,7 +165,7 @@ def vmb(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=sorted(networks.keys()),
         client=unprivileged_client,

--- a/tests/network/network_policy/conftest.py
+++ b/tests/network/network_policy/conftest.py
@@ -54,6 +54,7 @@ def allow_single_http_port(unprivileged_client, namespace_1):
 
 @pytest.fixture(scope="module")
 def network_policy_vma(
+    admin_client,
     unprivileged_client,
     worker_node1,
     namespace_1,
@@ -68,7 +69,7 @@ def network_policy_vma(
     with VirtualMachineForTests(
         namespace=namespace_1.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         client=unprivileged_client,
         cloud_init_data=cloud_init_data,
@@ -79,7 +80,9 @@ def network_policy_vma(
 
 
 @pytest.fixture(scope="module")
-def network_policy_vmb(unprivileged_client, worker_node1, namespace_2, ipv6_primary_interface_cloud_init_data):
+def network_policy_vmb(
+    admin_client, unprivileged_client, worker_node1, namespace_2, ipv6_primary_interface_cloud_init_data
+):
     name = "vmb-network-policy"
     cloud_init_data = compose_cloud_init_data_dict(ipv6_network_data=ipv6_primary_interface_cloud_init_data)
     with VirtualMachineForTests(
@@ -87,7 +90,7 @@ def network_policy_vmb(unprivileged_client, worker_node1, namespace_2, ipv6_prim
         name=name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cloud_init_data=cloud_init_data,
     ) as vm:
         vm.start(wait=True)

--- a/tests/network/network_service/conftest.py
+++ b/tests/network/network_service/conftest.py
@@ -16,6 +16,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 @pytest.fixture(scope="module")
 def running_vm_for_exposure(
+    admin_client,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -27,7 +28,7 @@ def running_vm_for_exposure(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=vm_name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         cloud_init_data=cloud_init_data,
         client=unprivileged_client,

--- a/tests/network/nmstate/conftest.py
+++ b/tests/network/nmstate/conftest.py
@@ -31,28 +31,28 @@ def worker_nodes_management_iface_stats(nodes_active_nics, worker_node1, worker_
 
 
 @pytest.fixture(scope="module")
-def nmstate_vma(schedulable_nodes, worker_node1, namespace, unprivileged_client):
+def nmstate_vma(admin_client, schedulable_nodes, worker_node1, namespace, unprivileged_client):
     name = "vma"
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         vm.start(wait=True)
         yield vm
 
 
 @pytest.fixture(scope="module")
-def nmstate_vmb(schedulable_nodes, worker_node2, namespace, unprivileged_client):
+def nmstate_vmb(admin_client, schedulable_nodes, worker_node2, namespace, unprivileged_client):
     name = "vmb"
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         vm.start(wait=True)
         yield vm

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -94,6 +94,7 @@ def nmstate_linux_nad(
 
 @pytest.fixture(scope="class")
 def nmstate_linux_bridge_attached_vma(
+    admin_client,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -115,7 +116,7 @@ def nmstate_linux_bridge_attached_vma(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -128,6 +129,7 @@ def nmstate_linux_bridge_attached_vma(
 
 @pytest.fixture(scope="class")
 def nmstate_linux_bridge_attached_vmb(
+    admin_client,
     worker_node2,
     namespace,
     unprivileged_client,
@@ -149,7 +151,7 @@ def nmstate_linux_bridge_attached_vmb(
     with VirtualMachineForTests(
         namespace=namespace.name,
         name=name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         networks=networks,
         interfaces=networks.keys(),
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),

--- a/tests/network/service_mesh/conftest.py
+++ b/tests/network/service_mesh/conftest.py
@@ -233,11 +233,13 @@ def httpbin_service_service_mesh(
 
 @pytest.fixture(scope="module")
 def vm_fedora_with_service_mesh_annotation(
+    admin_client,
     unprivileged_client,
     service_mesh_tests_namespace,
 ):
     vm_name = "service-mesh-vm"
     with FedoraVirtualMachineForServiceMesh(
+        admin_client=admin_client,
         client=unprivileged_client,
         name=vm_name,
         namespace=service_mesh_tests_namespace.name,
@@ -262,7 +264,7 @@ def outside_mesh_vm_fedora_with_service_mesh_annotation(
         name=vm_name,
         namespace=ns_outside_of_service_mesh.name,
         os_flavor=OS_FLAVOR_FEDORA,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
     ) as vm:
         vm.custom_service_enable(
             service_name=vm_name,

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -65,6 +65,7 @@ def sriov_network_vlan(admin_client, sriov_node_policy, namespace, sriov_namespa
 
 @pytest.fixture(scope="class")
 def sriov_vm1(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     index_number,
@@ -84,6 +85,7 @@ def sriov_vm1(
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
+        admin_client=admin_client,
         unprivileged_client=unprivileged_client,
         name="sriov-vm1",
         namespace=namespace,
@@ -95,6 +97,7 @@ def sriov_vm1(
 
 @pytest.fixture(scope="class")
 def sriov_vm2(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     index_number,
@@ -114,6 +117,7 @@ def sriov_vm2(
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
+        admin_client=admin_client,
         unprivileged_client=unprivileged_client,
         name="sriov-vm2",
         namespace=namespace,
@@ -125,6 +129,7 @@ def sriov_vm2(
 
 @pytest.fixture(scope="class")
 def sriov_vm3(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     index_number,
@@ -144,6 +149,7 @@ def sriov_vm3(
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
+        admin_client=admin_client,
         unprivileged_client=unprivileged_client,
         name="sriov-vm3",
         namespace=namespace,
@@ -155,6 +161,7 @@ def sriov_vm3(
 
 @pytest.fixture(scope="class")
 def sriov_vm4(
+    admin_client,
     ipv4_supported_cluster,
     ipv6_supported_cluster,
     index_number,
@@ -174,6 +181,7 @@ def sriov_vm4(
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
+        admin_client=admin_client,
         unprivileged_client=unprivileged_client,
         name="sriov-vm4",
         namespace=namespace,
@@ -239,6 +247,7 @@ def sriov_network_mtu_9000(sriov_vm1, sriov_vm2):
 
 @pytest.fixture(scope="class")
 def sriov_vm_migrate(
+    admin_client,
     index_number,
     unprivileged_client,
     namespace,
@@ -257,6 +266,7 @@ def sriov_vm_migrate(
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
+        admin_client=admin_client,
         unprivileged_client=unprivileged_client,
         name="sriov-vm-migrate",
         namespace=namespace,

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -20,6 +20,7 @@ def sriov_vm(
     namespace,
     sriov_network,
     cloud_init_data,
+    admin_client,
     worker=None,
 ):
     sriov_mac = cloud_init_data["networkData"]["ethernets"]["1"]["match"]["macaddress"]
@@ -28,7 +29,7 @@ def sriov_vm(
     vm_kwargs = {
         "namespace": namespace.name,
         "name": name,
-        "body": fedora_vm_body(name=name),
+        "body": fedora_vm_body(name=name, admin_client=admin_client),
         "networks": networks,
         "interfaces": networks.keys(),
         "cloud_init_data": cloud_init_data,

--- a/tests/network/upgrade/conftest.py
+++ b/tests/network/upgrade/conftest.py
@@ -38,7 +38,9 @@ def vm_nad_networks_data(upgrade_linux_macspoof_nad):
 
 
 @pytest.fixture(scope="session")
-def vma_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macspoof_nad, vm_nad_networks_data):
+def vma_upgrade_mac_spoof(
+    admin_client, worker_node1, unprivileged_client, upgrade_linux_macspoof_nad, vm_nad_networks_data
+):
     name = "vma-macspoof"
     with VirtualMachineForTests(
         name=name,
@@ -47,7 +49,7 @@ def vma_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macsp
         interfaces=sorted(vm_nad_networks_data.keys()),
         client=unprivileged_client,
         cloud_init_data=cloud_init(ip_address=random_ipv4_address(net_seed=0, host_address=1)),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         eviction_strategy=ES_NONE,
@@ -56,7 +58,9 @@ def vma_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macsp
 
 
 @pytest.fixture(scope="session")
-def vmb_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macspoof_nad, vm_nad_networks_data):
+def vmb_upgrade_mac_spoof(
+    admin_client, worker_node1, unprivileged_client, upgrade_linux_macspoof_nad, vm_nad_networks_data
+):
     name = "vmb-macspoof"
     with VirtualMachineForTests(
         name=name,
@@ -65,7 +69,7 @@ def vmb_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macsp
         interfaces=sorted(vm_nad_networks_data.keys()),
         client=unprivileged_client,
         cloud_init_data=cloud_init(ip_address=random_ipv4_address(net_seed=0, host_address=2)),
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         eviction_strategy=ES_NONE,
@@ -98,6 +102,7 @@ def namespace_with_disabled_kmp(admin_client):
 
 @pytest.fixture(scope="session")
 def running_vm_with_bridge(
+    admin_client,
     unprivileged_client,
     upgrade_namespace_scope_session,
     upgrade_br1test_nad,
@@ -109,7 +114,7 @@ def running_vm_with_bridge(
         networks={upgrade_br1test_nad.name: upgrade_br1test_nad.name},
         interfaces=[upgrade_br1test_nad.name],
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         eviction_strategy=ES_NONE,
     ) as vm:
         vm.start(wait=True)

--- a/tests/network/utils.py
+++ b/tests/network/utils.py
@@ -1,6 +1,7 @@
 import logging
 import shlex
 
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
 from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.service import Service
@@ -56,13 +57,18 @@ class FedoraVirtualMachineForServiceMesh(VirtualMachineForTests):
         name,
         namespace,
         client,
+        admin_client: DynamicClient,
     ):
         """
         Fedora VM Creation. Used for Service Mesh tests
         """
 
         super().__init__(
-            name=name, namespace=namespace, client=client, os_flavor=OS_FLAVOR_FEDORA, body=fedora_vm_body(name=name)
+            name=name,
+            namespace=namespace,
+            client=client,
+            os_flavor=OS_FLAVOR_FEDORA,
+            body=fedora_vm_body(name=name, admin_client=admin_client),
         )
 
     def to_dict(self):

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -116,7 +116,7 @@ def unique_namespace(admin_client, unprivileged_client):
 
 
 @pytest.fixture(scope="module")
-def vm_list(unique_namespace):
+def vm_list(admin_client, unique_namespace):
     """
     Creates n vms, waits for them all to go to running state and cleans them up at the end
 
@@ -126,7 +126,7 @@ def vm_list(unique_namespace):
     Yields:
         list: list of VirtualMachineForTests created
     """
-    vms_list = create_vms(name_prefix="key-metric-vm", namespace_name=unique_namespace.name)
+    vms_list = create_vms(admin_client=admin_client, name_prefix="key-metric-vm", namespace_name=unique_namespace.name)
     for vm in vms_list:
         running_vm(vm=vm)
         enable_swap_fedora_vm(vm=vm)
@@ -170,8 +170,9 @@ def single_metrics_namespace(admin_client, unprivileged_client):
 
 
 @pytest.fixture(scope="module")
-def single_metric_vm(single_metrics_namespace):
+def single_metric_vm(admin_client, single_metrics_namespace):
     vm = create_vms(
+        admin_client=admin_client,
         name_prefix="test-single-vm",
         namespace_name=single_metrics_namespace.name,
         vm_count=SINGLE_VM,
@@ -256,7 +257,7 @@ def network_packet_received_linux_vm(vm_for_test, linux_vm_for_test_interface_na
 
 
 @pytest.fixture(scope="class")
-def vm_with_cpu_spec(namespace, unprivileged_client, is_s390x_cluster):
+def vm_with_cpu_spec(admin_client, namespace, unprivileged_client, is_s390x_cluster):
     name = "vm-resource-test"
     with VirtualMachineForTests(
         name=name,
@@ -264,7 +265,7 @@ def vm_with_cpu_spec(namespace, unprivileged_client, is_s390x_cluster):
         cpu_cores=TWO_CPU_CORES,
         cpu_sockets=TWO_CPU_SOCKETS,
         cpu_threads=ONE_CPU_THREAD if is_s390x_cluster else TWO_CPU_THREADS,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm)
@@ -358,14 +359,14 @@ def file_system_metric_mountpoints_existence(request, prometheus, vm_for_test, d
 
 
 @pytest.fixture(scope="class")
-def vm_for_test_with_resource_limits(namespace):
+def vm_for_test_with_resource_limits(admin_client, namespace):
     vm_name = "vm-with-limits"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace.name,
         cpu_limits=ONE_CPU_CORE,
         memory_limits=Images.Fedora.DEFAULT_MEMORY_SIZE,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -473,12 +474,12 @@ def windows_vm_for_test(namespace, unprivileged_client):
 
 
 @pytest.fixture(scope="class")
-def vm_for_migration_metrics_test(namespace, cpu_for_migration):
+def vm_for_migration_metrics_test(admin_client, namespace, cpu_for_migration):
     name = "vm-for-migration-metrics-test"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
         additional_labels=MIGRATION_POLICY_VM_LABEL,
     ) as vm:

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -17,9 +17,10 @@ LOGGER = logging.getLogger(__name__)
 def fedora_vm_without_name_in_label(
     namespace,
     unprivileged_client,
+    admin_client,
 ):
     vm_name = "test-vm-label-fedora-vm"
-    vm_body = fedora_vm_body(name=vm_name)
+    vm_body = fedora_vm_body(name=vm_name, admin_client=admin_client)
     virt_launcher_pod_labels = vm_body["spec"]["template"]["metadata"].get("labels")
     vm_label = vm_body["metadata"].get("labels")
 

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -78,12 +78,12 @@ def stopped_vm_metric_1(vm_metric_1):
 
 
 @pytest.fixture()
-def vm_in_error_state(namespace):
+def vm_in_error_state(admin_client, namespace):
     vm_name = "vm-in-error-state"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         node_selector=get_node_selector_dict(node_selector="non-existent-node"),
     ) as vm:
         vm.start()
@@ -105,12 +105,12 @@ def pvc_for_vm_in_starting_state(unprivileged_client, namespace):
 
 
 @pytest.fixture()
-def vm_in_starting_state(namespace, pvc_for_vm_in_starting_state):
+def vm_in_starting_state(admin_client, namespace, pvc_for_vm_in_starting_state):
     vm_name = "vm-in-starting-state"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         pvc=pvc_for_vm_in_starting_state,
     ) as vm:
         vm.start()
@@ -119,12 +119,12 @@ def vm_in_starting_state(namespace, pvc_for_vm_in_starting_state):
 
 
 @pytest.fixture(scope="class")
-def vm_metric_1(namespace, unprivileged_client, cluster_common_node_cpu):
+def vm_metric_1(admin_client, namespace, unprivileged_client, cluster_common_node_cpu):
     vm_name = "vm-metrics-1"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         client=unprivileged_client,
         additional_labels=MIGRATION_POLICY_VM_LABEL,
         cpu_model=cluster_common_node_cpu,

--- a/tests/observability/upgrade/conftest.py
+++ b/tests/observability/upgrade/conftest.py
@@ -8,12 +8,14 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
 @pytest.fixture(scope="session")
-def vm_with_node_selector_for_upgrade(namespace_for_outdated_vm_upgrade, unprivileged_client, worker_node1):
+def vm_with_node_selector_for_upgrade(
+    namespace_for_outdated_vm_upgrade, unprivileged_client, worker_node1, admin_client
+):
     name = "vm-with-node-selector"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace_for_outdated_vm_upgrade.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         node_selector=get_node_selector_dict(node_selector=worker_node1.name),
         client=unprivileged_client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -296,12 +296,12 @@ def blank_disk_dv_for_storage_migration(unprivileged_client, namespace, source_s
 
 
 @pytest.fixture(scope="class")
-def fedora_vm_for_hotplug_and_storage_migration(unprivileged_client, namespace, cpu_for_migration):
+def fedora_vm_for_hotplug_and_storage_migration(admin_client, unprivileged_client, namespace, cpu_for_migration):
     name = "fedora-volume-hotplug-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
         client=unprivileged_client,
     ) as vm:

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -144,7 +144,9 @@ def param_substring_scope_class(storage_class_name_scope_class):
 
 
 @pytest.fixture(scope="class")
-def fedora_vm_for_hotplug_scope_class(unprivileged_client, namespace, param_substring_scope_class, cpu_for_migration):
+def fedora_vm_for_hotplug_scope_class(
+    unprivileged_client, namespace, param_substring_scope_class, cpu_for_migration, admin_client
+):
     name = f"fedora-hotplug-{param_substring_scope_class}"
     memory_requests = None
     cpu_requests = None
@@ -159,7 +161,7 @@ def fedora_vm_for_hotplug_scope_class(unprivileged_client, namespace, param_subs
         memory_requests=memory_requests,
         memory_limits=memory_requests,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
         cpu_limits=cpu_requests,
         cpu_requests=cpu_requests,

--- a/tests/storage/test_priority_class.py
+++ b/tests/storage/test_priority_class.py
@@ -53,6 +53,7 @@ def vm_with_priority_class(
     dv_dict,
     priority_class,
     unprivileged_client,
+    admin_client,
 ):
     vm_priority_class = priority_class["vm_priority_class"]
     vm_name = "priority-vm"
@@ -65,7 +66,7 @@ def vm_with_priority_class(
         },
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
         priority_class_name=vm_priority_class.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         client=unprivileged_client,
     ) as vm:

--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -150,12 +150,12 @@ def enabled_feature_gate_for_declarative_hotplug_volumes_upg(
 
 
 @pytest.fixture(scope="session")
-def fedora_vm_for_hotplug_upg(upgrade_namespace_scope_session, cluster_common_node_cpu):
+def fedora_vm_for_hotplug_upg(admin_client, upgrade_namespace_scope_session, cluster_common_node_cpu):
     name = "fedora-hotplug-upg"
     with VirtualMachineForTests(
         name=name,
         namespace=upgrade_namespace_scope_session.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cpu_model=cluster_common_node_cpu,
         client=upgrade_namespace_scope_session.client,
     ) as vm:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,6 +73,7 @@ LOGGER = logging.getLogger(__name__)
 def create_vms(
     name_prefix,
     namespace_name,
+    admin_client,
     vm_count=NUM_TEST_VMS,
     client=None,
     ssh=True,
@@ -85,6 +86,7 @@ def create_vms(
     Args:
         name_prefix (str): prefix to be used to name virtualmachines
         namespace_name (str): Namespace to be used for vm creation
+        admin_client (DynamicClient): Admin client for cluster-scoped operations
         vm_count (int): Number of vms to be created
         node_selector_labels (str): Labels for node selector.
         client (DynamicClient): DynamicClient object
@@ -100,7 +102,7 @@ def create_vms(
         with VirtualMachineForTests(
             name=vm_name,
             namespace=namespace_name,
-            body=fedora_vm_body(name=vm_name),
+            body=fedora_vm_body(name=vm_name, admin_client=admin_client),
             node_selector_labels=node_selector_labels,
             teardown=False,
             run_strategy=VirtualMachine.RunStrategy.ALWAYS,

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -105,14 +105,14 @@ def second_pod_for_aaq_test_in_gated_state(admin_client, namespace):
 
 
 @pytest.fixture(scope="class")
-def vm_for_aaq_test(namespace, unprivileged_client, cpu_for_migration):
+def vm_for_aaq_test(admin_client, namespace, unprivileged_client, cpu_for_migration):
     vm_name = "first-vm-for-aaq-test"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace.name,
         cpu_cores=VM_CPU_CORES,
         memory_guest=VM_MEMORY_GUEST,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         client=unprivileged_client,
         cpu_model=cpu_for_migration,
     ) as vm:
@@ -128,7 +128,7 @@ def vm_for_aaq_test_in_gated_state(admin_client, namespace, unprivileged_client)
         namespace=namespace.name,
         cpu_cores=VM_CPU_CORES,
         memory_guest=VM_MEMORY_GUEST,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         client=unprivileged_client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
     ) as vm:
@@ -206,14 +206,14 @@ def removed_acrq_label_from_second_namespace(second_namespace_for_acrq_test):
 
 
 @pytest.fixture(scope="class")
-def vm_in_second_namespace_for_acrq_test(second_namespace_for_acrq_test):
+def vm_in_second_namespace_for_acrq_test(admin_client, second_namespace_for_acrq_test):
     vm_name = "vm-another-namespace-for-acrq-test"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=second_namespace_for_acrq_test.name,
         cpu_cores=VM_CPU_CORES,
         memory_guest=VM_MEMORY_GUEST,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -284,7 +284,9 @@ def hotplugged_target_pod(namespace, unprivileged_client, hotplug_vm_for_aaq_tes
 
 
 @pytest.fixture(scope="class")
-def vm_for_aaq_allocation_methods_test(namespace, cpu_for_migration, aaq_allocation_methods_matrix__class__):
+def vm_for_aaq_allocation_methods_test(
+    admin_client, namespace, cpu_for_migration, aaq_allocation_methods_matrix__class__
+):
     vm_name = f"vm-aaq-test-{aaq_allocation_methods_matrix__class__.lower()}-allocation"
     with VirtualMachineForTests(
         name=vm_name,
@@ -292,7 +294,7 @@ def vm_for_aaq_allocation_methods_test(namespace, cpu_for_migration, aaq_allocat
         cpu_limits=1,
         memory_limits="1Gi",
         memory_requests="1Gi",
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
     ) as vm:
         running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)

--- a/tests/virt/cluster/general/test_cpu_allocation_ratio.py
+++ b/tests/virt/cluster/general/test_cpu_allocation_ratio.py
@@ -64,6 +64,7 @@ def hco_cr_with_vmi_cpu_allocation_ratio(
 
 @pytest.fixture()
 def vm_for_test_cpu_allocation_ratio(
+    admin_client,
     namespace,
 ):
     name = "vm-for-cpu-allocation-ratio-test"
@@ -73,7 +74,7 @@ def vm_for_test_cpu_allocation_ratio(
         cpu_cores=CPU_CORES,
         cpu_sockets=CPU_SOCKETS,
         cpu_threads=CPU_THREADS,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/cluster/general/test_smbios.py
+++ b/tests/virt/cluster/general/test_smbios.py
@@ -13,12 +13,12 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.gating, pytest.mark.conforma
 
 
 @pytest.fixture()
-def configmap_smbios_vm(namespace):
+def configmap_smbios_vm(admin_client, namespace):
     name = "configmap-smbios-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/cluster/longevity_tests/conftest.py
+++ b/tests/virt/cluster/longevity_tests/conftest.py
@@ -27,9 +27,10 @@ def vm_deploys():
 
 
 @pytest.fixture()
-def container_disk_vms(vm_deploys, namespace, unprivileged_client):
+def container_disk_vms(admin_client, vm_deploys, namespace, unprivileged_client):
     LOGGER.info("Deploying VM with container disk")
     yield from create_containerdisk_vms(
+        admin_client=admin_client,
         vm_deploys=vm_deploys,
         client=unprivileged_client,
         namespace=namespace,

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -287,12 +287,12 @@ def deploy_datasources(datasource_dict):
             ds.clean_up()
 
 
-def create_containerdisk_vms(vm_deploys, client, name, namespace):
+def create_containerdisk_vms(admin_client, vm_deploys, client, name, namespace):
     vms = [
         VirtualMachineForTests(
             name=f"{name}-{deployment + 1}",
             namespace=namespace.name,
-            body=fedora_vm_body(name=name),
+            body=fedora_vm_body(name=name, admin_client=admin_client),
             client=client,
         )
         for deployment in range(vm_deploys)

--- a/tests/virt/cluster/memory_overcommit/test_memory_overcommit.py
+++ b/tests/virt/cluster/memory_overcommit/test_memory_overcommit.py
@@ -11,12 +11,12 @@ VM_MEMORY = "2Gi"
 
 
 @pytest.fixture()
-def vm_for_memory_overcommit(request, namespace):
+def vm_for_memory_overcommit(request, admin_client, namespace):
     name = request.param["vm_name"]
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         memory_guest=VM_MEMORY,
         memory_requests=request.param.get("memory_requests"),
     ) as vm:

--- a/tests/virt/cluster/migration_and_maintenance/rbac_hardening/test_migration_rights.py
+++ b/tests/virt/cluster/migration_and_maintenance/rbac_hardening/test_migration_rights.py
@@ -30,13 +30,13 @@ def unprivileged_user_migrate_rolebinding(admin_client, namespace, kubevirt_migr
 
 
 @pytest.fixture(scope="module")
-def unprivileged_user_vm(unprivileged_client, namespace):
+def unprivileged_user_vm(admin_client, unprivileged_client, namespace):
     name = "namespace-admin-vm"
     with VirtualMachineForTests(
         name=name,
         client=unprivileged_client,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -80,6 +80,7 @@ def migration_policy_b(request):
 @pytest.fixture()
 def vm_for_migration_policy_test(
     request,
+    admin_client,
     namespace,
     cpu_for_migration,
 ):
@@ -87,7 +88,7 @@ def vm_for_migration_policy_test(
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         additional_labels=request.param,
         cpu_model=cpu_for_migration,
     ) as vm:

--- a/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
+++ b/tests/virt/cluster/resource_limits/test_auto_resource_limits.py
@@ -26,7 +26,7 @@ def resource_quota_for_auto_resource_limits_test(request, namespace):
 
 
 @pytest.fixture()
-def vm_auto_resource_limits(request, namespace, unprivileged_client, cpu_for_migration):
+def vm_auto_resource_limits(request, admin_client, namespace, unprivileged_client, cpu_for_migration):
     with VirtualMachineForTests(
         name=request.param["name"],
         namespace=namespace.name,
@@ -36,7 +36,7 @@ def vm_auto_resource_limits(request, namespace, unprivileged_client, cpu_for_mig
         cpu_limits=request.param.get("cpu_limits"),
         memory_limits=request.param.get("memory_limits"),
         cpu_model=cpu_for_migration,
-        body=fedora_vm_body(name=request.param["name"]),
+        body=fedora_vm_body(name=request.param["name"], admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)

--- a/tests/virt/cluster/vm_cloning/conftest.py
+++ b/tests/virt/cluster/vm_cloning/conftest.py
@@ -23,13 +23,13 @@ from utilities.virt import (
 
 
 @pytest.fixture(scope="class")
-def fedora_vm_for_cloning(request, unprivileged_client, namespace, cpu_for_migration):
+def fedora_vm_for_cloning(request, admin_client, unprivileged_client, namespace, cpu_for_migration):
     name = request.param["vm_name"]
     with VirtualMachineForCloning(
         name=name,
         client=unprivileged_client,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         vm_labels=request.param.get("labels"),
         vm_annotations=request.param.get("annotations"),
         smbios_serial=request.param.get("smbios_serial"),

--- a/tests/virt/cluster/vm_lifecycle/conftest.py
+++ b/tests/virt/cluster/vm_lifecycle/conftest.py
@@ -10,7 +10,7 @@ default_run_strategy = VirtualMachine.RunStrategy.MANUAL
 
 
 @contextmanager
-def container_disk_vm(namespace, unprivileged_client, cpu_model=None, data_volume_template=None):
+def container_disk_vm(admin_client, namespace, unprivileged_client, cpu_model=None, data_volume_template=None):
     """lifecycle_vm is used to call this fixture and data_volume_vm; data_source is not needed in this use cases"""
     name = "fedora-vm-lifecycle"
     with VirtualMachineForTests(
@@ -18,14 +18,14 @@ def container_disk_vm(namespace, unprivileged_client, cpu_model=None, data_volum
         namespace=namespace.name,
         cpu_model=cpu_model,
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         run_strategy=default_run_strategy,
     ) as vm:
         yield vm
 
 
 @contextmanager
-def data_volume_vm(unprivileged_client, namespace, data_volume_template, cpu_model=None):
+def data_volume_vm(admin_client, unprivileged_client, namespace, data_volume_template, cpu_model=None):
     with VirtualMachineForTests(
         name="rhel-vm-lifecycle",
         namespace=namespace.name,
@@ -40,6 +40,7 @@ def data_volume_vm(unprivileged_client, namespace, data_volume_template, cpu_mod
 
 @pytest.fixture(scope="class")
 def lifecycle_vm(
+    admin_client,
     cpu_for_migration,
     unprivileged_client,
     namespace,
@@ -52,6 +53,7 @@ def lifecycle_vm(
     request should be True to start vm and wait for interfaces, else False
     """
     with globals()[vm_volumes_matrix__class__](
+        admin_client=admin_client,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
         data_volume_template=golden_image_data_volume_template_for_test_scope_module,

--- a/tests/virt/cluster/vm_lifecycle/test_restart.py
+++ b/tests/virt/cluster/vm_lifecycle/test_restart.py
@@ -19,13 +19,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture()
-def vm_to_restart(unprivileged_client, namespace):
+def vm_to_restart(admin_client, unprivileged_client, namespace):
     name = "vm-to-restart"
     with VirtualMachineForTests(
         client=unprivileged_client,
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/node/cpu_sockets_threads/test_cpu_support_sockets_threads.py
+++ b/tests/virt/node/cpu_sockets_threads/test_cpu_support_sockets_threads.py
@@ -21,7 +21,7 @@ def check_vm_dumpxml(vm, admin_client, cores=None, sockets=None, threads=None):
 
 
 @pytest.fixture()
-def vm_with_cpu_support(request, is_s390x_cluster, namespace, unprivileged_client):
+def vm_with_cpu_support(request, admin_client, is_s390x_cluster, namespace, unprivileged_client):
     """
     VM with CPU support (cores,sockets,threads)
     """
@@ -33,7 +33,7 @@ def vm_with_cpu_support(request, is_s390x_cluster, namespace, unprivileged_clien
         cpu_sockets=request.param["sockets"],
         cpu_threads=1 if is_s390x_cluster else request.param["threads"],
         cpu_max_sockets=request.param["sockets"] or 1,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm)
@@ -81,7 +81,7 @@ def test_vm_with_cpu_support(admin_client, vm_with_cpu_support):
 
 
 @pytest.fixture()
-def no_cpu_settings_vm(namespace, unprivileged_client):
+def no_cpu_settings_vm(admin_client, namespace, unprivileged_client):
     """
     Create VM without specific CPU settings
     """
@@ -89,7 +89,7 @@ def no_cpu_settings_vm(namespace, unprivileged_client):
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         vm.start(wait=True)
@@ -125,7 +125,7 @@ def test_vm_with_cpu_limitation(admin_client, namespace, unprivileged_client):
         cpu_limits=2,
         cpu_requests=2,
         cpu_max_sockets=1,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         vm.start(wait=True)
@@ -135,7 +135,7 @@ def test_vm_with_cpu_limitation(admin_client, namespace, unprivileged_client):
 
 @pytest.mark.polarion("CNV-2819")
 @pytest.mark.s390x
-def test_vm_with_cpu_limitation_negative(namespace, unprivileged_client):
+def test_vm_with_cpu_limitation_negative(admin_client, namespace, unprivileged_client):
     """
     Test VM with cpu limitation
     negative case: CPU requests is larger then limits
@@ -147,7 +147,7 @@ def test_vm_with_cpu_limitation_negative(namespace, unprivileged_client):
             namespace=namespace.name,
             cpu_limits=2,
             cpu_requests=4,
-            body=fedora_vm_body(name=name),
+            body=fedora_vm_body(name=name, admin_client=admin_client),
             client=unprivileged_client,
         ):
             return

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -106,6 +106,7 @@ def calculated_vm_deployment_for_descheduler_test(
 
 @pytest.fixture(scope="class")
 def deployed_vms_for_descheduler_test(
+    admin_client,
     namespace,
     unprivileged_client,
     cpu_for_migration,
@@ -113,6 +114,7 @@ def deployed_vms_for_descheduler_test(
     calculated_vm_deployment_for_descheduler_test,
 ):
     yield from deploy_vms(
+        admin_client=admin_client,
         vm_prefix="vm-descheduler-test",
         client=unprivileged_client,
         namespace_name=namespace.name,
@@ -204,6 +206,7 @@ def calculated_vm_deployment_for_node_with_least_available_memory(
 
 @pytest.fixture(scope="class")
 def deployed_vms_for_utilization_imbalance(
+    admin_client,
     request,
     namespace,
     unprivileged_client,
@@ -213,6 +216,7 @@ def deployed_vms_for_utilization_imbalance(
     node_affinity_for_descheduler_label,
 ):
     yield from deploy_vms(
+        admin_client=admin_client,
         vm_prefix=request.param["vm_prefix"],
         client=unprivileged_client,
         namespace_name=namespace.name,
@@ -226,6 +230,7 @@ def deployed_vms_for_utilization_imbalance(
 
 @pytest.fixture(scope="class")
 def deployed_vms_on_labeled_node(
+    admin_client,
     namespace,
     unprivileged_client,
     cpu_for_migration,
@@ -234,6 +239,7 @@ def deployed_vms_on_labeled_node(
     node_affinity_for_descheduler_label,
 ):
     yield from deploy_vms(
+        admin_client=admin_client,
         vm_prefix="node-labels-test",
         client=unprivileged_client,
         namespace_name=namespace.name,

--- a/tests/virt/node/descheduler/utils.py
+++ b/tests/virt/node/descheduler/utils.py
@@ -204,6 +204,7 @@ def deploy_vms(
     vm_count,
     deployment_size,
     descheduler_eviction,
+    admin_client,
     node_selector_labels=None,
     vm_affinity=None,
 ):
@@ -218,7 +219,7 @@ def deploy_vms(
             memory_guest=deployment_size["memory"].bytes,
             cpu_model=cpu_model,
             descheduler_eviction=descheduler_eviction,
-            body=fedora_vm_body(name=vm_name),
+            body=fedora_vm_body(name=vm_name, admin_client=admin_client),
             node_selector_labels=node_selector_labels,
             vm_affinity=vm_affinity,
         )

--- a/tests/virt/node/general/test_cloud_init_disk_vm.py
+++ b/tests/virt/node/general/test_cloud_init_disk_vm.py
@@ -5,12 +5,12 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
 @pytest.fixture()
-def vm_with_cloud_init_disk(namespace):
+def vm_with_cloud_init_disk(admin_client, namespace):
     name = "vm-with-cloud-init-disk"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cloud_init_type=CLOUD_INIT_NO_CLOUD,
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)

--- a/tests/virt/node/general/test_cloud_init_vm.py
+++ b/tests/virt/node/general/test_cloud_init_vm.py
@@ -11,13 +11,13 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
 @pytest.fixture()
-def vm_with_cloud_init_type(namespace):
+def vm_with_cloud_init_type(admin_client, namespace):
     """VM with cloudInit disk."""
     name = "vm-cloud-init-test"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cloud_init_type=CLOUD_INIT_NO_CLOUD,
     ) as vm:
         running_vm(vm=vm)

--- a/tests/virt/node/general/test_container_disk_vm.py
+++ b/tests/virt/node/general/test_container_disk_vm.py
@@ -7,6 +7,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 @pytest.mark.smoke
 @pytest.mark.polarion("CNV-5501")
 def test_container_disk_vm(
+    admin_client,
     namespace,
     unprivileged_client,
 ):
@@ -15,6 +16,6 @@ def test_container_disk_vm(
         namespace=namespace.name,
         name=name,
         client=unprivileged_client,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)

--- a/tests/virt/node/general/test_disable_pvspinlock.py
+++ b/tests/virt/node/general/test_disable_pvspinlock.py
@@ -5,6 +5,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 @pytest.fixture(scope="class")
 def vm_for_test_pvspinlock(
+    admin_client,
     namespace,
     unprivileged_client,
 ):
@@ -12,7 +13,7 @@ def vm_for_test_pvspinlock(
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         pvspinlock_enabled=False,
     ) as vm:
         running_vm(vm=vm)

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -35,13 +35,13 @@ RHEL_8_10_TEMPLATE_LABELS = {
 
 
 @pytest.fixture(scope="class")
-def vm_for_machine_type_test(request, cpu_for_migration, unprivileged_client, namespace):
+def vm_for_machine_type_test(request, admin_client, cpu_for_migration, unprivileged_client, namespace):
     name = f"vm-{request.param['vm_name']}-machine-type"
 
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
         client=unprivileged_client,
         machine_type=request.param.get("machine_type"),
@@ -56,13 +56,13 @@ def explicit_machine_type(is_s390x_cluster):
 
 
 @pytest.fixture()
-def vm_with_explicit_machine_type(unprivileged_client, namespace, explicit_machine_type):
+def vm_with_explicit_machine_type(admin_client, unprivileged_client, namespace, explicit_machine_type):
     name = f"vm-machine-type-{explicit_machine_type}"
 
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         machine_type=explicit_machine_type,
     ) as vm:
@@ -232,14 +232,14 @@ def test_machine_type_kubevirt_config_update(admin_client, vm_for_machine_type_t
 
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-3688")
-def test_unsupported_machine_type(namespace, unprivileged_client):
+def test_unsupported_machine_type(admin_client, namespace, unprivileged_client):
     vm_name = "vm-invalid-machine-type"
 
     with pytest.raises(UnprocessibleEntityError):
         with VirtualMachineForTests(
             name=vm_name,
             namespace=namespace.name,
-            body=fedora_vm_body(name=vm_name),
+            body=fedora_vm_body(name=vm_name, admin_client=admin_client),
             client=unprivileged_client,
             machine_type=MachineTypesNames.pc_i440fx_rhel7_6,
         ):

--- a/tests/virt/node/general/test_oom.py
+++ b/tests/virt/node/general/test_oom.py
@@ -32,12 +32,12 @@ def verify_vm_not_crashed(vm, admin_client):
 
 
 @pytest.fixture()
-def fedora_oom_vm(namespace, unprivileged_client):
+def fedora_oom_vm(admin_client, namespace, unprivileged_client):
     name = "oom-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         cpu_cores=2,

--- a/tests/virt/node/general/test_vm_with_sidecar.py
+++ b/tests/virt/node/general/test_vm_with_sidecar.py
@@ -5,13 +5,23 @@ VM with sidecar
 import shlex
 
 import pytest
+from kubernetes.dynamic import DynamicClient
 from pyhelper_utils.shell import run_ssh_commands
 
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
 class FedoraVirtualMachineWithSideCar(VirtualMachineForTests):
-    def __init__(self, name, namespace, interfaces=None, networks=None, client=None):
+    def __init__(
+        self,
+        name,
+        namespace,
+        admin_client: DynamicClient,
+        interfaces=None,
+        networks=None,
+        client=None,
+    ):
+        self.admin_client = admin_client
         super().__init__(
             name=name,
             namespace=namespace,
@@ -21,7 +31,7 @@ class FedoraVirtualMachineWithSideCar(VirtualMachineForTests):
         )
 
     def to_dict(self):
-        self.body = fedora_vm_body(name=self.name)
+        self.body = fedora_vm_body(name=self.name, admin_client=self.admin_client)
         super().to_dict()
 
         self.res["spec"]["template"]["metadata"].setdefault("annotations", {})
@@ -36,10 +46,12 @@ class FedoraVirtualMachineWithSideCar(VirtualMachineForTests):
 
 
 @pytest.fixture()
-def sidecar_vm(namespace, unprivileged_client):
+def sidecar_vm(admin_client, namespace, unprivileged_client):
     """Test VM with sidecar hook"""
     name = "vmi-with-sidecar-hook"
-    with FedoraVirtualMachineWithSideCar(name=name, namespace=namespace.name, client=unprivileged_client) as vm:
+    with FedoraVirtualMachineWithSideCar(
+        name=name, namespace=namespace.name, admin_client=admin_client, client=unprivileged_client
+    ) as vm:
         running_vm(vm=vm)
         yield vm
 

--- a/tests/virt/node/high_performance_vm/test_numa.py
+++ b/tests/virt/node/high_performance_vm/test_numa.py
@@ -47,14 +47,14 @@ def sriov_net(admin_client, sriov_node_policy, namespace):
 
 
 @pytest.fixture()
-def vm_numa(namespace, unprivileged_client):
+def vm_numa(admin_client, namespace, unprivileged_client):
     name = "vm-numa"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         cpu_cores=8,
         cpu_sockets=2,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         cpu_placement=True,
     ) as vm:
@@ -64,7 +64,7 @@ def vm_numa(namespace, unprivileged_client):
 
 
 @pytest.fixture()
-def vm_numa_sriov(namespace, unprivileged_client, sriov_net):
+def vm_numa_sriov(admin_client, namespace, unprivileged_client, sriov_net):
     name = "vm-numa-sriov"
     networks = sriov_network_dict(namespace=namespace, network=sriov_net)
     with VirtualMachineForTests(
@@ -72,7 +72,7 @@ def vm_numa_sriov(namespace, unprivileged_client, sriov_net):
         namespace=namespace.name,
         cpu_cores=8,
         cpu_sockets=2,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
         cpu_placement=True,
         networks=networks,

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -64,6 +64,7 @@ def wait_for_all_progress_keys_in_pod_log(pod):
 
 @pytest.fixture(scope="class")
 def vm_for_migration_progress_test(
+    admin_client,
     namespace,
     unprivileged_client,
     cpu_for_migration,
@@ -73,7 +74,7 @@ def vm_for_migration_progress_test(
         name=name,
         client=unprivileged_client,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         additional_labels=MIGRATION_POLICY_VM_LABEL,
         cpu_model=cpu_for_migration,
     ) as vm:

--- a/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
+++ b/tests/virt/node/migration_and_maintenance/test_node_maintenance.py
@@ -67,6 +67,7 @@ def node_filter(pod, schedulable_nodes):
 
 @pytest.fixture()
 def vm_container_disk_fedora(
+    admin_client,
     unprivileged_client,
     cpu_for_migration,
     namespace,
@@ -76,7 +77,7 @@ def vm_container_disk_fedora(
         name=name,
         namespace=namespace.name,
         cpu_model=cpu_for_migration,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm)

--- a/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_features.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_features.py
@@ -30,13 +30,13 @@ def fail_if_amd_cpu_nodes(nodes_cpu_vendor):
     ],
     ids=["Feature: name: pcid", "Feature: name: pcid , policy:force"],
 )
-def cpu_features_vm_positive(request, unprivileged_client, namespace):
+def cpu_features_vm_positive(request, admin_client, unprivileged_client, namespace):
     name = f"vm-cpu-features-positive-{request.param[1]}"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         cpu_flags=request.param[0],
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm)
@@ -73,7 +73,7 @@ def test_vm_with_cpu_feature_positive(cpu_features_vm_positive):
     ],
 )
 @pytest.mark.s390x
-def test_invalid_cpu_feature_policy_negative(unprivileged_client, namespace, features):
+def test_invalid_cpu_feature_policy_negative(admin_client, unprivileged_client, namespace, features):
     """VM should not be created successfully"""
     vm_name = "invalid-cpu-feature-policy-vm"
     with pytest.raises(UnprocessibleEntityError):
@@ -81,7 +81,7 @@ def test_invalid_cpu_feature_policy_negative(unprivileged_client, namespace, fea
             name=vm_name,
             namespace=namespace.name,
             cpu_flags={"features": features},
-            body=fedora_vm_body(name=vm_name),
+            body=fedora_vm_body(name=vm_name, admin_client=admin_client),
             client=unprivileged_client,
         ):
             pytest.fail("VM was created with an invalid cpu feature policy.")

--- a/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_flag.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_vm_with_cpu_flag.py
@@ -12,13 +12,13 @@ pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
 
 @pytest.fixture()
-def cpu_flag_vm_positive(cluster_common_node_cpu, namespace, unprivileged_client):
+def cpu_flag_vm_positive(admin_client, cluster_common_node_cpu, namespace, unprivileged_client):
     name = "vm-cpu-flags-positive"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         cpu_flags={"model": cluster_common_node_cpu},
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm)
@@ -38,13 +38,13 @@ def cpu_flag_vm_positive(cluster_common_node_cpu, namespace, unprivileged_client
     ],
     ids=["CPU-flag: Bad-Skylake-Server", "CPU-flag: commodore64"],
 )
-def cpu_flag_vm_negative(request, unprivileged_client, namespace):
+def cpu_flag_vm_negative(request, admin_client, unprivileged_client, namespace):
     name = f"vm-cpu-flags-negative-{request.param[1]}"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
         cpu_flags=request.param[0],
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         vm.start()

--- a/tests/virt/node/owner_references/test_vm_owner_references.py
+++ b/tests/virt/node/owner_references/test_vm_owner_references.py
@@ -16,7 +16,7 @@ def fedora_vm(admin_client, unprivileged_client, namespace):
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         client=unprivileged_client,
     ) as vm:
         vm.start(wait=True)

--- a/tests/virt/node/rng/test_rng.py
+++ b/tests/virt/node/rng/test_rng.py
@@ -11,12 +11,12 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
 @pytest.fixture()
-def rng_vm(unprivileged_client, namespace):
+def rng_vm(admin_client, unprivileged_client, namespace):
     name = "vmi-with-rng"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/node/workload_density/test_free_page_reporting.py
+++ b/tests/virt/node/workload_density/test_free_page_reporting.py
@@ -22,13 +22,14 @@ def assert_vmi_free_page_reporting(vm, expected_free_page_reporting, admin_clien
 
 @pytest.fixture(scope="class")
 def free_page_reporting_vm(
+    admin_client,
     namespace,
 ):
     name = "free-page-reporting-vm"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -36,13 +37,14 @@ def free_page_reporting_vm(
 
 @pytest.fixture()
 def vm_with_dedicated_cpu(
+    admin_client,
     namespace,
 ):
     name = "vm-with-dedicated-cpu"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         cpu_placement=True,
     ) as vm:
         running_vm(vm=vm)
@@ -50,12 +52,12 @@ def vm_with_dedicated_cpu(
 
 
 @pytest.fixture()
-def vm_with_hugepages(namespace):
+def vm_with_hugepages(admin_client, namespace):
     name = "vm-with-hugepage"
     with VirtualMachineForTests(
         name=name,
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        body=fedora_vm_body(name=name, admin_client=admin_client),
         hugepages_page_size="1Gi",
     ) as vm:
         running_vm(vm=vm)

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -144,9 +144,10 @@ def ksm_deactivated_on_node(worker_node1, workers_utility_pods):
 
 
 @pytest.fixture(scope="class")
-def vms_for_ksm_test(namespace, cpu_for_migration):
+def vms_for_ksm_test(admin_client, namespace, cpu_for_migration):
     # We need several VMs for sharing memory
     vms_list = create_vms(
+        admin_client=admin_client,
         name_prefix="ksm-test-vm",
         namespace_name=namespace.name,
         node_selector_labels=KERNEL_SAMEPAGE_MERGING_TEST_LABEL,

--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -335,12 +335,12 @@ def post_copy_migration_policy_for_upgrade(admin_client):
 
 
 @pytest.fixture(scope="session")
-def vm_for_post_copy_upgrade(virt_upgrade_namespace, unprivileged_client, cpu_for_migration):
+def vm_for_post_copy_upgrade(admin_client, virt_upgrade_namespace, unprivileged_client, cpu_for_migration):
     vm_name = "vm-for-post-copy-upgrade-test"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=virt_upgrade_namespace.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         client=unprivileged_client,
         cpu_model=cpu_for_migration,
         additional_labels=VM_LABEL,

--- a/tests/virt/upgrade_custom/aaq/conftest.py
+++ b/tests/virt/upgrade_custom/aaq/conftest.py
@@ -48,12 +48,12 @@ def application_aware_resource_quota_upgrade(admin_client, namespace_for_arq_upg
 
 
 @pytest.fixture(scope="session")
-def vm_for_arq_upgrade_test(unprivileged_client, namespace_for_arq_upgrade_test, cpu_for_migration):
+def vm_for_arq_upgrade_test(admin_client, unprivileged_client, namespace_for_arq_upgrade_test, cpu_for_migration):
     vm_name = "vm-for-arq-upgrade-test"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace_for_arq_upgrade_test.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
         client=unprivileged_client,
     ) as vm:
@@ -67,7 +67,7 @@ def vm_for_arq_upgrade_test_in_gated_state(admin_client, unprivileged_client, na
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace_for_arq_upgrade_test.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         client=unprivileged_client,
     ) as vm:
@@ -99,12 +99,12 @@ def application_aware_cluster_resource_quota_upgrade(admin_client):
 
 
 @pytest.fixture(scope="session")
-def vm_for_acrq_upgrade_test(unprivileged_client, namespace_for_acrq_upgrade_test, cpu_for_migration):
+def vm_for_acrq_upgrade_test(admin_client, unprivileged_client, namespace_for_acrq_upgrade_test, cpu_for_migration):
     vm_name = "vm-for-acrq-upgrade-test"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace_for_acrq_upgrade_test.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         cpu_model=cpu_for_migration,
         client=unprivileged_client,
     ) as vm:
@@ -118,7 +118,7 @@ def vm_for_acrq_upgrade_test_in_gated_state(admin_client, unprivileged_client, n
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace_for_acrq_upgrade_test.name,
-        body=fedora_vm_body(name=vm_name),
+        body=fedora_vm_body(name=vm_name, admin_client=admin_client),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         client=unprivileged_client,
     ) as vm:

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1514,7 +1514,20 @@ def vm_console_run_commands(
     return output
 
 
-def fedora_vm_body(name: str) -> dict[str, Any]:
+def fedora_vm_body(name: str, admin_client: DynamicClient) -> dict[str, Any]:
+    """Generate a Fedora VM body dict from the vm-fedora.yaml manifest template.
+
+    Resolves the Fedora container image digest based on the cluster's architecture
+    and renders the YAML template with the given VM name.
+
+    Args:
+        name: Name of the VirtualMachine resource.
+        admin_client: Admin-privileged client, required to query cluster node
+            CPU architecture for selecting the correct container image.
+
+    Returns:
+        dict representing the VM resource body, ready to pass to VirtualMachineForTests.
+    """
     pull_secret = utilities.infra.generate_openshift_pull_secret_file()
 
     # Make sure we can find the file even if utilities was installed via pip.
@@ -1528,7 +1541,7 @@ def fedora_vm_body(name: str) -> dict[str, Any]:
         image=image,
         pull_secret=pull_secret,
         architecture=utilities.cpu.get_nodes_cpu_architecture(
-            nodes=list(Node.get(client=get_client())),
+            nodes=list(Node.get(client=admin_client)),
         ),
     )
     image_digest = image_info["digest"]


### PR DESCRIPTION


##### Short description:
Replace get_client() in func `fedora_vm_body` with an explicit admin_client parameter for querying cluster node CPU architecture. Update all callers to pass admin_client through fixture injection.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://issues.redhat.com/browse/CNV-73714

