### PR TITLE
Adapt test_metric_kubevirt_vm_disk_allocated_size_bytes to filesystem storageClass

### DIFF
--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -391,22 +391,23 @@ class TestVmDiskAllocatedSizeLinux:
         self,
         prometheus,
         vm_for_vm_disk_allocation_size_test,
+        cdi_config,
     ):
         validate_metrics_value(
             prometheus=prometheus,
             metric_name=KUBEVIRT_VM_DISK_ALLOCATED_SIZE_BYTES.format(vm_name=vm_for_vm_disk_allocation_size_test.name),
-            expected_value=get_pvc_size_bytes(vm=vm_for_vm_disk_allocation_size_test),
+            expected_value=get_pvc_size_bytes(vm=vm_for_vm_disk_allocation_size_test, cdi_config=cdi_config),
         )
 
 
 @pytest.mark.tier3
 class TestVmDiskAllocatedSizeWindows:
     @pytest.mark.polarion("CNV-11916")
-    def test_metric_kubevirt_vm_disk_allocated_size_bytes_windows(self, prometheus, windows_vm_for_test):
+    def test_metric_kubevirt_vm_disk_allocated_size_bytes_windows(self, prometheus, windows_vm_for_test, cdi_config):
         validate_metrics_value(
             prometheus=prometheus,
             metric_name=KUBEVIRT_VM_DISK_ALLOCATED_SIZE_BYTES.format(vm_name=windows_vm_for_test.name),
-            expected_value=get_pvc_size_bytes(vm=windows_vm_for_test),
+            expected_value=get_pvc_size_bytes(vm=windows_vm_for_test, cdi_config=cdi_config),
         )
 
 

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -9,6 +9,7 @@ from typing import Any, Generator, Optional
 
 import bitmath
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.cdi_config import CDIConfig
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.resource import Resource
@@ -706,20 +707,43 @@ def get_vmi_guest_os_kernel_release_info_metric_from_vm(
     }
 
 
-def get_pvc_size_bytes(vm: VirtualMachineForTests) -> str:
+def get_pvc_size_bytes(vm: VirtualMachineForTests, cdi_config: CDIConfig | None = None) -> str:
+    """Return expected PVC size in bytes as a string, adjusted for filesystem overhead.
+
+    When ``cdi_config`` is provided and the PVC's volumeMode is ``Filesystem``,
+    the raw PVC capacity is reduced by the filesystem overhead percentage stored
+    in CDIConfig (per-storage-class value with a global fallback).  For ``Block``
+    PVCs or when no ``cdi_config`` is supplied the raw capacity is returned.
+
+    Args:
+        vm: Virtual machine whose first DataVolume template PVC is inspected.
+        cdi_config: Optional CDIConfig resource used to look up filesystem
+            overhead.  When ``None``, no overhead adjustment is applied.
+
+    Returns:
+        The (possibly adjusted) PVC size in bytes, as a string.
+    """
     vm_dv_templates = vm.instance.spec.dataVolumeTemplates
     assert vm_dv_templates, "VM has no DataVolume templates"
