### PR TITLE
[4.20] Cherry-pick [virt] drop sku from smbios tests

### DIFF
--- a/tests/virt/cluster/general/test_smbios.py
+++ b/tests/virt/cluster/general/test_smbios.py
@@ -31,7 +31,6 @@ def smbios_defaults(cnv_current_version):
         "product": "OpenShift Virtualization",
         "manufacturer": "Red Hat",
         "version": cnv_current_version,
-        "sku": cnv_current_version,
     }
     return smbios_defaults
 


### PR DESCRIPTION
##### Short description:
SKU value was removed from all versions
in SMBIOS

(manual backport of https://github.com/RedHatQE/openshift-virtualization-tests/pull/4159)

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
