### PR TITLE
Remove KubeMacPool dry-run test

### DIFF
--- a/tests/network/dry_run/test_dry_run_kubemacpool.py
+++ b/tests/network/dry_run/test_dry_run_kubemacpool.py
@@ -2,7 +2,6 @@ import logging
 from contextlib import contextmanager
 
 import pytest
-from kubernetes.client import ApiException
 
 from utilities.network import LINUX_BRIDGE, network_device, network_nad
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
@@ -99,25 +98,6 @@ def vm_with_mac_address(
         yield vm
 
 
-@pytest.fixture()
-def dry_run_vm_with_mac_address(
-    unprivileged_client,
-    namespace,
-    linux_bridge_network_nad,
-    vm_with_mac_address,
-):
-    """Create a dry-run VM with a MAC address retrieved from a running VM."""
-    allocated_mac_address = vm_with_mac_address.get_interfaces()[1][MAC_ADDRESS]
-
-    return create_dry_run_vm(
-        name="dry-run-vm-with-mac",
-        namespace=namespace,
-        networks={linux_bridge_network_nad.name: linux_bridge_network_nad.name},
-        unprivileged_client=unprivileged_client,
-        macs={linux_bridge_network_nad.name: allocated_mac_address},
-    )
-
-
 @pytest.mark.polarion("CNV-7872")
 @pytest.mark.s390x
 def test_dry_run_mac_not_saved(
@@ -131,11 +111,3 @@ def test_dry_run_mac_not_saved(
         f"{vm_with_mac_address.name} MAC address is {secondary_net_mac}"
         f" and not {dry_run_vma_mac_address}, as it should be."
     )
-
-
-@pytest.mark.polarion("CNV-7873")
-@pytest.mark.s390x
-def test_allocated_mac_is_unavailable_for_dry_run(dry_run_vm_with_mac_address):
-    with pytest.raises(ApiException, match="Failed to allocate mac to the vm object"):
-        with dry_run_vm_with_mac_address as vm:
-            vm.create()


### PR DESCRIPTION
Starting 4.22, MAC collision detection is removed. This test covers exactly it, and therefore becomes redundant and false.
Other KMP tests will also be removed or changed as the work progresses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed tests and supporting fixtures that validated MAC-address allocation failure scenarios during dry-run VM creation, resulting in reduced test coverage for MAC re-allocation behavior when a dry-run VM is created with an already-allocated MAC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->