### PR TITLE
instance_type_centos_os_list os_name changed from centos to centos.stream

### DIFF
--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -26,7 +26,6 @@ from utilities.constants import (
     CNV_TESTS_CONTAINER,
     MULTIARCH,
     POD_SECURITY_NAMESPACE_LABELS,
-    S390X,
     SANITY_TESTS_FAILURE,
     SUPPORTED_CPU_ARCHITECTURES,
     SUPPORTED_MULTIARCH_OPTIONS,
@@ -521,9 +520,9 @@ def generate_instance_type_matrix_dicts(os_dict: dict[str, Any], cpu_arch: str |
         )
     if instance_type_centos_os_list := os_dict.get("instance_type_centos_os_list"):
         py_config["instance_type_centos_os_matrix"] = generate_linux_instance_type_os_matrix(
-            os_name="centos",
+            os_name="centos.stream",
             preferences=instance_type_centos_os_list,
-            arch_suffix=cpu_arch if cpu_arch != S390X else None,
+            arch_suffix=None,
         )
 
 

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -1627,7 +1627,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         generate_instance_type_matrix_dicts(os_dict=os_dict)
 
         mock_generate_instance_type.assert_called_once_with(
-            os_name="centos", preferences=["centos.stream9"], arch_suffix=None
+            os_name="centos.stream", preferences=["centos.stream9"], arch_suffix=None
         )
         assert mock_py_config["instance_type_centos_os_matrix"] == sample_centos_instance_type
 
@@ -1646,7 +1646,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch="s390x")
 
         mock_generate_instance_type.assert_called_once_with(
-            os_name="centos", preferences=["centos.stream9"], arch_suffix=None
+            os_name="centos.stream", preferences=["centos.stream9"], arch_suffix=None
         )
         assert mock_py_config["instance_type_centos_os_matrix"] == sample_centos_instance_type
 
@@ -1719,7 +1719,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch="arm64")
 
         mock_generate_instance_type.assert_called_once_with(
-            os_name="centos", preferences=["centos.stream9"], arch_suffix="arm64"
+            os_name="centos.stream", preferences=["centos.stream9"], arch_suffix=None
         )
 
 


### PR DESCRIPTION
##### Short description:
Changed instance_type_centos_os_list os_name changed from centos to centos.stream

##### More details:
instance_type_centos_os_list os_name was incorrect as the data source and preference name are centos-stream/centos.stream leading to failure on VM creation in test_centos_os.py

##### What this PR does / why we need it:
Fix failing tests at tests/infrastructure/instance_types/supported_os/test_centos_os.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CentOS naming in build/test matrices to "centos.stream" and simplified architecture suffix handling so S390X no longer receives special conditional treatment.

* **Tests**
  * Updated unit tests to expect the "centos.stream" naming and the revised arch-suffix behavior across affected matrix scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->