### PR TITLE
WIP: net, infra, stuntime: Measure connectivity gap during VM live migration

### DIFF
--- a/tests/network/stuntime/lib_helpers.py
+++ b/tests/network/stuntime/lib_helpers.py
@@ -1,0 +1,42 @@
+import itertools
+import logging
+import re
+
+LOGGER = logging.getLogger(__name__)
+
+
+class InsufficientStuntimeDataError(ValueError):
+    """Raised when ping log has too few replies to compute stuntime."""
+
+
+def compute_stuntime(ping_log: str) -> float:
+    """Parse ping -D output and compute stuntime as the largest gap between successful replies.
+
+    Stuntime is the connectivity gap duration: the largest interval where no ICMP replies
+    were received. For example, with ping at 0.1s intervals, any gap > 0.1s indicates packet loss.
+
+    Args:
+        ping_log: Raw output from ping -D (timestamped lines).
+
+    Returns:
+        Stuntime in seconds (float).
+
+    Raises:
+        InsufficientStuntimeDataError: When ping log has fewer than 2 reply timestamps.
+    """
+    timestamps: list[float] = []
+    for line in ping_log.splitlines():
+        if "bytes from" in line or "icmp_seq=" in line:
+            match = re.search(r"\[(\d+\.\d+)\]", line)
+            if match:
+                timestamps.append(float(match.group(1)))
+
+    if len(timestamps) < 2:
+        raise InsufficientStuntimeDataError(
+            f"Insufficient data to compute stuntime: {len(timestamps)} reply timestamps (need at least 2)"
+        )
+
+    stuntime = max(b - a for a, b in itertools.pairwise(timestamps))
+    session_duration = timestamps[-1] - timestamps[0]
+    LOGGER.info(f"Total ping session={session_duration:.3f}s, stuntime={stuntime:.3f}s")
+    return stuntime

--- a/tests/network/stuntime/test_stuntime_measurement.py
+++ b/tests/network/stuntime/test_stuntime_measurement.py
@@ -1,0 +1,102 @@
+"""
+VM stuntime measurement during live migration on secondary networks.
+
+Tests measure the connectivity gap (stuntime) during VM live migration across
+Linux bridge and OVN localnet secondary networks, for both IPv4 and IPv6,
+for regression detection.
+
+STP Reference:
+https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/stuntime_measurement.md
+"""
+
+import pytest
+
+
+class TestStuntimeLinuxBridge:
+    """Stuntime measurement on Linux bridge secondary network."""
+
+    @pytest.mark.polarion("CNV-00001")
+    def test_migration_stuntime(self):
+        """
+        Test that measured stuntime during live migration does not exceed the per-scenario threshold.
+
+        Markers:
+            - pytest.mark.ipv4, pytest.mark.ipv6 (applied per ip_family value for selective runs).
+
+        Parametrize:
+            - ip_family: IP family used for connectivity downtime measurements.
+              Values:
+               - ipv4 (ping -D -O -i 0.1).
+               - ipv6 (ping -6 -D -O -i 0.1).
+            - migration_path: Direction of VM migration relative to the peer's node.
+              Values:
+               - co_located_to_remote (migrate from peer's node to a remote node).
+               - remote_to_co_located (migrate from a remote node to peer's node).
+               - remote_to_remote (migrate between two remote nodes).
+            - ping_initiator: VM from which the ping command is launched toward the peer.
+              Values:
+               - migrated_vm (ping from the VM for migration toward the peer).
+               - peer_vm (ping from the peer toward the VM for migration).
+
+        Preconditions:
+            - Running VM for migration on Linux bridge secondary network, running on worker1.
+            - Running peer VM on Linux bridge secondary network, running on worker1.
+            - Ping running at 100 ms intervals from ping_initiator VM to peer.
+            - Predefined stuntime threshold to test against (per-scenario, derived from BM baseline runs).
+
+        Steps:
+            1. Restart ping before each parametrized run so the log captures only that run's connectivity gap.
+            2. Initiate live migration of the VM for migration along the specified path.
+            3. Parse ping output for connectivity gap (last success before loss to first success after recovery).
+            4. Compare measured stuntime against per-scenario threshold.
+
+        Expected:
+            - Measured stuntime does not exceed the per-scenario threshold.
+        """
+
+    test_migration_stuntime.__test__ = False
+
+
+class TestStuntimeOvnLocalnet:
+    """Stuntime measurement on OVN localnet secondary network."""
+
+    @pytest.mark.polarion("CNV-00000")
+    def test_migration_stuntime(self):
+        """
+        Test that measured stuntime during live migration does not exceed the per-scenario threshold.
+
+        Markers:
+            - pytest.mark.ipv4, pytest.mark.ipv6 (applied per ip_family value for selective runs).
+
+        Parametrize:
+            - ip_family: IP family used for connectivity downtime measurements.
+              Values:
+               - ipv4 (ping -D -O -i 0.1).
+               - ipv6 (ping -6 -D -O -i 0.1).
+            - migration_path: Direction of VM migration relative to the peer's node.
+              Values:
+               - co_located_to_remote (migrate from peer's node to a remote node).
+               - remote_to_co_located (migrate from a remote node to peer's node).
+               - remote_to_remote (migrate between two remote nodes).
+            - ping_initiator: VM from which the ping command is launched toward the peer.
+              Values:
+               - migrated_vm (ping from the VM for migration toward the peer).
+               - peer_vm (ping from the peer toward the VM for migration).
+
+        Preconditions:
+            - Running VM for migration on OVN localnet secondary network, running on worker1.
+            - Running peer VM on OVN localnet secondary network, running on worker1.
+            - Ping running at 100 ms intervals from ping_initiator VM to peer.
+            - Predefined stuntime threshold to test against (per-scenario, derived from BM baseline runs).
+
+        Steps:
+            1. Restart ping before each parametrized run so the log captures only that run's connectivity gap.
+            2. Initiate live migration of the VM for migration along the specified path.
+            3. Parse ping output for connectivity gap (last success before loss to first success after recovery).
+            4. Compare measured stuntime against per-scenario threshold.
+
+        Expected:
+            - Measured stuntime does not exceed the per-scenario threshold.
+        """
+
+    test_migration_stuntime.__test__ = False


