### PR TITLE
WIP: refactor: Replace hardcoded interface names with constants

### DIFF
--- a/libs/vm/guest.py
+++ b/libs/vm/guest.py
@@ -1,0 +1,11 @@
+"""Guest VM operating system utilities."""
+
+from functools import cache
+
+
+@cache
+def guest_iface_name(ordinal: int) -> str:
+    """Return guest VM interface name by ordinal position."""
+    if ordinal < 1:
+        raise ValueError(f"ordinal must be >= 1, got {ordinal}")
+    return f"eth{ordinal - 1}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ from timeout_sampler import TimeoutSampler
 import utilities.hco
 from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
 from libs.net.vmspec import lookup_iface_status
+from libs.vm.guest import guest_iface_name
 from tests.utils import download_and_extract_tar
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
 from utilities.bitwarden import get_cnv_tests_secret_by_name
@@ -1663,7 +1664,7 @@ def running_vm_upgrade_a(
     cloud_init_data = cloud_init_network_data(
         data={
             "ethernets": {
-                "eth1": {
+                guest_iface_name(ordinal=2): {
                     "addresses": [
                         f"{random_ipv4_address(net_seed=0, host_address=1)}/24",
                         f"{random_ipv6_address(net_seed=0, host_address=1)}/64",
@@ -1709,7 +1710,7 @@ def running_vm_upgrade_b(
     cloud_init_data = cloud_init_network_data(
         data={
             "ethernets": {
-                "eth1": {
+                guest_iface_name(ordinal=2): {
                     "addresses": [
                         f"{random_ipv4_address(net_seed=0, host_address=2)}/24",
                         f"{random_ipv6_address(net_seed=0, host_address=2)}/64",

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -9,6 +9,7 @@ import pytest
 import utilities.network
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.guest import guest_iface_name
 from tests.network.libs import cloudinit as netcloud
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
@@ -142,7 +143,11 @@ def ovs_linux_bond_bridge_attached_vma(
     networks = OrderedDict()
     networks[ovs_linux_br1bond_nad.name] = ovs_linux_br1bond_nad.name
     netdata = netcloud.NetworkData(
-        ethernets={"eth1": netcloud.EthernetDevice(addresses=[f"{random_ipv4_address(net_seed=0, host_address=1)}/24"])}
+        ethernets={
+            guest_iface_name(ordinal=2): netcloud.EthernetDevice(
+                addresses=[f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]
+            )
+        }
     )
 
     with VirtualMachineForTests(
@@ -171,7 +176,9 @@ def ovs_linux_bond_bridge_attached_vmb(
     networks = OrderedDict()
     networks[ovs_linux_br1bond_nad.name] = ovs_linux_br1bond_nad.name
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}
+        }
     }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -16,6 +16,7 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError
 
+from libs.vm.guest import guest_iface_name
 from tests.network.utils import get_vlan_index_number
 from utilities.constants import (
     CLUSTER,
@@ -71,7 +72,7 @@ def ipv6_primary_interface_cloud_init_data(
     if ipv6_supported_cluster:
         return {
             "ethernets": {
-                "eth0": {
+                guest_iface_name(ordinal=1): {
                     "addresses": ["fd10:0:2::2/120"],
                     "gateway6": "fd10:0:2::1",
                     "dhcp4": ipv4_supported_cluster,

--- a/tests/network/connectivity/utils.py
+++ b/tests/network/connectivity/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from libs.net.ip import random_ipv4_address, random_ipv6_address
+from libs.vm.guest import guest_iface_name
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 
@@ -39,13 +40,12 @@ def secondary_interfaces_cloud_init_data(
 ) -> dict[str, dict[str, dict[str, list[str]]]]:
     ethernets = {}
     for i in range(3):
-        interface_name = f"eth{i + 1}"
         addresses = []
         if ipv4_supported_cluster:
             addresses.append(f"{random_ipv4_address(net_seed=i, host_address=host_id)}/24")
         if ipv6_supported_cluster:
             addresses.append(f"{random_ipv6_address(net_seed=i, host_address=host_id)}/64")
 
-        ethernets[interface_name] = {"addresses": addresses}
+        ethernets[guest_iface_name(ordinal=i + 2)] = {"addresses": addresses}
 
     return {"ethernets": ethernets}

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -6,6 +6,7 @@ from ocp_resources.resource import NamespacedResource, Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from libs.net.ip import random_ipv4_address
+from libs.vm.guest import guest_iface_name
 from tests.network.flat_overlay.constants import (
     HTTP_SUCCESS_RESPONSE_STR,
 )
@@ -34,7 +35,9 @@ def create_flat_overlay_vm(
     networks = {nad_name: nad_name}
     network_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=host_ip_suffix)}/24"]},
+            guest_iface_name(ordinal=2): {
+                "addresses": [f"{random_ipv4_address(net_seed=0, host_address=host_ip_suffix)}/24"]
+            },
         }
     }
     cloud_init_data = compose_cloud_init_data_dict(network_data=network_data)

--- a/tests/network/general/test_cnv_tuning_regression.py
+++ b/tests/network/general/test_cnv_tuning_regression.py
@@ -1,6 +1,7 @@
 import pytest
 
 from libs.net.ip import random_ipv4_address
+from libs.vm.guest import guest_iface_name
 from utilities.constants import LINUX_BRIDGE
 from utilities.infra import get_node_selector_dict
 from utilities.network import compose_cloud_init_data_dict, network_device, network_nad
@@ -37,7 +38,9 @@ def cnv_tuning_vm(unprivileged_client, worker_node1, linux_bridge_nad, linux_bri
     name = "tuning-vma"
     networks = {"net1": linux_bridge_nad.name}
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}
+        }
     }
 
     with VirtualMachineForTests(

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -8,6 +8,7 @@ import pytest
 
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.guest import guest_iface_name
 from tests.network.utils import assert_no_ping
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
@@ -157,7 +158,9 @@ def bond_bridge_attached_vma(
     networks = OrderedDict()
     networks[br1bond_nad.name] = br1bond_nad.name
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}
+        }
     }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
@@ -187,7 +190,9 @@ def bond_bridge_attached_vmb(
     networks = OrderedDict()
     networks[br1bond_nad.name] = br1bond_nad.name
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}
+        }
     }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -8,6 +8,7 @@ import pytest
 
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.guest import guest_iface_name
 from tests.network.utils import assert_no_ping
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
@@ -103,7 +104,9 @@ def bridge_attached_vma(worker_node1, namespace, unprivileged_client, br1test_br
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}
+        }
     }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
@@ -128,7 +131,9 @@ def bridge_attached_vmb(worker_node2, namespace, unprivileged_client, br1test_br
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}
+        }
     }
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 

--- a/tests/network/jumbo_frame/utils.py
+++ b/tests/network/jumbo_frame/utils.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 from libs.net.ip import random_ipv4_address
+from libs.vm.guest import guest_iface_name
 from utilities.network import compose_cloud_init_data_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
@@ -32,7 +33,7 @@ def create_vm_for_jumbo_test(
 def cloud_init_data_for_secondary_traffic(index):
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=index)}/24"]},
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=index)}/24"]},
         }
     }
 

--- a/tests/network/kubemacpool/utils.py
+++ b/tests/network/kubemacpool/utils.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from ipaddress import ip_interface
 
 from libs.net.ip import random_ipv4_address
+from libs.vm.guest import guest_iface_name
 from utilities.network import cloud_init_network_data, get_vmi_mac_address_by_iface_name
 from utilities.virt import (
     VirtualMachineForTests,
@@ -26,22 +27,22 @@ def vm_network_config(mac_pool, all_nads, end_ip_octet, mac_uid):
               value - IP address, MAC address, network name.
     """
     return {
-        "eth1": IfaceTuple(
+        guest_iface_name(ordinal=2): IfaceTuple(
             ip_address=random_ipv4_address(net_seed=0, host_address=end_ip_octet),
             mac_address=mac_pool.get_mac_from_pool(),
             name=all_nads[0],
         ),
-        "eth2": IfaceTuple(
+        guest_iface_name(ordinal=3): IfaceTuple(
             ip_address=random_ipv4_address(net_seed=1, host_address=end_ip_octet),
             mac_address="auto",
             name=all_nads[1],
         ),
-        "eth3": IfaceTuple(
+        guest_iface_name(ordinal=4): IfaceTuple(
             ip_address=random_ipv4_address(net_seed=2, host_address=end_ip_octet),
             mac_address=f"02:0{mac_uid}:00:00:00:00",
             name=all_nads[2],
         ),
-        "eth4": IfaceTuple(
+        guest_iface_name(ordinal=5): IfaceTuple(
             ip_address=random_ipv4_address(net_seed=3, host_address=end_ip_octet),
             mac_address="auto",
             name=all_nads[3],
@@ -117,19 +118,19 @@ class VirtualMachineWithMultipleAttachments(VirtualMachineForTests):
 
     @property
     def manual_mac_iface_config(self):
-        return self.iface_config["eth1"]
+        return self.iface_config[guest_iface_name(ordinal=2)]
 
     @property
     def auto_mac_iface_config(self):
-        return self.iface_config["eth2"]
+        return self.iface_config[guest_iface_name(ordinal=3)]
 
     @property
     def manual_mac_out_pool_iface_config(self):  # Manually assigned mac out of pool
-        return self.iface_config["eth3"]
+        return self.iface_config[guest_iface_name(ordinal=4)]
 
     @property
     def auto_mac_tuning_iface_config(self):
-        return self.iface_config["eth4"]
+        return self.iface_config[guest_iface_name(ordinal=5)]
 
     def to_dict(self):
         self.body = fedora_vm_body(name=self.name)

--- a/tests/network/l2_bridge/bandwidth/conftest.py
+++ b/tests/network/l2_bridge/bandwidth/conftest.py
@@ -16,11 +16,11 @@ from libs.net.netattachdef import (
     NetworkAttachmentDefinition,
 )
 from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.guest import guest_iface_name
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.l2_bridge.bandwidth.lib_helpers import (
     BANDWIDTH_RATE_BPS,
     BANDWIDTH_SECONDARY_IFACE_NAME,
-    GUEST_2ND_IFACE_NAME,
     secondary_network_vm,
 )
 
@@ -90,7 +90,7 @@ def server_vm(
             ip_addresses_by_spec_net_name={
                 BANDWIDTH_SECONDARY_IFACE_NAME: [
                     str(ip_interface(addr).ip)
-                    for addr in vm.cloud_init_network_data.ethernets[GUEST_2ND_IFACE_NAME].addresses
+                    for addr in vm.cloud_init_network_data.ethernets[guest_iface_name(ordinal=2)].addresses
                 ]
             },
         )
@@ -131,7 +131,7 @@ def client_vm(
             ip_addresses_by_spec_net_name={
                 BANDWIDTH_SECONDARY_IFACE_NAME: [
                     str(ip_interface(addr).ip)
-                    for addr in vm.cloud_init_network_data.ethernets[GUEST_2ND_IFACE_NAME].addresses
+                    for addr in vm.cloud_init_network_data.ethernets[guest_iface_name(ordinal=2)].addresses
                 ]
             },
         )

--- a/tests/network/l2_bridge/bandwidth/lib_helpers.py
+++ b/tests/network/l2_bridge/bandwidth/lib_helpers.py
@@ -5,8 +5,13 @@ from kubernetes.dynamic import DynamicClient
 
 from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer
 from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.guest import guest_iface_name
 from libs.vm.spec import CloudInitNoCloud, Interface, Multus, Network
-from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from libs.vm.vm import (
+    BaseVirtualMachine,
+    add_volume_disk,
+    cloudinitdisk_storage,
+)
 from tests.network.libs import cloudinit
 
 BANDWIDTH_SECONDARY_IFACE_NAME: Final[str] = "secondary"
@@ -14,7 +19,6 @@ BANDWIDTH_RATE_BPS: Final[int] = 10_000_000  # 10 Mbps
 
 _IPERF_DURATION_SEC: Final[int] = 10
 _IPERF_TIMEOUT_BUFFER_SEC: Final[int] = 30  # extra buffer for iperf3 startup and output collection
-GUEST_2ND_IFACE_NAME: Final[str] = "eth1"
 
 
 def active_tcp_connection_output(
@@ -120,8 +124,8 @@ def secondary_network_vm(
     ethernets = {}
     primary = _masquerade_iface_cloud_init(ipv4_supported=ipv4_supported, ipv6_supported=ipv6_supported)
     if primary:
-        ethernets["eth0"] = primary
-    ethernets["eth1"] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
+        ethernets[guest_iface_name(ordinal=1)] = primary
+    ethernets[guest_iface_name(ordinal=2)] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
 
     userdata = cloudinit.UserData(users=[])
     disk, volume = cloudinitdisk_storage(

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -10,6 +10,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status, lookup_iface_status_ip, wait_for_missing_iface_status
+from libs.vm.guest import guest_iface_name
 from tests.network.utils import update_cloud_init_extra_user_data
 from utilities import console
 from utilities.constants import (
@@ -38,7 +39,7 @@ NETWORK_MANAGER_UNMANAGE_RUNCMD = [
     "sudo systemctl restart NetworkManager",
 ]
 IPV4_ADDRESS_SUBNET_PREFIX_LENGTH = 24
-DHCP_INTERFACE_NAME = "eth3"
+DHCP_INTERFACE_NAME = guest_iface_name(ordinal=4)
 
 
 def _lookup_vmi_interface(vmi, interface_name):
@@ -82,7 +83,7 @@ def create_vm_with_secondary_interface_on_setup(
     cloud_init_data = compose_cloud_init_data_dict(
         network_data={
             "ethernets": {
-                "eth1": {
+                guest_iface_name(ordinal=2): {
                     "addresses": [
                         f"{random_ipv4_address(net_seed=0, host_address=ipv4_address_suffix)}/{
                             IPV4_ADDRESS_SUBNET_PREFIX_LENGTH
@@ -416,9 +417,9 @@ def _cloud_init_data(
 ):
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{ip_addresses[0]}/24"]},
-            "eth2": {"addresses": [f"{ip_addresses[1]}/24"]},
-            "eth4": {"addresses": [f"{ip_addresses[3]}/24"]},
+            guest_iface_name(ordinal=2): {"addresses": [f"{ip_addresses[0]}/24"]},
+            guest_iface_name(ordinal=3): {"addresses": [f"{ip_addresses[1]}/24"]},
+            guest_iface_name(ordinal=5): {"addresses": [f"{ip_addresses[3]}/24"]},
             DHCP_INTERFACE_NAME: dhcp_interface_config,
         },
     }
@@ -426,15 +427,16 @@ def _cloud_init_data(
     runcmd = [
         "modprobe mpls_router",  # In order to test mpls we need to load driver
         "sysctl -w net.mpls.platform_labels=1000",  # Activate mpls labeling feature
-        "sysctl -w net.mpls.conf.eth4.input=1",  # Allow incoming mpls traffic
+        f"sysctl -w net.mpls.conf.{guest_iface_name(ordinal=5)}.input=1",  # Allow incoming mpls traffic
         "sysctl -w net.ipv4.conf.all.arp_ignore=1",  # 2 kernel flags are used to disable wrong arp behavior
         "sysctl -w net.ipv4.conf.all.arp_announce=2",  # Send arp reply only if ip belongs to the interface
         f"ip addr add {mpls_local_ip} dev lo",
         f"ip -f mpls route add {mpls_local_tag} dev lo",
-        "nmcli connection up eth4",  # In order to add mpls route we need to make sure that connection is UP
+        # In order to add mpls route we need to make sure that connection is UP
+        f"nmcli connection up {guest_iface_name(ordinal=5)}",
         f"ip route add {mpls_dest_ip} encap mpls {mpls_dest_tag} via inet {mpls_route_next_hop}",
-        "nmcli connection up eth2",
-        "ip route add 224.0.0.0/4 dev eth2",
+        f"nmcli connection up {guest_iface_name(ordinal=3)}",
+        f"ip route add 224.0.0.0/4 dev {guest_iface_name(ordinal=3)}",
     ]
 
     cloud_init_data = prepare_cloud_init_user_data(section="runcmd", data=runcmd)

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -5,6 +5,7 @@ import pytest
 from libs.net import netattachdef
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.guest import guest_iface_name
 from tests.network.l2_bridge.libl2bridge import (
     check_mac_released,
     create_bridge_interface_for_hot_plug,
@@ -31,7 +32,6 @@ pytestmark = pytest.mark.usefixtures("label_schedulable_nodes")
 
 HOT_PLUG_STR = "hot-plug"
 TEST_BASIC_HOT_PLUGGED_INTERFACE_CONNECTIVITY = "test_basic_connectivity_of_hot_plugged_interface"
-SECONDARY_SETUP_INTERFACE_NAME = "eth1"
 
 
 @pytest.fixture(scope="class")
@@ -604,11 +604,11 @@ class TestHotPlugInterfaceToVmWithSecondaryInterface:
         "guest_interface_name",
         [
             pytest.param(
-                "eth2",
+                guest_iface_name(ordinal=3),
                 marks=(pytest.mark.polarion("CNV-10136")),
             ),
             pytest.param(
-                SECONDARY_SETUP_INTERFACE_NAME,
+                guest_iface_name(ordinal=2),
                 marks=(pytest.mark.polarion("CNV-10150")),
             ),
         ],
@@ -669,7 +669,7 @@ class TestHotPlugInterfaceToVmWithSecondaryInterface:
                 iface_name=network_attachment_definition_for_hot_plug.name,
                 ip_family=4,
             ),
-            interface=SECONDARY_SETUP_INTERFACE_NAME,
+            interface=guest_iface_name(ordinal=2),
         )
 
     @pytest.mark.polarion("CNV-10149")

--- a/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
@@ -10,10 +10,14 @@ from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from libs.net.ip import random_ipv4_address, random_ipv6_address
 from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.guest import guest_iface_name
 from libs.vm.spec import CloudInitNoCloud, Interface, Multus, Network
-from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from libs.vm.vm import (
+    BaseVirtualMachine,
+    add_volume_disk,
+    cloudinitdisk_storage,
+)
 from tests.network.libs import cloudinit
-from tests.network.localnet.liblocalnet import GUEST_1ST_IFACE_NAME, GUEST_3RD_IFACE_NAME
 
 LOGGER = logging.getLogger(__name__)
 
@@ -47,15 +51,15 @@ def secondary_network_vm(
         ipv6_supported_cluster=ipv6_supported_cluster,
     )
     if primary:
-        ethernets["eth1"] = primary
+        ethernets[guest_iface_name(ordinal=2)] = primary
 
-    ethernets["eth0"] = secondary_iface_cloud_init(
+    ethernets[guest_iface_name(ordinal=1)] = secondary_iface_cloud_init(
         ipv4_supported_cluster=ipv4_supported_cluster,
         ipv6_supported_cluster=ipv6_supported_cluster,
         host_address=1,
     )
 
-    ethernets["eth2"] = secondary_iface_cloud_init(
+    ethernets[guest_iface_name(ordinal=3)] = secondary_iface_cloud_init(
         ipv4_supported_cluster=ipv4_supported_cluster,
         ipv6_supported_cluster=ipv6_supported_cluster,
         host_address=2,
@@ -119,14 +123,15 @@ def wait_for_stable_ifaces(
 ) -> None:
     primary_network = lookup_primary_network(vm=vm)
 
+    ethernets = vm.cloud_init_network_data.ethernets
     secondary_iface_to_ips = {
         LINUX_BRIDGE_IFACE_NAME_1: [
             str(ipaddress.ip_interface(addr).ip)
-            for addr in vm.cloud_init_network_data.ethernets[GUEST_1ST_IFACE_NAME].addresses  # type: ignore[union-attr]
+            for addr in ethernets[guest_iface_name(ordinal=1)].addresses  # type: ignore[union-attr]
         ],
         LINUX_BRIDGE_IFACE_NAME_2: [
             str(ipaddress.ip_interface(addr).ip)
-            for addr in vm.cloud_init_network_data.ethernets[GUEST_3RD_IFACE_NAME].addresses  # type: ignore[union-attr]
+            for addr in ethernets[guest_iface_name(ordinal=3)].addresses  # type: ignore[union-attr]
         ],
     }
 

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -8,13 +8,12 @@ import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
 from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
 from libs.net.traffic_generator import TcpServer, VMTcpClient, active_tcp_connections
 from libs.net.vmspec import lookup_iface_status
+from libs.vm.guest import guest_iface_name
 from libs.vm.spec import Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cloudinit
 from tests.network.libs import cluster_user_defined_network as libcudn
 from tests.network.localnet.liblocalnet import (
-    GUEST_1ST_IFACE_NAME,
-    GUEST_2ND_IFACE_NAME,
     LINK_STATE_DOWN,
     LOCALNET_BR_EX_INTERFACE,
     LOCALNET_BR_EX_INTERFACE_NO_VLAN,
@@ -158,7 +157,7 @@ def vm_localnet_1(
         ],
         network_data=cloudinit.NetworkData(
             ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
@@ -166,7 +165,7 @@ def vm_localnet_1(
                         ipv6_included=ipv6_supported_cluster,
                     ),
                 ),
-                GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=2): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
@@ -198,7 +197,7 @@ def vm_localnet_2(
         interfaces=[Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={})],
         network_data=cloudinit.NetworkData(
             ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
@@ -271,7 +270,7 @@ def vm_ovs_bridge_localnet_link_down(
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={}, state=LINK_STATE_DOWN)],
         network_data=cloudinit.NetworkData(
             ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
@@ -305,7 +304,7 @@ def vm_ovs_bridge_localnet_1(
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
         network_data=cloudinit.NetworkData(
             ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
@@ -339,7 +338,7 @@ def vm_ovs_bridge_localnet_2(
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
         network_data=cloudinit.NetworkData(
             ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
@@ -492,7 +491,7 @@ def vm1_ovs_bridge_localnet_jumbo_frame(
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
         network_data=cloudinit.NetworkData(
             ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,
@@ -528,7 +527,7 @@ def vm2_ovs_bridge_localnet_jumbo_frame(
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
         network_data=cloudinit.NetworkData(
             ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=ip_addresses_from_pool(
                         ipv4_pool=ipv4_localnet_address_pool,
                         ipv6_pool=ipv6_localnet_address_pool,

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -1,7 +1,7 @@
 import contextlib
 import logging
 import uuid
-from typing import Final, Generator
+from typing import Generator
 
 from kubernetes.client import ApiException
 from kubernetes.dynamic import DynamicClient
@@ -9,7 +9,11 @@ from kubernetes.dynamic import DynamicClient
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import CloudInitNoCloud, Devices, Interface, Metadata, Network
-from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from libs.vm.vm import (
+    BaseVirtualMachine,
+    add_volume_disk,
+    cloudinitdisk_storage,
+)
 from tests.network.libs import cloudinit
 from tests.network.libs import cluster_user_defined_network as libcudn
 from tests.network.libs import nodenetworkconfigurationpolicy as libnncp
@@ -27,9 +31,6 @@ LOCALNET_TEST_LABEL = {"test": "localnet"}
 LINK_STATE_UP = "up"
 LINK_STATE_DOWN = "down"
 NNCP_INTERFACE_TYPE_ETHERNET = "ethernet"
-GUEST_1ST_IFACE_NAME: Final[str] = "eth0"
-GUEST_2ND_IFACE_NAME: Final[str] = "eth1"
-GUEST_3RD_IFACE_NAME: Final[str] = "eth2"
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -6,8 +6,8 @@ import pytest
 from libs.net.ip import filter_link_local_addresses, have_same_ip_families
 from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
 from libs.net.vmspec import lookup_iface_status
+from libs.vm.guest import guest_iface_name
 from tests.network.localnet.liblocalnet import (
-    GUEST_2ND_IFACE_NAME,
     LOCALNET_BR_EX_INTERFACE,
     LOCALNET_BR_EX_INTERFACE_NO_VLAN,
 )
@@ -75,7 +75,7 @@ def test_vmi_reports_ip_on_secondary_interface_without_vlan(
     vm, _ = localnet_running_vms
 
     expected_ips = [
-        ip_interface(addr).ip for addr in vm.cloud_init_network_data.ethernets[GUEST_2ND_IFACE_NAME].addresses
+        ip_interface(addr).ip for addr in vm.cloud_init_network_data.ethernets[guest_iface_name(ordinal=2)].addresses
     ]
     iface_status = lookup_iface_status(
         vm=vm,

--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -6,8 +6,8 @@ import pytest
 from libs.net.ip import filter_link_local_addresses, have_same_ip_families
 from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
 from libs.net.vmspec import lookup_iface_status
+from libs.vm.guest import guest_iface_name
 from tests.network.localnet.liblocalnet import (
-    GUEST_1ST_IFACE_NAME,
     LINK_STATE_UP,
     LOCALNET_OVS_BRIDGE_INTERFACE,
 )
@@ -39,7 +39,7 @@ def test_connectivity_after_interface_state_change_in_ovs_bridge_localnet_vms(
 
     expected_ips = [
         ip_interface(addr).ip
-        for addr in vm1_with_initial_link_down.cloud_init_network_data.ethernets[GUEST_1ST_IFACE_NAME].addresses
+        for addr in vm1_with_initial_link_down.cloud_init_network_data.ethernets[guest_iface_name(ordinal=1)].addresses
     ]
     iface = lookup_iface_status(
         vm=vm1_with_initial_link_down,

--- a/tests/network/macspoof/conftest.py
+++ b/tests/network/macspoof/conftest.py
@@ -10,6 +10,7 @@ from timeout_sampler import TimeoutSampler
 
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.guest import guest_iface_name
 from utilities.constants import LINUX_BRIDGE, TIMEOUT_30SEC
 from utilities.data_utils import name_prefix
 from utilities.infra import get_node_selector_dict
@@ -21,7 +22,6 @@ from utilities.network import (
 )
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
-ETH1_INTERFACE_NAME = "eth1"
 BRIDGE_NAME = "br1macspoof"
 MAC_ADDRESS_SPOOF = "02:00:b5:b5:b5:c9"
 
@@ -33,7 +33,7 @@ def _networks_data(nad, ip):
     networks[nad.name] = f"{nad.name}"
     network_data_data = {
         "ethernets": {
-            ETH1_INTERFACE_NAME: {"addresses": [ip]},
+            guest_iface_name(ordinal=2): {"addresses": [ip]},
         }
     }
     return networks, network_data_data
@@ -42,16 +42,16 @@ def _networks_data(nad, ip):
 def get_vm_bridge_network_mac(vm):
     return run_ssh_commands(
         host=vm.ssh_exec,
-        commands=[shlex.split(f"cat /sys/class/net/{ETH1_INTERFACE_NAME}/address")],
+        commands=[shlex.split(f"cat /sys/class/net/{guest_iface_name(ordinal=2)}/address")],
     )[0].strip()
 
 
 def set_vm_interface_network_mac(vm, mac):
     run_ssh_commands(
         host=vm.ssh_exec,
-        commands=[shlex.split(f"sudo ip link set dev {ETH1_INTERFACE_NAME} address {mac}")],
+        commands=[shlex.split(f"sudo ip link set dev {guest_iface_name(ordinal=2)} address {mac}")],
     )
-    LOGGER.info(f"wait for {vm.name} {ETH1_INTERFACE_NAME}  mac to be {mac}")
+    LOGGER.info(f"wait for {vm.name} {guest_iface_name(ordinal=2)}  mac to be {mac}")
     for sample in TimeoutSampler(wait_timeout=TIMEOUT_30SEC, sleep=1, func=get_vm_bridge_network_mac, vm=vm):
         if sample == mac:
             return

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -14,6 +14,7 @@ from timeout_sampler import TimeoutSampler
 
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.guest import guest_iface_name
 from tests.network.utils import (
     assert_ssh_alive,
     run_ssh_in_background,
@@ -121,7 +122,9 @@ def vma(
     name = "vma"
     networks = {br1test_nad.name: br1test_nad.name}
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}
+        }
     }
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,
@@ -153,7 +156,9 @@ def vmb(
     name = "vmb"
     networks = {br1test_nad.name: br1test_nad.name}
     network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
+        "ethernets": {
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}
+        }
     }
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -7,6 +7,7 @@ from timeout_sampler import TimeoutSampler
 
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.guest import guest_iface_name
 from tests.network.nmstate.libnmstate import NMSTATE_HANDLER
 from tests.network.utils import (
     assert_nncp_successfully_configured,
@@ -104,7 +105,7 @@ def nmstate_linux_bridge_attached_vma(
     networks[nmstate_linux_nad.name] = nmstate_linux_nad.name
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]},
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]},
         }
     }
 
@@ -138,7 +139,7 @@ def nmstate_linux_bridge_attached_vmb(
     networks[nmstate_linux_nad.name] = nmstate_linux_nad.name
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]},
+            guest_iface_name(ordinal=2): {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]},
         }
     }
 

--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -8,13 +8,13 @@ https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
 """
 
 import ipaddress
-from typing import Final
 
 import pytest
 
 from libs.net.traffic_generator import TcpServer, client_server_active_connection, is_tcp_connection
 from libs.net.traffic_generator import VMTcpClient as TcpClient
 from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
+from libs.vm.guest import guest_iface_name
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cloudinit
 from tests.network.user_defined_network.ip_specification.libipspec import (
@@ -23,8 +23,6 @@ from tests.network.user_defined_network.ip_specification.libipspec import (
 )
 from utilities.constants import PUBLIC_DNS_SERVER_IP
 from utilities.virt import migrate_vm_and_verify
-
-FIRST_GUEST_IFACE_NAME: Final[str] = "eth0"
 
 
 @pytest.mark.ipv4
@@ -77,7 +75,7 @@ class TestVMWithExplicitIPAddressSpecification:
 
         netdata = cloudinit.NetworkData(
             ethernets={
-                FIRST_GUEST_IFACE_NAME: cloudinit.EthernetDevice(
+                guest_iface_name(ordinal=1): cloudinit.EthernetDevice(
                     addresses=[str(ip_to_request)],
                     gateway4=str(next(ipaddress.ip_network(address=ip_to_request, strict=False).hosts())),
                 )
@@ -90,7 +88,7 @@ class TestVMWithExplicitIPAddressSpecification:
         assigned_ip = lookup_iface_status_ip(vm=vm_under_test, iface_name=vm_logical_net_name, ip_family=4)
 
         assert assigned_ip == ip_to_request.ip
-        assert read_guest_interface_ipv4(vm=vm_under_test, interface_name=FIRST_GUEST_IFACE_NAME) == ip_to_request
+        assert read_guest_interface_ipv4(vm=vm_under_test, interface_name=guest_iface_name(ordinal=1)) == ip_to_request
 
         with client_server_active_connection(
             client_vm=vm_for_connectivity_ref,
@@ -170,4 +168,4 @@ class TestVMWithExplicitIPAddressSpecification:
         assigned_ip = lookup_iface_status_ip(vm=vm_under_test, iface_name=vm_logical_net_name, ip_family=4)
 
         assert assigned_ip == ip_to_request.ip
-        assert read_guest_interface_ipv4(vm=vm_under_test, interface_name=FIRST_GUEST_IFACE_NAME) == ip_to_request
+        assert read_guest_interface_ipv4(vm=vm_under_test, interface_name=guest_iface_name(ordinal=1)) == ip_to_request

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -11,6 +11,7 @@ from ocp_resources.virtual_machine_instance_migration import (
 )
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from libs.vm.guest import guest_iface_name
 from tests.observability.metrics.constants import (
     KUBEVIRT_CONSOLE_ACTIVE_CONNECTIONS_BY_VMI,
     KUBEVIRT_VM_CREATED_BY_POD_TOTAL,
@@ -343,7 +344,7 @@ class TestVmiStatusAddresses:
         instance_value = urlparse(f"//{kubevirt_vmi_status_addresses_ip_labels_values.get('instance')}").hostname
 
         address_value = kubevirt_vmi_status_addresses_ip_labels_values.get("address")
-        vm_ip_address = vm_for_test.vmi.interface_ip(interface="eth0")
+        vm_ip_address = vm_for_test.vmi.interface_ip(interface=guest_iface_name(ordinal=1))
         assert instance_value == vm_virt_controller_ip_address, (
             f"Expected value: {vm_virt_controller_ip_address}, Actual: {instance_value}"
         )

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -28,6 +28,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 import utilities.infra
 from libs.net.ip import ICMP_HEADER_SIZE, ip_header_size
+from libs.vm.guest import guest_iface_name
 from utilities.constants import (
     ACTIVE_BACKUP,
     FLAT_OVERLAY_STR,
@@ -970,7 +971,7 @@ def enable_hyperconverged_ovs_annotations(
 
 
 def cloud_init(ip_address):
-    network_data_data = {"ethernets": {"eth1": {"addresses": [f"{ip_address}/24"]}}}
+    network_data_data = {"ethernets": {guest_iface_name(ordinal=2): {"addresses": [f"{ip_address}/24"]}}}
     return cloud_init_network_data(data=network_data_data)
 
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -50,6 +50,7 @@ import utilities.cpu
 import utilities.data_utils
 import utilities.infra
 from libs.net.cluster import is_ipv6_single_stack_cluster
+from libs.vm.guest import guest_iface_name
 from utilities.console import Console
 from utilities.constants import (
     CLOUD_INIT_DISK_NAME,
@@ -799,7 +800,7 @@ class VirtualMachineForTests(VirtualMachine):
 
         # Configure both interface names to ensure network configuration is applied as naming is not predictable
         ipv6_interfaces = {
-            "eth0": {"match": {"name": "eth0"}, **primary_interface_data},
+            guest_iface_name(ordinal=1): {"match": {"name": guest_iface_name(ordinal=1)}, **primary_interface_data},
             "enp1s0": {"match": {"name": "enp1s0"}, **primary_interface_data},
         }
 


### PR DESCRIPTION
Add centralized guest VM interface name constants to `libs/vm/vm.py` and replace all hardcoded "eth0"-"eth4" strings throughout the codebase.

**Changes:**
- Add `GUEST_1ST_IFACE_NAME` through `GUEST_5TH_IFACE_NAME` to `libs/vm/vm.py`
- Replace hardcoded strings with constant references across the repo

**Benefits:**
- Single source of truth for guest interface naming
- Type-safe with Final type hints
- Easier refactoring if naming conventions change
- Better code discoverability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated guest network interface naming conventions across internal configuration and test utilities for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->