### PR TITLE
CherryPicked: [cnv-4.20] Update pyhelper-utils package - improved ssh cleanup flow

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1553,28 +1553,29 @@ wheels = [
 
 [[package]]
 name = "pyhelper-utils"
-version = "1.0.19"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipdb" },
+    { name = "paramiko" },
     { name = "python-rrmngmnt" },
     { name = "python-simple-logger" },
     { name = "requests" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/e1/1323546950a087c22564305bb4b1400a619599c07e7407bd127b40cfbbb5/pyhelper_utils-1.0.19.tar.gz", hash = "sha256:3881aaba7f9310da47b3ff317679f4b301c118ebc50da75943d6e15dd74c2e5e", size = 10770, upload-time = "2025-09-29T15:38:30.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/c3/ac6673c23c34970550143350ca825197d0ce4e12d7cf5f5147db723826ec/pyhelper_utils-2.0.1.tar.gz", hash = "sha256:6a1dd0fd63ba1dec8dabfd114a4948a19d049e784b04742cdc04be676e83611d", size = 10988, upload-time = "2026-03-18T09:43:08.89Z" }
 
 [[package]]
 name = "pylero"
-version = "0.1.1"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "suds" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/38/0c0ccaafbb8594cf50af8d2376a5afee9e7279b7715a928558e7b52eb6f6/pylero-0.1.1.tar.gz", hash = "sha256:de0ccd37da69e50993fe403eca5d093d70c57319640d6af6403ab9a3496ae16c", size = 309121, upload-time = "2025-05-30T13:38:52.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/a3/04efbc25a706d04d9d12cc5346b9ade9326d322496556eb07fa86b8cd3d5/pylero-0.2.0.tar.gz", hash = "sha256:534e86667e318ac353d24d041229d3f821316e0f3b659f2fd050adfcd4f3472f", size = 486274, upload-time = "2025-12-19T15:17:13.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/79/4a7ff895325f7226f846cf4e274be9bbeedcd2d9804027c5025e72134ff4/pylero-0.1.1-py3-none-any.whl", hash = "sha256:ada04668e36adaaed950e213699f8442466994142c127a3f07b5e4d19fc9709f", size = 101338, upload-time = "2025-12-19T15:11:28.422Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/24/d26a5582611ba222c2f36cbd06736af106e424776bb54277f93407672926/pylero-0.2.0-py3-none-any.whl", hash = "sha256:3fd52d56fa11b8f77313681523b2b90ab986d34cc504aa6ce846510e732a2894", size = 101341, upload-time = "2025-12-19T15:17:11.685Z" },
 ]
 
 [[package]]
@@ -1892,7 +1893,7 @@ wheels = [
 
 [[package]]
 name = "python-utility-scripts"
-version = "2.0.1"
+version = "2.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ast-comments" },
@@ -1905,7 +1906,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/fc/d0af117ae6a2507089047067300060bcb12ddd0da73a728f04db5338d28e/python_utility_scripts-2.0.1.tar.gz", hash = "sha256:e8045d9baec39fad6e065f6e766d026e9d269631dce56af8025ae1c9e2f6248e", size = 21124, upload-time = "2025-11-11T20:46:56.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/84/eb74b833ffad45287e19964102028d7cd69b9f1bf2c5308d0be6792791ab/python_utility_scripts-2.0.6.tar.gz", hash = "sha256:a43ac3eddea5b5865b0c182b04c43457e073da360ec202ad5b0f715011213c7a", size = 21742, upload-time = "2026-03-16T12:13:10.334Z" }
 
 [[package]]
 name = "pyvmomi"


### PR DESCRIPTION
Cherry-pick from `cnv-4.21` branch, original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/4222, PR owner: rnetser