### PR DESCRIPTION
##### Short description:
Quantify downtime between pings for regression detection and baselines.

##### What this PR does / why we need it:
Add compute_stuntime helper to parse ping -D output and compute connectivity gap. To be used in the measurement scenarios.

##### Special notes for reviewer:
Based on the stuntime STP, not yet merged.

## Verification
- Ran with 2 VMs on Linux bridge and live migration.
- Ping output captured from the static VM (/tmp/stuntime_ping.log) during migration of the other VM.
Output:
...
[1774185115.382314] 64 bytes from 172.16.2.2: icmp_seq=41 ttl=64 time=0.695 ms
[1774185115.486496] 64 bytes from 172.16.2.2: icmp_seq=42 ttl=64 time=0.785 ms
[1774185115.590352] 64 bytes from 172.16.2.2: icmp_seq=43 ttl=64 time=0.641 ms
[1774185115.694331] 64 bytes from 172.16.2.2: icmp_seq=44 ttl=64 time=0.676 ms
[1774185116.630529] 64 bytes from 172.16.2.2: icmp_seq=53 ttl=64 time=0.859 ms
[1774185126.824966] 64 bytes from 172.16.2.2: icmp_seq=151 ttl=64 time=3.22 ms
[1774185126.923577] 64 bytes from 172.16.2.2: icmp_seq=152 ttl=64 time=1.11 ms
[1774185127.023927] 64 bytes from 172.16.2.2: icmp_seq=153 ttl=64 time=0.907 ms
[1774185127.124168] 64 bytes from 172.16.2.2: icmp_seq=154 ttl=64 time=0.781 ms
[1774185127.230467] 64 bytes from 172.16.2.2: icmp_seq=155 ttl=64 time=0.719 ms
...
- Example measured stuntime: 10.194s (connectivity gap during migration) - from test output:
Measured stuntime: 10.194s


##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-80581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test infrastructure for measuring network performance during virtual machine migration scenarios across different network configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->