### PR TITLE
[Storage] remove test_cdi_config_scratch_space_value_is_default

### DIFF
--- a/tests/storage/test_cdi_config.py
+++ b/tests/storage/test_cdi_config.py
@@ -214,17 +214,6 @@ def test_cdiconfig_scratch_space_not_default(
 
 @pytest.mark.sno
 @pytest.mark.gating
-@pytest.mark.polarion("CNV-2412")
-@pytest.mark.s390x
-def test_cdi_config_scratch_space_value_is_default(
-    default_sc_as_fallback_for_scratch,
-    cdi_config,
-):
-    wait_for_default_sc_in_cdiconfig(cdi_config=cdi_config, sc=default_sc_as_fallback_for_scratch.name)
-
-
-@pytest.mark.sno
-@pytest.mark.gating
 @pytest.mark.polarion("CNV-2208")
 @pytest.mark.s390x
 def test_cdi_config_exists(cdi_config, upload_proxy_route):


### PR DESCRIPTION
CDI now inherits Storage Class for Scratch Space PVCs from the target PVC Storage Class:
https://github.com/kubevirt/containerized-data-importer/pull/4054

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an outdated test case to improve test suite maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->