### PR TITLE
net: Drop cluster net stack fixtures

### DIFF
--- a/libs/net/cluster.py
+++ b/libs/net/cluster.py
@@ -9,13 +9,23 @@ LOGGER = logging.getLogger(__name__)
 
 @cache
 def is_ipv6_single_stack_cluster() -> bool:
-    ipv4_supported = cluster_ip_family_supported(ip_family=4)
-    ipv6_supported = cluster_ip_family_supported(ip_family=6)
+    ipv4_supported = ipv4_supported_cluster()
+    ipv6_supported = ipv6_supported_cluster()
 
     is_ipv6_only = ipv6_supported and not ipv4_supported
     LOGGER.info(f"Cluster network detection: IPv4={ipv4_supported}, IPv6={ipv6_supported}, IPv6-only={is_ipv6_only}")
     return is_ipv6_only
 
 
-def cluster_ip_family_supported(ip_family: int) -> bool:
+@cache
+def ipv4_supported_cluster() -> bool:
+    return _cluster_ip_family_supported(ip_family=4)
+
+
+@cache
+def ipv6_supported_cluster() -> bool:
+    return _cluster_ip_family_supported(ip_family=6)
+
+
+def _cluster_ip_family_supported(ip_family: int) -> bool:
     return any(ipaddress.ip_network(ip).version == ip_family for ip in py_config.get("cluster_service_network"))

--- a/libs/net/ip.py
+++ b/libs/net/ip.py
@@ -3,6 +3,8 @@ import random
 from functools import cache
 from typing import Final
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
+
 _MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION: Final[int] = 16
 _MAX_NUM_OF_RANDOM_HEXTETS_PER_SESSION: Final[int] = 16
 _IPV4_ADDRESS_SUBNET_PREFIX_VMI: Final[str] = "172.16"
@@ -80,26 +82,22 @@ def _random_hextets(count: int) -> list[int]:
 
 
 def random_ip_addresses_by_family(
-    ipv4_supported: bool,
-    ipv6_supported: bool,
     net_seed: int,
     host_address: int,
 ) -> list[str]:
-    """Generate IP addresses for each supported IP family.
+    """Generate IP addresses for each IP family supported by the cluster network stack.
 
     Args:
-        ipv4_supported: Whether IPv4 is supported.
-        ipv6_supported: Whether IPv6 is supported.
         net_seed: Seed index for selecting the random network portion of the address.
         host_address: Host portion of the address, used to place VMs on the same subnet.
 
     Returns:
-        List of IP address strings, one per supported IP family.
+        List of IP address strings, one per IP family supported by the cluster.
     """
     ips = []
-    if ipv4_supported:
+    if ipv4_supported_cluster():
         ips.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
-    if ipv6_supported:
+    if ipv6_supported_cluster():
         ips.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
     return ips
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ Pytest conftest file for CNV tests
 """
 
 import copy
-import ipaddress
 import logging
 import os
 import os.path
@@ -44,7 +43,6 @@ from ocp_resources.migration_policy import MigrationPolicy
 from ocp_resources.mutating_webhook_config import MutatingWebhookConfiguration
 from ocp_resources.namespace import Namespace
 from ocp_resources.network_addons_config import NetworkAddonsConfig
-from ocp_resources.network_config_openshift_io import Network
 from ocp_resources.node import Node
 from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.oauth import OAuth
@@ -73,6 +71,7 @@ from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
 import utilities.hco
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
 from libs.net.vmspec import lookup_iface_status
 from tests.utils import download_and_extract_tar
@@ -1470,8 +1469,6 @@ def cluster_info(
     hco_image,
     ocs_current_version,
     kubevirt_resource_scope_session,
-    ipv6_supported_cluster,
-    ipv4_supported_cluster,
     workers_type,
     nodes_cpu_architecture,
 ):
