### PR TITLE
[4.19] Storage: replace artifactory with DataSource in restricted namespace cloning tests

### DIFF
--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -49,6 +49,7 @@ from utilities.constants import (
     CDI_UPLOADPROXY,
     CNV_TEST_SERVICE_ACCOUNT,
     CNV_TESTS_CONTAINER,
+    OS_FLAVOR_FEDORA,
     OS_FLAVOR_RHEL,
     RHEL10_PREFERENCE,
     SECURITY_CONTEXT,
@@ -552,6 +553,16 @@ def storage_class_name_immediate_binding_scope_module(storage_class_matrix_immed
 @pytest.fixture(scope="session")
 def cluster_csi_drivers_names():
     yield [csi_driver.name for csi_driver in list(CSIDriver.get())]
+
+
+@pytest.fixture(scope="module")
+def fedora_data_source_scope_module(golden_images_namespace):
+    return DataSource(
+        namespace=golden_images_namespace.name,
+        name=OS_FLAVOR_FEDORA,
+        client=golden_images_namespace.client,
+        ensure_exists=True,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -46,6 +46,7 @@ from utilities.constants import (
     CDI_UPLOADPROXY,
     CNV_TEST_SERVICE_ACCOUNT,
     CNV_TESTS_CONTAINER,
+    OS_FLAVOR_FEDORA,
     OS_FLAVOR_RHEL,
     RHEL10_PREFERENCE,
     SECURITY_CONTEXT,
@@ -502,6 +503,16 @@ def storage_class_name_immediate_binding_scope_module(storage_class_matrix_immed
 @pytest.fixture(scope="session")
 def cluster_csi_drivers_names():
     yield [csi_driver.name for csi_driver in list(CSIDriver.get())]
+
+
+@pytest.fixture(scope="module")
+def fedora_data_source_scope_module(golden_images_namespace):
+    return DataSource(
+        namespace=golden_images_namespace.name,
+        name=OS_FLAVOR_FEDORA,
+        client=golden_images_namespace.client,
+        ensure_exists=True,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -30,7 +30,7 @@ from tests.storage.utils import (
     create_role_binding,
     set_permissions,
 )
-from utilities.constants import OS_FLAVOR_CIRROS, PVC, UNPRIVILEGED_USER, Images
+from utilities.constants import OS_FLAVOR_FEDORA, PVC, UNPRIVILEGED_USER, Images
 from utilities.infra import create_ns
 from utilities.storage import create_dv
 from utilities.virt import VirtualMachineForTests, running_vm
@@ -58,16 +58,52 @@ def cluster_role_for_creating_pods():
         yield cluster_role_pod_creator
 
 
+@pytest.fixture(scope="module")
+def dv_cloned_from_datasource(
+    request,
+    namespace,
+    storage_class_name_scope_module,
+    fedora_data_source_scope_module,
+):
+    """
+    Create a source DV in the test namespace by cloning from the golden image DataSource.
+    When cloning from a DataSource, the target DV must be at least as large as the source.
+    """
+    dv_name = request.param["dv_name"]
+
+    source_dict = fedora_data_source_scope_module.source.instance.to_dict()
+    source_spec_dict = source_dict["spec"]
+    dv_size = source_spec_dict.get("resources", {}).get("requests", {}).get("storage") or source_dict.get(
+        "status", {}
+    ).get("restoreSize")
+    # dv_size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
+
+    with create_dv(
+        dv_name=f"{dv_name}-{storage_class_name_scope_module}",
+        namespace=namespace.name,
+        source_ref={
+            "kind": fedora_data_source_scope_module.kind,
+            "name": fedora_data_source_scope_module.name,
+            "namespace": fedora_data_source_scope_module.namespace,
+        },
+        size=dv_size,
+        storage_class=storage_class_name_scope_module,
+        client=namespace.client,
+    ) as dv:
+        dv.wait_for_dv_success()
+        yield dv
+
+
 @pytest.fixture()
-def data_volume_clone_settings(destination_namespace, data_volume_multi_storage_scope_module):
-    storage_class = data_volume_multi_storage_scope_module.storage_class
+def data_volume_clone_settings(destination_namespace, dv_cloned_from_datasource):
+    storage_class = dv_cloned_from_datasource.storage_class
     dv = DataVolume(
         name=f"{TARGET_DV}-{storage_class}",
         namespace=destination_namespace.name,
         source=PVC,
-        size=data_volume_multi_storage_scope_module.size,
-        source_pvc=data_volume_multi_storage_scope_module.name,
-        source_namespace=data_volume_multi_storage_scope_module.namespace,
+        size=dv_cloned_from_datasource.size,
+        source_pvc=dv_cloned_from_datasource.name,
+        source_namespace=dv_cloned_from_datasource.namespace,
         storage_class=storage_class,
         api_name="storage",
     )
@@ -226,17 +262,17 @@ def permission_destination_service_account_for_creating_pods(
 def dv_cloned_by_unprivileged_user_in_the_same_namespace(
     request,
     storage_class_name_scope_module,
-    data_volume_multi_storage_scope_module,
+    dv_cloned_from_datasource,
     unprivileged_client,
     permissions_datavolume_source,
 ):
-    namespace = data_volume_multi_storage_scope_module.namespace
+    namespace = dv_cloned_from_datasource.namespace
     with create_dv(
         dv_name=f"{request.param['dv_name']}-{storage_class_name_scope_module}",
         namespace=namespace,
         source=PVC,
-        size=data_volume_multi_storage_scope_module.size,
-        source_pvc=data_volume_multi_storage_scope_module.pvc.name,
+        size=dv_cloned_from_datasource.size,
+        source_pvc=dv_cloned_from_datasource.pvc.name,
         source_namespace=namespace,
         client=unprivileged_client,
         storage_class=storage_class_name_scope_module,
@@ -248,7 +284,7 @@ def dv_cloned_by_unprivileged_user_in_the_same_namespace(
 def dv_destination_cloned_from_pvc(
     request,
     storage_class_name_scope_module,
-    data_volume_multi_storage_scope_module,
+    dv_cloned_from_datasource,
     destination_namespace,
     unprivileged_client,
     permissions_datavolume_source,
@@ -258,9 +294,9 @@ def dv_destination_cloned_from_pvc(
         dv_name=f"{request.param['dv_name']}-{storage_class_name_scope_module}",
         namespace=destination_namespace.name,
         source=PVC,
-        size=data_volume_multi_storage_scope_module.size,
-        source_pvc=data_volume_multi_storage_scope_module.pvc.name,
-        source_namespace=data_volume_multi_storage_scope_module.namespace,
+        size=dv_cloned_from_datasource.size,
+        source_pvc=dv_cloned_from_datasource.pvc.name,
+        source_namespace=dv_cloned_from_datasource.namespace,
         client=unprivileged_client,
         storage_class=storage_class_name_scope_module,
     ) as cdv:
@@ -279,23 +315,19 @@ def vm_for_restricted_namespace_cloning_test(
     with VirtualMachineForTests(
         name=VM_FOR_TEST,
         namespace=destination_namespace.name,
-        os_flavor=OS_FLAVOR_CIRROS,
+        os_flavor=OS_FLAVOR_FEDORA,
         service_accounts=[restricted_namespace_service_account.name],
         client=unprivileged_client,
-        memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
         data_volume_template=data_volume_clone_settings.res,
     ) as vm:
-        running_vm(vm=vm, wait_for_interfaces=False)
+        running_vm(vm=vm)
         yield vm
 
 
 @pytest.fixture()
-def user_has_get_permissions_in_source_namespace(
-    namespace, unprivileged_client, data_volume_multi_storage_scope_module
-):
-    _ = DataVolume(
-        namespace=namespace.name, name=data_volume_multi_storage_scope_module.name, client=unprivileged_client
-    ).instance
+def user_has_get_permissions_in_source_namespace(namespace, unprivileged_client, dv_cloned_from_datasource):
+    _ = DataVolume(namespace=namespace.name, name=dv_cloned_from_datasource.name, client=unprivileged_client).instance
 
 
 @pytest.fixture()

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -32,7 +32,7 @@ from tests.storage.utils import (
 )
 from utilities.constants import OS_FLAVOR_FEDORA, PVC, UNPRIVILEGED_USER, Images
 from utilities.infra import create_ns
-from utilities.storage import create_dv, create_dv_with_source_ref
+from utilities.storage import create_dv, create_dv_with_source_ref, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm
 
 
@@ -71,12 +71,7 @@ def dv_cloned_from_datasource(
     """
     dv_name = request.param["dv_name"]
 
-    source_dict = fedora_data_source_scope_module.source.instance.to_dict()
-    source_spec_dict = source_dict["spec"]
-    dv_size = source_spec_dict.get("resources", {}).get("requests", {}).get("storage") or source_dict.get(
-        "status", {}
-    ).get("restoreSize")
-    # dv_size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
+    dv_size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
 
     with create_dv_with_source_ref(
         dv_name=f"{dv_name}-{storage_class_name_scope_module}",

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -32,7 +32,7 @@ from tests.storage.utils import (
 )
 from utilities.constants import OS_FLAVOR_FEDORA, PVC, UNPRIVILEGED_USER, Images
 from utilities.infra import create_ns
-from utilities.storage import create_dv
+from utilities.storage import create_dv, create_dv_with_source_ref
 from utilities.virt import VirtualMachineForTests, running_vm
 
 
@@ -78,14 +78,10 @@ def dv_cloned_from_datasource(
     ).get("restoreSize")
     # dv_size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
 
-    with create_dv(
+    with create_dv_with_source_ref(
         dv_name=f"{dv_name}-{storage_class_name_scope_module}",
         namespace=namespace.name,
-        source_ref={
-            "kind": fedora_data_source_scope_module.kind,
-            "name": fedora_data_source_scope_module.name,
-            "namespace": fedora_data_source_scope_module.namespace,
-        },
+        data_source=fedora_data_source_scope_module,
         size=dv_size,
         storage_class=storage_class_name_scope_module,
         client=namespace.client,

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -32,7 +32,7 @@ from tests.storage.utils import (
 )
 from utilities.constants import OS_FLAVOR_FEDORA, PVC, UNPRIVILEGED_USER, Images
 from utilities.infra import create_ns
-from utilities.storage import create_dv, create_dv_with_source_ref, get_dv_size_from_datasource
+from utilities.storage import create_dv, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm
 
 
@@ -73,13 +73,17 @@ def dv_cloned_from_datasource(
 
     dv_size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
 
-    with create_dv_with_source_ref(
+    with create_dv(
         dv_name=f"{dv_name}-{storage_class_name_scope_module}",
         namespace=namespace.name,
-        data_source=fedora_data_source_scope_module,
         size=dv_size,
         storage_class=storage_class_name_scope_module,
         client=namespace.client,
+        source_ref={
+            "kind": fedora_data_source_scope_module.kind,
+            "name": fedora_data_source_scope_module.name,
+            "namespace": fedora_data_source_scope_module.namespace,
+        },
     ) as dv:
         dv.wait_for_dv_success()
         yield dv

--- a/tests/storage/restricted_namespace_cloning/constants.py
+++ b/tests/storage/restricted_namespace_cloning/constants.py
@@ -1,9 +1,6 @@
 # Permissions and Verbs for set_permissions
 from ocp_resources.resource import Resource
 
-from tests.storage.constants import CIRROS_QCOW2_IMG
-from utilities.constants import Images
-
 DATAVOLUMES = ["datavolumes"]
 DATAVOLUMES_SRC = ["datavolumes/source"]
 DATAVOLUMES_AND_DVS_SRC = ["datavolumes", "datavolumes/source"]
@@ -20,6 +17,7 @@ PERMISSIONS_DST = "permissions_destination"
 VERBS_SRC = "verbs_src"
 VERBS_DST = "verbs_dst"
 
+SOURCE_DV = "source-dv"
 TARGET_DV = "target-dv"
 
 PERMISSIONS_SRC_SA = "perm_src_service_account"
@@ -31,10 +29,3 @@ METADATA = "metadata"
 SPEC = "spec"
 
 RBAC_AUTHORIZATION_API_GROUP = Resource.ApiGroup.RBAC_AUTHORIZATION_K8S_IO
-
-DV_PARAMS = {
-    "dv_name": "source-dv",
-    "source": "http",
-    "image": CIRROS_QCOW2_IMG,
-    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-}

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -95,7 +95,6 @@ def test_user_permissions_positive(
     if requested_verify_image_permissions:
         with create_vm_from_dv(
             dv=dv_destination_cloned_from_pvc,
-            client=admin_client,
             vm_name="fedora-vm",
             os_flavor=OS_FLAVOR_FEDORA,
             memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -15,15 +15,16 @@ from tests.storage.restricted_namespace_cloning.constants import (
     DATAVOLUMES,
     DATAVOLUMES_AND_DVS_SRC,
     DATAVOLUMES_SRC,
-    DV_PARAMS,
     LIST_GET,
     PERMISSIONS_DST,
     PERMISSIONS_SRC,
+    SOURCE_DV,
     VERBS_DST,
     VERBS_SRC,
 )
 from tests.storage.restricted_namespace_cloning.utils import create_dv_negative, verify_snapshot_used_namespace_transfer
 from tests.storage.utils import verify_vm_disk_image_permission
+from utilities.constants import OS_FLAVOR_FEDORA, Images
 from utilities.storage import create_vm_from_dv
 
 LOGGER = logging.getLogger(__name__)
@@ -33,12 +34,12 @@ pytestmark = pytest.mark.usefixtures("fail_when_no_unprivileged_client_available
 
 @pytest.mark.sno
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module, permissions_datavolume_source, "
+    "namespace, dv_cloned_from_datasource, permissions_datavolume_source, "
     "dv_cloned_by_unprivileged_user_in_the_same_namespace",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC: DATAVOLUMES_AND_DVS_SRC, VERBS_SRC: ALL},
             {"dv_name": "cnv-8905"},
             marks=pytest.mark.polarion("CNV-8905"),
@@ -55,13 +56,13 @@ def test_unprivileged_user_clone_dv_same_namespace_positive(
 
 @pytest.mark.sno
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module, "
+    "namespace, dv_cloned_from_datasource, "
     "permissions_datavolume_source, permissions_datavolume_destination, "
     "dv_destination_cloned_from_pvc, requested_verify_image_permissions",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC: DATAVOLUMES_AND_DVS_SRC, VERBS_SRC: ALL},
             {PERMISSIONS_DST: DATAVOLUMES_AND_DVS_SRC, VERBS_DST: ALL},
             {"dv_name": "cnv-2692"},
@@ -71,7 +72,7 @@ def test_unprivileged_user_clone_dv_same_namespace_positive(
         ),
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC: DATAVOLUMES_SRC, VERBS_SRC: CREATE},
             {PERMISSIONS_DST: DATAVOLUMES, VERBS_DST: CREATE_DELETE_LIST_GET},
             {"dv_name": "cnv-2971"},
@@ -92,22 +93,23 @@ def test_user_permissions_positive(
 ):
     verify_snapshot_used_namespace_transfer(cdv=dv_destination_cloned_from_pvc, unprivileged_client=unprivileged_client)
     if requested_verify_image_permissions:
-        with create_vm_from_dv(dv=dv_destination_cloned_from_pvc) as vm:
-            if (
-                storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"]
-                == DataVolume.VolumeMode.FILE
-            ):
-                verify_vm_disk_image_permission(vm=vm)
+        with create_vm_from_dv(
+            dv=dv_destination_cloned_from_pvc,
+            client=admin_client,
+            vm_name="fedora-vm",
+            os_flavor=OS_FLAVOR_FEDORA,
+            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        ):
+            pass
 
 
 @pytest.mark.sno
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module, "
-    "permissions_datavolume_source, permissions_datavolume_destination",
+    "namespace, dv_cloned_from_datasource, permissions_datavolume_source, permissions_datavolume_destination",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC: DATAVOLUMES, VERBS_SRC: ALL},
             {PERMISSIONS_DST: DATAVOLUMES_AND_DVS_SRC, VERBS_DST: ALL},
             marks=pytest.mark.polarion("CNV-2793"),
@@ -115,7 +117,7 @@ def test_user_permissions_positive(
         ),
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC: DATAVOLUMES_AND_DVS_SRC, VERBS_SRC: LIST_GET},
             {PERMISSIONS_DST: DATAVOLUMES_AND_DVS_SRC, VERBS_DST: ALL},
             marks=pytest.mark.polarion("CNV-2691"),
@@ -127,7 +129,7 @@ def test_user_permissions_positive(
 def test_user_permissions_negative(
     storage_class_name_scope_module,
     namespace,
-    data_volume_multi_storage_scope_module,
+    dv_cloned_from_datasource,
     destination_namespace,
     unprivileged_client,
     permissions_datavolume_source,
@@ -137,20 +139,20 @@ def test_user_permissions_negative(
     create_dv_negative(
         namespace=destination_namespace.name,
         storage_class=storage_class_name_scope_module,
-        size=data_volume_multi_storage_scope_module.size,
-        source_pvc=data_volume_multi_storage_scope_module.pvc.name,
-        source_namespace=data_volume_multi_storage_scope_module.namespace,
+        size=dv_cloned_from_datasource.size,
+        source_pvc=dv_cloned_from_datasource.pvc.name,
+        source_namespace=dv_cloned_from_datasource.namespace,
         unprivileged_client=unprivileged_client,
     )
 
 
 @pytest.mark.sno
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module",
+    "namespace, dv_cloned_from_datasource",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             marks=pytest.mark.polarion("CNV-2688"),
         ),
     ],
@@ -159,15 +161,15 @@ def test_user_permissions_negative(
 def test_unprivileged_user_clone_same_namespace_negative(
     storage_class_name_scope_module,
     namespace,
-    data_volume_multi_storage_scope_module,
+    dv_cloned_from_datasource,
     unprivileged_client,
 ):
     create_dv_negative(
         namespace=namespace.name,
         storage_class=storage_class_name_scope_module,
-        size=data_volume_multi_storage_scope_module.size,
-        source_pvc=data_volume_multi_storage_scope_module.pvc.name,
-        source_namespace=data_volume_multi_storage_scope_module.namespace,
+        size=dv_cloned_from_datasource.size,
+        source_pvc=dv_cloned_from_datasource.pvc.name,
+        source_namespace=dv_cloned_from_datasource.namespace,
         unprivileged_client=unprivileged_client,
     )
 
@@ -175,11 +177,11 @@ def test_unprivileged_user_clone_same_namespace_negative(
 @pytest.mark.sno
 @pytest.mark.gating
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module, permissions_datavolume_destination",
+    "namespace, dv_cloned_from_datasource, permissions_datavolume_destination",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_DST: DATAVOLUMES_AND_DVS_SRC, VERBS_DST: ALL},
             marks=pytest.mark.polarion("CNV-8907"),
         ),
@@ -188,7 +190,7 @@ def test_unprivileged_user_clone_same_namespace_negative(
 )
 def test_user_permissions_only_for_dst_ns_negative(
     storage_class_name_scope_module,
-    data_volume_multi_storage_scope_module,
+    dv_cloned_from_datasource,
     destination_namespace,
     unprivileged_client,
     permissions_datavolume_destination,
@@ -196,8 +198,8 @@ def test_user_permissions_only_for_dst_ns_negative(
     create_dv_negative(
         namespace=destination_namespace.name,
         storage_class=storage_class_name_scope_module,
-        size=data_volume_multi_storage_scope_module.size,
-        source_pvc=data_volume_multi_storage_scope_module.pvc.name,
-        source_namespace=data_volume_multi_storage_scope_module.namespace,
+        size=dv_cloned_from_datasource.size,
+        source_pvc=dv_cloned_from_datasource.pvc.name,
+        source_namespace=dv_cloned_from_datasource.namespace,
         unprivileged_client=unprivileged_client,
     )

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -5,7 +5,6 @@ Restricted namespace cloning
 import logging
 
 import pytest
-from ocp_resources.datavolume import DataVolume
 
 from tests.storage.constants import ADMIN_NAMESPACE_PARAM
 from tests.storage.restricted_namespace_cloning.constants import (
@@ -23,7 +22,6 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VERBS_SRC,
 )
 from tests.storage.restricted_namespace_cloning.utils import create_dv_negative, verify_snapshot_used_namespace_transfer
-from tests.storage.utils import verify_vm_disk_image_permission
 from utilities.constants import OS_FLAVOR_FEDORA, Images
 from utilities.storage import create_vm_from_dv
 

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
@@ -13,7 +13,6 @@ from tests.storage.restricted_namespace_cloning.constants import (
     DATAVOLUMES,
     DATAVOLUMES_AND_DVS_SRC,
     DATAVOLUMES_SRC,
-    LIST_GET,
     METADATA,
     PERMISSIONS_DST,
     PERMISSIONS_DST_SA,

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
@@ -13,12 +13,13 @@ from tests.storage.restricted_namespace_cloning.constants import (
     DATAVOLUMES,
     DATAVOLUMES_AND_DVS_SRC,
     DATAVOLUMES_SRC,
-    DV_PARAMS,
+    LIST_GET,
     METADATA,
     PERMISSIONS_DST,
     PERMISSIONS_DST_SA,
     PERMISSIONS_SRC,
     PERMISSIONS_SRC_SA,
+    SOURCE_DV,
     SPEC,
     VERBS_DST,
     VERBS_DST_SA,
@@ -27,7 +28,7 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VM_FOR_TEST,
 )
 from tests.storage.restricted_namespace_cloning.utils import verify_snapshot_used_namespace_transfer
-from utilities.constants import OS_FLAVOR_CIRROS, QUARANTINED, Images
+from utilities.constants import OS_FLAVOR_FEDORA, QUARANTINED, Images
 from utilities.storage import ErrorMsg
 from utilities.virt import VirtualMachineForTests
 
@@ -60,22 +61,24 @@ def create_vm_negative(
         with VirtualMachineForTests(
             name=VM_FOR_TEST,
             namespace=namespace,
-            os_flavor=OS_FLAVOR_CIRROS,
+            os_flavor=OS_FLAVOR_FEDORA,
             service_accounts=service_accounts,
             client=unprivileged_client,
-            memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
             data_volume_template=get_dv_template(data_volume_clone_settings=data_volume_clone_settings),
+            username="dummy",
+            password="dummy",
         ):
             return
 
 
 @pytest.mark.sno
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module, perm_src_service_account, perm_destination_service_account",
+    "namespace, dv_cloned_from_datasource, perm_src_service_account, perm_destination_service_account",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC_SA: DATAVOLUMES_AND_DVS_SRC, VERBS_SRC_SA: ALL},
             {PERMISSIONS_DST_SA: DATAVOLUMES_AND_DVS_SRC, VERBS_DST_SA: ALL},
             marks=pytest.mark.polarion("CNV-2826"),
@@ -103,12 +106,11 @@ def test_create_vm_with_cloned_data_volume_positive(
     run=False,
 )
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module, "
-    "permissions_datavolume_source, permissions_datavolume_destination",
+    "namespace, dv_cloned_from_datasource, permissions_datavolume_source, permissions_datavolume_destination",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC: DATAVOLUMES_SRC, VERBS_SRC: ALL},
             {PERMISSIONS_DST: DATAVOLUMES, VERBS_DST: ALL},
             marks=pytest.mark.polarion("CNV-2828"),
@@ -135,11 +137,11 @@ def test_create_vm_with_cloned_data_volume_grant_unprivileged_client_permissions
 
 
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module, perm_src_service_account, perm_destination_service_account",
+    "namespace, dv_cloned_from_datasource, perm_src_service_account, perm_destination_service_account",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             {PERMISSIONS_SRC_SA: DATAVOLUMES, VERBS_SRC_SA: ALL},
             {PERMISSIONS_DST_SA: DATAVOLUMES, VERBS_DST_SA: ALL},
             marks=pytest.mark.polarion("CNV-2827"),
@@ -166,11 +168,11 @@ def test_create_vm_cloned_data_volume_restricted_ns_service_account_no_clone_per
 
 @pytest.mark.gating
 @pytest.mark.parametrize(
-    "namespace, data_volume_multi_storage_scope_module",
+    "namespace, dv_cloned_from_datasource",
     [
         pytest.param(
             ADMIN_NAMESPACE_PARAM,
-            DV_PARAMS,
+            {"dv_name": SOURCE_DV},
             marks=pytest.mark.polarion("CNV-2829"),
         ),
     ],

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -170,6 +170,85 @@ def create_dv(
     )
 
 
+@contextmanager
+def create_dv_with_source_ref(
+    dv_name,
+    namespace,
+    storage_class,
+    size,
+    data_source,
+    volume_mode=None,
+    access_modes=None,
+    client=None,
+    multus_annotation=None,
+    teardown=True,
+    consume_wffc=True,
+    bind_immediate=None,
+    preallocation=None,
+    api_name="storage",
+):
+    """Create a DataVolume with sourceRef pointing to a DataSource.
+
+    This function creates a DataVolume using sourceRef instead of traditional
+    source methods (http, pvc, etc). It's designed for backporting to versions
+    where openshift-python-wrapper doesn't support source_ref parameter.
+
+    Args:
+        dv_name: Name of the DataVolume
+        namespace: Namespace for the DataVolume
+        storage_class: Storage class name
+        size: DataVolume size (e.g., "5Gi")
+        data_source: DataSource object to reference
+        volume_mode: Volume mode (Block/Filesystem)
+        access_modes: Access modes
+        client: Kubernetes client
+        multus_annotation: Multus network annotation
+        teardown: Whether to delete DV on cleanup
+        consume_wffc: Create dummy pod for WaitForFirstConsumer
+        bind_immediate: Bind immediately annotation
+        preallocation: Preallocate disk space
+        api_name: API name (storage/pvc)
+
+    Yields:
+        DataVolume: DataVolume resource with sourceRef
+    """
+    # Create DataVolume with blank source as placeholder
+    dv = DataVolume(
+        source="blank",
+        name=dv_name,
+        namespace=namespace,
+        size=size,
+        storage_class=storage_class,
+        volume_mode=volume_mode,
+        access_modes=access_modes,
+        client=client,
+        bind_immediate_annotation=bind_immediate,
+        multus_annotation=multus_annotation,
+        teardown=teardown,
+        preallocation=preallocation,
+        api_name=api_name,
+    )
+
+    # Modify to use sourceRef by converting to dict first
+    dv.to_dict()
+    # Remove source and contentType that were added by DataVolume init
+    if "source" in dv.res["spec"]:
+        del dv.res["spec"]["source"]
+    if "contentType" in dv.res["spec"]:
+        del dv.res["spec"]["contentType"]
+    # Add sourceRef
+    dv.res["spec"]["sourceRef"] = {
+        "kind": data_source.kind,
+        "name": data_source.name,
+        "namespace": data_source.namespace,
+    }
+
+    with dv:
+        if sc_volume_binding_mode_is_wffc(sc=storage_class) and consume_wffc:
+            create_dummy_first_consumer_pod(dv=dv)
+        yield dv
+
+
 def data_volume(
     namespace,
     storage_class_matrix=None,

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -187,32 +187,7 @@ def create_dv_with_source_ref(
     preallocation=None,
     api_name="storage",
 ):
-    """Create a DataVolume with sourceRef pointing to a DataSource.
-
-    This function creates a DataVolume using sourceRef instead of traditional
-    source methods (http, pvc, etc). It's designed for backporting to versions
-    where openshift-python-wrapper doesn't support source_ref parameter.
-
-    Args:
-        dv_name: Name of the DataVolume
-        namespace: Namespace for the DataVolume
-        storage_class: Storage class name
-        size: DataVolume size (e.g., "5Gi")
-        data_source: DataSource object to reference
-        volume_mode: Volume mode (Block/Filesystem)
-        access_modes: Access modes
-        client: Kubernetes client
-        multus_annotation: Multus network annotation
-        teardown: Whether to delete DV on cleanup
-        consume_wffc: Create dummy pod for WaitForFirstConsumer
-        bind_immediate: Bind immediately annotation
-        preallocation: Preallocate disk space
-        api_name: API name (storage/pvc)
-
-    Yields:
-        DataVolume: DataVolume resource with sourceRef
-    """
-    # Create DataVolume with blank source as placeholder
+    # openshift-python-wrapper doesn't support source_ref parameter.
     dv = DataVolume(
         source="blank",
         name=dv_name,
@@ -228,21 +203,16 @@ def create_dv_with_source_ref(
         preallocation=preallocation,
         api_name=api_name,
     )
-
-    # Modify to use sourceRef by converting to dict first
     dv.to_dict()
-    # Remove source and contentType that were added by DataVolume init
     if "source" in dv.res["spec"]:
         del dv.res["spec"]["source"]
     if "contentType" in dv.res["spec"]:
         del dv.res["spec"]["contentType"]
-    # Add sourceRef
     dv.res["spec"]["sourceRef"] = {
         "kind": data_source.kind,
         "name": data_source.name,
         "namespace": data_source.namespace,
     }
-
     with dv:
         if sc_volume_binding_mode_is_wffc(sc=storage_class) and consume_wffc:
             create_dummy_first_consumer_pod(dv=dv)

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -192,32 +192,7 @@ def create_dv_with_source_ref(
     preallocation=None,
     api_name="storage",
 ):
-    """Create a DataVolume with sourceRef pointing to a DataSource.
-
-    This function creates a DataVolume using sourceRef instead of traditional
-    source methods (http, pvc, etc). It's designed for backporting to versions
-    where openshift-python-wrapper doesn't support source_ref parameter.
-
-    Args:
-        dv_name: Name of the DataVolume
-        namespace: Namespace for the DataVolume
-        storage_class: Storage class name
-        size: DataVolume size (e.g., "5Gi")
-        data_source: DataSource object to reference
-        volume_mode: Volume mode (Block/Filesystem)
-        access_modes: Access modes
-        client: Kubernetes client
-        multus_annotation: Multus network annotation
-        teardown: Whether to delete DV on cleanup
-        consume_wffc: Create dummy pod for WaitForFirstConsumer
-        bind_immediate: Bind immediately annotation
-        preallocation: Preallocate disk space
-        api_name: API name (storage/pvc)
-
-    Yields:
-        DataVolume: DataVolume resource with sourceRef
-    """
-    # Create DataVolume with blank source as placeholder
+    # openshift-python-wrapper doesn't support source_ref parameter.
     dv = DataVolume(
         source="blank",
         name=dv_name,
@@ -233,21 +208,16 @@ def create_dv_with_source_ref(
         preallocation=preallocation,
         api_name=api_name,
     )
-
-    # Modify to use sourceRef by converting to dict first
     dv.to_dict()
-    # Remove source and contentType that were added by DataVolume init
     if "source" in dv.res["spec"]:
         del dv.res["spec"]["source"]
     if "contentType" in dv.res["spec"]:
         del dv.res["spec"]["contentType"]
-    # Add sourceRef
     dv.res["spec"]["sourceRef"] = {
         "kind": data_source.kind,
         "name": data_source.name,
         "namespace": data_source.namespace,
     }
-
     with dv:
         if sc_volume_binding_mode_is_wffc(sc=storage_class) and consume_wffc:
             create_dummy_first_consumer_pod(dv=dv)

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -175,6 +175,85 @@ def create_dv(
     )
 
 
+@contextmanager
+def create_dv_with_source_ref(
+    dv_name,
+    namespace,
+    storage_class,
+    size,
+    data_source,
+    volume_mode=None,
+    access_modes=None,
+    client=None,
+    multus_annotation=None,
+    teardown=True,
+    consume_wffc=True,
+    bind_immediate=None,
+    preallocation=None,
+    api_name="storage",
+):
+    """Create a DataVolume with sourceRef pointing to a DataSource.
+
+    This function creates a DataVolume using sourceRef instead of traditional
+    source methods (http, pvc, etc). It's designed for backporting to versions
+    where openshift-python-wrapper doesn't support source_ref parameter.
+
+    Args:
+        dv_name: Name of the DataVolume
+        namespace: Namespace for the DataVolume
+        storage_class: Storage class name
+        size: DataVolume size (e.g., "5Gi")
+        data_source: DataSource object to reference
+        volume_mode: Volume mode (Block/Filesystem)
+        access_modes: Access modes
+        client: Kubernetes client
+        multus_annotation: Multus network annotation
+        teardown: Whether to delete DV on cleanup
+        consume_wffc: Create dummy pod for WaitForFirstConsumer
+        bind_immediate: Bind immediately annotation
+        preallocation: Preallocate disk space
+        api_name: API name (storage/pvc)
+
+    Yields:
+        DataVolume: DataVolume resource with sourceRef
+    """
+    # Create DataVolume with blank source as placeholder
+    dv = DataVolume(
+        source="blank",
+        name=dv_name,
+        namespace=namespace,
+        size=size,
+        storage_class=storage_class,
+        volume_mode=volume_mode,
+        access_modes=access_modes,
+        client=client,
+        bind_immediate_annotation=bind_immediate,
+        multus_annotation=multus_annotation,
+        teardown=teardown,
+        preallocation=preallocation,
+        api_name=api_name,
+    )
+
+    # Modify to use sourceRef by converting to dict first
+    dv.to_dict()
+    # Remove source and contentType that were added by DataVolume init
+    if "source" in dv.res["spec"]:
+        del dv.res["spec"]["source"]
+    if "contentType" in dv.res["spec"]:
+        del dv.res["spec"]["contentType"]
+    # Add sourceRef
+    dv.res["spec"]["sourceRef"] = {
+        "kind": data_source.kind,
+        "name": data_source.name,
+        "namespace": data_source.namespace,
+    }
+
+    with dv:
+        if sc_volume_binding_mode_is_wffc(sc=storage_class) and consume_wffc:
+            create_dummy_first_consumer_pod(dv=dv)
+        yield dv
+
+
 def data_volume(
     namespace,
     storage_class_matrix=None,

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -175,55 +175,6 @@ def create_dv(
     )
 
 
-@contextmanager
-def create_dv_with_source_ref(
-    dv_name,
-    namespace,
-    storage_class,
-    size,
-    data_source,
-    volume_mode=None,
-    access_modes=None,
-    client=None,
-    multus_annotation=None,
-    teardown=True,
-    consume_wffc=True,
-    bind_immediate=None,
-    preallocation=None,
-    api_name="storage",
-):
-    # openshift-python-wrapper doesn't support source_ref parameter.
-    dv = DataVolume(
-        source="blank",
-        name=dv_name,
-        namespace=namespace,
-        size=size,
-        storage_class=storage_class,
-        volume_mode=volume_mode,
-        access_modes=access_modes,
-        client=client,
-        bind_immediate_annotation=bind_immediate,
-        multus_annotation=multus_annotation,
-        teardown=teardown,
-        preallocation=preallocation,
-        api_name=api_name,
-    )
-    dv.to_dict()
-    if "source" in dv.res["spec"]:
-        del dv.res["spec"]["source"]
-    if "contentType" in dv.res["spec"]:
-        del dv.res["spec"]["contentType"]
-    dv.res["spec"]["sourceRef"] = {
-        "kind": data_source.kind,
-        "name": data_source.name,
-        "namespace": data_source.namespace,
-    }
-    with dv:
-        if sc_volume_binding_mode_is_wffc(sc=storage_class) and consume_wffc:
-            create_dummy_first_consumer_pod(dv=dv)
-        yield dv
-
-
 def data_volume(
     namespace,
     storage_class_matrix=None,


### PR DESCRIPTION
##### Short description:
Manual cherry-pick: https://github.com/RedHatQE/openshift-virtualization-tests/pull/3892

##### More details:
This PR was recently updated due to changes in openshift-python-wrapper https://github.com/RedHatQE/openshift-python-wrapper/pull/2723

Outdated:
Since there is no  source_ref support in  openshift-python-wrapper 4.19.0 and cnv-4.19 and earlier
https://github.com/RedHatQE/openshift-virtualization-tests/blob/cnv-4.19/utilities/storage.py#L107
https://github.com/RedHatQE/openshift-python-wrapper/blob/v4.19/ocp_resources/datavolume.py#L14
this PR adds create_dv_with_source_ref

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
