### PR TITLE
[4.21] Cherry-pick [virt] drop sku from smbios tests

### DIFF
--- a/tests/virt/cluster/general/test_smbios.py
+++ b/tests/virt/cluster/general/test_smbios.py
@@ -31,7 +31,6 @@ def smbios_defaults(cnv_current_version):
         "product": "OpenShift Virtualization",
         "manufacturer": "Red Hat",
         "version": cnv_current_version,
-        "sku": cnv_current_version,
     }
     return smbios_defaults
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2507,7 +2507,6 @@ def check_vm_xml_smbios(vm: VirtualMachineForTests, cm_values: Dict[str, str]) -
         "product": smbios_vm_dict["product"] == cm_values["product"],
         "family": smbios_vm_dict["family"] == cm_values["family"],
         "version": smbios_vm_dict["version"] == cm_values["version"],
-        "sku": smbios_vm_dict["sku"] == cm_values["sku"],
         "serial": smbios_vm_dict.get("serial"),
         "uuid": smbios_vm_dict.get("uuid"),
     }


### PR DESCRIPTION
##### Short description:
SKU value was removed from all versions
in SMBIOS

manual backport of https://github.com/RedHatQE/openshift-virtualization-tests/pull/4159 because currently 4.22 builds are broken

##### More details:
https://redhat.atlassian.net/browse/CNV-81613

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
