### PR TITLE
[virt] drop sku from smbios tests

### DIFF
--- a/tests/virt/cluster/general/test_smbios.py
+++ b/tests/virt/cluster/general/test_smbios.py
@@ -31,7 +31,6 @@ def smbios_defaults(cnv_current_version):
         "product": "OpenShift Virtualization",
         "manufacturer": "Red Hat",
         "version": cnv_current_version,
-        "sku": cnv_current_version,
     }
     return smbios_defaults
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2597,7 +2597,6 @@ def check_vm_xml_smbios(vm: VirtualMachineForTests, cm_values: Dict[str, str], a
         "product": smbios_vm_dict["product"] == cm_values["product"],
         "family": smbios_vm_dict["family"] == cm_values["family"],
         "version": smbios_vm_dict["version"] == cm_values["version"],
-        "sku": smbios_vm_dict["sku"] == cm_values["sku"],
         "serial": smbios_vm_dict.get("serial"),
         "uuid": smbios_vm_dict.get("uuid"),
     }


### PR DESCRIPTION
##### Short description:
SKU value was removed from all versions
in SMBIOS

##### More details:
https://redhat.atlassian.net/browse/CNV-81613

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests & Chores**
  * Removed SKU field from SMBIOS validation checks and updated test fixtures accordingly. SMBIOS validation now focuses on manufacturer, product, family, version, serial, and UUID fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->