### PR TITLE
net: Introduce bandwidth throttling test

### DIFF
--- a/libs/net/ip.py
+++ b/libs/net/ip.py
@@ -79,6 +79,31 @@ def _random_hextets(count: int) -> list[int]:
     return random.sample(range(1, 0xFFFE), count)
 
 
+def random_ip_addresses_by_family(
+    ipv4_supported: bool,
+    ipv6_supported: bool,
+    net_seed: int,
+    host_address: int,
+) -> list[str]:
+    """Generate IP addresses for each supported IP family.
+
+    Args:
+        ipv4_supported: Whether IPv4 is supported.
+        ipv6_supported: Whether IPv6 is supported.
+        net_seed: Seed index for selecting the random network portion of the address.
+        host_address: Host portion of the address, used to place VMs on the same subnet.
+
+    Returns:
+        List of IP address strings, one per supported IP family.
+    """
+    ips = []
+    if ipv4_supported:
+        ips.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
+    if ipv6_supported:
+        ips.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
+    return ips
+
+
 def filter_link_local_addresses(ip_addresses: list[str]) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
     """
     Filter out link-local IP addresses from a list of IP address strings.

--- a/libs/net/netattachdef.py
+++ b/libs/net/netattachdef.py
@@ -85,6 +85,20 @@ class CNIPluginOvnK8sConfig(CNIPluginConfig):
 
 
 @dataclass
+class CNIPluginBandwidthConfig(CNIPluginConfig):
+    """
+    CNI Bandwidth Plugin
+    Ref: https://www.cni.dev/plugins/current/meta/bandwidth/
+    """
+
+    type: str = field(default="bandwidth", init=False)
+    ingressRate: int  # noqa: N815
+    ingressBurst: int  # noqa: N815
+    egressRate: int  # noqa: N815
+    egressBurst: int  # noqa: N815
+
+
+@dataclass
 class CNIPluginMacvlanConfig(CNIPluginConfig):
     """
     CNI Macvlan Plugin

--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -163,3 +163,30 @@ def _lookup_first_ip_address(
     ip_family: int,
 ) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
     return next((ip for ip_addr in ip_addresses if (ip := ipaddress.ip_address(ip_addr)).version == ip_family), None)
+
+
+def wait_for_ifaces_status(
+    vm: BaseVirtualMachine,
+    ip_addresses_by_spec_net_name: dict[str, list[str]],
+) -> None:
+    """Wait for all VM interfaces to be ready.
+
+    Args:
+        vm: The virtual machine to wait for.
+        ip_addresses_by_spec_net_name: Mapping of spec network name to its expected IP addresses.
+            Primary (masquerade) interfaces are detected automatically from the VM spec.
+    """
+    for iface in vm.template_spec.domain.devices.interfaces:  # type: ignore
+        if iface.masquerade is not None:
+            lookup_iface_status(vm=vm, iface_name=iface.name)
+        else:
+            lookup_iface_status(
+                vm=vm,
+                iface_name=iface.name,
+                predicate=lambda iface_status: (
+                    "guest-agent" in iface_status["infoSource"]
+                    and all(
+                        ip in iface_status.get("ipAddresses", []) for ip in ip_addresses_by_spec_net_name[iface.name]
+                    )
+                ),
+            )

--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -11,7 +11,17 @@ from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
-from libs.vm.spec import CloudInitNoCloud, ContainerDisk, Devices, Disk, Metadata, SpecDisk, VMISpec, VMSpec, Volume
+from libs.vm.spec import (
+    CloudInitNoCloud,
+    ContainerDisk,
+    Devices,
+    Disk,
+    Metadata,
+    SpecDisk,
+    VMISpec,
+    VMSpec,
+    Volume,
+)
 from tests.network.libs import cloudinit
 from utilities import infra
 from utilities.constants import CLOUD_INIT_DISK_NAME
@@ -103,6 +113,10 @@ class BaseVirtualMachine(VirtualMachine):
             self: {"spec": {"template": {"metadata": {"annotations": self._spec.template.metadata.annotations}}}}
         }
         ResourceEditor(patches=patches).update()
+
+    @property
+    def template_spec(self) -> VMISpec:
+        return self._spec.template.spec
 
     @property
     def cloud_init_network_data(self) -> cloudinit.NetworkData:

--- a/tests/network/l2_bridge/bandwidth/conftest.py
+++ b/tests/network/l2_bridge/bandwidth/conftest.py
@@ -1,0 +1,138 @@
+import ipaddress
+from collections.abc import Generator
+from ipaddress import ip_interface
+from typing import Final
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
+from libs.net.ip import random_ip_addresses_by_family
+from libs.net.netattachdef import (
+    CNIPluginBandwidthConfig,
+    CNIPluginBridgeConfig,
+    NetConfig,
+    NetworkAttachmentDefinition,
+)
+from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.l2_bridge.bandwidth.lib_helpers import (
+    BANDWIDTH_RATE_BPS,
+    BANDWIDTH_SECONDARY_IFACE_NAME,
+    GUEST_2ND_IFACE_NAME,
+    secondary_network_vm,
+)
+
+_NAD_NAME: Final[str] = "br-bw-test-nad"
+
+
+@pytest.fixture(scope="module")
+def bandwidth_nad(
+    admin_client: DynamicClient,
+    namespace: Namespace,
+    bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
+) -> Generator[NetworkAttachmentDefinition]:
+    config = NetConfig(
+        name=_NAD_NAME,
+        plugins=[
+            CNIPluginBridgeConfig(
+                bridge=bridge_nncp.desired_state_spec.interfaces[0].name  # type: ignore
+            ),
+            CNIPluginBandwidthConfig(
+                ingressRate=BANDWIDTH_RATE_BPS,
+                ingressBurst=BANDWIDTH_RATE_BPS,
+                egressRate=BANDWIDTH_RATE_BPS,
+                egressBurst=BANDWIDTH_RATE_BPS,
+            ),
+        ],
+    )
+    with NetworkAttachmentDefinition(
+        name=_NAD_NAME,
+        namespace=namespace.name,
+        config=config,
+        client=admin_client,
+    ) as bw_nad:
+        yield bw_nad
+
+
+@pytest.fixture(scope="module")
+def server_vm(
+    ipv4_supported_cluster: bool,
+    ipv6_supported_cluster: bool,
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    bandwidth_nad: NetworkAttachmentDefinition,
+) -> Generator[BaseVirtualMachine]:
+    addresses = [
+        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
+        for ip in random_ip_addresses_by_family(
+            ipv4_supported=ipv4_supported_cluster,
+            ipv6_supported=ipv6_supported_cluster,
+            net_seed=0,
+            host_address=1,
+        )
+    ]
+    with secondary_network_vm(
+        namespace=namespace.name,
+        name="bw-server-vm",
+        client=unprivileged_client,
+        nad_name=bandwidth_nad.name,
+        secondary_iface_name=BANDWIDTH_SECONDARY_IFACE_NAME,
+        secondary_iface_addresses=addresses,
+        ipv4_supported=ipv4_supported_cluster,
+        ipv6_supported=ipv6_supported_cluster,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                BANDWIDTH_SECONDARY_IFACE_NAME: [
+                    str(ip_interface(addr).ip)
+                    for addr in vm.cloud_init_network_data.ethernets[GUEST_2ND_IFACE_NAME].addresses
+                ]
+            },
+        )
+        yield vm
+
+
+@pytest.fixture(scope="module")
+def client_vm(
+    ipv4_supported_cluster: bool,
+    ipv6_supported_cluster: bool,
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    bandwidth_nad: NetworkAttachmentDefinition,
+) -> Generator[BaseVirtualMachine]:
+    addresses = [
+        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
+        for ip in random_ip_addresses_by_family(
+            ipv4_supported=ipv4_supported_cluster,
+            ipv6_supported=ipv6_supported_cluster,
+            net_seed=0,
+            host_address=2,
+        )
+    ]
+    with secondary_network_vm(
+        namespace=namespace.name,
+        name="bw-client-vm",
+        client=unprivileged_client,
+        nad_name=bandwidth_nad.name,
+        secondary_iface_name=BANDWIDTH_SECONDARY_IFACE_NAME,
+        secondary_iface_addresses=addresses,
+        ipv4_supported=ipv4_supported_cluster,
+        ipv6_supported=ipv6_supported_cluster,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                BANDWIDTH_SECONDARY_IFACE_NAME: [
+                    str(ip_interface(addr).ip)
+                    for addr in vm.cloud_init_network_data.ethernets[GUEST_2ND_IFACE_NAME].addresses
+                ]
+            },
+        )
+        yield vm

