### PR TITLE
Change test_vm_with_uploaded_golden_image_opt_out to use fedora

### DIFF
--- a/tests/infrastructure/golden_images/conftest.py
+++ b/tests/infrastructure/golden_images/conftest.py
@@ -2,10 +2,11 @@ import logging
 
 import pytest
 import requests
+from ocp_resources.data_source import DataSource
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.storage_class import StorageClass
 
-from utilities.constants import TIMEOUT_30SEC
+from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_30SEC
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,3 +43,10 @@ def latest_fedora_release_version():
     latest_fedora_version = str(max(versions))
     LOGGER.info(f"Latest Fedora release: {latest_fedora_version}")
     return latest_fedora_version
+
+
+@pytest.fixture(scope="module")
+def fedora_data_source(unprivileged_client, golden_images_namespace):
+    return DataSource(
+        client=unprivileged_client, name=OS_FLAVOR_FEDORA, namespace=golden_images_namespace.name, ensure_exists=True
+    )

--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -1,10 +1,9 @@
 import pytest
-from ocp_resources.data_source import DataSource
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from pytest_testconfig import config as py_config
 
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS, FEDORA_LATEST_OS
-from utilities.constants import OS_FLAVOR_FEDORA, U1_SMALL, Images
+from utilities.constants import U1_SMALL, Images
 from utilities.storage import data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, running_vm
 
@@ -69,13 +68,6 @@ def storage_class_from_config_different_from_data_source(fedora_data_source):
     if different_storage_class is None:
         pytest.xfail("storage_class_matrix only has 1 storage class defined")
     return different_storage_class
-
-
-@pytest.fixture(scope="module")
-def fedora_data_source(unprivileged_client, golden_images_namespace):
-    return DataSource(
-        client=unprivileged_client, name=OS_FLAVOR_FEDORA, namespace=golden_images_namespace.name, ensure_exists=True
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_common_templates_boot_sources.py
@@ -11,12 +11,7 @@ from tests.infrastructure.golden_images.utils import (
     assert_missing_golden_image_pvc,
     assert_os_version_mismatch_in_vm,
 )
-from utilities.artifactory import (
-    cleanup_artifactory_secret_and_config_map,
-    get_artifactory_config_map,
-    get_artifactory_secret,
-)
-from utilities.constants import OS_FLAVOR_FEDORA, RHEL9_STR, TIMEOUT_5MIN, TIMEOUT_5SEC, Images
+from utilities.constants import DEFAULT_FEDORA_REGISTRY_URL, OS_FLAVOR_FEDORA, TIMEOUT_5MIN, TIMEOUT_5SEC, Images
 from utilities.infra import (
     validate_os_info_vmi_vs_linux_os,
 )
@@ -79,13 +74,13 @@ def auto_update_boot_source_vm(
 
 
 @pytest.fixture()
-def vm_without_boot_source(unprivileged_client, namespace, rhel9_data_source_scope_session):
+def vm_without_boot_source(unprivileged_client, namespace, fedora_data_source):
     with VirtualMachineForTestsFromTemplate(
-        name=f"{rhel9_data_source_scope_session.name}-vm",
+        name=f"{fedora_data_source.name}-vm",
         namespace=namespace.name,
         client=unprivileged_client,
-        labels=template_labels(os="rhel9.0"),
-        data_source=rhel9_data_source_scope_session,
+        labels=template_labels(os=OS_FLAVOR_FEDORA),
+        data_source=fedora_data_source,
         non_existing_pvc=True,
     ) as vm:
         vm.start()
@@ -94,43 +89,36 @@ def vm_without_boot_source(unprivileged_client, namespace, rhel9_data_source_sco
 
 
 @pytest.fixture()
-def opted_out_rhel9_data_source(rhel9_data_source_scope_session):
-    LOGGER.info(f"Wait for DataSource {rhel9_data_source_scope_session.name} to opt out")
+def opted_out_fedora_data_source(fedora_data_source):
+    LOGGER.info(f"Wait for DataSource {fedora_data_source.name} to opt out")
     try:
         for sample in TimeoutSampler(
             wait_timeout=TIMEOUT_5MIN,
             sleep=TIMEOUT_5SEC,
-            func=lambda: rhel9_data_source_scope_session.source.name == RHEL9_STR,
+            func=lambda: fedora_data_source.source.name == OS_FLAVOR_FEDORA,
         ):
             if sample:
                 return
     except TimeoutExpiredError:
-        LOGGER.error(f"{rhel9_data_source_scope_session.name} DataSource source was not updated.")
+        LOGGER.error(f"{fedora_data_source.name} DataSource source was not updated.")
         raise
 
 
 @pytest.fixture()
-def rhel9_dv(admin_client, golden_images_namespace, rhel9_data_source_scope_session, rhel9_http_image_url):
-    artifactory_secret = get_artifactory_secret(namespace=golden_images_namespace.name)
-    artifactory_config_map = get_artifactory_config_map(namespace=golden_images_namespace.name)
+def imported_fedora_dv(admin_client, golden_images_namespace, fedora_data_source):
     with DataVolume(
         client=admin_client,
-        name=rhel9_data_source_scope_session.source.name,
+        name=fedora_data_source.name,
         namespace=golden_images_namespace.name,
-        url=rhel9_http_image_url,
-        secret=artifactory_secret,
-        cert_configmap=artifactory_config_map.name,
-        source="http",
-        size=Images.Rhel.DEFAULT_DV_SIZE,
-        storage_class=py_config["default_storage_class"],
-        bind_immediate_annotation=True,
         api_name="storage",
+        source="registry",
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=py_config["default_storage_class"],
+        url=DEFAULT_FEDORA_REGISTRY_URL,
+        bind_immediate_annotation=True,
     ) as dv:
         dv.wait_for_dv_success()
         yield dv
-    cleanup_artifactory_secret_and_config_map(
-        artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
-    )
 
 
 @pytest.mark.polarion("CNV-7586")
@@ -167,9 +155,9 @@ def test_vm_with_uploaded_golden_image_opt_out(
     admin_client,
     golden_images_namespace,
     disabled_common_boot_image_import_hco_spec_scope_function,
-    opted_out_rhel9_data_source,
+    opted_out_fedora_data_source,
     vm_without_boot_source,
-    rhel9_dv,
+    imported_fedora_dv,
 ):
-    LOGGER.info(f"Test VM with manually uploaded {rhel9_dv.name} golden image DV")
+    LOGGER.info(f"Test VM with manually uploaded {imported_fedora_dv.name} golden image DV")
     running_vm(vm=vm_without_boot_source)


### PR DESCRIPTION
##### Short description:
Change test_vm_with_uploaded_golden_image_opt_out to use fedora

##### More details:
The test currently fetches the image from Artifactory. Instead, we can use a public registry such as `quay.io` for this test case.

##### What this PR does / why we need it:
Updates the image source to use the Fedora image from `quay.io`, reducing the test's dependency on private Artifactory images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to migrate from RHEL9-based to Fedora-based image provisioning.
  * Modified provisioning approach from artifact-based to registry-based image sourcing.
  * Refactored test fixtures to support Fedora image data sources and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->