### PR TITLE
refactor: use watch API instead of polling in lookup_iface_status

### DIFF
--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -4,7 +4,7 @@ from typing import Any, Final
 
 from kubernetes.dynamic.client import ResourceField
 from ocp_resources.virtual_machine import VirtualMachine
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
+from timeout_sampler import retry
 
 from libs.vm.spec import Network
 from libs.vm.vm import BaseVirtualMachine
@@ -59,38 +59,36 @@ def lookup_iface_status(
     Raises:
         VMInterfaceStatusNotFoundError: If the requested interface was not found in the vmi status.
     """
-    sampler = TimeoutSampler(
-        wait_timeout=timeout,
-        sleep=RETRY_INTERVAL_SEC,
-        func=_lookup_iface_status,
-        vm=vm,
-        iface_name=iface_name,
-        predicate=predicate,
-    )
-    try:
-        for iface in sampler:
-            if iface:
+    if iface := _lookup_iface_status(interfaces=vm.vmi.interfaces, iface_name=iface_name, predicate=predicate):
+        return iface
+
+    for event in vm.vmi.watcher(timeout=timeout):
+        if event["type"] != "MODIFIED":
+            continue
+        if interfaces := event["object"].status.interfaces:
+            if iface := _lookup_iface_status(interfaces=interfaces, iface_name=iface_name, predicate=predicate):
                 return iface
-    except TimeoutExpiredError:
-        raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
+
+    raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
 
 
-def _lookup_iface_status(vm: VirtualMachine, iface_name: str, predicate: Callable[[Any], bool]) -> ResourceField | None:
+def _lookup_iface_status(
+    interfaces: list[ResourceField], iface_name: str, predicate: Callable[[Any], bool]
+) -> ResourceField | None:
     """
-    Returns the interface requested if found and the predicate function (to which the interface is
-    sent) Else, returns None.
+    Returns the interface requested if found and the predicate function returns True, else None.
 
     Args:
-        vm: VM in which to search for the network interface.
+        interfaces: List of VMI interface status objects to search through.
         iface_name: The name of the requested interface.
         predicate: A function that takes a network interface as an argument
-            and returns a boolean value. this function should define the condition that
+            and returns a boolean value. This function should define the condition that
             the interface needs to meet.
 
     Returns:
         iface (ResourceField) | None: The requested interface or None
     """
-    for iface in vm.vmi.interfaces:
+    for iface in interfaces:
         if iface.name == iface_name and predicate(iface):
             return iface
     return None
@@ -115,7 +113,7 @@ def wait_for_missing_iface_status(vm: BaseVirtualMachine, iface_name: str) -> bo
     Raises:
         VMInterfaceStatusStillExistsError: If the interface still exists after the timeout period.
     """
-    if _lookup_iface_status(vm=vm, iface_name=iface_name, predicate=lambda _: True) is not None:
+    if _lookup_iface_status(interfaces=vm.vmi.interfaces, iface_name=iface_name, predicate=lambda _: True) is not None:
         raise VMInterfaceStatusStillExistsError(f"Interface {iface_name} still exists in {vm.name}")
 
     return True


### PR DESCRIPTION
## Summary

Replace `TimeoutSampler` polling with Kubernetes watch API in `lookup_iface_status` for instant reaction to VMI status changes.

## Changes

- **`libs/net/vmspec.py`**:
  - `lookup_iface_status` now uses `vmi.watcher()` instead of `TimeoutSampler` polling
  - First checks current state, then watches for `MODIFIED` events
  - `_lookup_iface_status` refactored to accept `interfaces` list directly (instead of `vm`), enabling reuse in both the initial check and watch loop
  - Removed `TimeoutExpiredError` and `TimeoutSampler` imports (no longer needed)

## Why

- **Instant reaction** — no 5s polling delay; events arrive as soon as VMI status changes
- **Lower API load** — single long-lived watch connection instead of repeated GET requests
- **Consistent pattern** — matches existing `monitor_vmi_events` usage in `tests/network/l2_bridge/vmi_interfaces_stability/`

Assisted-by: Claude <noreply@anthropic.com>

## Test plan

- [ ] Run network tests that use `lookup_iface_status` (localnet, sriov, l2_bridge, flat_overlay, migration)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced interface status lookup mechanism to improve responsiveness through event-driven updates and optimized synchronous detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->