### PR TITLE
[4.20] tests, net, hot plug: quarantine multiple interfaces hot plug scenario

### DIFF
--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -19,7 +19,7 @@ from tests.network.l2_bridge.utils import (
     set_secondary_static_ip_address,
     wait_for_interface_hot_plug_completion,
 )
-from utilities.constants import FLAT_OVERLAY_STR, SRIOV
+from utilities.constants import FLAT_OVERLAY_STR, QUARANTINED, SRIOV
 from utilities.network import (
     IfaceNotFound,
     assert_ping_successful,
@@ -450,6 +450,10 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
     @pytest.mark.dependency(
         name="test_multiple_interfaces_hot_plugged",
         depends=["test_vmi_spec_updated_with_hot_plugged_interface"],
+    )
+    @pytest.mark.xfail(
+        reason=(f"{QUARANTINED}: Failing due to hot plugging too many interfaces to the VM. Tracked in CNV-76670"),
+        run=False,
     )
     def test_multiple_interfaces_hot_plugged(
         self,


### PR DESCRIPTION
## Short description

Backport of RedHatQE/openshift-virtualization-tests#3455 to cnv-4.20.

Hot-plug tests are showing flakiness because the test tries to hot-plug
too many interfaces (more than 4, which is the maximum allowed for the
VM spec used in this module). Quarantining the scenario that creates 3
additional hot-plug interfaces will stabilize the module until a proper
fix is applied.

**Jira ticket:**
This effort is tracked in [CNV-76670](https://issues.redhat.com/browse/CNV-76670)