### PR TITLE
Add STD docstring format rules and module-level preconditions example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,8 @@ When writing or reviewing STD (Software Test Description) test docstrings, follo
 - **No implementation details in STD docstrings** — no fixture names, no code references, no variable names; describe behavior in natural language
 - **STP link REQUIRED** — module docstring must contain the STP (Software Test Plan) link directly, not a reference to a README or other file
 - **Markers can be at any level** — module, class, or test docstring; place them at the level they apply to
+- **Parametrized markers** — parameter values may have inline markers using `[Markers: ...]` syntax (e.g., `- ipv4 [Markers: ipv4]`) to differentiate common markers from parameter-specific ones
+- **Name resources by function** — in Preconditions, name objects by their role (e.g., "client VM", "server VM", "under-test VM"), not generic labels (e.g., "VM-A", "VM-B")
 - **Shared vs. test-specific preconditions** — class/module docstring holds shared `Preconditions:`, individual tests add only their own. When a shared resource (e.g., a VM) is directly used by a test, it must appear in both the shared and test-level preconditions.
 - **`[NEGATIVE]` indicator REQUIRED** — tests verifying failure scenarios must include `[NEGATIVE]` in the description
 

--- a/docs/SOFTWARE_TEST_DESCRIPTION.md
+++ b/docs/SOFTWARE_TEST_DESCRIPTION.md
@@ -147,6 +147,14 @@ test_isolated_vms_cannot_communicate.__test__ = False
 
 When a test should run with multiple parameter combinations, add a `Parametrize:` section.
 
+Parameter values may have their own markers using inline `[Markers: ...]` syntax to differentiate between common test markers and parameter-specific ones:
+
+```text
+Parametrize:
+    - ip_family:
+        - ipv4 [Markers: ipv4]
+        - ipv6 [Markers: ipv6]
+```
 
 ### Markers Section
 
@@ -266,13 +274,18 @@ test_<specific_behavior>.__test__ = False
    - Good: `- Running Fedora virtual machine`
    - Bad: `- Running Fedora VM (vm_to_restart fixture)`
 
-5. **Single Expected Behavior per Test**: One assertion: clear pass/fail.
+5. **Name Resources by Function**: Name objects by their role, not generic labels.
+   - Good: `- Connectivity reference VM`, `- Client VM`
+   - Bad: `- VM-A`, `- VM-B`, `- First VM`
+   - This is especially important when multiple resources of the same kind are used, to clarify each resource's purpose.
+
+6. **Single Expected Behavior per Test**: One assertion: clear pass/fail.
    - Good: `Expected: - Ping succeeds with 0% packet loss`
    - Bad: `Expected: - Ping succeeds - VM remains running - No errors logged`
    - There may be **exceptions**, where multiple assertions are required to verify a **single** behavior.
      - Example: `Expected: - VM reports valid IP addres. Expected - User can access VM via SSH`
 
-6. **Tests Must Be Independent**: Tests should not depend on other tests.
+7. **Tests Must Be Independent**: Tests should not depend on other tests.
    - Dependencies between tests mean that one test depends on the result of a previous test.
    - If testing of a feature requires dependencies between tests, make sure that:
      - They are grouped under a class with shared preconditions


### PR DESCRIPTION
## Summary

- Add mandatory STD (Software Test Description) docstring format rules to CLAUDE.md
- Clarify that shared resources used directly by tests must appear in both shared and test-level preconditions (in both CLAUDE.md and docs/SOFTWARE_TEST_DESCRIPTION.md)
- Add Example 6 (module-level preconditions) to docs/SOFTWARE_TEST_DESCRIPTION.md

## Changes

### CLAUDE.md
- New **STD Docstring Format (MANDATORY)** section with rules for:
  - Required sections: `Preconditions:`, `Steps:`, `Expected:`
  - Prohibition of alternative headings (e.g., `Checks:`, `Verification:`)
  - STP link requirement
  - `[NEGATIVE]` indicator for failure tests
  - Shared vs. test-specific preconditions (including dual-level rule for shared resources)

### docs/SOFTWARE_TEST_DESCRIPTION.md
- Updated key principles to include module-level shared preconditions
- Added rule: shared resources used directly by tests must appear at both levels
- Added Example 6: module-level preconditions showing a VM shared across the module appearing in both module and test preconditions

## Motivation

PR #4116 used `Checks:` instead of the standard `Expected:` heading in STD docstrings, and CodeRabbit did not catch it. These changes codify the STD format rules so AI reviewers and contributors have explicit guidance.

Assisted-by: Claude <noreply@anthropic.com>

## Test plan

- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify docs/SOFTWARE_TEST_DESCRIPTION.md renders correctly
- [ ] Confirm rules align with existing STD template and examples