### PR TITLE
[4.19] Increase the number of parallel migrations in upgrade (#3575)

### DIFF
--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import pytest
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
+from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.migration_policy import MigrationPolicy
 from ocp_resources.template import Template
 from ocp_resources.virtual_machine import VirtualMachine
@@ -26,6 +27,7 @@ from utilities.constants import (
     TIMEOUT_90MIN,
     Images,
 )
+from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     check_pod_disruption_budget_for_completed_migrations,
 )
@@ -336,3 +338,19 @@ def vm_for_post_copy_upgrade(upgrade_namespace_scope_session, unprivileged_clien
     ) as vm:
         running_vm(vm=vm)
         yield vm
+
+
+@pytest.fixture(scope="session")
+def parallel_live_migrations_increased(hyperconverged_resource_scope_session):
+    with ResourceEditorValidateHCOReconcile(
+        patches={
+            hyperconverged_resource_scope_session: {
+                "spec": {
+                    "liveMigrationConfig": {"parallelOutboundMigrationsPerNode": 5},
+                }
+            }
+        },
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -53,7 +53,10 @@ pytestmark = [
 ]
 
 
-@pytest.mark.usefixtures("base_templates")
+@pytest.mark.usefixtures(
+    "base_templates",
+    "parallel_live_migrations_increased",
+)
 class TestUpgradeVirt:
     """Pre-upgrade tests"""
 


### PR DESCRIPTION
In upgrade with multiple SIGs we have too many non-migratable vms which may block the migration of the good (migratable) vms. Increasing the parallel migrations helps to unblock tests where we need to migrate the VMs (even when non-migratable blocked the lane for 5 minutes - we have extra lanes for good (migratable) VMs

<!-- full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged If the task is not tracked by a Jira ticket, just write "NONE". -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

* **Tests**
* Added test fixture for configuring increased parallel live migrations during upgrade scenarios, enabling more comprehensive testing of concurrent migration handling during system upgrades.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
