### PR TITLE
[4.21] Change docker image dir from docker to docker-local

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -63,7 +63,7 @@ class Windows:
     WIN2022_ISO_IMG: str | None = None
     WIN2025_ISO_IMG: str | None = None
     DIR: str = f"{BASE_IMAGES_DIR}/windows-images"
-    DOCKER_IMAGE_DIR = "docker/kubevirt-common-instancetypes"
+    DOCKER_IMAGE_DIR: str = "docker-local/kubevirt-common-instancetypes"
     UEFI_WIN_DIR: str = f"{DIR}/uefi"
     HA_DIR: str = f"{DIR}/HA-images"
     ISO_BASE_DIR = f"{DIR}/install_iso"


### PR DESCRIPTION
##### Short description:
Change docker image dir from docker to docker-local

##### More details:
The new artifactory server now changed it's repository name from docker to docker-local, this means that the windows images are now targeting the wrong location.

##### What this PR does / why we need it:
Fix windows images image pulling, in specific tests/infrastructure/instance_types/supported_os/test_windows_os.py

##### Special notes for reviewer:
Manual cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/4281