### PR TITLE
Fix s390x test compatibility issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2179,7 +2179,7 @@ def vm_preference_for_test(namespace, common_vm_preference_param_dict):
 
 
 @pytest.fixture(scope="class")
-def common_vm_preference_param_dict(request):
+def common_vm_preference_param_dict(request, is_s390x_cluster):
     common_preference_dict = {
         "name": request.param["name"],
         "client": request.param.get("client"),
@@ -2194,7 +2194,12 @@ def common_vm_preference_param_dict(request):
             }
         }
     if request.param.get("clock_preferred_timer"):
-        common_preference_dict.setdefault("clock", {})["preferredTimer"] = request.param["clock_preferred_timer"]
+        if is_s390x_cluster:
+            LOGGER.info(
+                "Skipping preferredTimer in VirtualMachinePreference: x86-specific timers not available on s390x"
+            )
+        else:
+            common_preference_dict.setdefault("clock", {})["preferredTimer"] = request.param["clock_preferred_timer"]
 
     if request.param.get("cpu_topology"):
         common_preference_dict["cpu"] = {"preferredCPUTopology": request.param["cpu_topology"]}

--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -23,6 +23,8 @@ instance_type_rhel_os_list = [RHEL9_PREFERENCE]
 instance_type_fedora_os_list = [OS_FLAVOR_FEDORA]
 instance_type_centos_os_list = [CENTOS_STREAM9_PREFERENCE]
 
+nic_models_matrix = ["virtio"]
+
 
 for _dir in dir():
     if not config:  # noqa: F821

--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
 import pytest
 from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
@@ -7,6 +12,11 @@ from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_lab
 from tests.infrastructure.instance_types.vm_preference_list import VM_PREFERENCES_LIST
 from utilities.constants import VIRT_OPERATOR, Images
 from utilities.virt import VirtualMachineForTests, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
@@ -52,10 +62,19 @@ def start_vm_with_cluster_preference(client, preference_name, namespace_name):
         running_vm(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
 
 
-def run_general_vm_preferences(client, namespace, preferences):
+def _preference_requires_efi(client: DynamicClient, preference_name: str) -> bool:
+    """Check if a VirtualMachineClusterPreference requires EFI firmware."""
+    preference = VirtualMachineClusterPreference(client=client, name=preference_name)
+    return bool(preference.instance.spec.get("firmware", {}).get("preferredEfi"))
+
+
+def run_general_vm_preferences(client, namespace, preferences, is_s390x):
     for preference_name in preferences:
         # TODO remove arm64 skip when openshift-virtualization-tests support arm64
         if all(suffix not in preference_name for suffix in ["virtio", "arm64"]):
+            if is_s390x and _preference_requires_efi(client=client, preference_name=preference_name):
+                LOGGER.info(f"Skipping preference {preference_name}: EFI/OVMF not available on s390x")
+                continue
             start_vm_with_cluster_preference(
                 client=client,
                 preference_name=preference_name,
@@ -87,12 +106,13 @@ def test_common_preferences_vendor_labels(base_vm_cluster_preferences):
 @pytest.mark.tier3
 class TestCommonVmPreference:
     @pytest.mark.polarion("CNV-9894")
-    def test_common_vm_preference_windows(self, unprivileged_client, namespace):
+    def test_common_vm_preference_windows(self, unprivileged_client, namespace, is_s390x_cluster):
         run_general_vm_preferences(
             client=unprivileged_client,
             namespace=namespace,
             # drop legacy preferences with pcihole
             preferences=[pref for pref in VM_PREFERENCES_LIST["windows"] if pref not in {"windows.2k3", "windows.xp"}],
+            is_s390x=is_s390x_cluster,
         )
 
     @pytest.mark.parametrize(
@@ -113,16 +133,22 @@ class TestCommonVmPreference:
         ],
     )
     @pytest.mark.s390x
-    def test_common_vm_preference_linux(self, cluster_preferences, unprivileged_client, namespace):
+    def test_common_vm_preference_linux(self, cluster_preferences, unprivileged_client, namespace, is_s390x_cluster):
         run_general_vm_preferences(
-            client=unprivileged_client, namespace=namespace, preferences=VM_PREFERENCES_LIST[cluster_preferences]
+            client=unprivileged_client,
+            namespace=namespace,
+            preferences=VM_PREFERENCES_LIST[cluster_preferences],
+            is_s390x=is_s390x_cluster,
         )
 
     @pytest.mark.special_infra
     @pytest.mark.polarion("CNV-10806")
-    def test_common_vm_preference_dpdk(self, unprivileged_client, namespace):
+    def test_common_vm_preference_dpdk(self, unprivileged_client, namespace, is_s390x_cluster):
         run_general_vm_preferences(
-            client=unprivileged_client, namespace=namespace, preferences=VM_PREFERENCES_LIST["network"]
+            client=unprivileged_client,
+            namespace=namespace,
+            preferences=VM_PREFERENCES_LIST["network"],
+            is_s390x=is_s390x_cluster,
         )
 
 

--- a/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
+++ b/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
@@ -155,7 +155,6 @@ class TestVmWithInstanceTypeAndPref:
 
     @pytest.mark.dependency(depends=["start_vm_with_instance_type_and_preference"])
     @pytest.mark.polarion("CNV-9821")
-    @pytest.mark.s390x
     def test_validate_clock_values(self, rhel_vm_with_instance_type_and_preference):
         clock_dict = rhel_vm_with_instance_type_and_preference.vmi.instance.to_dict()["spec"]["domain"]["clock"]
         vmi_clock_values = [

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -78,7 +78,6 @@ def create_vm_from_clone_dv_template(
     ],
     indirect=True,
 )
-@pytest.mark.s390x
 def test_successful_clone_of_large_image(
     namespace,
     data_volume_multi_storage_scope_function,


### PR DESCRIPTION




##### Short description:
When trying to [move to fedora43 for s390x](https://github.com/RedHatQE/openshift-virtualization-tests/pull/3760) and trying to run affected tests, have come across some issues, whose fixes are in this PR

##### More details:
- Fix centos DataSource name: use os_name="centos-stream" to generate correct "centos-stream9" DataSource name instead of "centos9"
- Add retry logic to get_ip_from_vm_or_virt_handler_pod with TimeoutSampler to handle guest agent IP reporting timing
- Skip x86-specific clock timers (hpet, pit, kvm, hyperv, rtc) in VirtualMachinePreference fixture on s390x
- Remove s390x marker from test_validate_clock_values (x86-only)
- Skip EFI/OVMF preferences on s390x in common VM preference tests
- Override nic_models_matrix for s390x to exclude unsupported e1000e
- Remove s390x marker from test_successful_clone_of_large_image (Windows image not available for s390x)

##### What this PR does / why we need it:
Fixes some test issues for s390x arch.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Please review changes from respective files as you are more familiar or making fixes there - 
1. @aditi-sharma-1 . tests/infrastructure/instance_types/test_common_vm_preference.py , tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py, utilities/pytest_utils.py, utilities/unittests/test_pytest_utils.py

2. @HarshithaMS005 tests/network/connectivity/test_pod_network.py , utilities/network.py
 
3. @Davo911 tests/storage/cdi_clone/test_clone.py

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved architecture-aware testing with enhanced s390x compatibility handling for VM preferences and hardware features
  * Extended test coverage for clock validation and storage clone operations across all architectures
  * Enhanced configuration support for s390x testing environments with updated NIC model specifications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->