### PR TITLE
[4.19] Upgrade: skip virt-launcher update check when image unchanged

### DIFF
--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -15,6 +15,7 @@ from pytest_testconfig import py_config
 from tests.virt.constants import VM_LABEL
 from tests.virt.upgrade.utils import (
     get_all_migratable_vms,
+    get_virt_launcher_image_from_csv,
     validate_vms_pod_updated,
     vm_from_template,
     wait_for_automatic_vm_migrations,
@@ -30,6 +31,7 @@ from utilities.constants import (
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     check_pod_disruption_budget_for_completed_migrations,
+    get_csv_by_name,
 )
 from utilities.storage import (
     create_dv,
@@ -166,8 +168,21 @@ def migratable_vms(admin_client, hco_namespace, upgrade_namespaces):
 
 @pytest.fixture()
 def unupdated_vmi_pods_names(
-    admin_client, hco_namespace, hco_target_csv_name, eus_hco_target_csv_name, upgrade_namespaces, migratable_vms
+    admin_client,
+    hco_namespace,
+    hco_target_csv_name,
+    eus_hco_target_csv_name,
+    upgrade_namespaces,
+    migratable_vms,
+    virt_launcher_from_csv_before_upgrade,
+    csv_after_upgrade,
 ):
+    virt_launcher_image_after_upgrade = get_virt_launcher_image_from_csv(csv=csv_after_upgrade)
+
+    if virt_launcher_from_csv_before_upgrade == virt_launcher_image_after_upgrade:
+        LOGGER.warning(f"virt-launcher unchanged, skipping migration check: {virt_launcher_from_csv_before_upgrade}")
+        return []
+
     wait_for_automatic_vm_migrations(vm_list=migratable_vms)
 
     for ns in upgrade_namespaces:
@@ -178,8 +193,7 @@ def unupdated_vmi_pods_names(
 
     return validate_vms_pod_updated(
         admin_client=admin_client,
-        hco_namespace=hco_namespace,
-        hco_target_csv_name=hco_target_csv_name or eus_hco_target_csv_name,
+        expected_virt_launcher_image=virt_launcher_image_after_upgrade,
         vm_list=migratable_vms,
     )
 
@@ -354,3 +368,17 @@ def parallel_live_migrations_increased(hyperconverged_resource_scope_session):
         wait_for_reconcile_post_update=True,
     ):
         yield
+
+
+@pytest.fixture(scope="session")
+def virt_launcher_from_csv_before_upgrade(csv_scope_session):
+    return get_virt_launcher_image_from_csv(csv=csv_scope_session)
+
+
+@pytest.fixture()
+def csv_after_upgrade(admin_client, hco_namespace, hco_target_csv_name, eus_hco_target_csv_name):
+    return get_csv_by_name(
+        admin_client=admin_client,
+        namespace=hco_namespace.name,
+        csv_name=hco_target_csv_name or eus_hco_target_csv_name,
+    )

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -56,6 +56,7 @@ pytestmark = [
 @pytest.mark.usefixtures(
     "base_templates",
     "parallel_live_migrations_increased",
+    "virt_launcher_from_csv_before_upgrade",
 )
 class TestUpgradeVirt:
     """Pre-upgrade tests"""

--- a/tests/virt/upgrade/utils.py
+++ b/tests/virt/upgrade/utils.py
@@ -16,12 +16,11 @@ from utilities.constants import (
     TIMEOUT_3MIN,
     TIMEOUT_10SEC,
     TIMEOUT_180MIN,
+    VIRT_LAUNCHER,
 )
 from utilities.exceptions import ResourceMissingFieldError
 from utilities.infra import (
-    get_csv_by_name,
     get_pod_disruption_budget,
-    get_related_images_name_and_version,
 )
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
@@ -32,6 +31,13 @@ from utilities.virt import (
 LOGGER = logging.getLogger(__name__)
 
 TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def get_virt_launcher_image_from_csv(csv):
+    for item in csv.instance.spec.relatedImages:
+        if VIRT_LAUNCHER in item["name"]:
+            return item["image"]
+    raise ValueError(f"Image digest for {VIRT_LAUNCHER} not found")
 
 
 def verify_vms_ssh_connectivity(vms_list):
@@ -158,17 +164,11 @@ def wait_for_automatic_vm_migrations(vm_list):
         raise
 
 
-def validate_vms_pod_updated(admin_client, hco_namespace, hco_target_csv_name, vm_list):
-    csv = get_csv_by_name(
-        admin_client=admin_client,
-        namespace=hco_namespace.name,
-        csv_name=hco_target_csv_name,
-    )
-    target_related_images = get_related_images_name_and_version(csv=csv)
+def validate_vms_pod_updated(admin_client, expected_virt_launcher_image, vm_list):
     return [
         {pod.name: pod.instance.spec.containers[0].image}
         for pod in [vm.vmi.virt_launcher_pod for vm in vm_list]
-        if pod.instance.spec.containers[0].image not in target_related_images.values()
+        if pod.instance.spec.containers[0].image != expected_virt_launcher_image
     ]
 
 


### PR DESCRIPTION
Manual cherry-pick for #4269

The test_vmi_pod_image_updates_after_upgrade_optin test was failing on Z
release upgrades where virt-launcher image doesn't change. Skip automatic
workload update migration verification when virt-launcher image is unchanged.

Changes:
- Add virt_launcher_from_csv_before_upgrade fixture to capture
  virt-launcher image before upgrade
- Add csv_after_upgrade fixture to get target CSV
- Compare virt-launcher images before/after upgrade in unupdated_vmi_pods_names
- Skip automatic migration check with warning when image unchanged
- Simplify validate_vms_pod_updated to accept expected image directly

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>