--- a/tests/network/l2_bridge/bandwidth/lib_helpers.py
+++ b/tests/network/l2_bridge/bandwidth/lib_helpers.py
@@ -1,0 +1,157 @@
+import json
+from typing import Final
+
+from kubernetes.dynamic import DynamicClient
+
+from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import CloudInitNoCloud, Interface, Multus, Network
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+
+BANDWIDTH_SECONDARY_IFACE_NAME: Final[str] = "secondary"
+BANDWIDTH_RATE_BPS: Final[int] = 10_000_000  # 10 Mbps
+
+_IPERF_DURATION_SEC: Final[int] = 10
+_IPERF_TIMEOUT_BUFFER_SEC: Final[int] = 30  # extra buffer for iperf3 startup and output collection
+GUEST_2ND_IFACE_NAME: Final[str] = "eth1"
+
+
+def active_tcp_connection_output(
+    server_vm: BaseVirtualMachine,
+    client_vm: BaseVirtualMachine,
+    server_ip: str,
+    duration: int = _IPERF_DURATION_SEC,
+) -> dict:
+    """Run a timed iperf3 bidirectional session and return the parsed JSON result.
+
+    Args:
+        server_vm: VM running the iperf3 server.
+        client_vm: VM running the iperf3 client.
+        server_ip: IP address to bind the server and connect the client to.
+        duration: Test duration in seconds.
+
+    Returns:
+        Parsed iperf3 JSON output dict, e.g.::
+
+            {
+                "end": {
+                    "sum_received": {"bits_per_second": 9_500_000.0},
+                    "sum_received_bidir_reverse": {"bits_per_second": 9_300_000.0},
+                }
+            }
+    """
+    with TcpServer(vm=server_vm, port=IPERF_SERVER_PORT, bind_ip=server_ip):
+        output = client_vm.console(
+            commands=[
+                f"iperf3 --client {server_ip} --time {duration} --port {IPERF_SERVER_PORT} --json --bidir 2>/dev/null"
+            ],
+            timeout=duration + _IPERF_TIMEOUT_BUFFER_SEC,
+        )
+    try:
+        lines = next(iter((output or {}).values()))
+    except StopIteration:
+        raise ValueError(f"No iperf3 output received for {server_ip}")
+    return json.loads("\n".join(lines[1:-1]))
+
+
+def assert_bidir_throughput_within_limit(
+    iperf3_json_report: dict,
+    rate_bps: int,
+    tolerance: float,
+    server_ip: str,
+) -> None:
+    """Assert that measured bidirectional throughput does not exceed the configured limit.
+
+    Args:
+        iperf3_json_report: Parsed iperf3 JSON output dict, e.g.::
+
+            {
+                "end": {
+                    "sum_received": {"bits_per_second": 9_500_000.0},
+                    "sum_received_bidir_reverse": {"bits_per_second": 9_300_000.0},
+                }
+            }
+
+        rate_bps: Configured bandwidth limit in bits per second.
+        tolerance: Multiplier applied to the rate limit (e.g. 1.1 for 10% tolerance).
+        server_ip: Server IP address used in the test session (for error messages).
+    """
+    for direction, key in [("ingress", "sum_received"), ("egress", "sum_received_bidir_reverse")]:
+        throughput_bps = iperf3_json_report["end"][key]["bits_per_second"]
+        assert throughput_bps <= rate_bps * tolerance, (
+            f"Measured {direction} throughput {throughput_bps:.0f} bps exceeds "
+            f"configured limit {rate_bps} bps for {server_ip}"
+        )
+
+
+def secondary_network_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    nad_name: str,
+    secondary_iface_name: str,
+    secondary_iface_addresses: list[str],
+    ipv4_supported: bool,
+    ipv6_supported: bool,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with a masquerade primary interface and a secondary Linux bridge interface.
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name.
+        client: Kubernetes dynamic client.
+        nad_name: NetworkAttachmentDefinition name for the secondary interface.
+        secondary_iface_name: Name of the secondary network interface in the VM spec.
+        secondary_iface_addresses: CIDR addresses to assign to the secondary interface via cloud-init.
+        ipv4_supported: Whether IPv4 is supported on the cluster.
+        ipv6_supported: Whether IPv6 is supported on the cluster.
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.devices.interfaces = [  # type: ignore
+        Interface(name="default", masquerade={}),
+        Interface(name=secondary_iface_name, bridge={}),
+    ]
+    spec.template.spec.networks = [
+        Network(name="default", pod={}),
+        Network(name=secondary_iface_name, multus=Multus(networkName=nad_name)),
+    ]
+
+    ethernets = {}
+    primary = _masquerade_iface_cloud_init(ipv4_supported=ipv4_supported, ipv6_supported=ipv6_supported)
+    if primary:
+        ethernets["eth0"] = primary
+    ethernets["eth1"] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
+
+    userdata = cloudinit.UserData(users=[])
+    disk, volume = cloudinitdisk_storage(
+        data=CloudInitNoCloud(
+            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)),
+            userData=cloudinit.format_cloud_config(userdata=userdata),
+        )
+    )
+    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
+
+
+def _masquerade_iface_cloud_init(
+    ipv4_supported: bool,
+    ipv6_supported: bool,
+) -> cloudinit.EthernetDevice | None:
+    """Return cloud-init ethernet config for a masquerade (primary) interface.
+
+    Args:
+        ipv4_supported: Whether IPv4 is supported on the cluster.
+        ipv6_supported: Whether IPv6 is supported on the cluster.
+
+    Returns:
+        EthernetDevice with static IPv6 and optional DHCP4, or None if IPv6 is not supported.
+    """
+    if not ipv6_supported:
+        return None
+    return cloudinit.EthernetDevice(
+        addresses=["fd10:0:2::2/120"],
+        gateway6="fd10:0:2::1",
+        dhcp4=ipv4_supported,
+        dhcp6=False,
+    )

