### PR TITLE
scripts: Generate a PR force-push history report

### DIFF
--- a/scripts/pr_force_push_report/README.md
+++ b/scripts/pr_force_push_report/README.md
@@ -1,0 +1,97 @@
+# GitHub PR Force-Push Event Reporter
+
+Generates a markdown report of force-push events for a GitHub pull request, with clickable comparison links.
+
+## Prerequisites
+
+- **GitHub CLI (`gh`)** - [Installation guide](https://cli.github.com/)
+- **Authentication** - Run `gh auth login` before first use
+
+## Installation
+
+No additional installation needed. The script uses the project's existing dependencies.
+
+## Usage
+
+```bash
+# Basic usage
+uv run python scripts/pr_tools/force_push_report.py https://github.com/owner/repo/pull/123
+
+# Limit number of events fetched
+uv run python scripts/pr_tools/force_push_report.py --page-size 50 https://github.com/owner/repo/pull/123
+```
+
+## Example Output
+
+```markdown
+## Force-Push Events for PR #35
+
+1. [2026-02-17 12:55:53 UTC](https://github.com/owner/repo/compare/abc1234...def5678) - `abc1234` → `def5678` by username1
+2. [2026-02-18 09:30:12 UTC](https://github.com/owner/repo/compare/def5678...ghi9012) - `def5678` → `ghi9012` by username2
+3. [2026-02-19 14:15:45 UTC](https://github.com/owner/repo/compare/ghi9012...jkl3456) - `ghi9012` → `jkl3456` by username1
+```
+
+Each line contains:
+- **Timestamp** - When the force-push occurred (clickable link to GitHub compare view)
+- **Commit SHAs** - Before and after commits (shortened to 7 characters)
+- **Actor** - GitHub username who performed the force-push
+
+## Common Errors
+
+### `gh CLI not found`
+
+**Solution:** Install GitHub CLI from https://cli.github.com/
+
+```bash
+# Fedora/RHEL
+sudo dnf install gh
+
+# macOS
+brew install gh
+
+# Ubuntu/Debian
+sudo apt install gh
+```
+
+### `GitHub API error: HTTP 401`
+
+**Solution:** Authenticate with GitHub CLI:
+
+```bash
+gh auth login
+```
+
+### `Invalid GitHub PR URL format`
+
+**Solution:** Ensure URL follows this exact format:
+
+```
+https://github.com/owner/repo/pull/NUMBER
+```
+
+## CI Integration Example
+
+```bash
+# Generate report and save to file
+uv run python scripts/pr_tools/force_push_report.py \
+  https://github.com/RedHatQE/cnv-tests/pull/3783 > force_push_report.md
+
+# Use in CI to detect force-pushes during code freeze
+FORCE_PUSHES=$(uv run python scripts/pr_tools/force_push_report.py "$PR_URL" | grep -c "→" || true)
+if [ "$FORCE_PUSHES" -gt 0 ]; then
+  echo "Warning: PR has $FORCE_PUSHES force-push(es)"
+fi
+```
+
+## Technical Details
+
+- **API**: GitHub GraphQL API via `gh` CLI
+- **Event Type**: `HEAD_REF_FORCE_PUSHED_EVENT`
+- **Timeout**: 30 seconds for API requests
+- **Default Page Size**: 100 events
+- **Output Format**: GitHub-flavored Markdown
+
+## Related Scripts
+
+- `scripts/tests_analyzer/` - Test analysis tools
+- `scripts/quarantine_stats/` - Quarantine statistics dashboard

--- a/scripts/pr_force_push_report/__init__.py
+++ b/scripts/pr_force_push_report/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub PR Tools Package."""

--- a/scripts/pr_force_push_report/force_push_report.py
+++ b/scripts/pr_force_push_report/force_push_report.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+# Generated using Claude cli
+
+"""GitHub PR Force-Push Event Reporter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from simple_logger.logger import get_logger
+
+LOGGER = get_logger(name=__name__)
+
+
+@dataclass
+class ForcePushEvent:
+    """Represents a force-push event in a GitHub PR."""
+
+    timestamp: str
+    actor: str
+    before_commit: str
+    after_commit: str
+    before_commit_full: str
+    after_commit_full: str
+
+
+@dataclass
+class ParsedPRUrl:
+    """Parsed GitHub PR URL components."""
+
+    owner: str
+    repo: str
+    pr_number: int
+    base_url: str
+
+
+def parse_pr_url(pr_url: str) -> ParsedPRUrl:
+    """Parse GitHub PR URL into components.
+
+    Args:
+        pr_url: GitHub PR URL in format https://github.com/owner/repo/pull/NUMBER
+
+    Returns:
+        ParsedPRUrl with extracted owner, repo, pr_number, and base_url
+
+    Raises:
+        ValueError: If URL format is invalid
+    """
+    pattern = r"^https://github\.com/([a-zA-Z0-9][a-zA-Z0-9._-]*)/([a-zA-Z0-9][a-zA-Z0-9._-]*)/pull/(\d+)/?$"
+    match = re.match(pattern=pattern, string=pr_url)
+
+    if not match:
+        raise ValueError("Invalid GitHub PR URL format. Expected: https://github.com/owner/repo/pull/NUMBER")
+
+    owner = match.group(1)
+    repo = match.group(2)
+    pr_number = int(match.group(3))
+    base_url = f"https://github.com/{owner}/{repo}"
+
+    return ParsedPRUrl(owner=owner, repo=repo, pr_number=pr_number, base_url=base_url)
+
+
+def build_graphql_query(owner: str, repo: str, pr_number: int, page_size: int = 100) -> str:
+    """Build GraphQL query for PR force-push events.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        pr_number: Pull request number
+        page_size: Maximum events to fetch per page
+
+    Returns:
+        GraphQL query string
+    """
+    query = f"""
+    {{
+      repository(owner: "{owner}", name: "{repo}") {{
+        pullRequest(number: {pr_number}) {{
+          timelineItems(itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT], first: {page_size}) {{
+            nodes {{
+              ... on HeadRefForcePushedEvent {{
+                createdAt
+                actor {{
+                  login
+                }}
+                beforeCommit {{
+                  oid
+                }}
+                afterCommit {{
+                  oid
+                }}
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    return query
+
+
+def query_github_graphql(query: str) -> dict[str, Any]:
+    """Execute GraphQL query using gh CLI.
+
+    Args:
+        query: GraphQL query string
+
+    Returns:
+        Parsed JSON response from GitHub API
+
+    Raises:
+        RuntimeError: If gh CLI is missing, auth fails, or API returns error
+    """
+    # Check gh CLI availability
+    try:
+        subprocess.run(
+            args=["gh", "--version"],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh CLI not found. Install via: https://cli.github.com/") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"gh CLI check failed: {exc.stderr.decode()}") from exc
+
+    # Execute GraphQL query
+    try:
+        result = subprocess.run(
+            args=["gh", "api", "graphql", "-f", f"query={query}"],
+            check=True,
+            capture_output=True,
+            timeout=30,
+            text=True,
+        )
+        LOGGER.info("GitHub API query successful")
+        return json.loads(result.stdout)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("GitHub API request timed out after 30 seconds") from exc
+    except subprocess.CalledProcessError as exc:
+        error_msg = exc.stderr if exc.stderr else "Unknown error"
+        raise RuntimeError(f"GitHub API error: {error_msg}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse GitHub API response: {exc}") from exc
+
+
+def parse_force_push_events(response: dict[str, Any]) -> list[ForcePushEvent]:
+    """Parse force-push events from GraphQL response.
+
+    Args:
+        response: Parsed JSON response from GitHub GraphQL API
+
+    Returns:
+        List of ForcePushEvent objects sorted chronologically (oldest first)
+    """
+    events: list[ForcePushEvent] = []
+
+    try:
+        nodes = response["data"]["repository"]["pullRequest"]["timelineItems"]["nodes"]
+    except (KeyError, TypeError) as exc:
+        LOGGER.warning(f"Unexpected response structure: {exc}")
+        return events
+
+    for node in nodes:
+        try:
+            timestamp = node["createdAt"]
+            actor = node["actor"]["login"]
+            before_full = node["beforeCommit"]["oid"]
+            after_full = node["afterCommit"]["oid"]
+
+            event = ForcePushEvent(
+                timestamp=timestamp,
+                actor=actor,
+                before_commit=before_full[:7],
+                after_commit=after_full[:7],
+                before_commit_full=before_full,
+                after_commit_full=after_full,
+            )
+            events.append(event)
+        except (KeyError, TypeError) as exc:
+            LOGGER.warning(f"Skipping malformed event: {exc}")
+            continue
+
+    # Sort chronologically (oldest first)
+    events.sort(key=lambda event: event.timestamp)
+
+    return events
+
+
+def format_markdown_report(parsed_url: ParsedPRUrl, events: list[ForcePushEvent]) -> str:
+    """Format force-push events as markdown report.
+
+    Args:
+        parsed_url: Parsed PR URL components
+        events: List of force-push events
+
+    Returns:
+        Markdown formatted report string
+    """
+    report_lines = [f"## Force-Push Events for PR #{parsed_url.pr_number}", ""]
+
+    if not events:
+        report_lines.append("No force-push events found for this pull request.")
+        return "\n".join(report_lines)
+
+    for idx, event in enumerate(iterable=events, start=1):
+        # Parse ISO 8601 timestamp and format as "YYYY-MM-DD HH:MM:SS UTC"
+        timestamp_dt = datetime.fromisoformat(event.timestamp.replace("Z", "+00:00"))
+        formatted_time = timestamp_dt.strftime(format="%Y-%m-%d %H:%M:%S UTC")
+
+        # Generate compare URL
+        compare_url = f"{parsed_url.base_url}/compare/{event.before_commit_full}..{event.after_commit_full}"
+
+        # Format line
+        line = (
+            f"{idx}. [{formatted_time}]({compare_url}) - "
+            f"`{event.before_commit}` → `{event.after_commit}` by {event.actor}"
+        )
+        report_lines.append(line)
+
+    return "\n".join(report_lines)
+
+
+def main() -> int:
+    """Main entry point for force-push event reporter.
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate force-push event report for GitHub PR",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "pr_url",
+        help="GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=100,
+        help="Maximum number of events to fetch (default: 100)",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        # Parse PR URL
+        parsed_url = parse_pr_url(pr_url=args.pr_url)
+
+        # Build and execute GraphQL query
+        query = build_graphql_query(
+            owner=parsed_url.owner,
+            repo=parsed_url.repo,
+            pr_number=parsed_url.pr_number,
+            page_size=args.page_size,
+        )
+        response = query_github_graphql(query=query)
+
+        # Parse events
+        events = parse_force_push_events(response=response)
+
+        # Format and print report
+        report = format_markdown_report(parsed_url=parsed_url, events=events)
+        print(report)
+
+        return 0
+
+    except ValueError as exc:
+        LOGGER.error(f"Invalid input: {exc}")
+        return 1
+    except RuntimeError as exc:
+        LOGGER.error(f"Operation failed: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr_force_push_report/plan.md
+++ b/scripts/pr_force_push_report/plan.md
@@ -1,0 +1,235 @@
+# Force-Push Event Reporter Script - Implementation Plan
+
+## Context
+
+The user frequently needs to review force-push history for GitHub pull requests to understand what changes were made during the review process. Currently, this requires manual querying of the GitHub API and formatting the results. This script automates the process by:
+
+- Accepting a GitHub PR URL as input
+- Querying the GitHub GraphQL API for force-push events
+- Generating a markdown report with clickable comparison links
+
+This enables quick analysis of PR revision history for code review and debugging purposes.
+
+## Approach
+
+Create a standalone Python script `scripts/pr_tools/force_push_report.py` that:
+1. Uses `gh` CLI with GraphQL API (user preference, handles auth automatically)
+2. Outputs markdown format with clickable GitHub compare links (user preference)
+3. Follows existing script patterns from `scripts/tests_analyzer/` and `scripts/quarantine_stats/`
+
+## File Structure
+
+```
+scripts/pr_tools/
+├── __init__.py              # Empty package marker
+├── force_push_report.py     # Main executable script
+├── README.md                # Usage documentation
+└── plan.md                  # Design document (copy of this plan)
+```
+
+## Implementation Details
+
+### Script Header
+```python
+#!/usr/bin/env python3
+
+"""GitHub PR Force-Push Event Reporter"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from simple_logger.logger import get_logger
+
+LOGGER = get_logger(name=__name__)
+```
+
+### Data Models
+
+**ForcePushEvent dataclass:**
+- `timestamp: str` - ISO 8601 timestamp
+- `actor: str` - GitHub username
+- `before_commit: str` - Short SHA (7 chars) for display
+- `after_commit: str` - Short SHA (7 chars) for display
+- `before_commit_full: str` - Full SHA for URLs
+- `after_commit_full: str` - Full SHA for URLs
+
+**ParsedPRUrl dataclass:**
+- `owner: str` - Repository owner
+- `repo: str` - Repository name
+- `pr_number: int` - PR number
+- `base_url: str` - Base repo URL for compare links
+
+### Core Functions
+
+1. **`parse_pr_url(pr_url: str) -> ParsedPRUrl`**
+   - Regex: `r"^https://github\.com/([a-zA-Z0-9][a-zA-Z0-9._-]*)/([a-zA-Z0-9][a-zA-Z0-9._-]*)/pull/(\d+)/?$"`
+   - Raises `ValueError` on invalid URL
+   - Returns `ParsedPRUrl` with extracted components
+
+2. **`build_graphql_query(owner: str, repo: str, pr_number: int, page_size: int = 100) -> str`**
+   - Returns GraphQL query string for `HEAD_REF_FORCE_PUSHED_EVENT` timeline items
+   - Fetches: `createdAt`, `actor.login`, `beforeCommit.oid`, `afterCommit.oid`
+
+3. **`query_github_graphql(query: str) -> dict[str, Any]`**
+   - Checks `gh` CLI availability first (`gh --version`)
+   - Executes: `gh api graphql -f query={query}` via subprocess
+   - Timeout: 30 seconds
+   - Raises `RuntimeError` on gh CLI missing, auth failure, API errors
+   - Returns parsed JSON response
+
+4. **`parse_force_push_events(response: dict[str, Any]) -> list[ForcePushEvent]`**
+   - Navigates: `data.repository.pullRequest.timelineItems.nodes`
+   - Extracts short (7-char) and full SHAs
+   - Skips malformed events with WARNING logs
+   - Sorts chronologically (oldest first)
+   - Returns list of `ForcePushEvent` objects
+
+5. **`format_markdown_report(parsed_url: ParsedPRUrl, events: list[ForcePushEvent]) -> str`**
+   - Formats timestamps as "YYYY-MM-DD HH:MM:SS UTC"
+   - Generates compare URLs: `{base_url}/compare/{before_full}..{after_full}`
+   - Output format:
+     ```markdown
+     ## Force-Push Events for PR #123
+
+     1. [2026-02-17 12:55:53 UTC](https://github.com/owner/repo/compare/abc1234..def5678) - `abc1234` → `def5678` by username
+     ```
+   - Handles empty events list: "No force-push events found for this pull request."
+
+6. **`main() -> int`**
+   - Argument parser with `pr_url` positional argument
+   - Optional `--page-size` (default: 100)
+   - Orchestrates all functions with named arguments
+   - Catches `ValueError` and `RuntimeError` specifically
+   - Logs errors at ERROR level with context
+   - Returns exit code 0 (success) or 1 (error)
+
+### Error Handling
+
+| Error Type | Exception | Exit Code | User Message |
+|------------|-----------|-----------|--------------|
+| Invalid URL format | `ValueError` | 1 | "Invalid GitHub PR URL format. Expected: https://github.com/owner/repo/pull/NUMBER" |
+| gh CLI missing | `RuntimeError` | 1 | "gh CLI not found. Install via: https://cli.github.com/" |
+| API failure | `RuntimeError` | 1 | "GitHub API error: {details from stderr}" |
+| Network timeout | `RuntimeError` | 1 | "GitHub API request timed out after 30 seconds" |
+| No force-pushes | (not error) | 0 | "No force-push events found for this pull request." |
+
+All exceptions re-raised with `from exc` to preserve stack traces.
+
+### Existing Patterns to Follow
+
+**From `scripts/tests_analyzer/compare_coderabbit_decisions.py`:**
+- Shebang: `#!/usr/bin/env python3`
+- Comment: `# Generated using Claude cli`
+- Logging: `logger = get_logger(name=__name__)` (note: lowercase `logger` used in this file)
+- Dataclass usage for data modeling
+- ArgumentParser with `RawDescriptionHelpFormatter`
+
+**From `scripts/quarantine_stats/generate_dashboard.py`:**
+- Logging: `LOGGER = get_logger(name=__name__)` (note: uppercase `LOGGER` used in this file)
+- Subprocess with explicit timeouts
+- Named arguments for function calls
+
+**Project standards (CLAUDE.md):**
+- Type hints mandatory on all public functions
+- Google-format docstrings for public functions
+- Named arguments for 2+ parameter function calls
+- No single-letter variables
+- Import pattern: `from module import func`
+- INFO logging for API responses
+- ERROR logging for exceptions with context
+
+**Note:** Use uppercase `LOGGER` to match the project standard in CLAUDE.md.
+
+## Implementation Steps
+
+1. Create directory structure:
+   ```bash
+   mkdir -p scripts/pr_tools
+   touch scripts/pr_tools/__init__.py
+   ```
+
+2. Create `force_push_report.py`:
+   - Add shebang, docstring, imports
+   - Implement data models (dataclasses)
+   - Implement functions in order: parse_pr_url → build_graphql_query → query_github_graphql → parse_force_push_events → format_markdown_report → main
+   - Add `if __name__ == "__main__": sys.exit(main())`
+
+3. Create `README.md` with:
+   - Prerequisites (gh CLI installation)
+   - Usage examples
+   - Output format example
+   - Common errors and solutions
+   - CI integration example
+
+4. Create `plan.md`:
+   - Copy this design document to `scripts/pr_tools/plan.md` for future reference
+
+5. Test manually:
+   - Valid PR with force-pushes: `https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/pull/35`
+   - Valid PR without force-pushes (test empty case)
+   - Invalid URL (test error handling)
+   - Non-existent PR (test API error handling)
+
+6. Run verification:
+   ```bash
+   pre-commit run --all-files
+   ```
+
+## Critical Files
+
+**To create:**
+- `scripts/pr_tools/force_push_report.py` - Main script (all logic)
+- `scripts/pr_tools/README.md` - Documentation
+- `scripts/pr_tools/__init__.py` - Empty package marker
+- `scripts/pr_tools/plan.md` - Design document (copy of this plan)
+
+**Reference patterns:**
+- `scripts/tests_analyzer/compare_coderabbit_decisions.py` - URL validation, dataclasses, argparse
+- `scripts/quarantine_stats/generate_dashboard.py` - Subprocess patterns, logging
+
+## Verification
+
+### Manual Testing
+```bash
+# Test with PR that has force-pushes
+python scripts/pr_tools/force_push_report.py \
+  https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/pull/35
+
+# Test with PR without force-pushes (if available)
+python scripts/pr_tools/force_push_report.py \
+  https://github.com/RedHatQE/cnv-tests/pull/XXXX
+
+# Test invalid URL
+python scripts/pr_tools/force_push_report.py "not-a-url"
+
+# Test --page-size flag
+python scripts/pr_tools/force_push_report.py --page-size 5 \
+  https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/pull/35
+```
+
+### Expected Behavior
+- ✅ Markdown output with numbered list
+- ✅ Clickable timestamp links to GitHub compare view
+- ✅ Commit SHAs shortened to 7 characters in display
+- ✅ Full SHAs in compare URLs (two-dot notation: `..`)
+- ✅ Events sorted chronologically (oldest first)
+- ✅ Empty events show friendly message
+- ✅ Invalid URL returns exit code 1 with clear error
+- ✅ Missing gh CLI returns helpful installation message
+- ✅ All errors go to stderr
+- ✅ Passes `pre-commit run --all-files`
+
+### Linting
+```bash
+pre-commit run --all-files
+```
+
+All checks must pass before completion.


### PR DESCRIPTION
##### What this PR does / why we need it:

The GitHub web is not always showing the event history with the force-push links like it did in the past.

For users who preserve the commit clean history (i.e. not pushing a new commit as response to code-review or other fixes), the usage of force-push is a common practice. Reviewers of such PRs need a way to observe the changes in order to help the review.

Assisted-by: Claude

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a GitHub PR force-push reporting tool that analyzes pull requests and generates Markdown reports
  * Accepts PR URLs and retrieves force-push event history from GitHub with configurable page size
  * Automatically formats events with commit comparison links and human-readable UTC timestamps
  * Handles errors gracefully and provides clear output when no force-push events are found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->