### PR TITLE
storage, infra, ipv6: Adjust import http tests

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -23,6 +23,8 @@ class Cirros:
 @dataclass
 class Alpine:
     QCOW2_IMG: str | None = None
+    QCOW2_IMG_VERSIONED: str | None = None
+    RAW_IMG_XZ: str | None = None
     DIR: str = f"{BASE_IMAGES_DIR}/alpine-images"
     DEFAULT_DV_SIZE: str = "1Gi"
     DEFAULT_MEMORY_SIZE: str = "128M"

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -13,7 +13,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.os_params import FEDORA_LATEST, RHEL_LATEST
 from tests.storage.constants import (
-    CIRROS_QCOW2_IMG,
+    ALPINE_QCOW2_IMG,
     HTTP,
     HTTPS,
     HTTPS_CONFIG_MAP_NAME,
@@ -58,7 +58,7 @@ LOGGER = logging.getLogger(__name__)
 
 ISO_IMG = "Core-current.iso"
 TAR_IMG = "archive.tar"
-DEFAULT_DV_SIZE = Images.Cirros.DEFAULT_DV_SIZE
+DEFAULT_DV_SIZE = Images.Alpine.DEFAULT_DV_SIZE
 SMALL_DV_SIZE = "200Mi"
 
 LATEST_WINDOWS_OS_DICT = py_config.get("latest_windows_os_dict", {})
@@ -116,7 +116,7 @@ def dv_with_annotation(admin_client, namespace, linux_nad):
             {
                 "dv_name": "import-http-dv",
                 "source": HTTP,
-                "image": CIRROS_QCOW2_IMG,
+                "image": ALPINE_QCOW2_IMG,
                 "dv_size": DEFAULT_DV_SIZE,
             },
             marks=pytest.mark.polarion("CNV-675"),
@@ -234,7 +234,7 @@ def test_successful_import_secure_archive(
         pytest.param(
             {
                 "dv_name": "cnv-2719",
-                "file_name": Images.Cdi.QCOW2_IMG,
+                "file_name": Images.Alpine.QCOW2_IMG_VERSIONED,
                 "source": HTTPS,
                 "configmap_name": INTERNAL_HTTP_CONFIGMAP_NAME,
             },
@@ -255,7 +255,7 @@ def test_successful_import_secure_image(internal_http_configmap, dv_from_http_im
     [
         pytest.param(
             DataVolume.ContentType.KUBEVIRT,
-            Images.Cirros.RAW_IMG_XZ,
+            Images.Alpine.RAW_IMG_XZ,
             marks=(pytest.mark.polarion("CNV-784"), pytest.mark.smoke()),
         ),
     ],
@@ -291,7 +291,7 @@ def test_successful_import_basic_auth(
         pytest.param(
             {
                 "dv_name": "cnv-2144",
-                "file_name": Images.Cdi.QCOW2_IMG,
+                "file_name": Images.Alpine.QCOW2_IMG_VERSIONED,
                 "content_type": DataVolume.ContentType.ARCHIVE,
             },
             marks=pytest.mark.polarion("CNV-2144"),
@@ -314,54 +314,13 @@ def test_wrong_content_type(
 
 @pytest.mark.sno
 @pytest.mark.parametrize(
-    "dv_from_http_import",
-    [
-        pytest.param(
-            {
-                "dv_name": "cnv-2220",
-                "file_name": Images.Cirros.RAW_IMG_XZ,
-                "content_type": DataVolume.ContentType.ARCHIVE,
-                "size": SMALL_DV_SIZE,
-            },
-            marks=pytest.mark.polarion("CNV-2220"),
-            id="compressed_xz_archive_content_type",
-        ),
-        pytest.param(
-            {
-                "dv_name": "cnv-2710",
-                "file_name": Images.Cirros.RAW_IMG_GZ,
-                "content_type": DataVolume.ContentType.ARCHIVE,
-                "size": SMALL_DV_SIZE,
-            },
-            marks=pytest.mark.polarion("CNV-2710"),
-            id="compressed_gz_archive_content_type",
-        ),
-    ],
-    indirect=True,
-)
-@pytest.mark.s390x
-def test_unpack_compressed(
-    admin_client,
-    dv_from_http_import,
-):
-    wait_for_importer_container_message(
-        importer_pod=wait_dv_and_get_importer(
-            dv=dv_from_http_import,
-            admin_client=admin_client,
-        ),
-        msg=ErrorMsg.EXIT_STATUS_2,
-    )
-
-
-@pytest.mark.sno
-@pytest.mark.parametrize(
     ("https_config_map", "dv_from_http_import"),
     [
         pytest.param(
             {"data": "-----BEGIN CERTIFICATE-----"},
             {
                 "dv_name": "cnv-2812",
-                "file_name": Images.Cdi.QCOW2_IMG,
+                "file_name": Images.Alpine.QCOW2_IMG_VERSIONED,
                 "source": HTTPS,
                 "configmap_name": HTTPS_CONFIG_MAP_NAME,
             },
@@ -371,7 +330,7 @@ def test_unpack_compressed(
             {"data": None},
             {
                 "dv_name": "cnv-2813",
-                "file_name": Images.Cdi.QCOW2_IMG,
+                "file_name": Images.Alpine.QCOW2_IMG_VERSIONED,
                 "source": HTTPS,
                 "configmap_name": HTTPS_CONFIG_MAP_NAME,
             },
@@ -399,7 +358,7 @@ def test_certconfigmap_incorrect_cert(
             {
                 "dv_name": "cnv-2815",
                 "source": HTTP,
-                "image": CIRROS_QCOW2_IMG,
+                "image": ALPINE_QCOW2_IMG,
                 "dv_size": DEFAULT_DV_SIZE,
                 "cert_configmap": "wrong_name",
                 "wait": False,

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -5,6 +5,7 @@ Pytest conftest file for CNV CDI tests
 """
 
 import base64
+import ipaddress
 import logging
 import os
 import ssl
@@ -86,7 +87,7 @@ INTERNAL_HTTP_TEMPLATE = {
         "containers": [
             {
                 "name": "http",
-                "image": "quay.io/openshift-cnv/qe-cnv-tests-internal-http:v1.1.0",
+                "image": "quay.io/openshift-cnv/qe-cnv-tests-internal-http:v1.2.0",
                 "imagePullPolicy": "Always",
                 "command": ["/usr/sbin/nginx"],
                 "readinessProbe": {
@@ -119,12 +120,14 @@ def hpp_resources(request, admin_client):
 @pytest.fixture(scope="module")
 def internal_http_configmap(namespace, internal_http_service, workers_utility_pods, worker_node1, admin_client):
     svc_ip = internal_http_service.instance.to_dict()["spec"]["clusterIP"]
+    ip = ipaddress.ip_address(address=svc_ip)
+    connect_addr = f"[{ip}]:443" if ip.version == 6 else f"{ip}:443"
 
     def _fetch_cert():
         try:
             return ExecCommandOnPod(utility_pods=workers_utility_pods, node=worker_node1).exec(
                 command=(
-                    f"openssl s_client -showcerts -connect {svc_ip}:443 </dev/null 2>/dev/null | "
+                    f"openssl s_client -showcerts -connect {connect_addr} </dev/null 2>/dev/null | "
                     "sed -n '/-----BEGIN/,/-----END/p'"
                 )
             )

--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -2,6 +2,7 @@ from utilities.constants import Images, StorageClassNames
 from utilities.storage import HppCsiStorageClass
 
 CIRROS_QCOW2_IMG = f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}"
+ALPINE_QCOW2_IMG = f"{Images.Alpine.DIR}/{Images.Alpine.QCOW2_IMG_VERSIONED}"
 
 ADMIN_NAMESPACE_PARAM = {"use_unprivileged_client": False}
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -56,11 +56,14 @@ FEDORA_DISK_DEMO = "fedora-cloud-registry-disk-demo"
 CIRROS_DISK_DEMO = "cirros-registry-disk-demo"
 CIRROS_QCOW2_IMG = "cirros-qcow2.img"
 
+ALPINE_VERSION = "3.20.1"
+
 
 class ArchImages:
     class AMD64:
         BASE_CIRROS_NAME = "cirros-0.4.0-x86_64-disk"
         BASE_ALPINE_NAME = "alpine-x86_64-disk"
+        BASE_VERSIONED_ALPINE_NAME = f"alpine-{ALPINE_VERSION}-x86_64-disk"
         Cirros = Cirros(
             RAW_IMG=f"{BASE_CIRROS_NAME}.raw",
             RAW_IMG_GZ=f"{BASE_CIRROS_NAME}.raw.gz",
@@ -73,6 +76,8 @@ class ArchImages:
 
         Alpine = Alpine(
             QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
+            QCOW2_IMG_VERSIONED=f"{BASE_VERSIONED_ALPINE_NAME}.qcow2",
+            RAW_IMG_XZ=f"{BASE_VERSIONED_ALPINE_NAME}.raw.xz",
         )
 
         Rhel = Rhel(
@@ -118,6 +123,7 @@ class ArchImages:
     class ARM64:
         BASE_CIRROS_NAME = "cirros-0.5.2-aarch64-disk"
         BASE_ALPINE_NAME = "alpine-aarch64-disk"
+        BASE_VERSIONED_ALPINE_NAME = f"alpine-{ALPINE_VERSION}-aarch64-disk"
         Cirros = Cirros(
             RAW_IMG=f"{BASE_CIRROS_NAME}.raw",
             RAW_IMG_GZ=f"{BASE_CIRROS_NAME}.raw.gz",
@@ -130,6 +136,8 @@ class ArchImages:
 
         Alpine = Alpine(
             QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
+            QCOW2_IMG_VERSIONED=f"{BASE_VERSIONED_ALPINE_NAME}.qcow2",
+            RAW_IMG_XZ=f"{BASE_VERSIONED_ALPINE_NAME}.raw.xz",
         )
 
         Rhel = Rhel(
@@ -153,6 +161,7 @@ class ArchImages:
 
     class S390X:
         BASE_ALPINE_NAME = "alpine-s390x-disk"
+        BASE_VERSIONED_ALPINE_NAME = f"alpine-{ALPINE_VERSION}-s390x-disk"
         Cirros = Cirros(
             # TODO: S390X does not support Cirros; this is a workaround until tests are moved to Fedora
             RAW_IMG="Fedora-Cloud-Base-Generic-41-1.4.s390x.raw",
@@ -170,6 +179,8 @@ class ArchImages:
 
         Alpine = Alpine(
             QCOW2_IMG=f"{BASE_ALPINE_NAME}.qcow2",
+            QCOW2_IMG_VERSIONED=f"{BASE_VERSIONED_ALPINE_NAME}.qcow2",
+            RAW_IMG_XZ=f"{BASE_VERSIONED_ALPINE_NAME}.raw.xz",
         )
 
         Rhel = Rhel(

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -77,7 +77,7 @@ from utilities.ssp import guest_agent_version_parser
 
 NON_EXIST_URL = "https://noneexist.test"  # Use 'test' domain rfc6761
 EXCLUDED_FROM_URL_VALIDATION = ("", NON_EXIST_URL)
-INTERNAL_HTTP_SERVER_ADDRESS = "internal-http.cnv-tests-utilities"
+INTERNAL_HTTP_SERVER_ADDRESS = "internal-http.cnv-tests-utilities.svc.cluster.local"
 HOST_MODEL_CPU_LABEL = f"host-model-cpu.node.{Resource.ApiGroup.KUBEVIRT_IO}"
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Storage gating tests in `tests/storage/cdi_import/test_import_http.py` require the following changes for running on IPv6 single-stack clusters:
- Short hostname internal-http.cnv-tests-utilities went through the external HTTP proxy (not in no_proxy); FQDN .svc.cluster.local matches and bypasses it.
- openssl s_client - IPv6 addresses need bracket syntax [::1]:443
- Use Alpine v3.20.1 from artifactory for all architectures

These changes are followed by update of the image used in test to v1.2.0:
- TLS cert SAN - old cert baked into the image only had the short name; needed to regenerate with FQDN included
- Makefile update to use Alpine v3.20.1 from artifactory for all architectures
- Add IPv6 listening sockets to Nginx server blocks

test_unpack_compressed is dropped as it's covered in Tier1

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-80593
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal HTTP test image tag to v1.2.0
  * Added Artifactory-backed Alpine image references for multiple architectures

* **Bug Fixes**
  * Certificate retrieval now formats IPv6 addresses with brackets for host:port
  * Internal service address recognition updated to use fully-qualified in-cluster DNS

* **Tests**
  * Storage/import tests switched to Alpine images and removed a failing compressed-unpack case
<!-- end of auto-generated comment: release notes by coderabbit.ai -->