@@ -1491,8 +1488,8 @@ def cluster_info(
         f"\tCNI type: {get_cluster_cni_type(admin_client=admin_client)}\n"
         f"\tWorkers type: {workers_type}\n"
         f"\tCluster CPU Architecture: {nodes_cpu_architecture}\n"
-        f"\tIPv4 cluster: {ipv4_supported_cluster}\n"
-        f"\tIPv6 cluster: {ipv6_supported_cluster}\n"
+        f"\tIPv4 cluster: {ipv4_supported_cluster()}\n"
+        f"\tIPv6 cluster: {ipv6_supported_cluster()}\n"
         f"\tVirtctl version: \n\t{virtctl_client_version}\n\t{virtctl_server_version}\n"
     )
 
@@ -1656,8 +1653,6 @@ def running_vm_upgrade_a(
     upgrade_bridge_marker_nad,
     kmp_enabled_namespace,
     upgrade_br1test_nad,
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
 ):
     name = "vm-upgrade-a"
     cloud_init_data = cloud_init_network_data(
@@ -1684,7 +1679,7 @@ def running_vm_upgrade_a(
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)
         ip_families = [
-            family for family, enabled in ((4, ipv4_supported_cluster), (6, ipv6_supported_cluster)) if enabled
+            family for family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
         ]
         lookup_iface_status(
             vm=vm,
@@ -1702,8 +1697,6 @@ def running_vm_upgrade_b(
     upgrade_bridge_marker_nad,
     kmp_enabled_namespace,
     upgrade_br1test_nad,
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
 ):
     name = "vm-upgrade-b"
     cloud_init_data = cloud_init_network_data(
@@ -1730,7 +1723,7 @@ def running_vm_upgrade_b(
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)
         ip_families = [
-            family for family, enabled in ((4, ipv4_supported_cluster), (6, ipv6_supported_cluster)) if enabled
+            family for family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
         ]
         lookup_iface_status(
             vm=vm,
@@ -1873,23 +1866,6 @@ def eus_target_cnv_version(pytestconfig, cnv_current_version):
 @pytest.fixture()
 def ssp_resource_scope_function(admin_client, hco_namespace):
     return get_ssp_resource(admin_client=admin_client, namespace=hco_namespace)
-
-
-@pytest.fixture(scope="session")
-def cluster_service_network(admin_client):
-    return Network(client=admin_client, name="cluster").instance.status.serviceNetwork
-
-
-@pytest.fixture(scope="session")
-def ipv4_supported_cluster(cluster_service_network):
-    if cluster_service_network:
-        return any([ipaddress.ip_network(ip).version == 4 for ip in cluster_service_network])
-
-
-@pytest.fixture(scope="session")
-def ipv6_supported_cluster(cluster_service_network):
-    if cluster_service_network:
-        return any([ipaddress.ip_network(ip).version == 6 for ip in cluster_service_network])
 
 
 @pytest.fixture()
@@ -2713,11 +2689,6 @@ def nmstate_dependent_placeholder():
     and mark tests that depend on NMState functionality.
     """
     return
-
-
-@pytest.fixture()
-def ipv6_single_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
-    return ipv6_supported_cluster and not ipv4_supported_cluster
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -16,6 +16,7 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from tests.network.utils import get_vlan_index_number
 from utilities.constants import (
     CLUSTER,
@@ -59,22 +60,15 @@ def virt_handler_pod(admin_client):
     raise ResourceNotFoundError(f"No {VIRT_HANDLER} Pod found.")
 
 
-@pytest.fixture(scope="session")
-def dual_stack_cluster(ipv4_supported_cluster, ipv6_supported_cluster):
-    return ipv4_supported_cluster and ipv6_supported_cluster
-
-
 @pytest.fixture(scope="module")
-def ipv6_primary_interface_cloud_init_data(
-    ipv4_supported_cluster: bool, ipv6_supported_cluster: bool
-) -> dict[str, dict] | None:
-    if ipv6_supported_cluster:
+def ipv6_primary_interface_cloud_init_data() -> dict[str, dict] | None:
+    if ipv6_supported_cluster():
         return {
             "ethernets": {
                 "eth0": {
                     "addresses": ["fd10:0:2::2/120"],
                     "gateway6": "fd10:0:2::1",
-                    "dhcp4": ipv4_supported_cluster,
+                    "dhcp4": ipv4_supported_cluster(),
                     "dhcp6": False,
                 },
             },
@@ -173,8 +167,6 @@ def network_sanity(
     cluster_network_mtu,
     network_overhead,
     sriov_workers,
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     conformance_tests,
     nmstate_namespace,
     mtv_namespace_scope_session,
@@ -315,8 +307,8 @@ def network_sanity(
     _verify_service_mesh()
     _verify_jumbo_frame()
     _verify_sriov()
-    _verify_ip_family(family="ipv4", is_supported_in_cluster=ipv4_supported_cluster)
-    _verify_ip_family(family="ipv6", is_supported_in_cluster=ipv6_supported_cluster)
+    _verify_ip_family(family="ipv4", is_supported_in_cluster=ipv4_supported_cluster())
+    _verify_ip_family(family="ipv6", is_supported_in_cluster=ipv6_supported_cluster())
     _verify_nmstate_running_pods(_admin_client=admin_client, namespace=nmstate_namespace)
     _verify_mtv_installed()
 

--- a/tests/network/connectivity/conftest.py
+++ b/tests/network/connectivity/conftest.py
@@ -261,8 +261,6 @@ def nad_ovs_bridge_vlan_3(
 
 @pytest.fixture(scope="class")
 def vm_linux_bridge_attached_vma_source(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -279,11 +277,7 @@ def vm_linux_bridge_attached_vma_source(
 
     cloud_init_data = compose_cloud_init_data_dict(
         ipv6_network_data=ipv6_primary_interface_cloud_init_data,
-        network_data=secondary_interfaces_cloud_init_data(
-            ipv4_supported_cluster=ipv4_supported_cluster,
-            ipv6_supported_cluster=ipv6_supported_cluster,
-            host_id=1,
-        ),
+        network_data=secondary_interfaces_cloud_init_data(host_id=1),
     )
 
     yield from create_running_vm(
@@ -298,8 +292,6 @@ def vm_linux_bridge_attached_vma_source(
 
 @pytest.fixture(scope="class")
 def vm_ovs_bridge_attached_vma_source(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     worker_node1,
     namespace,
     unprivileged_client,
@@ -316,11 +308,7 @@ def vm_ovs_bridge_attached_vma_source(
 
     cloud_init_data = compose_cloud_init_data_dict(
         ipv6_network_data=ipv6_primary_interface_cloud_init_data,
-        network_data=secondary_interfaces_cloud_init_data(
-            ipv4_supported_cluster=ipv4_supported_cluster,
-            ipv6_supported_cluster=ipv6_supported_cluster,
-            host_id=1,
-        ),
+        network_data=secondary_interfaces_cloud_init_data(host_id=1),
     )
 
     yield from create_running_vm(
@@ -335,8 +323,6 @@ def vm_ovs_bridge_attached_vma_source(
 
 @pytest.fixture(scope="class")
 def vm_linux_bridge_attached_vmb_destination(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     worker_node2,
     namespace,
     unprivileged_client,
@@ -353,11 +339,7 @@ def vm_linux_bridge_attached_vmb_destination(
 
     cloud_init_data = compose_cloud_init_data_dict(
         ipv6_network_data=ipv6_primary_interface_cloud_init_data,
-        network_data=secondary_interfaces_cloud_init_data(
-            ipv4_supported_cluster=ipv4_supported_cluster,
-            ipv6_supported_cluster=ipv6_supported_cluster,
-            host_id=2,
-        ),
+        network_data=secondary_interfaces_cloud_init_data(host_id=2),
     )
 
     yield from create_running_vm(
@@ -372,8 +354,6 @@ def vm_linux_bridge_attached_vmb_destination(
 
 @pytest.fixture(scope="class")
 def vm_ovs_bridge_attached_vmb_destination(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     worker_node2,
     namespace,
     unprivileged_client,
@@ -390,11 +370,7 @@ def vm_ovs_bridge_attached_vmb_destination(
 
     cloud_init_data = compose_cloud_init_data_dict(
         ipv6_network_data=ipv6_primary_interface_cloud_init_data,
-        network_data=secondary_interfaces_cloud_init_data(
-            ipv4_supported_cluster=ipv4_supported_cluster,
-            ipv6_supported_cluster=ipv6_supported_cluster,
-            host_id=2,
-        ),
+        network_data=secondary_interfaces_cloud_init_data(host_id=2),
     )
 
     yield from create_running_vm(

--- a/tests/network/connectivity/utils.py
+++ b/tests/network/connectivity/utils.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import random_ipv4_address, random_ipv6_address
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
@@ -33,17 +34,15 @@ def create_running_vm(
 
 
 def secondary_interfaces_cloud_init_data(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
     host_id: int,
 ) -> dict[str, dict[str, dict[str, list[str]]]]:
     ethernets = {}
     for i in range(3):
         interface_name = f"eth{i + 1}"
         addresses = []
-        if ipv4_supported_cluster:
+        if ipv4_supported_cluster():
             addresses.append(f"{random_ipv4_address(net_seed=i, host_address=host_id)}/24")
-        if ipv6_supported_cluster:
+        if ipv6_supported_cluster():
             addresses.append(f"{random_ipv6_address(net_seed=i, host_address=host_id)}/64")
 
         ethernets[interface_name] = {"addresses": addresses}

--- a/tests/network/l2_bridge/bandwidth/conftest.py
+++ b/tests/network/l2_bridge/bandwidth/conftest.py
@@ -58,20 +58,13 @@ def bandwidth_nad(
 
 @pytest.fixture(scope="module")
 def server_vm(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
     unprivileged_client: DynamicClient,
     namespace: Namespace,
     bandwidth_nad: NetworkAttachmentDefinition,
 ) -> Generator[BaseVirtualMachine]:
     addresses = [
         f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
-        for ip in random_ip_addresses_by_family(
-            ipv4_supported=ipv4_supported_cluster,
-            ipv6_supported=ipv6_supported_cluster,
-            net_seed=0,
-            host_address=1,
-        )
+        for ip in random_ip_addresses_by_family(net_seed=0, host_address=1)
     ]
     with secondary_network_vm(
         namespace=namespace.name,
@@ -80,8 +73,6 @@ def server_vm(
         nad_name=bandwidth_nad.name,
         secondary_iface_name=BANDWIDTH_SECONDARY_IFACE_NAME,
         secondary_iface_addresses=addresses,
-        ipv4_supported=ipv4_supported_cluster,
-        ipv6_supported=ipv6_supported_cluster,
     ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()
@@ -99,20 +90,13 @@ def server_vm(
 
 @pytest.fixture(scope="module")
 def client_vm(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
     unprivileged_client: DynamicClient,
     namespace: Namespace,
     bandwidth_nad: NetworkAttachmentDefinition,
 ) -> Generator[BaseVirtualMachine]:
     addresses = [
         f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
-        for ip in random_ip_addresses_by_family(
-            ipv4_supported=ipv4_supported_cluster,
-            ipv6_supported=ipv6_supported_cluster,
-            net_seed=0,
-            host_address=2,
-        )
+        for ip in random_ip_addresses_by_family(net_seed=0, host_address=2)
     ]
     with secondary_network_vm(
         namespace=namespace.name,
@@ -121,8 +105,6 @@ def client_vm(
         nad_name=bandwidth_nad.name,
         secondary_iface_name=BANDWIDTH_SECONDARY_IFACE_NAME,
         secondary_iface_addresses=addresses,
-        ipv4_supported=ipv4_supported_cluster,
-        ipv6_supported=ipv6_supported_cluster,
     ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()

--- a/tests/network/l2_bridge/bandwidth/lib_helpers.py
+++ b/tests/network/l2_bridge/bandwidth/lib_helpers.py
@@ -3,6 +3,7 @@ from typing import Final
 
 from kubernetes.dynamic import DynamicClient
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import CloudInitNoCloud, Interface, Multus, Network
@@ -92,8 +93,6 @@ def secondary_network_vm(
     nad_name: str,
     secondary_iface_name: str,
     secondary_iface_addresses: list[str],
-    ipv4_supported: bool,
-    ipv6_supported: bool,
 ) -> BaseVirtualMachine:
     """Create a Fedora VM with a masquerade primary interface and a secondary Linux bridge interface.
 
@@ -104,8 +103,6 @@ def secondary_network_vm(
         nad_name: NetworkAttachmentDefinition name for the secondary interface.
         secondary_iface_name: Name of the secondary network interface in the VM spec.
         secondary_iface_addresses: CIDR addresses to assign to the secondary interface via cloud-init.
-        ipv4_supported: Whether IPv4 is supported on the cluster.
-        ipv6_supported: Whether IPv6 is supported on the cluster.
     """
     spec = base_vmspec()
     spec.template.spec.domain.devices.interfaces = [  # type: ignore
@@ -118,7 +115,7 @@ def secondary_network_vm(
     ]
 
     ethernets = {}
-    primary = _masquerade_iface_cloud_init(ipv4_supported=ipv4_supported, ipv6_supported=ipv6_supported)
+    primary = _masquerade_iface_cloud_init()
     if primary:
         ethernets["eth0"] = primary
     ethernets["eth1"] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
@@ -134,24 +131,17 @@ def secondary_network_vm(
     return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
 
 
-def _masquerade_iface_cloud_init(
-    ipv4_supported: bool,
-    ipv6_supported: bool,
-) -> cloudinit.EthernetDevice | None:
+def _masquerade_iface_cloud_init() -> cloudinit.EthernetDevice | None:
     """Return cloud-init ethernet config for a masquerade (primary) interface.
-
-    Args:
-        ipv4_supported: Whether IPv4 is supported on the cluster.
-        ipv6_supported: Whether IPv6 is supported on the cluster.
 
     Returns:
         EthernetDevice with static IPv6 and optional DHCP4, or None if IPv6 is not supported.
     """
-    if not ipv6_supported:
+    if not ipv6_supported_cluster():
         return None
     return cloudinit.EthernetDevice(
         addresses=["fd10:0:2::2/120"],
         gateway6="fd10:0:2::1",
-        dhcp4=ipv4_supported,
+        dhcp4=ipv4_supported_cluster(),
         dhcp6=False,
     )

--- a/tests/network/l2_bridge/vmi_interfaces_stability/conftest.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/conftest.py
@@ -15,8 +15,6 @@ from tests.network.l2_bridge.vmi_interfaces_stability.lib_helpers import (
 
 @pytest.fixture(scope="class")
 def running_linux_bridge_vm(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
     unprivileged_client: DynamicClient,
     namespace: Namespace,
     bridge_nad: NetworkAttachmentDefinition,
@@ -26,8 +24,6 @@ def running_linux_bridge_vm(
         name="vm-iface-stability",
         client=unprivileged_client,
         bridge_network_name=bridge_nad.name,
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
     ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()

--- a/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
@@ -7,6 +7,7 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.resource import ResourceField
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import random_ipv4_address, random_ipv6_address
 from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm.factory import base_vmspec, fedora_vm
@@ -26,8 +27,6 @@ def secondary_network_vm(
     name: str,
     client: DynamicClient,
     bridge_network_name: str,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
 ) -> BaseVirtualMachine:
     spec = base_vmspec()
     spec.template.spec.domain.devices.interfaces = [  # type: ignore
@@ -42,24 +41,13 @@ def secondary_network_vm(
     ]
 
     ethernets = {}
-    primary = primary_iface_cloud_init(
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
-    )
+    primary = primary_iface_cloud_init()
     if primary:
         ethernets["eth1"] = primary
 
-    ethernets["eth0"] = secondary_iface_cloud_init(
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
-        host_address=1,
-    )
+    ethernets["eth0"] = secondary_iface_cloud_init(host_address=1)
 
-    ethernets["eth2"] = secondary_iface_cloud_init(
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
-        host_address=2,
-    )
+    ethernets["eth2"] = secondary_iface_cloud_init(host_address=2)
 
     userdata = cloudinit.UserData(users=[])
     disk, volume = cloudinitdisk_storage(
@@ -73,43 +61,28 @@ def secondary_network_vm(
     return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
 
 
-def primary_iface_cloud_init(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
-) -> cloudinit.EthernetDevice | None:
-    if not ipv6_supported_cluster:
+def primary_iface_cloud_init() -> cloudinit.EthernetDevice | None:
+    if not ipv6_supported_cluster():
         return None
     return cloudinit.EthernetDevice(
         addresses=["fd10:0:2::2/120"],
         gateway6="fd10:0:2::1",
-        dhcp4=ipv4_supported_cluster,
+        dhcp4=ipv4_supported_cluster(),
         dhcp6=False,
     )
 
 
-def secondary_iface_cloud_init(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
-    host_address: int,
-) -> cloudinit.EthernetDevice:
-    ips = secondary_iface_ips(
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
-        host_address=host_address,
-    )
+def secondary_iface_cloud_init(host_address: int) -> cloudinit.EthernetDevice:
+    ips = secondary_iface_ips(host_address=host_address)
     addresses = [f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24" for ip in ips]
     return cloudinit.EthernetDevice(addresses=addresses)
 
 
-def secondary_iface_ips(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
-    host_address: int,
-) -> list[str]:
+def secondary_iface_ips(host_address: int) -> list[str]:
     ips = []
-    if ipv4_supported_cluster:
+    if ipv4_supported_cluster():
         ips.append(random_ipv4_address(net_seed=0, host_address=host_address))
-    if ipv6_supported_cluster:
+    if ipv6_supported_cluster():
         ips.append(random_ipv6_address(net_seed=0, host_address=host_address))
     return ips
 

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -5,6 +5,7 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
 from libs.net.traffic_generator import TcpServer, VMTcpClient, active_tcp_connections
 from libs.net.vmspec import lookup_iface_status
@@ -131,8 +132,6 @@ def ipv6_localnet_address_pool() -> Generator[str]:
 @pytest.fixture(scope="module")
 def vm_localnet_1(
     unprivileged_client: DynamicClient,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
     ipv4_localnet_address_pool: Generator[str],
     ipv6_localnet_address_pool: Generator[str],
     namespace_localnet_1: Namespace,
@@ -162,16 +161,12 @@ def vm_localnet_1(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     ),
                 ),
                 GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     ),
                 ),
             }
@@ -187,8 +182,6 @@ def vm_localnet_2(
     ipv6_localnet_address_pool: Generator[str],
     cudn_localnet: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_2.name,
@@ -202,8 +195,6 @@ def vm_localnet_2(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     ),
                 )
             }
@@ -214,14 +205,12 @@ def vm_localnet_2(
 
 @pytest.fixture(scope="module")
 def localnet_running_vms(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
     vm_localnet_1: BaseVirtualMachine,
     vm_localnet_2: BaseVirtualMachine,
 ) -> tuple[BaseVirtualMachine, BaseVirtualMachine]:
     vm1, vm2 = run_vms(vms=(vm_localnet_1, vm_localnet_2))
     ip_families = [
-        ip_family for ip_family, enabled in ((4, ipv4_supported_cluster), (6, ipv6_supported_cluster)) if enabled
+        ip_family for ip_family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
     ]
     for vm in (vm1, vm2):
         lookup_iface_status(
@@ -258,8 +247,6 @@ def vm_ovs_bridge_localnet_link_down(
     ipv6_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -275,8 +262,6 @@ def vm_ovs_bridge_localnet_link_down(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     )
                 )
             }
@@ -292,8 +277,6 @@ def vm_ovs_bridge_localnet_1(
     ipv6_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -309,8 +292,6 @@ def vm_ovs_bridge_localnet_1(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     )
                 )
             }
@@ -326,8 +307,6 @@ def vm_ovs_bridge_localnet_2(
     ipv6_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -343,8 +322,6 @@ def vm_ovs_bridge_localnet_2(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     )
                 )
             }
@@ -370,14 +347,12 @@ def ovs_bridge_localnet_running_vms_one_with_interface_down(
 
 @pytest.fixture(scope="module")
 def ovs_bridge_localnet_running_vms(
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
     vm_ovs_bridge_localnet_1: BaseVirtualMachine,
     vm_ovs_bridge_localnet_2: BaseVirtualMachine,
 ) -> Generator[tuple[BaseVirtualMachine, BaseVirtualMachine]]:
     vm1, vm2 = run_vms(vms=(vm_ovs_bridge_localnet_1, vm_ovs_bridge_localnet_2))
     ip_families = [
-        ip_family for ip_family, enabled in ((4, ipv4_supported_cluster), (6, ipv6_supported_cluster)) if enabled
+        ip_family for ip_family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
     ]
     for vm in (vm1, vm2):
         lookup_iface_status(
@@ -477,8 +452,6 @@ def vm1_ovs_bridge_localnet_jumbo_frame(
     ipv6_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge_jumbo_frame: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -496,8 +469,6 @@ def vm1_ovs_bridge_localnet_jumbo_frame(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     )
                 )
             }
@@ -513,8 +484,6 @@ def vm2_ovs_bridge_localnet_jumbo_frame(
     ipv6_localnet_address_pool: Generator[str],
     cudn_localnet_ovs_bridge_jumbo_frame: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
-    ipv4_supported_cluster: bool,
-    ipv6_supported_cluster: bool,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -532,8 +501,6 @@ def vm2_ovs_bridge_localnet_jumbo_frame(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
-                        ipv4_included=ipv4_supported_cluster,
-                        ipv6_included=ipv6_supported_cluster,
                     )
                 )
             }

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -6,6 +6,7 @@ from typing import Final, Generator
 from kubernetes.client import ApiException
 from kubernetes.dynamic import DynamicClient
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import CloudInitNoCloud, Devices, Interface, Metadata, Network
@@ -37,13 +38,20 @@ LOGGER = logging.getLogger(__name__)
 def ip_addresses_from_pool(
     ipv4_pool: Generator[str],
     ipv6_pool: Generator[str],
-    ipv4_included: bool,
-    ipv6_included: bool,
 ) -> list[str]:
+    """Draw IP addresses from pools according to the cluster network IP stack.
+
+    Args:
+        ipv4_pool: Generator yielding IPv4 address.
+        ipv6_pool: Generator yielding IPv6 address.
+
+    Returns:
+        List of IP addresses, one per IP family supported by the cluster.
+    """
     addresses = []
-    if ipv4_included:
+    if ipv4_supported_cluster():
         addresses.append(next(ipv4_pool))
-    if ipv6_included:
+    if ipv6_supported_cluster():
         addresses.append(next(ipv6_pool))
     return addresses
 

--- a/tests/network/network_service/conftest.py
+++ b/tests/network/network_service/conftest.py
@@ -3,6 +3,7 @@ import shlex
 import pytest
 from ocp_resources.service import Service
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from tests.network.network_service.libservice import (
     SERVICE_IP_FAMILY_POLICY_SINGLE_STACK,
     basic_expose_command,
@@ -79,8 +80,12 @@ def virtctl_expose_service(
 
 
 @pytest.fixture()
-def expected_num_families_in_service(request, dual_stack_cluster):
+def expected_num_families_in_service(request):
     ip_family_policy = request.param
-    if ip_family_policy != SERVICE_IP_FAMILY_POLICY_SINGLE_STACK and dual_stack_cluster:
+    if (
+        ip_family_policy != SERVICE_IP_FAMILY_POLICY_SINGLE_STACK
+        and ipv4_supported_cluster()
+        and ipv6_supported_cluster()
+    ):
         return 2
     return 1

--- a/tests/network/sriov/conftest.py
+++ b/tests/network/sriov/conftest.py
@@ -65,8 +65,6 @@ def sriov_network_vlan(admin_client, sriov_node_policy, namespace, sriov_namespa
 
 @pytest.fixture(scope="class")
 def sriov_vm1(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     index_number,
     unprivileged_client,
     namespace,
@@ -79,8 +77,6 @@ def sriov_vm1(
         sriov_mac=vm_sriov_mac(mac_suffix_index=mac_suffix_index),
         net_seed=0,
         host_address=1,
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
@@ -95,8 +91,6 @@ def sriov_vm1(
 
 @pytest.fixture(scope="class")
 def sriov_vm2(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     index_number,
     unprivileged_client,
     namespace,
@@ -109,8 +103,6 @@ def sriov_vm2(
         sriov_mac=vm_sriov_mac(mac_suffix_index=mac_suffix_index),
         net_seed=0,
         host_address=2,
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
@@ -125,8 +117,6 @@ def sriov_vm2(
 
 @pytest.fixture(scope="class")
 def sriov_vm3(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     index_number,
     unprivileged_client,
     namespace,
@@ -139,8 +129,6 @@ def sriov_vm3(
         sriov_mac=vm_sriov_mac(mac_suffix_index=mac_suffix_index),
         net_seed=1,
         host_address=1,
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
@@ -155,8 +143,6 @@ def sriov_vm3(
 
 @pytest.fixture(scope="class")
 def sriov_vm4(
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     index_number,
     unprivileged_client,
     namespace,
@@ -169,8 +155,6 @@ def sriov_vm4(
         sriov_mac=vm_sriov_mac(mac_suffix_index=mac_suffix_index),
         net_seed=1,
         host_address=2,
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(
@@ -243,8 +227,6 @@ def sriov_vm_migrate(
     unprivileged_client,
     namespace,
     sriov_network,
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     ipv6_primary_interface_cloud_init_data,
 ):
     mac_suffix_index = next(index_number)
@@ -252,8 +234,6 @@ def sriov_vm_migrate(
         sriov_mac=vm_sriov_mac(mac_suffix_index=mac_suffix_index),
         net_seed=0,
         host_address=3,
-        ipv4_supported_cluster=ipv4_supported_cluster,
-        ipv6_supported_cluster=ipv6_supported_cluster,
         ipv6_primary_interface_cloud_init_data=ipv6_primary_interface_cloud_init_data,
     )
     yield from sriov_vm(

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -1,5 +1,6 @@
 """SR-IOV library constants and utilities."""
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import random_ipv4_address, random_ipv6_address
 from utilities.constants import SRIOV
 from utilities.infra import get_node_selector_dict
@@ -49,14 +50,12 @@ def sriov_cloud_init_data(
     sriov_mac,
     net_seed,
     host_address,
-    ipv4_supported_cluster,
-    ipv6_supported_cluster,
     ipv6_primary_interface_cloud_init_data=None,
 ):
     sriov_addresses = []
-    if ipv4_supported_cluster:
+    if ipv4_supported_cluster():
         sriov_addresses.append(f"{random_ipv4_address(net_seed=net_seed, host_address=host_address)}/24")
-    if ipv6_supported_cluster:
+    if ipv6_supported_cluster():
         sriov_addresses.append(f"{random_ipv6_address(net_seed=net_seed, host_address=host_address)}/64")
 
     sriov_interface_data = {

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -4,6 +4,7 @@ import pytest
 from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine import VirtualMachine
 
+from libs.net.cluster import is_ipv6_single_stack_cluster
 from tests.observability.metrics.constants import KUBEVIRT_VMI_NODE_CPU_AFFINITY
 from tests.observability.metrics.utils import validate_vmi_node_cpu_affinity_with_prometheus
 from tests.observability.utils import validate_metrics_value
@@ -93,9 +94,9 @@ class TestVirtHCOSingleStackIpv6:
     @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11740")
     @pytest.mark.s390x
-    def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus, ipv6_single_stack_cluster):
+    def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus):
         validate_metrics_value(
             prometheus=prometheus,
             metric_name="kubevirt_hco_single_stack_ipv6",
-            expected_value="1" if ipv6_single_stack_cluster else "0",
+            expected_value="1" if is_ipv6_single_stack_cluster() else "0",
         )


### PR DESCRIPTION
Both ipv4_supported_cluster and ipv6_supported_cluster fixtures are used frequently as parameters.
For cleaner data usage, these fixtures can be removed and replaced with cached helper functions that retrieve the cluster network stack once.

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-81266
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and cached IPv4/IPv6 capability detection so runtime IP-family support is resolved consistently at call time.

* **Tests**
  * Updated test fixtures, helpers and VM/cloud-init generation to use the centralized detection at runtime rather than injected IP-support flags, simplifying fixture signatures and making address/interface behavior deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->