### PR TITLE
[IUO][Upgrade] Use range vector to catch all alerts fired during upgrade

### DIFF
--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime, timezone
 
 import pytest
 from ocp_resources.cluster_version import ClusterVersion
@@ -291,19 +292,31 @@ def prometheus_scope_function():
 
 
 @pytest.fixture(scope="session")
-def fired_alerts_before_upgrade(pytestconfig, prometheus, alert_dir):
-    return get_all_cnv_alerts(
+def upgrade_start_timestamp():
+    return datetime.now(tz=timezone.utc)
+
+
+@pytest.fixture(scope="session")
+def fired_alerts_before_upgrade(pytestconfig, prometheus, alert_dir, upgrade_start_timestamp):
+    cnv_alerts = get_all_cnv_alerts(
         prometheus=prometheus,
         file_name=f"before_{pytestconfig.option.upgrade}_upgrade_alerts.json",
         base_directory=alert_dir,
     )
+    return {alert["labels"]["alertname"] for alert in cnv_alerts}
 
 
 @pytest.fixture()
-def fired_alerts_during_upgrade(fired_alerts_before_upgrade, alert_dir, prometheus_scope_function):
+def fired_alerts_during_upgrade(
+    fired_alerts_before_upgrade,
+    upgrade_start_timestamp,
+    alert_dir,
+    prometheus_scope_function,
+):
     return get_alerts_fired_during_upgrade(
         prometheus=prometheus_scope_function,
-        before_upgrade_alerts=fired_alerts_before_upgrade,
+        before_upgrade_alert_names=fired_alerts_before_upgrade,
+        upgrade_start_time=upgrade_start_timestamp,
         base_directory=alert_dir,
     )
 

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -17,7 +17,7 @@ from tests.install_upgrade_operators.product_upgrade.utils import (
     approve_cnv_upgrade_install_plan,
     extract_ocp_version_from_ocp_image,
     get_alerts_fired_during_upgrade,
-    get_all_cnv_alerts,
+    get_all_firing_cnv_alerts,
     get_iib_images_of_cnv_versions,
     get_nodes_labels,
     get_nodes_taints,
@@ -151,7 +151,9 @@ def updated_cnv_subscription_source(cnv_subscription_scope_session, cnv_registry
 
 
 @pytest.fixture()
-def approved_cnv_upgrade_install_plan(admin_client, hco_namespace, hco_target_csv_name, is_production_source):
+def approved_cnv_upgrade_install_plan(
+    admin_client, hco_namespace, hco_target_csv_name, is_production_source, upgrade_start_timestamp
+):
     approve_cnv_upgrade_install_plan(
         client=admin_client,
         hco_namespace=hco_namespace.name,
@@ -266,7 +268,7 @@ def updated_ocp_upgrade_channel(extracted_ocp_version_from_image_url, cluster_ve
 
 
 @pytest.fixture()
-def triggered_ocp_upgrade(ocp_image_url, is_disconnected_cluster):
+def triggered_ocp_upgrade(ocp_image_url, is_disconnected_cluster, upgrade_start_timestamp):
     image_url = ocp_image_url
     if is_disconnected_cluster:
         image_info = get_oc_image_info(image=ocp_image_url, pull_secret=generate_openshift_pull_secret_file())
@@ -297,10 +299,10 @@ def upgrade_start_timestamp():
 
 
 @pytest.fixture(scope="session")
-def fired_alerts_before_upgrade(pytestconfig, prometheus, alert_dir, upgrade_start_timestamp):
-    cnv_alerts = get_all_cnv_alerts(
+def fired_alerts_before_upgrade(pytestconfig, prometheus, alert_dir):
+    cnv_alerts = get_all_firing_cnv_alerts(
         prometheus=prometheus,
-        file_name=f"before_{pytestconfig.option.upgrade}_upgrade_alerts.json",
+        file_name=f"before_{pytestconfig.option.upgrade}_upgrade_firing_cnv_alerts.json",
         base_directory=alert_dir,
     )
     return {alert["labels"]["alertname"] for alert in cnv_alerts}
@@ -479,7 +481,7 @@ def ocp_version_non_eus_to_eus_from_image_url(eus_ocp_image_urls):
 
 
 @pytest.fixture()
-def triggered_source_eus_to_non_eus_ocp_upgrade(eus_ocp_image_urls):
+def triggered_source_eus_to_non_eus_ocp_upgrade(eus_ocp_image_urls, upgrade_start_timestamp):
     run_ocp_upgrade_command(ocp_image_url=eus_ocp_image_urls[0])
 
 

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
@@ -3,7 +3,6 @@ import logging
 import pytest
 
 from tests.install_upgrade_operators.product_upgrade.utils import (
-    process_alerts_fired_during_upgrade,
     verify_nodes_labels_after_upgrade,
     verify_nodes_taints_after_upgrade,
 )
@@ -13,7 +12,6 @@ from tests.upgrade_params import (
     IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
 )
 from utilities.constants import DEPENDENCY_SCOPE_SESSION
-from utilities.data_collector import collect_alerts_data
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,17 +35,12 @@ class TestUpgradeIUO:
     )
     def test_alerts_fired_during_upgrade(
         self,
-        prometheus_scope_function,
         fired_alerts_during_upgrade,
     ):
         LOGGER.info("Verify if any alerts were fired during upgrade")
-        process_alerts_fired_during_upgrade(
-            prometheus=prometheus_scope_function,
-            fired_alerts_during_upgrade=fired_alerts_during_upgrade,
+        assert not fired_alerts_during_upgrade, (
+            f"Following alerts were fired during upgrade: {fired_alerts_during_upgrade}"
         )
-        if fired_alerts_during_upgrade:
-            collect_alerts_data()
-            raise AssertionError(f"Following alerts were fired during upgrade: {fired_alerts_during_upgrade}")
 
     @pytest.mark.eus_upgrade
     @pytest.mark.polarion("CNV-6866")

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
@@ -37,9 +37,8 @@ class TestUpgradeIUO:
         self,
         fired_alerts_during_upgrade,
     ):
-        LOGGER.info("Verify if any alerts were fired during upgrade")
         assert not fired_alerts_during_upgrade, (
-            f"Following alerts were fired during upgrade: {fired_alerts_during_upgrade}"
+            f"Following alerts were fired during upgrade: {list(fired_alerts_during_upgrade.keys())}"
         )
 
     @pytest.mark.eus_upgrade

--- a/tests/install_upgrade_operators/product_upgrade/utils.py
+++ b/tests/install_upgrade_operators/product_upgrade/utils.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import json
 import logging
 import re
+from datetime import datetime, timezone
 from pprint import pformat
 from threading import Thread
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ocp_utilities.monitoring import Prometheus
 
 from deepdiff import DeepDiff
 from kubernetes.dynamic import DynamicClient
@@ -59,9 +63,6 @@ from utilities.operator import (
 
 LOGGER = logging.getLogger(__name__)
 TIER_2_PODS_TYPE = "tier-2"
-
-# list of whitelisted alerts
-WHITELIST_ALERTS_UPGRADE_LIST = ["OutdatedVirtualMachineInstanceWorkloads"]
 
 
 def wait_for_pod_replacement(client, hco_namespace, pod_name, related_images, status_dict):
@@ -462,20 +463,23 @@ def verify_upgrade_ocp(
     )
 
 
-def get_all_cnv_alerts(prometheus, file_name, base_directory):
-    cnv_alerts = []
-    alerts_fired = prometheus.alerts()
-    for alert in alerts_fired["data"].get("alerts"):
-        if (
-            alert["labels"].get("kubernetes_operator_part_of")
-            and alert["labels"]["kubernetes_operator_part_of"] == "kubevirt"
-        ):
-            alert_name = alert["labels"]["alertname"]
-            if alert_name in WHITELIST_ALERTS_UPGRADE_LIST:
-                LOGGER.info(f"Whitelist alert {alert_name}")
-                continue
-            cnv_alerts.append(alert)
+def get_all_cnv_alerts(prometheus: Prometheus, file_name: str, base_directory: str) -> list[dict[str, Any]]:
+    """Returns all currently firing CNV alerts.
 
+    Args:
+        prometheus: Prometheus client instance.
+        file_name: Name of the file to write alert data to.
+        base_directory: Directory path for writing alert data files.
+
+    Returns:
+        List of alert dicts for alerts with kubernetes_operator_part_of=kubevirt.
+    """
+    cnv_alerts = [
+        alert
+        for alert in prometheus.alerts()["data"].get("alerts", [])
+        if alert["labels"].get("kubernetes_operator_part_of") == "kubevirt"
+    ]
+    LOGGER.info(f"CNV alerts: {[alert['labels']['alertname'] for alert in cnv_alerts]}")
     write_to_file(
         base_directory=base_directory,
         file_name=file_name,
@@ -484,73 +488,78 @@ def get_all_cnv_alerts(prometheus, file_name, base_directory):
     return cnv_alerts
 
 
-def get_alerts_fired_during_upgrade(prometheus, before_upgrade_alerts, base_directory):
-    after_upgrade_alerts = get_all_cnv_alerts(
-        prometheus=prometheus,
-        file_name="after_upgrade_alerts.json",
+def query_alerts_fired_in_range(
+    prometheus: Prometheus,
+    start_time: datetime,
+    end_time: datetime,
+    step: str = "30s",
+) -> set[str]:
+    """Returns deduplicated alert names that were firing during the given time range.
+
+    Uses PromQL query_range to find all alerts that reached firing state at any point,
+    including alerts that have since resolved.
+
+    Args:
+        prometheus: Prometheus client instance.
+        start_time: Start of the time range.
+        end_time: End of the time range.
+        step: Query resolution step.
+
+    Returns:
+        Set of unique alert names that were firing during the range.
+    """
+    query = f'ALERTS{{alertstate="{FIRING_STATE}",kubernetes_operator_part_of="kubevirt"}}'
+    start_time = start_time.isoformat()
+    end_time = end_time.isoformat()
+    response = prometheus._get_response(
+        query=f"{prometheus.api_v1}/query_range?query={query}&start={start_time}&end={end_time}&step={step}"
+    )
+    alert_names = {
+        alert_name
+        for result in response.get("data", {}).get("result", [])
+        if (alert_name := result["metric"].get("alertname"))
+    }
+    LOGGER.info(f"Alerts fired in range [{start_time}, {end_time}]: {alert_names}")
+    return alert_names
+
+
+def get_alerts_fired_during_upgrade(
+    prometheus: Prometheus,
+    before_upgrade_alert_names: set[str],
+    upgrade_start_time: datetime,
+    base_directory: str,
+) -> set[str]:
+    """Returns alert names that newly fired during the upgrade.
+
+    Uses a PromQL range query over the upgrade window to catch all alerts that reached
+    firing state, including those that resolved before this function runs. Filters out
+    alerts that were already firing before the upgrade started.
+
+    Args:
+        prometheus: Prometheus client instance.
+        before_upgrade_alert_names: Alert names captured before upgrade.
+        upgrade_start_time: Datetime of when the upgrade started.
+        base_directory: Directory path for writing alert data files.
+
+    Returns:
+        Set of alert names that newly fired during the upgrade.
+    """
+    new_alerts = (
+        query_alerts_fired_in_range(
+            prometheus=prometheus,
+            start_time=upgrade_start_time,
+            end_time=datetime.now(tz=timezone.utc),
+        )
+        - before_upgrade_alert_names
+    )
+
+    LOGGER.error(f"New alerts fired during upgrade: {new_alerts}")
+    write_to_file(
         base_directory=base_directory,
+        file_name="alerts_fired_during_upgrade.json",
+        content=json.dumps(sorted(new_alerts)),
     )
-    before_upgrade_alert_names = [alert["labels"]["alertname"] for alert in before_upgrade_alerts]
-    fired_during_upgrade = []
-    for alert in after_upgrade_alerts:
-        alert_name = alert["labels"]["alertname"]
-        if alert_name in before_upgrade_alert_names:
-            continue
-        LOGGER.info(f"Alert {alert_name}, state: {alert['state']} fired during upgrade.")
-        fired_during_upgrade.append(alert)
-    return fired_during_upgrade
-
-
-def process_alerts_fired_during_upgrade(prometheus, fired_alerts_during_upgrade):
-    pending_alerts = []
-    for alert in fired_alerts_during_upgrade:
-        if alert["state"] == "pending":
-            pending_alerts.append(alert["labels"]["alertname"])
-
-    LOGGER.info(f"Pending alerts: {pending_alerts}")
-    if pending_alerts:
-        # wait for the pending alerts to be fired within 10 minutes, since pending alerts would be part of alerts fired
-        # during upgrade, we don't need to fail, if pending alerts did not fire.
-        wait_for_pending_alerts_to_fire(prometheus=prometheus, pending_alerts=pending_alerts)
-
-
-def wait_for_pending_alerts_to_fire(pending_alerts, prometheus):
-    def _get_fired_alerts(_prometheus, _alert_list):
-        _all_alerts = _prometheus.alerts()
-        current_firing_alerts = []
-        current_pending_alerts = []
-        for _alert in _all_alerts["data"].get("alerts"):
-            if (
-                not _alert["labels"].get("kubernetes_operator_part_of")
-                or _alert["labels"]["kubernetes_operator_part_of"] != "kubevirt"
-            ):
-                continue
-            _alert_name = _alert["labels"]["alertname"]
-            if _alert["state"] == FIRING_STATE:
-                current_firing_alerts.append(_alert_name)
-            elif _alert["state"] == "pending":
-                current_pending_alerts.append(_alert_name)
-
-        not_fired = [_alert for _alert in _alert_list if _alert not in current_firing_alerts]
-        LOGGER.warning(f"Out of {_alert_list}, following alerts are still not fired: {not_fired}")
-        return not_fired
-
-    _pending_alerts = pending_alerts
-    sampler = TimeoutSampler(
-        wait_timeout=TIMEOUT_10MIN,
-        sleep=2,
-        func=_get_fired_alerts,
-        _prometheus=prometheus,
-        _alert_list=_pending_alerts,
-    )
-    try:
-        for sample in sampler:
-            if not sample:
-                return
-            _pending_alerts = sample
-            LOGGER.warning(f"Waiting on alerts: {_pending_alerts}")
-    except TimeoutExpiredError:
-        LOGGER.error(f"Out of {pending_alerts}, following alerts did not get to {FIRING_STATE}: {_pending_alerts}")
+    return new_alerts
 
 
 def get_upgrade_path(target_version: str) -> dict[str, list[dict[str, str | list[str]]]]:

--- a/tests/install_upgrade_operators/product_upgrade/utils.py
+++ b/tests/install_upgrade_operators/product_upgrade/utils.py
@@ -493,11 +493,10 @@ def query_alerts_fired_in_range(
     start_time: datetime,
     end_time: datetime,
     step: str = "30s",
-) -> set[str]:
-    """Returns deduplicated alert names that were firing during the given time range.
+) -> list[dict[str, Any]]:
+    """Returns raw CNV firing-alert results from a PromQL range query.
 
-    Uses PromQL query_range to find all alerts that reached firing state at any point,
-    including alerts that have since resolved.
+    Includes alerts that have since resolved because range queries cover historical data.
 
     Args:
         prometheus: Prometheus client instance.
@@ -506,21 +505,14 @@ def query_alerts_fired_in_range(
         step: Query resolution step.
 
     Returns:
-        Set of unique alert names that were firing during the range.
+        List of result dicts, each containing 'metric' labels and 'values' timestamps.
     """
     query = f'ALERTS{{alertstate="{FIRING_STATE}",kubernetes_operator_part_of="kubevirt"}}'
-    start_time = start_time.isoformat()
-    end_time = end_time.isoformat()
     response = prometheus._get_response(
-        query=f"{prometheus.api_v1}/query_range?query={query}&start={start_time}&end={end_time}&step={step}"
+        query=f"{prometheus.api_v1}/query_range?query={query}"
+        f"&start={start_time.isoformat()}&end={end_time.isoformat()}&step={step}"
     )
-    alert_names = {
-        alert_name
-        for result in response.get("data", {}).get("result", [])
-        if (alert_name := result["metric"].get("alertname"))
-    }
-    LOGGER.info(f"Alerts fired in range [{start_time}, {end_time}]: {alert_names}")
-    return alert_names
+    return response.get("data", {}).get("result", [])
 
 
 def get_alerts_fired_during_upgrade(
@@ -528,8 +520,8 @@ def get_alerts_fired_during_upgrade(
     before_upgrade_alert_names: set[str],
     upgrade_start_time: datetime,
     base_directory: str,
-) -> set[str]:
-    """Returns alert names that newly fired during the upgrade.
+) -> dict[str, list[dict[str, Any]]]:
+    """Returns new alerts that fired during the upgrade, grouped by alertname.
 
     Uses a PromQL range query over the upgrade window to catch all alerts that reached
     firing state, including those that resolved before this function runs. Filters out
@@ -542,24 +534,27 @@ def get_alerts_fired_during_upgrade(
         base_directory: Directory path for writing alert data files.
 
     Returns:
-        Set of alert names that newly fired during the upgrade.
+        Dict mapping alertname to the list of full result objects (metric + values) for that alert.
     """
-    new_alerts = (
-        query_alerts_fired_in_range(
-            prometheus=prometheus,
-            start_time=upgrade_start_time,
-            end_time=datetime.now(tz=timezone.utc),
-        )
-        - before_upgrade_alert_names
+    fired_alerts = query_alerts_fired_in_range(
+        prometheus=prometheus,
+        start_time=upgrade_start_time,
+        end_time=datetime.now(tz=timezone.utc),
     )
 
-    LOGGER.error(f"New alerts fired during upgrade: {new_alerts}")
-    write_to_file(
-        base_directory=base_directory,
-        file_name="alerts_fired_during_upgrade.json",
-        content=json.dumps(sorted(new_alerts)),
-    )
-    return new_alerts
+    alerts_by_name: dict[str, list[dict[str, Any]]] = {}
+    for alert in fired_alerts:
+        alert_name = alert["metric"]["alertname"]
+        if alert_name not in before_upgrade_alert_names:
+            alerts_by_name.setdefault(alert_name, []).append(alert)
+
+    if alerts_by_name:
+        write_to_file(
+            base_directory=base_directory,
+            file_name="alerts_fired_during_upgrade.json",
+            content=json.dumps(alerts_by_name, indent=2),
+        )
+    return alerts_by_name
 
 
 def get_upgrade_path(target_version: str) -> dict[str, list[dict[str, str | list[str]]]]:

--- a/tests/install_upgrade_operators/product_upgrade/utils.py
+++ b/tests/install_upgrade_operators/product_upgrade/utils.py
@@ -463,7 +463,7 @@ def verify_upgrade_ocp(
     )
 
 
-def get_all_cnv_alerts(prometheus: Prometheus, file_name: str, base_directory: str) -> list[dict[str, Any]]:
+def get_all_firing_cnv_alerts(prometheus: Prometheus, file_name: str, base_directory: str) -> list[dict[str, Any]]:
     """Returns all currently firing CNV alerts.
 
     Args:
@@ -472,14 +472,14 @@ def get_all_cnv_alerts(prometheus: Prometheus, file_name: str, base_directory: s
         base_directory: Directory path for writing alert data files.
 
     Returns:
-        List of alert dicts for alerts with kubernetes_operator_part_of=kubevirt.
+        List of alert dicts for firing alerts with kubernetes_operator_part_of=kubevirt.
     """
     cnv_alerts = [
         alert
-        for alert in prometheus.alerts()["data"].get("alerts", [])
-        if alert["labels"].get("kubernetes_operator_part_of") == "kubevirt"
+        for alert in prometheus.alerts()["data"]["alerts"]
+        if alert["labels"].get("kubernetes_operator_part_of") == "kubevirt" and alert["state"] == FIRING_STATE
     ]
-    LOGGER.info(f"CNV alerts: {[alert['labels']['alertname'] for alert in cnv_alerts]}")
+    LOGGER.info(f"Firing CNV alerts: {[alert['labels']['alertname'] for alert in cnv_alerts]}")
     write_to_file(
         base_directory=base_directory,
         file_name=file_name,
@@ -491,28 +491,23 @@ def get_all_cnv_alerts(prometheus: Prometheus, file_name: str, base_directory: s
 def query_alerts_fired_in_range(
     prometheus: Prometheus,
     start_time: datetime,
-    end_time: datetime,
-    step: str = "30s",
 ) -> list[dict[str, Any]]:
-    """Returns raw CNV firing-alert results from a PromQL range query.
+    """Returns raw CNV firing-alert results since start_time using a range vector selector.
 
-    Includes alerts that have since resolved because range queries cover historical data.
+    Uses an instant query with a PromQL range vector selector to retrieve all alert
+    samples since start_time, including alerts that have since resolved.
 
     Args:
         prometheus: Prometheus client instance.
-        start_time: Start of the time range.
-        end_time: End of the time range.
-        step: Query resolution step.
+        start_time: Start of the lookback window.
 
     Returns:
         List of result dicts, each containing 'metric' labels and 'values' timestamps.
     """
-    query = f'ALERTS{{alertstate="{FIRING_STATE}",kubernetes_operator_part_of="kubevirt"}}'
-    response = prometheus._get_response(
-        query=f"{prometheus.api_v1}/query_range?query={query}"
-        f"&start={start_time.isoformat()}&end={end_time.isoformat()}&step={step}"
-    )
-    return response.get("data", {}).get("result", [])
+    duration_seconds = int((datetime.now(tz=timezone.utc) - start_time).total_seconds())
+    query = f'ALERTS{{alertstate="{FIRING_STATE}",kubernetes_operator_part_of="kubevirt"}}[{duration_seconds}s]'
+    response = prometheus.query(query=query)
+    return response["data"]["result"]
 
 
 def get_alerts_fired_during_upgrade(
@@ -523,9 +518,9 @@ def get_alerts_fired_during_upgrade(
 ) -> dict[str, list[dict[str, Any]]]:
     """Returns new alerts that fired during the upgrade, grouped by alertname.
 
-    Uses a PromQL range query over the upgrade window to catch all alerts that reached
-    firing state, including those that resolved before this function runs. Filters out
-    alerts that were already firing before the upgrade started.
+    Uses an instant query with a PromQL range vector selector over the upgrade window to
+    catch all alerts that reached firing state, including those that resolved before this
+    function runs. Filters out alerts that were already firing before the upgrade started.
 
     Args:
         prometheus: Prometheus client instance.
@@ -539,7 +534,6 @@ def get_alerts_fired_during_upgrade(
     fired_alerts = query_alerts_fired_in_range(
         prometheus=prometheus,
         start_time=upgrade_start_time,
-        end_time=datetime.now(tz=timezone.utc),
     )
 
     alerts_by_name: dict[str, list[dict[str, Any]]] = {}
@@ -552,7 +546,7 @@ def get_alerts_fired_during_upgrade(
         write_to_file(
             base_directory=base_directory,
             file_name="alerts_fired_during_upgrade.json",
-            content=json.dumps(alerts_by_name, indent=2),
+            content=json.dumps(fired_alerts, indent=2),
         )
     return alerts_by_name
 

--- a/tests/install_upgrade_operators/product_upgrade/utils.py
+++ b/tests/install_upgrade_operators/product_upgrade/utils.py
@@ -506,8 +506,7 @@ def query_alerts_fired_in_range(
     """
     duration_seconds = int((datetime.now(tz=timezone.utc) - start_time).total_seconds())
     query = f'ALERTS{{alertstate="{FIRING_STATE}",kubernetes_operator_part_of="kubevirt"}}[{duration_seconds}s]'
-    response = prometheus.query(query=query)
-    return response["data"]["result"]
+    return prometheus.query_sampler(query=query)
 
 
 def get_alerts_fired_during_upgrade(


### PR DESCRIPTION
##### Short description:
Fix alert upgrade test
##### More details:

##### What this PR does / why we need it:
Instead of comparing snapshots before/after upgrade (which misses
transient alerts), query the full upgrade time window so alerts
that fired and resolved mid-upgrade are no longer lost.

In addition, no need to fail upon a pending alert.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Add a session-scoped UTC timestamp to mark upgrade start and thread it into upgrade-related fixtures.
  * Collect only currently firing CNV alerts before upgrades and pass just their names into during-upgrade checks.
  * Replace polling with a precise time-range query to detect alerts fired during the upgrade window; group and persist results when present.
  * Simplify verification by asserting no unexpected alerts fired and failing immediately with detected alert names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->