### PR TITLE
fix: auto-retest workflow to support all branches

### DIFF
--- a/.github/workflows/auto-retest-needs-rebase.yml
+++ b/.github/workflows/auto-retest-needs-rebase.yml
@@ -3,14 +3,13 @@ name: Auto-retest PRs after merge
 on:
   pull_request_target:
     types: [closed]
-    branches: [main]
 
 permissions:
   pull-requests: write
   contents: read
 
 concurrency:
-  group: auto-retest-main
+  group: auto-retest-${{ github.event.pull_request.base.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -28,6 +27,7 @@ jobs:
         id: merged-files
         env:
           GH_TOKEN: ${{ secrets.BOT3_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
@@ -53,25 +53,26 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.BOT3_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
 
-          # Get all open PRs with main as base branch (excluding drafts)
-          OPEN_PRS=$(gh pr list --base main --state open --limit 100 --json number,isDraft --jq '.[] | select(.isDraft == false) | .number')
+          # Get all open PRs targeting the same base branch (excluding drafts)
+          OPEN_PRS=$(gh pr list --base "$BASE_REF" --state open --limit 100 --json number,isDraft --jq '.[] | select(.isDraft == false) | .number')
 
           if [ -z "$OPEN_PRS" ]; then
-            echo "No open PRs targeting main branch"
+            echo "No open PRs targeting $BASE_REF branch"
             exit 0
           fi
 
-          echo "Open PRs targeting main: $OPEN_PRS"
+          echo "Open PRs targeting $BASE_REF: $OPEN_PRS"
 
           for PR_NUM in $OPEN_PRS; do
             echo "================================================"
             echo "Checking PR #$PR_NUM"
 
             # Check if PR has has-conflict, hold, wip, or stale labels
-            SKIP_LABELS=$(gh pr view $PR_NUM --json labels --jq '.labels[].name' | grep -iE "^(has-conflicts|hold|wip|stale)$" || true)
+            SKIP_LABELS=$(gh pr view "$PR_NUM" --json labels --jq '[.labels // [] | .[].name | select(test("(?i)^(has-conflicts|hold|wip|stale)$"))] | join(",")')
 
             if [ -n "$SKIP_LABELS" ]; then
               echo "PR #$PR_NUM has skip label(s): $SKIP_LABELS, skipping retest"


### PR DESCRIPTION
## Summary

Update the auto-retest workflow to trigger on PR merges to **any** branch, not just `main`.

## Changes

- Remove `branches: [main]` filter — workflow now triggers on merges to all branches
- Use `${{ github.event.pull_request.base.ref }}` for dynamic branch targeting in:
  - Concurrency group (per-branch isolation)
  - `gh pr list --base` (check PRs targeting the same branch)
- Fix `SKIP_LABELS` detection — replace fragile `grep` pipe with robust `jq` expression:
  - Handles null/missing labels safely (`// []`)
  - Case-insensitive matching entirely in jq
  - No longer silently swallows `gh` CLI errors
  - Properly quotes `$PR_NUM`

## Before / After

| Aspect | Before | After |
|--------|--------|-------|
| Branches | `main` only | All branches |
| Concurrency | `auto-retest-main` | `auto-retest-<branch>` |
| Label check | `gh ... \| grep \|\| true` | Single jq expression |
| Error handling | `gh` failures silently swallowed | `gh` failures visible |

## Test plan

- [x] Tested jq expression on PRs with skip labels (wip, has-conflicts) — correctly detected
- [x] Tested on PRs without skip labels — returned empty string
- [x] Tested edge cases (no labels, null labels) — handled safely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflow now detects and respects each pull request’s base branch instead of using a single hardcoded branch.
  * Open-PR selection and related steps were updated to operate against the detected base branch.
  * Skip-label detection and logging were simplified for more reliable, efficient workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->