### PR TITLE
fix: drop explicit DV clean_up in created_persistent_volume_claim 

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/conftest.py
+++ b/tests/infrastructure/golden_images/update_boot_source/conftest.py
@@ -213,7 +213,7 @@ def data_import_cron_namespace(admin_client, unprivileged_client):
 
 
 @pytest.fixture()
-def created_persistent_volume_claim(unprivileged_client, data_import_cron_namespace):
+def data_import_cron_pvc(unprivileged_client, data_import_cron_namespace):
     def _get_first_pvc():
         return next(
             PersistentVolumeClaim.get(
@@ -230,14 +230,12 @@ def created_persistent_volume_claim(unprivileged_client, data_import_cron_namesp
             func=_get_first_pvc,
         ):
             if sample:
-                created_dv = DataVolume(
+                DataVolume(
                     name=sample.name,
                     namespace=sample.namespace,
                     client=unprivileged_client,
-                )
-                created_dv.wait_for_dv_success()
+                ).wait_for_dv_success()
                 yield sample
-                created_dv.clean_up()
                 return
     except TimeoutExpiredError:
         LOGGER.error(f"No PVCs were created in {data_import_cron_namespace.name}")

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -296,15 +296,15 @@ class TestDataImportCronDefaultStorageClass:
 
     @pytest.mark.polarion("CNV-7594")
     def test_data_import_cron_uses_default_storage_class(
-        self, updated_default_storage_class_scope_function, created_data_import_cron, created_persistent_volume_claim
+        self, updated_default_storage_class_scope_function, created_data_import_cron, data_import_cron_pvc
     ):
         LOGGER.info(
             "Test DataImportCron and DV creation when using default storage class "
             f"{updated_default_storage_class_scope_function.name}"
         )
-        current_sc = created_persistent_volume_claim.instance.spec.storageClassName
+        current_sc = data_import_cron_pvc.instance.spec.storageClassName
         assert current_sc == updated_default_storage_class_scope_function.name, (
-            f"PVC {created_persistent_volume_claim.name} expected storage class: "
+            f"PVC {data_import_cron_pvc.name} expected storage class: "
             f"{updated_default_storage_class_scope_function.name}, "
             f"current storage class: {current_sc}"
         )


### PR DESCRIPTION
##### Short description:
The fixture does not create a PVC.Drop the
explicit DV clean_up since the namespace fixture handles deletion. deleting explicitly sometimes fails with 404 error. 
##### More details:
fix sometimes flaky test
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored internal test infrastructure code for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->