### PR TITLE
[VIRT] skip virt-launcher update check when image unchanged during upgrade

### DIFF
--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -14,6 +14,7 @@ from pytest_testconfig import py_config
 
 from tests.virt.constants import VM_LABEL
 from tests.virt.upgrade.utils import (
+    get_virt_launcher_image_from_csv,
     validate_vms_pod_updated,
     vm_from_template,
     wait_for_automatic_vm_migrations,
@@ -169,11 +170,7 @@ def unupdated_vmi_pods_names(
     virt_launcher_from_csv_before_upgrade,
     csv_after_upgrade,
 ):
-    virt_launcher_image_after_upgrade = None
-    for item in csv_after_upgrade.instance.spec.relatedImages:
-        if "virt-launcher" in item["name"]:
-            virt_launcher_image_after_upgrade = item["image"]
-            break
+    virt_launcher_image_after_upgrade = get_virt_launcher_image_from_csv(csv=csv_after_upgrade)
 
     if virt_launcher_from_csv_before_upgrade == virt_launcher_image_after_upgrade:
         LOGGER.warning(f"virt-launcher unchanged, skipping migration check: {virt_launcher_from_csv_before_upgrade}")
@@ -379,10 +376,7 @@ def parallel_live_migrations_increased(hyperconverged_resource_scope_session):
 
 @pytest.fixture(scope="session")
 def virt_launcher_from_csv_before_upgrade(csv_scope_session):
-    for item in csv_scope_session.instance.spec.relatedImages:
-        if "virt-launcher" in item["name"]:
-            return item["image"]
-    raise ValueError("Image digest for virt-launcher not found")
+    return get_virt_launcher_image_from_csv(csv=csv_scope_session)
 
 
 @pytest.fixture()

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -60,6 +60,7 @@ pytestmark = [
 @pytest.mark.usefixtures(
     "base_templates",
     "parallel_live_migrations_increased",
+    "virt_launcher_from_csv_before_upgrade",
 )
 class TestUpgradeVirt:
     """Pre-upgrade tests"""

--- a/tests/virt/upgrade/utils.py
+++ b/tests/virt/upgrade/utils.py
@@ -16,6 +16,7 @@ from utilities.constants import (
     TIMEOUT_3MIN,
     TIMEOUT_10SEC,
     TIMEOUT_180MIN,
+    VIRT_LAUNCHER,
 )
 from utilities.exceptions import ResourceMissingFieldError
 from utilities.virt import (
@@ -26,6 +27,13 @@ from utilities.virt import (
 LOGGER = logging.getLogger(__name__)
 
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def get_virt_launcher_image_from_csv(csv):
+    for item in csv.instance.spec.relatedImages:
+        if VIRT_LAUNCHER in item["name"]:
+            return item["image"]
+    raise ValueError(f"Image digest for {VIRT_LAUNCHER} not found")
 
 
 def verify_vms_ssh_connectivity(vms_list):


### PR DESCRIPTION
##### Short description:
The test_vmi_pod_image_updates_after_upgrade_optin test was failing on Z
release upgrades where virt-launcher image doesn't change. Skip automatic
workload update migration verification when virt-launcher image is unchanged.

##### More details:
Changes:
- Add virt_launcher_from_csv_before_upgrade fixture to capture
  virt-launcher image before upgrade
- Add csv_after_upgrade fixture to get target CSV
- Compare virt-launcher images before/after upgrade in unupdated_vmi_pods_names
- Skip automatic migration check with warning when image unchanged
- Simplify validate_vms_pod_updated to accept expected image directly

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored upgrade tests to compute pre- and post-upgrade virt-launcher images from cluster metadata and skip migration/validation when unchanged.
  * Updated pod validation to check against an explicit expected virt-launcher image.
  * Added fixtures to capture pre- and post-upgrade image values, simplifying test setup and reducing configuration coupling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->