### PR TITLE
Fix: Change docker image dir from docker to docker-local

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -64,7 +64,7 @@ class Windows:
     WIN2022_ISO_IMG: str | None = None
     WIN2025_ISO_IMG: str | None = None
     DIR: str = f"{BASE_IMAGES_DIR}/windows-images"
-    DOCKER_IMAGE_DIR = "docker/kubevirt-common-instancetypes"
+    DOCKER_IMAGE_DIR: str = "docker-local/kubevirt-common-instancetypes"
     UEFI_WIN_DIR: str = f"{DIR}/uefi"
     HA_DIR: str = f"{DIR}/HA-images"
     ISO_BASE_DIR = f"{DIR}/install_iso"

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -22,7 +22,7 @@ from utilities.os_utils import (
 class TestGetWindowsContainerDiskPath:
     """Test cases for get_windows_container_disk_path function"""
 
-    EXPECTED_DIR = "docker/kubevirt-common-instancetypes"
+    EXPECTED_DIR = "docker-local/kubevirt-common-instancetypes"
 
     @pytest.mark.parametrize(
         "os_value, expected_suffix",


### PR DESCRIPTION
##### Short description:
Change docker image dir from docker to docker-local

##### More details:
The new artifactory server now changed it's repository name from `docker` to `docker-local`, this means that the windows images are now targeting the wrong location.

##### What this PR does / why we need it:
Fix windows images image pulling, in specific tests/infrastructure/instance_types/supported_os/test_windows_os.py

##### Which issue(s) this PR fixes:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/4267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image directory reference used for Windows instances to point to the new local image storage location.
* **Tests**
  * Updated unit tests to expect the revised Windows image directory path so test expectations match the new storage location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->