### PR TITLE
chore: update Fedora base image from version 41 to 43

### DIFF
--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -13,8 +13,8 @@ jobs:
   guest-fedora-amd64:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-      FEDORA_VERSION: 41
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+      FEDORA_VERSION: 43
       CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -34,7 +34,7 @@ jobs:
         run: sudo chmod 0644 /boot/vmlinuz*
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -13,8 +13,8 @@ jobs:
   guest-fedora-amd64:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-      FEDORA_VERSION: 41
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+      FEDORA_VERSION: 43
       CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -34,7 +34,7 @@ jobs:
         run: sudo chmod 0644 /boot/vmlinuz*
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -11,8 +11,8 @@ jobs:
   guest-fedora-amd64:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-      FEDORA_VERSION: 41
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+      FEDORA_VERSION: 43
       CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -32,7 +32,7 @@ jobs:
         run: sudo chmod 0644 /boot/vmlinuz*
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -11,8 +11,8 @@ jobs:
   guest-fedora-amd64:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-      FEDORA_VERSION: 41
+      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+      FEDORA_VERSION: 43
       CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -32,7 +32,7 @@ jobs:
         run: sudo chmod 0644 /boot/vmlinuz*
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
Update GitHub Actions workflow to use Fedora 43 (1.6) instead of Fedora 41.

Most of s390x tests are now passing, so it is safe to move to the newer Fedora version.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build-system VM configuration to Fedora 43 across CI workflows and adjusted base image download references to the Fedora 43 release path.
  * Only workflow configuration changed; no application code, public APIs, or user-facing functionality were modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->