### PR TITLE
fix: reduce false positives in pytest_marker_analyzer smoke detection

### DIFF
--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2119,6 +2119,7 @@ def _check_test_impact(
     conftest_opaque_deps: dict[Path, set[Path]] | None = None,
     pr_diffs_cache: dict[str, str] | None = None,
     pr_file_statuses: dict[str, str] | None = None,
+    is_checkout: bool = False,
 ) -> dict[str, Any] | None:
     """Check if a single test is affected by changed files (for parallel execution).
 
@@ -2233,6 +2234,7 @@ def _check_test_impact(
                 github_pr_info=github_pr_info,
                 pr_diffs_cache=pr_diffs_cache,
                 file_status=file_status_conftest,
+                is_checkout=is_checkout,
             )
 
             # Get all transitively affected fixtures
@@ -2388,6 +2390,7 @@ def _extract_modified_items_from_conftest(
     github_pr_info: dict[str, Any] | None,
     pr_diffs_cache: dict[str, str] | None = None,
     file_status: str | None = None,
+    is_checkout: bool = False,
 ) -> tuple[set[str], set[str]]:
     """Extract modified fixtures and functions from conftest.py.
 
@@ -2438,6 +2441,7 @@ def _extract_modified_items_from_conftest(
             repo_root=repo_root,
             github_pr_info=github_pr_info,
             pr_diffs_cache=pr_diffs_cache,
+            is_checkout=is_checkout,
         )
 
         # None means diff retrieval failed — fall back conservatively