--- a/tests/network/l2_bridge/bandwidth/test_bandwidth.py
+++ b/tests/network/l2_bridge/bandwidth/test_bandwidth.py
@@ -5,11 +5,29 @@ RFE Reference:
 https://redhat.atlassian.net/browse/RFE-7066
 """
 
+from typing import Final
+
 import pytest
+
+from libs.net.ip import filter_link_local_addresses
+from libs.net.vmspec import lookup_iface_status
+from tests.network.l2_bridge.bandwidth.lib_helpers import (
+    BANDWIDTH_RATE_BPS,
+    BANDWIDTH_SECONDARY_IFACE_NAME,
+    active_tcp_connection_output,
+    assert_bidir_throughput_within_limit,
+)
+
+_BANDWIDTH_TOLERANCE: Final[float] = 1.1
 
 
 @pytest.mark.polarion("CNV-15244")
-def test_bandwidth_limit_enforced_on_secondary_interface():
+def test_bandwidth_limit_enforced_on_secondary_interface(
+    subtests,
+    server_vm,
+    client_vm,
+    bandwidth_nad,
+):
     """
     Test that bandwidth throttling is enforced on a secondary network interface.
 
@@ -29,6 +47,17 @@ def test_bandwidth_limit_enforced_on_secondary_interface():
           with a 10% tolerance
 
     """
-
-
-test_bandwidth_limit_enforced_on_secondary_interface.__test__ = False
+    iface = lookup_iface_status(vm=server_vm, iface_name=BANDWIDTH_SECONDARY_IFACE_NAME)
+    for server_ip in filter_link_local_addresses(ip_addresses=iface.ipAddresses):
+        with subtests.test(msg=f"Bandwidth limit for {server_ip}"):
+            json_output = active_tcp_connection_output(
+                server_vm=server_vm,
+                client_vm=client_vm,
+                server_ip=str(server_ip),
+            )
+            assert_bidir_throughput_within_limit(
+                iperf3_json_report=json_output,
+                rate_bps=BANDWIDTH_RATE_BPS,
+                tolerance=_BANDWIDTH_TOLERANCE,
+                server_ip=str(server_ip),
+            )

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -6,8 +6,6 @@ from kubernetes.dynamic import DynamicClient
 from pyhelper_utils.shell import run_ssh_commands
 
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
-from utilities.constants import LINUX_BRIDGE, WORKER_NODE_LABEL_KEY
-
 from libs.net.ip import random_ipv4_address
 from tests.network.l2_bridge.libl2bridge import DHCP_INTERFACE_NAME, bridge_attached_vm
 from tests.network.libs.dhcpd import (
@@ -19,6 +17,7 @@ from tests.network.libs.dhcpd import (
     UNIQUE_CLIENT_ID,
     verify_dhcpd_activated,
 )
+from utilities.constants import LINUX_BRIDGE, WORKER_NODE_LABEL_KEY
 from utilities.data_utils import name_prefix
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
@@ -288,7 +287,7 @@ def started_vmb_dhcp_client(l2_bridge_running_vm_b, eth3_nmcli_connection_uuid):
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="package")
 def bridge_nncp(
     nmstate_dependent_placeholder: None,
     admin_client: DynamicClient,
@@ -305,6 +304,7 @@ def bridge_nncp(
                     state=libnncp.Resource.Interface.State.UP,
                     bridge=libnncp.Bridge(
                         port=[libnncp.Port(name=hosts_common_available_ports[-1])],
+                        options=libnncp.BridgeOptions(libnncp.STP(enabled=False)),
                     ),
                 )
             ]

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -1,7 +1,12 @@
 import shlex
+from collections.abc import Generator
 
 import pytest
+from kubernetes.dynamic import DynamicClient
 from pyhelper_utils.shell import run_ssh_commands
+
+import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
+from utilities.constants import LINUX_BRIDGE, WORKER_NODE_LABEL_KEY
 
 from libs.net.ip import random_ipv4_address
 from tests.network.l2_bridge.libl2bridge import DHCP_INTERFACE_NAME, bridge_attached_vm
@@ -281,3 +286,30 @@ def started_vmb_dhcp_client(l2_bridge_running_vm_b, eth3_nmcli_connection_uuid):
             shlex.split("sudo systemctl restart qemu-guest-agent.service"),
         ],
     )
+
+
+@pytest.fixture(scope="class")
+def bridge_nncp(
+    nmstate_dependent_placeholder: None,
+    admin_client: DynamicClient,
+    hosts_common_available_ports: list[str],
+) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
+    with libnncp.NodeNetworkConfigurationPolicy(
+        client=admin_client,
+        name="l2-bridge-test-nncp",
+        desired_state=libnncp.DesiredState(
+            interfaces=[
+                libnncp.Interface(
+                    name="br1-test",
+                    type=LINUX_BRIDGE,
+                    state=libnncp.Resource.Interface.State.UP,
+                    bridge=libnncp.Bridge(
+                        port=[libnncp.Port(name=hosts_common_available_ports[-1])],
+                    ),
+                )
+            ]
+        ),
+        node_selector={WORKER_NODE_LABEL_KEY: ""},
+    ) as nncp_br:
+        nncp_br.wait_for_status_success()
+        yield nncp_br

--- a/tests/network/l2_bridge/vmi_interfaces_stability/conftest.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/conftest.py
@@ -11,7 +11,6 @@ from tests.network.l2_bridge.vmi_interfaces_stability.lib_helpers import (
     secondary_network_vm,
     wait_for_stable_ifaces,
 )
-from utilities.constants import LINUX_BRIDGE, WORKER_NODE_LABEL_KEY
 
 
 @pytest.fixture(scope="class")
@@ -57,33 +56,6 @@ def bridge_nad(
         client=admin_client,
     ) as nad:
         yield nad
-
-
-@pytest.fixture(scope="class")
-def bridge_nncp(
-    nmstate_dependent_placeholder: None,
-    admin_client: DynamicClient,
-    hosts_common_available_ports: list[str],
-) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
-    with libnncp.NodeNetworkConfigurationPolicy(
-        client=admin_client,
-        name="iface-stability-bridge",
-        desired_state=libnncp.DesiredState(
-            interfaces=[
-                libnncp.Interface(
-                    name="br1-test",
-                    type=LINUX_BRIDGE,
-                    state=libnncp.Resource.Interface.State.UP,
-                    bridge=libnncp.Bridge(
-                        port=[libnncp.Port(name=hosts_common_available_ports[-1])],
-                    ),
-                )
-            ]
-        ),
-        node_selector={WORKER_NODE_LABEL_KEY: ""},
-    ) as nncp_br:
-        nncp_br.wait_for_status_success()
-        yield nncp_br
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
Add bandwidth throttling test for Multus secondary
interface via bridge CNI.
Users are interested to apply bandwidth limitations on
ingress and egress traffic passing to and from the VM interfaces.
Implements test coverage for SUPPORTEX-29574
https://redhat.atlassian.net/browse/SUPPORTEX-29574

In order to cover the BW rating limits, a Network Attachment Definition
with the bridge CNI and the Bandwidth CNI is defined and linked to a
secondary VM network.
The test covers all available IP families, per the deployed cluster.
An existing NNCP is used to configure the node network.

Some new helpers are similar to existing helpers from `vmi_interfaces_stability` module and will be adjusted in a follow-up to focus this PR on the BW test.

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-82064
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bandwidth shaping and rate limiting capabilities for secondary network interfaces.
  * Introduced dual-stack IPv4/IPv6 networking support with automatic address configuration and cloud-init integration.
  * Enhanced VM interface status monitoring and verification functionality.

* **Tests**
  * Added comprehensive test suite for bandwidth limit enforcement on secondary network interfaces.
  * Implemented supporting test infrastructure and helpers for network configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->