### PR TITLE
Added new template keys from HCO

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -29,7 +29,9 @@ CUSTOM_CRON_TEMPLATE = {
     },
     "spec": {
         "garbageCollect": OUTDATED,
+        "importsToKeep": 1,
         "managedDataSource": CUSTOM_DATASOURCE_NAME,
+        "retentionPolicy": "None",
         "schedule": WILDCARD_CRON_EXPRESSION,
         "template": {
             "metadata": {},


### PR DESCRIPTION
##### Short description:
HCO hard coded custom template is missing the newly populated `importsToKeep` and `retentionPolicy` keys, so fails when comparing with HCO's template

##### More details:

##### What this PR does / why we need it:
Part of 4.22 gating fix

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Having trouble reproducing the failure, the test runs and succeeds both before and after on a new 4.22 cluster. Might only happen on bare metal clusters

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-83849


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for operator image updates to improve test reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->