### PR TITLE
Add SecureExecution feature gate to expected KubeVirt feature gates for s390x

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -12,6 +12,8 @@ from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
+    EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
+    S390X_SPECIFIC_KUBEVIRT_FEATUREGATES,
     RESOURCE_NAME_STR,
     RESOURCE_NAMESPACE_STR,
     RESOURCE_TYPE_STR,
@@ -244,3 +246,10 @@ def updated_resource(
 @pytest.fixture(scope="session")
 def jira_76659_open():
     return is_jira_open(jira_id="CNV-76659")
+
+
+@pytest.fixture()
+def expected_value(request, is_s390x_cluster):
+    if request.param == EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES and is_s390x_cluster:
+        return request.param | S390X_SPECIFIC_KUBEVIRT_FEATUREGATES
+    return request.param

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -13,10 +13,10 @@ from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
     EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
-    S390X_SPECIFIC_KUBEVIRT_FEATUREGATES,
     RESOURCE_NAME_STR,
     RESOURCE_NAMESPACE_STR,
     RESOURCE_TYPE_STR,
+    S390X_SPECIFIC_KUBEVIRT_FEATUREGATES,
 )
 from tests.install_upgrade_operators.utils import (
     get_network_addon_config,

--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -35,6 +35,7 @@ EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
     "HotplugVolumes",
     "DecentralizedLiveMigration",
 }
+S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
 EXPECTED_CDI_HARDCODED_FEATUREGATES = {
     "DataVolumeClaimAdoption",
     "HonorWaitForFirstConsumer",

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -41,7 +41,7 @@ def resource_object_value_by_key(request, admin_client):
 
 
 @pytest.mark.parametrize(
-    ("expected", "resource_object_value_by_key"),
+    ("expected_value", "resource_object_value_by_key"),
     [
         pytest.param(
             HCO_DEFAULT_FEATUREGATES,
@@ -77,13 +77,13 @@ def resource_object_value_by_key(request, admin_client):
             id="verify_defaults_featuregates_kubevirt_cr",
         ),
     ],
-    indirect=["resource_object_value_by_key"],
+    indirect=["resource_object_value_by_key", "expected_value"],
 )
 def test_default_featuregates_by_resource(
-    expected,
+    expected_value,
     resource_object_value_by_key,
 ):
     if isinstance(resource_object_value_by_key, list):
         resource_object_value_by_key = set(resource_object_value_by_key)
-    error_message = f"Expected featuregates: {expected}, actual: {resource_object_value_by_key}"
-    assert expected == resource_object_value_by_key, error_message
+    error_message = f"Expected featuregates: {expected_value}, actual: {resource_object_value_by_key}"
+    assert expected_value == resource_object_value_by_key, error_message

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -50,7 +50,7 @@ class TestHardcodedFeatureGates:
                 id="delete_featuregates_cdi_cr",
             ),
         ],
-        indirect=["updated_resource"],
+        indirect=["updated_resource", "expected_value"],
     )
     def test_managed_cr_featuregate_reconcile(
         self,


### PR DESCRIPTION

##### Short description:
Add SecureExecution featuregate support for s390x in featuregate tests
##### More details:
SecureExecution is a feature gate present in the KubeVirt CR on s390x clusters. The existing feature gate tests were failing on s390x because the expected feature gate set did not include SecureExecution.

This PR introduces `EXPECTED_KUBEVIRT_S390X_FEATUREGATES` and conditionally merges it into the expected feature gates using the `is_s390x_cluster` fixture.


##### What this PR does / why we need it:

Ensures feature gate tests pass on s390x by including SecureExecution in the expected KubeVirt feature gates. Without this change, the following tests fail on s390x clusters because SecureExecution is present in the KubeVirt CR but missing from the expected set:

- test_managed_cr_featuregate_reconcile[delete_featuregates_kubevirt_cr]
- test_default_featuregates_by_resource[verify_defaults_featuregates_kubevirt_cr]

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added s390x-specific expected feature-gates and a fixture that computes expected feature-gates per architecture.
  * Introduced an expected-value fixture and updated test parameterization/parameter names for clarity.
  * Expanded test coverage to validate default and reconciled KubeVirt feature-gates across architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->