### PR TITLE
ci: skip team membership check for bot actors

### DIFF
--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -14,7 +14,7 @@ jobs:
   comment-on-commit:
     if: |
       github.event.label.name == 'verified' &&
-      !contains(github.event.pull_request.user.login, 'renovate')
+      !endsWith(github.event.pull_request.user.login, '[bot]')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problem

The `comment-on-commit` job in the `request-coderabbit-test-instructions` workflow fails when a PR is triggered by a GitHub App bot (e.g., `cnv-tests-github-webhook-dollierp[bot]`).

The `tspascoal/get-user-teams-membership@v3` action uses GitHub's GraphQL `user(login:)` query, which cannot resolve bot accounts (`Bot` nodes vs `User` nodes), resulting in:

```
GraphqlResponseError: Could not resolve to a User with the login of 'cnv-tests-github-webhook-dollierp[bot]'.
```

**Failed run:** https://github.com/RedHatQE/openshift-virtualization-tests/actions/runs/23626976494/job/69053639334

## Fix

Add `!endsWith(github.event.pull_request.user.login, '[bot]')` to the job's `if` condition to skip the entire job for bot actors. Bot-authored PRs don't need CodeRabbit test execution plan comments.

## Changes

- `.github/workflows/request-coderabbit-test-instructions.yml`: Added bot actor exclusion to job condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened an internal GitHub Actions workflow condition to more precisely exclude automated pull requests from triggering a comment-on-commit step.

---

Note: No user-facing changes. This update refines background automation and infrastructure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->