### PR TITLE
switch to golden images DataSource instead of Artifactory boot image import

### DIFF
--- a/tests/infrastructure/vhostmd/test_vhostmd.py
+++ b/tests/infrastructure/vhostmd/test_vhostmd.py
@@ -6,14 +6,15 @@ import pytest
 import requests
 import xmltodict
 from bs4 import BeautifulSoup
+from ocp_resources.data_source import DataSource
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.resource import Resource
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 
-from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
+from tests.os_params import RHEL_LATEST_LABELS
 from utilities.artifactory import get_artifactory_header
-from utilities.constants import S390X, TIMEOUT_3MIN, TIMEOUT_30SEC
+from utilities.constants import DATA_SOURCE_NAME, S390X, TIMEOUT_3MIN, TIMEOUT_30SEC
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import get_node_selector_dict, get_node_selector_name
 from utilities.virt import (
@@ -68,19 +69,29 @@ def rpm_file_name(is_s390x_cluster):
     return next(file_name for file_name in rpm_file_names if (S390X in file_name) == is_s390x_cluster)
 
 
+@pytest.fixture(scope="module")
+def latest_rhel_data_source(golden_images_namespace):
+    return DataSource(
+        client=golden_images_namespace.client,
+        name=py_config["latest_instance_type_rhel_os_dict"][DATA_SOURCE_NAME],
+        namespace=golden_images_namespace.name,
+        ensure_exists=True,
+    )
+
+
 @pytest.fixture()
 def vhostmd_vm1(
     request,
     unprivileged_client,
     namespace,
-    golden_image_data_source_scope_function,
+    latest_rhel_data_source,
     worker_node1,
 ):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_scope_function,
+        data_source=latest_rhel_data_source,
         node_selector=get_node_selector_dict(node_selector=worker_node1.name),
     ) as vhostmd_vm1:
         vhostmd_vm1.start()
@@ -92,14 +103,14 @@ def vhostmd_vm2(
     request,
     unprivileged_client,
     namespace,
-    golden_image_data_source_scope_function,
+    latest_rhel_data_source,
     worker_node1,
 ):
     with vm_instance_from_template(
         request=request,
         unprivileged_client=unprivileged_client,
         namespace=namespace,
-        data_source=golden_image_data_source_scope_function,
+        data_source=latest_rhel_data_source,
         node_selector=get_node_selector_dict(node_selector=worker_node1.name),
     ) as vhostmd_vm2:
         vhostmd_vm2.start()
@@ -126,15 +137,9 @@ def run_vm_dump_metrics(vm):
 
 
 @pytest.mark.parametrize(
-    "golden_image_data_volume_scope_function, vhostmd_vm1, vhostmd_vm2,",
+    "vhostmd_vm1, vhostmd_vm2",
     [
         pytest.param(
-            {
-                "dv_name": RHEL_LATEST_OS,
-                "image": RHEL_LATEST["image_path"],
-                "storage_class": py_config["default_storage_class"],
-                "dv_size": RHEL_LATEST["dv_size"],
-            },
             {
                 "vm_name": "vhostmd1",
                 "vhostmd": True,


### PR DESCRIPTION
##### Short description:
There are 2 main artifactory calls done in this file.
1. when creating VM via golden_image_data_volume_scope_function 
2. getting rpms for vm-dump-metrics
-- ( this is TBD because we need to understand how we want to add such rpms in quay). It would be another PR moving rpms/tar out of this repo.
With this change,downloading boot image from artifactory can be skipped and we test execution will be faster. (addressing first artifactory call)
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new shared data-backed fixture for RHEL image sourcing; updated VM fixtures to use it.
  * Simplified test parametrization by removing the prior volume-focused parameter and retaining only the VM fixtures.
  * Adjusted test imports to reflect the new data-source approach, improving setup consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->