-    return str(
-        int(
-            bitmath.parse_string_unsafe(
-                PersistentVolumeClaim(
-                    name=vm_dv_templates[0].metadata.name,
-                    namespace=vm.namespace,
-                    client=vm.client,
-                ).instance.spec.resources.requests.storage
-            ).Byte.bytes
-        )
+
+    pvc = PersistentVolumeClaim(
+        name=vm_dv_templates[0].metadata.name,
+        namespace=vm.namespace,
+        client=vm.client,
     )
+    raw_size_bytes = int(bitmath.parse_string_unsafe(pvc.instance.spec.resources.requests.storage).bytes)
+
+    if cdi_config is None or pvc.instance.spec.volumeMode != "Filesystem":
+        return str(raw_size_bytes)
+
+    filesystem_overhead = cdi_config.instance.status.filesystemOverhead
+    storage_class_name = pvc.instance.spec.storageClassName
+    per_sc_overhead = (
+        filesystem_overhead.get("storageClass", {}).get(storage_class_name) if storage_class_name else None
+    )
+    overhead_value = float(per_sc_overhead if per_sc_overhead is not None else filesystem_overhead["global"])
+    adjusted_size_bytes = int(raw_size_bytes * (1 - overhead_value))
+    return str(adjusted_size_bytes)
 
 
 def validate_metric_value_greater_than_initial_value(

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -9,6 +9,7 @@ from typing import Any, Generator, Optional
 
 import bitmath
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.cdi_config import CDIConfig
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.resource import Resource
@@ -706,20 +707,44 @@ def get_vmi_guest_os_kernel_release_info_metric_from_vm(
     }
 
 
-def get_pvc_size_bytes(vm: VirtualMachineForTests) -> str:
+def get_pvc_size_bytes(vm: VirtualMachineForTests, cdi_config: CDIConfig | None = None) -> str:
+    """Return expected PVC size in bytes as a string, adjusted for filesystem overhead.
+
+    When ``cdi_config`` is provided and the PVC's volumeMode is ``Filesystem``,
+    the raw PVC capacity is reduced by the filesystem overhead percentage stored
+    in CDIConfig (per-storage-class value with a global fallback).  For ``Block``
+    PVCs or when no ``cdi_config`` is supplied the raw capacity is returned.
+
+    Args:
+        vm: Virtual machine whose first DataVolume template PVC is inspected.
+        cdi_config: Optional CDIConfig resource used to look up filesystem
+            overhead.  When ``None``, no overhead adjustment is applied.
+
+    Returns:
+        The (possibly adjusted) PVC size in bytes, as a string.
+    """
     vm_dv_templates = vm.instance.spec.dataVolumeTemplates
     assert vm_dv_templates, "VM has no DataVolume templates"
-    return str(
-        int(
-            bitmath.parse_string_unsafe(
-                PersistentVolumeClaim(
-                    name=vm_dv_templates[0].metadata.name,
-                    namespace=vm.namespace,
-                    client=vm.client,
-                ).instance.spec.resources.requests.storage
-            ).Byte.bytes
-        )
+
+    pvc = PersistentVolumeClaim(
+        name=vm_dv_templates[0].metadata.name,
+        namespace=vm.namespace,
+        client=vm.client,
     )
+    raw_size_bytes = int(bitmath.parse_string_unsafe(pvc.instance.spec.resources.requests.storage).bytes)
+
+    pvc_volume_mode = pvc.instance.spec.volumeMode or "Filesystem"
+    if cdi_config is None or pvc_volume_mode != "Filesystem":
+        return str(raw_size_bytes)
+
+    filesystem_overhead = cdi_config.instance.status.filesystemOverhead
+    storage_class_name = pvc.instance.spec.storageClassName
+    per_sc_overhead = (
+        filesystem_overhead.get("storageClass", {}).get(storage_class_name) if storage_class_name else None
+    )
+    overhead_value = float(per_sc_overhead if per_sc_overhead is not None else filesystem_overhead["global"])
+    adjusted_size_bytes = int(raw_size_bytes * (1 - overhead_value))
+    return str(adjusted_size_bytes)
 
 
 def validate_metric_value_greater_than_initial_value(


### PR DESCRIPTION
test_metric_kubevirt_vm_disk_allocated_size_bytes fails on filesystem-backed
storage classes (e.g., gcnv-flex on GCP) because get_pvc_size_bytes() returns
the raw PVC capacity while the Prometheus metric reports usable space after
filesystem overhead (~6%).

Modified get_pvc_size_bytes() to check the PVC volumeMode and, when set to
Filesystem, subtract the filesystem overhead from CDIConfig
(per-storage-class lookup with global fallback). Block PVCs remain unchanged.
Updated both Linux and Windows test call-sites to pass the cdi_config fixture.

Refs: CNV-70944

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-70944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated disk allocated size metric tests to accept injected storage-config data so expected values account for storage-class or global filesystem overhead. This makes metric expectations more accurate across different storage configurations and improves test alignment with real provisioned VM disk capacities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->