### PR TITLE
chore: update mypy v1.19.1 → v1.20.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v1.20.0
     hooks:
       - id: mypy
         exclude: "test_(.*).py$"


### PR DESCRIPTION
## Summary
- Update mypy pre-commit hook from v1.19.1 to v1.20.0
- Better type narrowing (substantial rework for more aggressive, consistent, and correct narrowing)
- Python 3.14 t-string support (PEP 750)
- Performance improvements (fixed-format binary cache and SQLite cache now default)
- No new errors on this codebase

## Changes
- `.pre-commit-config.yaml`: mirrors-mypy rev bump only

## Test plan
- [x] `pre-commit run mypy --all-files` passes
- [x] `pre-commit run --all-files` passes (all 15 hooks)
- [x] `tox` passes (all 5 environments, 715 unit tests, 98.66% coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis tool version in development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->