### PR TITLE
[Storage] Storage Tier2: use DataSource instead of artifactory in test_wffc.py

### DIFF
--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -81,12 +81,14 @@ def blank_dv_wffc_scope_function(request, unprivileged_client, namespace, storag
 
 @pytest.fixture()
 def blank_dv_template_wffc_scope_function(request, namespace, storage_class_matrix_wffc_matrix__module__):
+    storage_class_name = next(iter(storage_class_matrix_wffc_matrix__module__))
     blank_dv_template = DataVolume(
         name=f"dv-{request.param['dv_name']}",
         namespace=namespace.name,
         source="blank",
         size="1Gi",
-        storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
+        storage_class=storage_class_name,
+        access_modes=storage_class_matrix_wffc_matrix__module__[storage_class_name]["access_mode"],
     )
     blank_dv_template.to_dict()
     return blank_dv_template.res
@@ -284,7 +286,7 @@ def test_wffc_vm_with_two_data_volume_templates(
             data_source=rhel10_data_source_scope_module,
             storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
         ),
-        memory_guest=Images.RHEL.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
         add_dv_to_vm(
             vm=vm,

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 HonorWaitForFirstConsumer test suite
 """
@@ -26,6 +24,7 @@ from utilities.storage import (
     create_dv,
     create_vm_from_dv,
     data_volume,
+    data_volume_template_with_source_ref_dict,
     virtctl_upload_dv,
 )
 from utilities.virt import VirtualMachineForTests, running_vm, wait_for_ssh_connectivity
@@ -71,61 +70,6 @@ def data_volume_multi_wffc_storage_scope_function(
         storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
         client=namespace.client,
     )
-
-
-def get_dv_template_dict_from_data_source(dv_name, storage_class, data_source, size):
-    return {
-        "metadata": {
-            "name": f"{dv_name}",
-        },
-        "spec": {
-            "storage": {
-                "resources": {"requests": {"storage": size}},
-                "storageClassName": storage_class,
-            },
-            "sourceRef": {
-                "kind": data_source.kind,
-                "name": data_source.name,
-                "namespace": data_source.namespace,
-            },
-        },
-    }
-
-
-@pytest.fixture(scope="module")
-def create_rhel_dv_from_data_source(unprivileged_client, namespace, name, storage_class, rhel10_data_source):
-    with create_dv(
-        dv_name=f"dv-{name}",
-        namespace=namespace,
-        client=unprivileged_client,
-        size=Images.RHEL.DEFAULT_DV_SIZE,
-        storage_class=storage_class,
-        source_ref={
-            "kind": rhel10_data_source.kind,
-            "name": rhel10_data_source.name,
-            "namespace": rhel10_data_source.namespace,
-        },
-    ) as dv:
-        dv.wait_for_dv_success()
-        yield dv
-
-
-@pytest.fixture(scope="module")
-def rhel_dv_for_wffc_tests(
-    request,
-    namespace,
-    unprivileged_client,
-    data_volume_multi_wffc_storage_scope_function,
-    rhel10_data_source_scope_module,
-):
-    with create_rhel_dv_from_data_source(
-        unprivileged_client=unprivileged_client,
-        namespace=namespace.name,
-        name=request.param["dv_name"],
-        storage_class=data_volume_multi_wffc_storage_scope_function.storage_class,
-        rhel_data_source=rhel10_data_source_scope_module,
-    ) as dv:
-        yield dv
 
 
 def validate_vm_and_disk_count(vm):
@@ -262,7 +206,7 @@ def test_wffc_import_registry_dv(
     "data_volume_multi_wffc_storage_scope_module",
     [
         pytest.param(
-            {**DV_PARAMS, **{"consume_wffc": True}},
+            {**DV_PARAMS, "consume_wffc": True},
             marks=pytest.mark.polarion("CNV-4379"),
         ),
     ],
@@ -285,24 +229,10 @@ def test_wffc_clone_dv(unprivileged_client, data_volume_multi_wffc_storage_scope
 
 
 @pytest.mark.sno
-@pytest.mark.parametrize(
-    "data_volume_multi_wffc_storage_scope_function",
-    [
-        pytest.param(
-            {
-                "dv_name": "dv-wffc-4742",
-                "consume_wffc": False,
-            },
-            marks=pytest.mark.polarion("CNV-4742"),
-        ),
-    ],
-    indirect=True,
-)
 @pytest.mark.s390x
 @pytest.mark.parametrize(
-    "rhel_dv_for_wffc_tests",
-    [pytest.param({"dv_name": "template"})],
-    indirect=True,
+    "dv_params",
+    [pytest.param({"dv_name": "template-dv"})],
 )
 def test_wffc_add_dv_to_vm_with_data_volume_template(
     request,
@@ -311,36 +241,36 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
     data_volume_multi_wffc_storage_scope_function,
     rhel10_data_source_scope_module,
 ):
+    dv_template = data_volume_template_with_source_ref_dict(
+        data_source=rhel10_data_source_scope_module,
+        storage_class=data_volume_multi_wffc_storage_scope_function.storage_class,
+    )
+    dv_template["metadata"]["name"] = request.param["dv_name"]
+
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4742-vm",
         namespace=namespace.name,
         os_flavor=OS_FLAVOR_RHEL,
-        data_volume_template=get_dv_template_dict_from_data_source(
-            dv_name=request.param["dv_name"],
-            storage_class=data_volume_multi_wffc_storage_scope_function.storage_class,
-            data_source=rhel10_data_source_scope_module,
-            size=Images.RHEL.DEFAULT_DV_SIZE,
-        ),
+        data_volume_template=dv_template,
         memory_guest=Images.RHEL.DEFAULT_MEMORY_SIZE,
     ) as vm:
         validate_vm_and_disk_count(vm=vm)
         # Add DV
         vm.stop(wait=True)
-        add_dv_to_vm(vm=vm, dv_name=data_volume_multi_wffc_storage_scope_function.name)
+        add_dv_to_vm(vm=vm, dv_name=request.param["dv_name"])
         # Check DV was added
         validate_vm_and_disk_count(vm=vm)
 
 
 @pytest.mark.sno
 @pytest.mark.s390x
+@pytest.mark.polarion("CNV-4743")
 @pytest.mark.parametrize(
-    "rhel_dv_for_wffc_tests",
+    "dv_params",
     [
-        pytest.param({"first_dv_name": "template-1", "second_dv_name": "template-2"}),
-        pytest.mark.polarion("CNV-4743"),
+        pytest.param([{"dv_name": "template-dv-1"}, {"dv_name": "template-dv-2"}]),
     ],
-    indirect=True,
 )
 def test_wffc_vm_with_two_data_volume_templates(
     request,
@@ -350,26 +280,27 @@ def test_wffc_vm_with_two_data_volume_templates(
     rhel10_data_source_scope_module,
 ):
     storage_class = [*storage_class_matrix_wffc_matrix__module__][0]
+    dv_1_template = data_volume_template_with_source_ref_dict(
+        data_source=rhel10_data_source_scope_module,
+        storage_class=storage_class,
+    )
+    dv_2_template = data_volume_template_with_source_ref_dict(
+        data_source=rhel10_data_source_scope_module,
+        storage_class=storage_class,
+    )
+    dv_1_template["metadata"]["name"] = request.param[0]["dv_name"]
+    dv_2_template["metadata"]["name"] = request.param[1]["dv_name"]
+
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4743-vm",
         namespace=namespace.name,
         os_flavor=OS_FLAVOR_RHEL,
-        data_volume_template=get_dv_template_dict_from_data_source(
-            dv_name=request.param["first_dv_name"],
-            storage_class=storage_class,
-            data_source=rhel10_data_source_scope_module,
-            size=Images.RHEL.DEFAULT_DV_SIZE,
-        ),
+        data_volume_template=dv_1_template,
         memory_guest=Images.RHEL.DEFAULT_MEMORY_SIZE,
     ) as vm:
         add_dv_to_vm(
             vm=vm,
-            template_dv=get_dv_template_dict_from_data_source(
-                dv_name=request.param["second_dv_name"],
-                storage_class=storage_class,
-                data_source=rhel10_data_source_scope_module,
-                size=Images.RHEL.DEFAULT_DV_SIZE,
-            ),
+            template_dv=dv_2_template,
         )
         validate_vm_and_disk_count(vm=vm)

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -21,7 +21,6 @@ from utilities.storage import (
     check_upload_virtctl_result,
     create_dv,
     create_vm_from_dv,
-    data_volume,
     data_volume_template_with_source_ref_dict,
     virtctl_upload_dv,
 )
@@ -35,34 +34,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 WFFC_DV_NAME = "wffc-dv-name"
-
-
-@pytest.fixture(scope="module")
-def data_volume_multi_wffc_storage_scope_module(
-    request,
-    namespace,
-    storage_class_matrix_wffc_matrix__module__,
-):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
-        client=namespace.client,
-    )
-
-
-@pytest.fixture()
-def data_volume_multi_wffc_storage_scope_function(
-    request,
-    namespace,
-    storage_class_matrix_wffc_matrix__module__,
-):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
-        client=namespace.client,
-    )
 
 
 @pytest.fixture()
@@ -135,7 +106,8 @@ def vm_from_uploaded_dv(namespace, uploaded_dv_via_virtctl_wffc, uploaded_wffc_d
         pvc = uploaded_wffc_dv.pvc
         vm_dv.start(wait=False)
         if pvc.use_populator:
-            vm_status = VirtualMachineInstance.Status.SCHEDULING
+            # No scheduling status in VirtualMachineInstance.Status, using string literal instead
+            vm_status = "Scheduling"
             bounded_pvc = pvc.prime_pvc
         else:
             vm_status = VirtualMachineInstance.Status.PENDING

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -235,17 +235,17 @@ def test_wffc_clone_dv(unprivileged_client, data_volume_multi_wffc_storage_scope
     [pytest.param({"dv_name": "template-dv"})],
 )
 def test_wffc_add_dv_to_vm_with_data_volume_template(
-    request,
+    dv_params,
     unprivileged_client,
     namespace,
-    data_volume_multi_wffc_storage_scope_function,
+    storage_class_matrix_wffc_matrix__module__,
     rhel10_data_source_scope_module,
 ):
     dv_template = data_volume_template_with_source_ref_dict(
         data_source=rhel10_data_source_scope_module,
-        storage_class=data_volume_multi_wffc_storage_scope_function.storage_class,
+        storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
     )
-    dv_template["metadata"]["name"] = request.param["dv_name"]
+    dv_template["metadata"]["name"] = dv_params["dv_name"]
 
     with VirtualMachineForTests(
         client=unprivileged_client,
@@ -253,12 +253,12 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
         namespace=namespace.name,
         os_flavor=OS_FLAVOR_RHEL,
         data_volume_template=dv_template,
-        memory_guest=Images.RHEL.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
         validate_vm_and_disk_count(vm=vm)
         # Add DV
         vm.stop(wait=True)
-        add_dv_to_vm(vm=vm, dv_name=request.param["dv_name"])
+        add_dv_to_vm(vm=vm, dv_name=dv_params["dv_name"])
         # Check DV was added
         validate_vm_and_disk_count(vm=vm)
 
@@ -273,7 +273,7 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
     ],
 )
 def test_wffc_vm_with_two_data_volume_templates(
-    request,
+    dv_params,
     unprivileged_client,
     namespace,
     storage_class_matrix_wffc_matrix__module__,
@@ -288,8 +288,8 @@ def test_wffc_vm_with_two_data_volume_templates(
         data_source=rhel10_data_source_scope_module,
         storage_class=storage_class,
     )
-    dv_1_template["metadata"]["name"] = request.param[0]["dv_name"]
-    dv_2_template["metadata"]["name"] = request.param[1]["dv_name"]
+    dv_1_template["metadata"]["name"] = dv_params[0]["dv_name"]
+    dv_2_template["metadata"]["name"] = dv_params[1]["dv_name"]
 
     with VirtualMachineForTests(
         client=unprivileged_client,

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 HonorWaitForFirstConsumer test suite
 """
@@ -34,16 +35,24 @@ LOGGER = logging.getLogger(__name__)
 
 
 WFFC_DV_NAME = "wffc-dv-name"
+DEFAULT_BLANK_DV_SIZE = "1Gi"
+
+
+@pytest.fixture(scope="module")
+def wffc_storage_class_name_scope_module(
+    storage_class_matrix_wffc_matrix__module__,
+):
+    return next(iter(storage_class_matrix_wffc_matrix__module__))
 
 
 @pytest.fixture()
-def blank_dv_wffc_scope_function(request, unprivileged_client, namespace, storage_class_matrix_wffc_matrix__module__):
+def blank_dv_wffc_scope_function(request, unprivileged_client, namespace, wffc_storage_class_name_scope_module):
     with create_dv(
         source="blank",
         dv_name=f"dv-{request.param['dv_name']}",
         namespace=namespace.name,
-        size="1Gi",
-        storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
+        size=DEFAULT_BLANK_DV_SIZE,
+        storage_class=wffc_storage_class_name_scope_module,
         consume_wffc=False,
         client=unprivileged_client,
     ) as dv:
@@ -51,15 +60,14 @@ def blank_dv_wffc_scope_function(request, unprivileged_client, namespace, storag
 
 
 @pytest.fixture()
-def blank_dv_template_wffc_scope_function(request, namespace, storage_class_matrix_wffc_matrix__module__):
-    storage_class_name = next(iter(storage_class_matrix_wffc_matrix__module__))
+def blank_dv_template_wffc_scope_function(request, namespace, wffc_storage_class_name_scope_module):
     blank_dv_template = DataVolume(
         name=f"dv-{request.param['dv_name']}",
         namespace=namespace.name,
         source="blank",
-        size="1Gi",
-        storage_class=storage_class_name,
-        access_modes=storage_class_matrix_wffc_matrix__module__[storage_class_name]["access_mode"],
+        size=DEFAULT_BLANK_DV_SIZE,
+        storage_class=wffc_storage_class_name_scope_module,
+        api_name="storage",
     )
     blank_dv_template.to_dict()
     return blank_dv_template.res
@@ -79,8 +87,7 @@ def uploaded_wffc_dv(namespace, unprivileged_client):
 def uploaded_dv_via_virtctl_wffc(
     namespace,
     downloaded_cirros_image_full_path,
-    downloaded_cirros_image_scope_class,
-    storage_class_matrix_wffc_matrix__module__,
+    wffc_storage_class_name_scope_module,
 ):
     with virtctl_upload_dv(
         client=namespace.client,
@@ -88,7 +95,7 @@ def uploaded_dv_via_virtctl_wffc(
         name=WFFC_DV_NAME,
         size=Images.Cirros.DEFAULT_DV_SIZE,
         image_path=downloaded_cirros_image_full_path,
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
+        storage_class=wffc_storage_class_name_scope_module,
         insecure=True,
         consume_wffc=False,
     ) as res:
@@ -96,7 +103,7 @@ def uploaded_dv_via_virtctl_wffc(
 
 
 @pytest.fixture()
-def vm_from_uploaded_dv(namespace, uploaded_dv_via_virtctl_wffc, uploaded_wffc_dv, unprivileged_client):
+def vm_from_uploaded_dv(uploaded_wffc_dv, unprivileged_client):
     with create_vm_from_dv(
         dv=uploaded_wffc_dv,
         vm_name=WFFC_DV_NAME,
@@ -124,7 +131,6 @@ class TestWFFCUploadVirtctl:
     @pytest.mark.s390x
     def test_wffc_fail_to_upload_dv_via_virtctl(
         self,
-        namespace,
         uploaded_dv_via_virtctl_wffc,
         uploaded_wffc_dv,
     ):
@@ -154,7 +160,7 @@ class TestWFFCUploadVirtctl:
         self,
         downloaded_cirros_image_full_path,
         vm_from_uploaded_dv,
-        storage_class_matrix_wffc_matrix__module__,
+        wffc_storage_class_name_scope_module,
     ):
         with virtctl_upload_dv(
             client=vm_from_uploaded_dv.client,
@@ -162,7 +168,7 @@ class TestWFFCUploadVirtctl:
             name=WFFC_DV_NAME,
             size=Images.Cirros.DEFAULT_DV_SIZE,
             image_path=downloaded_cirros_image_full_path,
-            storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
+            storage_class=wffc_storage_class_name_scope_module,
             insecure=True,
             consume_wffc=False,
             cleanup=False,
@@ -174,58 +180,31 @@ class TestWFFCUploadVirtctl:
 
 
 @pytest.mark.sno
-@pytest.mark.polarion("CNV-4739")
-@pytest.mark.s390x
-def test_wffc_import_registry_dv(
-    unprivileged_client,
-    namespace,
-    storage_class_matrix_wffc_matrix__module__,
-):
-    dv_name = "cnv-4739"
-    with create_dv(
-        source="registry",
-        dv_name=dv_name,
-        namespace=namespace.name,
-        url=f"docker://quay.io/kubevirt/{Images.Cirros.DISK_DEMO}",
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
-        consume_wffc=True,
-        client=unprivileged_client,
-    ) as dv:
-        dv.wait_for_dv_success()
-        create_vm_from_dv(client=unprivileged_client, dv=dv, vm_name=dv_name)
-
-
-@pytest.mark.sno
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-4742")
 @pytest.mark.parametrize(
-    "rhel10_data_source_scope_module",
-    [pytest.param({"dv_name": "wffc-4742"})],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "blank_dv_wffc_scope_function",
-    [pytest.param({"dv_name": "blank-wffc-4742"})],
+    "rhel10_data_source_scope_module,blank_dv_wffc_scope_function",
+    [
+        ({"dv_name": "wffc-4742"}, {"dv_name": "blank-wffc-4742"}),
+    ],
     indirect=True,
 )
 def test_wffc_add_dv_to_vm_with_data_volume_template(
     unprivileged_client,
     namespace,
-    storage_class_matrix_wffc_matrix__module__,
+    wffc_storage_class_name_scope_module,
     rhel10_data_source_scope_module,
     blank_dv_wffc_scope_function,
 ):
-    dv_template = data_volume_template_with_source_ref_dict(
-        data_source=rhel10_data_source_scope_module,
-        storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
-    )
-
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4742-vm",
         namespace=namespace.name,
         os_flavor=OS_FLAVOR_RHEL,
-        data_volume_template=dv_template,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=rhel10_data_source_scope_module,
+            storage_class=wffc_storage_class_name_scope_module,
+        ),
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
         validate_vm_and_disk_count(vm=vm)
@@ -245,7 +224,7 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
 def test_wffc_vm_with_two_data_volume_templates(
     unprivileged_client,
     namespace,
-    storage_class_matrix_wffc_matrix__module__,
+    wffc_storage_class_name_scope_module,
     rhel10_data_source_scope_module,
     blank_dv_template_wffc_scope_function,
 ):
@@ -256,7 +235,7 @@ def test_wffc_vm_with_two_data_volume_templates(
         os_flavor=OS_FLAVOR_RHEL,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=rhel10_data_source_scope_module,
-            storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
+            storage_class=wffc_storage_class_name_scope_module,
         ),
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -1,7 +1,3 @@
-from pyVmomi.sms import storage
-
-from utilities.constants import UNPRIVILEGED_USER
-
 # -*- coding: utf-8 -*-
 
 """

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -9,11 +9,9 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
-from tests.storage.constants import CIRROS_QCOW2_IMG
 from utilities.constants import (
     OS_FLAVOR_RHEL,
     TIMEOUT_2MIN,
-    TIMEOUT_4MIN,
     TIMEOUT_30SEC,
     Images,
 )
@@ -37,11 +35,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 WFFC_DV_NAME = "wffc-dv-name"
-DV_PARAMS = {
-    "dv_name": "dv-wffc-tests",
-    "image": CIRROS_QCOW2_IMG,
-    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-}
 
 
 @pytest.fixture(scope="module")
@@ -72,8 +65,35 @@ def data_volume_multi_wffc_storage_scope_function(
     )
 
 
+@pytest.fixture()
+def blank_dv_wffc_scope_function(request, unprivileged_client, namespace, storage_class_matrix_wffc_matrix__module__):
+    with create_dv(
+        source="blank",
+        dv_name=f"dv-{request.param['dv_name']}",
+        namespace=namespace.name,
+        size="1Gi",
+        storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
+        consume_wffc=False,
+        client=unprivileged_client,
+    ) as dv:
+        yield dv
+
+
+@pytest.fixture()
+def blank_dv_template_wffc_scope_function(request, namespace, storage_class_matrix_wffc_matrix__module__):
+    blank_dv_template = DataVolume(
+        name=f"dv-{request.param['dv_name']}",
+        namespace=namespace.name,
+        source="blank",
+        size="1Gi",
+        storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
+    )
+    blank_dv_template.to_dict()
+    return blank_dv_template.res
+
+
 def validate_vm_and_disk_count(vm):
-    running_vm(vm=vm, wait_for_interfaces=False)
+    running_vm(vm=vm)
     check_disk_count_in_vm(vm=vm)
 
 
@@ -202,50 +222,29 @@ def test_wffc_import_registry_dv(
 
 
 @pytest.mark.sno
+@pytest.mark.s390x
+@pytest.mark.polarion("CNV-4742")
 @pytest.mark.parametrize(
-    "data_volume_multi_wffc_storage_scope_module",
-    [
-        pytest.param(
-            {**DV_PARAMS, "consume_wffc": True},
-            marks=pytest.mark.polarion("CNV-4379"),
-        ),
-    ],
+    "rhel10_data_source_scope_module",
+    [pytest.param({"dv_name": "wffc-4742"})],
     indirect=True,
 )
-@pytest.mark.s390x
-def test_wffc_clone_dv(unprivileged_client, data_volume_multi_wffc_storage_scope_module):
-    with create_dv(
-        client=unprivileged_client,
-        source="pvc",
-        dv_name="dv-target",
-        namespace=data_volume_multi_wffc_storage_scope_module.namespace,
-        size=data_volume_multi_wffc_storage_scope_module.size,
-        source_pvc=data_volume_multi_wffc_storage_scope_module.name,
-        storage_class=data_volume_multi_wffc_storage_scope_module.storage_class,
-        consume_wffc=True,
-    ) as cdv:
-        cdv.wait_for_dv_success(timeout=TIMEOUT_4MIN)
-        create_vm_from_dv(client=unprivileged_client, dv=cdv, vm_name=cdv.name)
-
-
-@pytest.mark.sno
-@pytest.mark.s390x
 @pytest.mark.parametrize(
-    "dv_params",
-    [pytest.param({"dv_name": "template-dv"})],
+    "blank_dv_wffc_scope_function",
+    [pytest.param({"dv_name": "blank-wffc-4742"})],
+    indirect=True,
 )
 def test_wffc_add_dv_to_vm_with_data_volume_template(
-    dv_params,
     unprivileged_client,
     namespace,
     storage_class_matrix_wffc_matrix__module__,
     rhel10_data_source_scope_module,
+    blank_dv_wffc_scope_function,
 ):
     dv_template = data_volume_template_with_source_ref_dict(
         data_source=rhel10_data_source_scope_module,
         storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
     )
-    dv_template["metadata"]["name"] = dv_params["dv_name"]
 
     with VirtualMachineForTests(
         client=unprivileged_client,
@@ -258,7 +257,7 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
         validate_vm_and_disk_count(vm=vm)
         # Add DV
         vm.stop(wait=True)
-        add_dv_to_vm(vm=vm, dv_name=dv_params["dv_name"])
+        add_dv_to_vm(vm=vm, dv_name=blank_dv_wffc_scope_function.name)
         # Check DV was added
         validate_vm_and_disk_count(vm=vm)
 
@@ -267,40 +266,28 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-4743")
 @pytest.mark.parametrize(
-    "dv_params",
-    [
-        pytest.param([{"dv_name": "template-dv-1"}, {"dv_name": "template-dv-2"}]),
-    ],
+    "blank_dv_template_wffc_scope_function", [pytest.param({"dv_name": "blank-wffc-4743"})], indirect=True
 )
 def test_wffc_vm_with_two_data_volume_templates(
-    dv_params,
     unprivileged_client,
     namespace,
     storage_class_matrix_wffc_matrix__module__,
     rhel10_data_source_scope_module,
+    blank_dv_template_wffc_scope_function,
 ):
-    storage_class = [*storage_class_matrix_wffc_matrix__module__][0]
-    dv_1_template = data_volume_template_with_source_ref_dict(
-        data_source=rhel10_data_source_scope_module,
-        storage_class=storage_class,
-    )
-    dv_2_template = data_volume_template_with_source_ref_dict(
-        data_source=rhel10_data_source_scope_module,
-        storage_class=storage_class,
-    )
-    dv_1_template["metadata"]["name"] = dv_params[0]["dv_name"]
-    dv_2_template["metadata"]["name"] = dv_params[1]["dv_name"]
-
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4743-vm",
         namespace=namespace.name,
         os_flavor=OS_FLAVOR_RHEL,
-        data_volume_template=dv_1_template,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=rhel10_data_source_scope_module,
+            storage_class=next(iter(storage_class_matrix_wffc_matrix__module__)),
+        ),
         memory_guest=Images.RHEL.DEFAULT_MEMORY_SIZE,
     ) as vm:
         add_dv_to_vm(
             vm=vm,
-            template_dv=dv_2_template,
+            template_dv=blank_dv_template_wffc_scope_function,
         )
         validate_vm_and_disk_count(vm=vm)

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -87,6 +87,7 @@ def uploaded_wffc_dv(namespace, unprivileged_client):
 def uploaded_dv_via_virtctl_wffc(
     namespace,
     downloaded_cirros_image_full_path,
+    downloaded_cirros_image_scope_class,
     wffc_storage_class_name_scope_module,
 ):
     with virtctl_upload_dv(
@@ -103,7 +104,7 @@ def uploaded_dv_via_virtctl_wffc(
 
 
 @pytest.fixture()
-def vm_from_uploaded_dv(uploaded_wffc_dv, unprivileged_client):
+def vm_from_uploaded_dv(namespace, uploaded_dv_via_virtctl_wffc, uploaded_wffc_dv, unprivileged_client):
     with create_vm_from_dv(
         dv=uploaded_wffc_dv,
         vm_name=WFFC_DV_NAME,
@@ -131,6 +132,7 @@ class TestWFFCUploadVirtctl:
     @pytest.mark.s390x
     def test_wffc_fail_to_upload_dv_via_virtctl(
         self,
+        namespace,
         uploaded_dv_via_virtctl_wffc,
         uploaded_wffc_dv,
     ):
@@ -183,9 +185,9 @@ class TestWFFCUploadVirtctl:
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-4742")
 @pytest.mark.parametrize(
-    "rhel10_data_source_scope_module,blank_dv_wffc_scope_function",
+    "blank_dv_wffc_scope_function",
     [
-        ({"dv_name": "wffc-4742"}, {"dv_name": "blank-wffc-4742"}),
+        pytest.param({"dv_name": "blank-wffc-4742"}),
     ],
     indirect=True,
 )

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -1,3 +1,7 @@
+from pyVmomi.sms import storage
+
+from utilities.constants import UNPRIVILEGED_USER
+
 # -*- coding: utf-8 -*-
 
 """
@@ -12,8 +16,8 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from tests.storage.constants import CIRROS_QCOW2_IMG
-from utilities.artifactory import get_artifactory_config_map, get_artifactory_secret, get_test_artifact_server_url
 from utilities.constants import (
+    OS_FLAVOR_RHEL,
     TIMEOUT_2MIN,
     TIMEOUT_4MIN,
     TIMEOUT_30SEC,
@@ -73,27 +77,59 @@ def data_volume_multi_wffc_storage_scope_function(
     )
 
 
-def get_dv_template_dict(namespace, dv_name, storage_class):
-    artifactory_secret = get_artifactory_secret(namespace=namespace)
-    artifactory_config_map = get_artifactory_config_map(namespace=namespace)
+def get_dv_template_dict_from_data_source(dv_name, storage_class, data_source, size):
     return {
         "metadata": {
             "name": f"{dv_name}",
         },
         "spec": {
             "storage": {
-                "resources": {"requests": {"storage": Images.Cirros.DEFAULT_DV_SIZE}},
+                "resources": {"requests": {"storage": size}},
                 "storageClassName": storage_class,
             },
-            "source": {
-                "http": {
-                    "certConfigMap": artifactory_config_map.name,
-                    "secretRef": artifactory_secret.name,
-                    "url": f"{get_test_artifact_server_url()}{CIRROS_QCOW2_IMG}",
-                }
+            "sourceRef": {
+                "kind": data_source.kind,
+                "name": data_source.name,
+                "namespace": data_source.namespace,
             },
         },
     }
+
+
+@pytest.fixture(scope="module")
+def create_rhel_dv_from_data_source(unprivileged_client, namespace, name, storage_class, rhel10_data_source):
+    with create_dv(
+        dv_name=f"dv-{name}",
+        namespace=namespace,
+        client=unprivileged_client,
+        size=Images.RHEL.DEFAULT_DV_SIZE,
+        storage_class=storage_class,
+        source_ref={
+            "kind": rhel10_data_source.kind,
+            "name": rhel10_data_source.name,
+            "namespace": rhel10_data_source.namespace,
+        },
+    ) as dv:
+        dv.wait_for_dv_success()
+        yield dv
+
+
+@pytest.fixture(scope="module")
+def rhel_dv_for_wffc_tests(
+    request,
+    namespace,
+    unprivileged_client,
+    data_volume_multi_wffc_storage_scope_function,
+    rhel10_data_source_scope_module,
+):
+    with create_rhel_dv_from_data_source(
+        unprivileged_client=unprivileged_client,
+        namespace=namespace.name,
+        name=request.param["dv_name"],
+        storage_class=data_volume_multi_wffc_storage_scope_function.storage_class,
+        rhel_data_source=rhel10_data_source_scope_module,
+    ) as dv:
+        yield dv
 
 
 def validate_vm_and_disk_count(vm):
@@ -259,8 +295,6 @@ def test_wffc_clone_dv(unprivileged_client, data_volume_multi_wffc_storage_scope
         pytest.param(
             {
                 "dv_name": "dv-wffc-4742",
-                "image": CIRROS_QCOW2_IMG,
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
                 "consume_wffc": False,
             },
             marks=pytest.mark.polarion("CNV-4742"),
@@ -269,22 +303,30 @@ def test_wffc_clone_dv(unprivileged_client, data_volume_multi_wffc_storage_scope
     indirect=True,
 )
 @pytest.mark.s390x
+@pytest.mark.parametrize(
+    "rhel_dv_for_wffc_tests",
+    [pytest.param({"dv_name": "template"})],
+    indirect=True,
+)
 def test_wffc_add_dv_to_vm_with_data_volume_template(
+    request,
     unprivileged_client,
     namespace,
     data_volume_multi_wffc_storage_scope_function,
+    rhel10_data_source_scope_module,
 ):
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4742-vm",
         namespace=namespace.name,
-        os_flavor=Images.Cirros.OS_FLAVOR,
-        data_volume_template=get_dv_template_dict(
-            namespace=namespace.name,
-            dv_name="template-dv",
+        os_flavor=OS_FLAVOR_RHEL,
+        data_volume_template=get_dv_template_dict_from_data_source(
+            dv_name=request.param["dv_name"],
             storage_class=data_volume_multi_wffc_storage_scope_function.storage_class,
+            data_source=rhel10_data_source_scope_module,
+            size=Images.RHEL.DEFAULT_DV_SIZE,
         ),
-        memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.RHEL.DEFAULT_MEMORY_SIZE,
     ) as vm:
         validate_vm_and_disk_count(vm=vm)
         # Add DV
@@ -295,32 +337,43 @@ def test_wffc_add_dv_to_vm_with_data_volume_template(
 
 
 @pytest.mark.sno
-@pytest.mark.polarion("CNV-4743")
 @pytest.mark.s390x
+@pytest.mark.parametrize(
+    "rhel_dv_for_wffc_tests",
+    [
+        pytest.param({"first_dv_name": "template-1", "second_dv_name": "template-2"}),
+        pytest.mark.polarion("CNV-4743"),
+    ],
+    indirect=True,
+)
 def test_wffc_vm_with_two_data_volume_templates(
+    request,
     unprivileged_client,
     namespace,
     storage_class_matrix_wffc_matrix__module__,
+    rhel10_data_source_scope_module,
 ):
     storage_class = [*storage_class_matrix_wffc_matrix__module__][0]
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4743-vm",
         namespace=namespace.name,
-        os_flavor=Images.Cirros.OS_FLAVOR,
-        data_volume_template=get_dv_template_dict(
-            namespace=namespace.name,
-            dv_name="template-dv-1",
+        os_flavor=OS_FLAVOR_RHEL,
+        data_volume_template=get_dv_template_dict_from_data_source(
+            dv_name=request.param["first_dv_name"],
             storage_class=storage_class,
+            data_source=rhel10_data_source_scope_module,
+            size=Images.RHEL.DEFAULT_DV_SIZE,
         ),
-        memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.RHEL.DEFAULT_MEMORY_SIZE,
     ) as vm:
         add_dv_to_vm(
             vm=vm,
-            template_dv=get_dv_template_dict(
-                namespace=namespace.name,
-                dv_name="template-dv-2",
+            template_dv=get_dv_template_dict_from_data_source(
+                dv_name=request.param["second_dv_name"],
                 storage_class=storage_class,
+                data_source=rhel10_data_source_scope_module,
+                size=Images.RHEL.DEFAULT_DV_SIZE,
             ),
         )
         validate_vm_and_disk_count(vm=vm)


### PR DESCRIPTION
##### Short description:
Use DataSource instead of artifactory in test_wffc.py

##### More details:
https://redhat.atlassian.net/browse/CNV-83360

Currently, most storage tests use import from HTTP as the default method to deploy DataVolumes/VMs.

Switching to golden images (except for tests that explicitly validate the import workflow) will improve test stability and reduce flakiness.

Acceptance criteria:

    Update storage tests to use golden image as the default deployment method.

    Keep HTTP import only for tests explicitly covering import functionality.

##### What this PR does / why we need it:
In `test_wffc.py` the tests are using HTTP to create DVs which can make them fail when the requrest for the image is unsuccessful.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Don't hold out on critisism, I'm new and I want to get better.

Assisted with Claude Code

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
--> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched storage tests to use RHEL images and updated VM memory to match RHEL.
  * Replaced external-image/template workflow with a blank-source DataVolume flow and added reusable blank DV and DV-template fixtures.
  * Consolidated storage-class selection into a single module-scoped fixture and improved virtctl/upload wiring.
  * Simplified runtime waiting and VMI status handling.
  * Removed two obsolete registry/clone tests and updated affected test parametrization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->