### PR TITLE
chore: update autoflake v2.3.1 → v2.3.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/PyCQA/autoflake
-    rev: "v2.3.1"
+    rev: "v2.3.3"
     hooks:
       - id: autoflake
         args:


### PR DESCRIPTION
## Summary
- Update autoflake pre-commit hook from v2.3.1 to v2.3.3
- Bug fixes for `TypeError` on unhashable set literals and `IndexError` on malformed import lines
- No behavioral changes — identical output on this codebase

## Changes
- `.pre-commit-config.yaml`: autoflake rev bump only

## Test plan
- [x] `pre-commit run --all-files` passes (all 15 hooks)
- [x] `tox` passes (all 5 environments, 715 unit tests, 98.66% coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->