@@ -2490,6 +2494,7 @@ def _get_modified_function_names(
     repo_root: Path,
     github_pr_info: dict[str, Any] | None,
     pr_diffs_cache: dict[str, str] | None = None,
+    is_checkout: bool = False,
 ) -> set[str] | None:
     """Get names of functions modified in a file based on diff analysis.
 
@@ -2523,7 +2528,9 @@ def _get_modified_function_names(
         diff_content = get_pr_file_diff(repo=repo, pr_number=pr_number, file_path=str(relative_path), token=token)
         if diff_content:
             return _parse_diff_for_functions(diff_content=diff_content)
-        return None  # Diff retrieval failed
+        if not is_checkout:
+            return None  # Remote mode: no local fallback
+        # Checkout mode: fall through to local git diff
 
     # Use local git
     try:
@@ -3387,6 +3394,7 @@ class MarkerTestAnalyzer:
                     conftest_opaque_deps=self.conftest_opaque_deps,
                     pr_diffs_cache=pr_diffs_cache,
                     pr_file_statuses=pr_file_statuses,
+                    is_checkout=self.is_checkout,
                 ): node_id
                 for node_id, marked_test in self.marked_tests.items()
             }

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -834,6 +834,62 @@ class TestGetModifiedFunctionNames:
 
         assert result == {"my_fixture"}
 
+    def test_checkout_mode_falls_through_to_local_git_when_github_api_empty(self, tmp_path: Path) -> None:
+        """In checkout mode, when GitHub API returns empty diff, fall through to local git diff."""
+        file_path = tmp_path / "conftest.py"
+        file_path.write_text("def my_func(): pass\n")
+        github_pr_info = {"repo": "org/repo", "pr_number": 1, "token": "fake"}
+        diff_content = (
+            "--- a/conftest.py\n"
+            "+++ b/conftest.py\n"
+            "@@ -1,3 +1,3 @@ def my_func\n"
+            " def my_func():\n"
+            "-    pass\n"
+            "+    return 42\n"
+        )
+        mock_result = type("Result", (), {"returncode": 0, "stdout": diff_content, "stderr": ""})()
+
+        with (
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer.get_pr_file_diff",
+                return_value="",
+            ),
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer.subprocess.run",
+                return_value=mock_result,
+            ),
+        ):
+            result = _get_modified_function_names(
+                file_path=file_path,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=github_pr_info,
+                is_checkout=True,
+            )
+
+        assert result is not None, "Checkout mode should fall through to local git diff"
+        assert result == {"my_func"}
+
+    def test_remote_mode_returns_none_when_github_api_empty(self, tmp_path: Path) -> None:
+        """In remote mode (default), when GitHub API returns empty diff, returns None without local fallback."""
+        file_path = tmp_path / "conftest.py"
+        file_path.write_text("def my_func(): pass\n")
+        github_pr_info = {"repo": "org/repo", "pr_number": 1, "token": "fake"}
+
+        with patch(
+            "scripts.tests_analyzer.pytest_marker_analyzer.get_pr_file_diff",
+            return_value="",
+        ):
+            result = _get_modified_function_names(
+                file_path=file_path,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=github_pr_info,
+                is_checkout=False,
+            )
+
+        assert result is None
+
 
 class TestExtractModifiedItemsFromConftestDiffFailure:
     """Tests that _extract_modified_items_from_conftest handles diff failure vs empty diff correctly."""
@@ -905,6 +961,35 @@ class TestExtractModifiedItemsFromConftestDiffFailure:
 
         assert modified_fixtures == {"my_fixture", "another_fixture"}
         assert modified_functions == set()
+
+    def test_passes_is_checkout_to_get_modified_function_names(self, tmp_path: Path) -> None:
+        """Verify is_checkout parameter is threaded through to _get_modified_function_names."""
+        conftest = tmp_path / "conftest.py"
+        conftest.write_text(
+            textwrap.dedent("""\
+            import pytest
+
+            @pytest.fixture()
+            def my_fixture():
+                return 42
+        """)
+        )
+
+        with patch(
+            "scripts.tests_analyzer.pytest_marker_analyzer._get_modified_function_names",
+            return_value=set(),
+        ) as mock_get_modified:
+            _extract_modified_items_from_conftest(
+                changed_file=conftest,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+                is_checkout=True,
+            )
+
+        mock_get_modified.assert_called_once()
+        call_kwargs = mock_get_modified.call_args[1]
+        assert call_kwargs["is_checkout"] is True, "is_checkout must be passed through"
 
 
 class TestSymbolClassificationHasUnattributedChanges:


### PR DESCRIPTION
## Summary

- Five fixes to reduce false positive smoke test triggers in `scripts/tests_analyzer/pytest_marker_analyzer.py`
- Tested on 150 recent PRs: false positives reduced from 57 to 34 (40% reduction)
- Many PRs that previously flagged all 83 smoke tests now correctly flag only the 1-2 actually affected

## Changes

1. **Conftest import-only changes** — `_get_modified_function_names` returns `None` (diff failure) vs empty `set()` (no functions modified), preventing the all-fixtures fallback when only imports change in conftest files
2. **Module-level tracking** — `_extract_modified_symbols` continues past unattributed lines (imports, comments between functions) instead of returning `None`, preserving symbol info for narrowing
3. **API fetch fallback** — failed `_fetch_file_at_ref` falls through to local file read instead of returning `None`
4. **Checkout mode API cache** — `github_pr_info` is now preserved in checkout mode so the GitHub API diffs cache is available as fallback when local git diff fails
5. **Conftest no-fixture-match** — when a conftest imports a modified symbol but no fixture used by the test calls it, resolve as safe instead of conservatively flagging

## Test plan

- [x] All 74 unit tests pass
- [x] Ran script on 150 recent PRs (merged + open, excluding draft/WIP)
- [x] Verified previously false-positive PRs (#4308, #4314, #4310, #4312, #4242, #4105, #4092, etc.) now correctly return False
- [x] Verified legitimate True PRs (#4277, #4159, #4177, etc.) still correctly return True

Co-authored-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise test-impact detection: harmless module edits (imports/comments/blank/docstrings) are treated safe while executable module changes are still flagged.
  * Renamed or pure-deletion cases now yield explicit empty results instead of ambiguous fallbacks.
  * Improved fallback semantics: checkout mode uses local analysis when remote fetches fail; remote mode remains conservative.
  * Tracks unattributed changed lines to reduce false positives.

* **Tests**
  * Expanded coverage for diff retrieval, change-classification semantics, conftest interactions, renamed-file handling, and mode-specific fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->