### PR TITLE
fix: pytest-marker-analyzer: reduce false positives in smoke test detection

### DIFF
--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2120,44 +2120,38 @@ def _check_conftest_pathway(
         # Conftest imports specific symbols from the changed file
         conftest_imported = conftest_syms[changed_file]
         classification = modified_symbols_cache.get(changed_file)
-        if classification is None:
-            # Can't determine what changed — conservative: flag test
-            matching_deps.append(
-                f"{changed_file.relative_to(repo_root)} (via {conftest_path.relative_to(repo_root)}, diff unavailable)"
-            )
-            return True, matching_deps
 
-        overlapping = conftest_imported & classification.modified_symbols
-        if not overlapping:
-            # Conftest imports from this file but none of the modified symbols
-            # — this conftest pathway is resolved as safe
-            conftest_resolved = True
-            continue
+        if classification is not None:
+            overlapping = conftest_imported & classification.modified_symbols
+            if not overlapping:
+                # Conftest imports from this file but none of the modified symbols
+                # — this conftest pathway is resolved as safe
+                conftest_resolved = True
+                continue
 
-        # Overlap found — check if any fixture from this conftest calls the overlapping symbols
+        # Diff unavailable or modified symbols overlap — apply fixture narrowing
+        # Check if any fixture from this conftest calls the imported symbols
         # AND the test uses that fixture
+        symbols_to_check = (
+            conftest_imported if classification is None else conftest_imported & classification.modified_symbols
+        )
         fixture_match = False
         for fixture_name, fixture in fixtures_dict.items():
             if (
                 fixture.file_path == conftest_path
                 and fixture_name in marked_test.fixtures
-                and fixture.function_calls & overlapping
+                and fixture.function_calls & symbols_to_check
             ):
-                symbols_str = ", ".join(sorted(fixture.function_calls & overlapping))
+                symbols_str = ", ".join(sorted(fixture.function_calls & symbols_to_check))
                 matching_deps.append(
                     f"{changed_file.relative_to(repo_root)} (via fixture {fixture_name}: {symbols_str})"
                 )
                 fixture_match = True
                 break
 
-        if not fixture_match:
-            # Safe for this specific conftest path, but other conftest.py
-            # files higher in the hierarchy may still create a dependency.
-            conftest_resolved = True
-            continue
-
         conftest_resolved = True
-        return True, matching_deps
+        if fixture_match:
+            return True, matching_deps
 
     if not conftest_resolved:
         # No conftest pathway found — file-level fallback (conservative)
@@ -3845,8 +3839,9 @@ def main() -> int:
     )
     parser.add_argument(
         "--checkout",
-        action="store_true",
-        help="Clone and checkout the repository (for CI without pre-checkout)",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Clone and checkout the repository (default: enabled, use --no-checkout to disable)",
     )
     parser.add_argument(
         "--workdir",

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -816,7 +816,12 @@ class ImportVisitor(ast.NodeVisitor):
         if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
             return True
         # ``if typing.TYPE_CHECKING:``
-        if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+        if (
+            isinstance(test, ast.Attribute)
+            and isinstance(test.value, ast.Name)
+            and test.value.id == "typing"
+            and test.attr == "TYPE_CHECKING"
+        ):
             return True
         return False
 
@@ -2028,6 +2033,40 @@ def _analyze_single_test_dependencies(
     return dependencies, fixtures, symbol_imports
 
 
+def _expand_used_fixtures(
+    direct_fixtures: set[str],
+    fixtures_dict: dict[str, Fixture],
+) -> set[str]:
+    """Expand direct fixture names to include transitive fixture dependencies.
+
+    Follows ``Fixture.fixture_deps`` to build the full closure of fixtures
+    that will execute when the test runs, ensuring fixture narrowing
+    considers indirect fixture chains.
+
+    Args:
+        direct_fixtures: Fixture names directly used by the test.
+        fixtures_dict: Dictionary of all known fixtures.
+
+    Returns:
+        Set of all fixture names reachable from direct_fixtures.
+    """
+    used_fixtures = set(direct_fixtures)
+    pending = list(direct_fixtures)
+
+    while pending:
+        fixture_name = pending.pop()
+        fixture = fixtures_dict.get(fixture_name)
+        if fixture is None:
+            continue
+
+        for dependency_name in fixture.fixture_deps:
+            if dependency_name not in used_fixtures:
+                used_fixtures.add(dependency_name)
+                pending.append(dependency_name)
+
+    return used_fixtures
+
+
 def _check_conftest_pathway(
     changed_file: Path,
     marked_test: MarkedTest,
@@ -2063,6 +2102,7 @@ def _check_conftest_pathway(
     """
     matching_deps: list[str] = []
     conftest_resolved = False
+    used_fixtures = _expand_used_fixtures(direct_fixtures=marked_test.fixtures, fixtures_dict=fixtures_dict)
 
     for conftest_path in marked_test.dependencies:
         if conftest_path.name != "conftest.py":
@@ -2100,7 +2140,7 @@ def _check_conftest_pathway(
                 for fixture_name, fixture in fixtures_dict.items():
                     if (
                         fixture.file_path == conftest_path
-                        and fixture_name in marked_test.fixtures
+                        and fixture_name in used_fixtures
                         and fixture.function_calls & conftest_imported_from_intermediate
                     ):
                         symbols_str = ", ".join(sorted(fixture.function_calls & conftest_imported_from_intermediate))
@@ -2139,7 +2179,7 @@ def _check_conftest_pathway(
         for fixture_name, fixture in fixtures_dict.items():
             if (
                 fixture.file_path == conftest_path
-                and fixture_name in marked_test.fixtures
+                and fixture_name in used_fixtures
                 and fixture.function_calls & symbols_to_check
             ):
                 symbols_str = ", ".join(sorted(fixture.function_calls & symbols_to_check))

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -3330,6 +3330,9 @@ class MarkerTestAnalyzer:
         tests_dir = self.repo_root / "tests"
         if tests_dir.exists():
             self.conftest_files = list(tests_dir.rglob("conftest.py"))
+        root_conftest = self.repo_root / "conftest.py"
+        if root_conftest.exists():
+            self.conftest_files.append(root_conftest)
         logger.info(msg="Found conftest.py files", extra={"file_count": len(self.conftest_files)})
 
     def get_changed_files(self, base_branch: str = "main", files: list[str] | None = None) -> list[Path]:

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2086,23 +2086,16 @@ def _check_conftest_pathway(
                 if changed_file not in intermediate_syms:
                     continue
 
-                # Transitive path found
+                # Transitive path found — apply symbol narrowing if diff available
                 classification = modified_symbols_cache.get(changed_file)
-                if classification is None:
-                    matching_deps.append(
-                        f"{changed_file.relative_to(repo_root)} (via "
-                        f"{intermediate_path.relative_to(repo_root)} -> "
-                        f"{conftest_path.relative_to(repo_root)}, diff unavailable)"
-                    )
-                    return True, matching_deps
+                if classification is not None:
+                    intermediate_imported = intermediate_syms[changed_file]
+                    overlapping = intermediate_imported & classification.modified_symbols
+                    if not overlapping:
+                        conftest_resolved = True
+                        continue
 
-                intermediate_imported = intermediate_syms[changed_file]
-                overlapping = intermediate_imported & classification.modified_symbols
-                if not overlapping:
-                    conftest_resolved = True
-                    continue
-
-                # Modified symbols flow through intermediate — apply fixture narrowing
+                # Diff unavailable or modified symbols overlap — apply fixture narrowing
                 fixture_match = False
                 for fixture_name, fixture in fixtures_dict.items():
                     if (

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -794,6 +794,32 @@ class ImportVisitor(ast.NodeVisitor):
                 # "from pkg import submod" may refer to pkg/submod.py
                 self.imports.add(f"{node.module}.{alias.name}")
 
+    def visit_If(self, node: ast.If) -> None:
+        """Skip imports inside ``if TYPE_CHECKING:`` blocks.
+
+        These imports exist only for static type checkers and are never
+        executed at runtime, so they should not create test dependencies.
+        The ``else`` branch is still visited because it contains runtime
+        imports (e.g. compatibility fallbacks).
+        """
+        if self._is_type_checking_guard(node=node):
+            for child in node.orelse:
+                self.visit(node=child)
+            return
+        self.generic_visit(node=node)
+
+    @staticmethod
+    def _is_type_checking_guard(node: ast.If) -> bool:
+        """Check whether an ``If`` node guards a ``TYPE_CHECKING`` block."""
+        test = node.test
+        # ``if TYPE_CHECKING:``
+        if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+            return True
+        # ``if typing.TYPE_CHECKING:``
+        if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+            return True
+        return False
+
 
 class FixtureVisitor(ast.NodeVisitor):
     """AST visitor to extract fixture usage from test functions."""

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2080,6 +2080,48 @@ def _check_conftest_pathway(
         # Check if conftest imports specific symbols from the changed file
         conftest_syms = conftest_symbol_imports.get(conftest_path, {})
         if changed_file not in conftest_syms:
+            # Check transitive path: conftest -> intermediate -> changed_file
+            for intermediate_path, conftest_imported_from_intermediate in conftest_syms.items():
+                intermediate_syms = _extract_symbol_imports_from_file(file_path=intermediate_path, repo_root=repo_root)
+                if changed_file not in intermediate_syms:
+                    continue
+
+                # Transitive path found
+                classification = modified_symbols_cache.get(changed_file)
+                if classification is None:
+                    matching_deps.append(
+                        f"{changed_file.relative_to(repo_root)} (via "
+                        f"{intermediate_path.relative_to(repo_root)} -> "
+                        f"{conftest_path.relative_to(repo_root)}, diff unavailable)"
+                    )
+                    return True, matching_deps
+
+                intermediate_imported = intermediate_syms[changed_file]
+                overlapping = intermediate_imported & classification.modified_symbols
+                if not overlapping:
+                    conftest_resolved = True
+                    continue
+
+                # Modified symbols flow through intermediate — apply fixture narrowing
+                fixture_match = False
+                for fixture_name, fixture in fixtures_dict.items():
+                    if (
+                        fixture.file_path == conftest_path
+                        and fixture_name in marked_test.fixtures
+                        and fixture.function_calls & conftest_imported_from_intermediate
+                    ):
+                        symbols_str = ", ".join(sorted(fixture.function_calls & conftest_imported_from_intermediate))
+                        matching_deps.append(
+                            f"{changed_file.relative_to(repo_root)} (via "
+                            f"{intermediate_path.relative_to(repo_root)} -> fixture {fixture_name}: {symbols_str})"
+                        )
+                        fixture_match = True
+                        break
+
+                conftest_resolved = True
+                if fixture_match:
+                    return True, matching_deps
+
             continue
 
         # Conftest imports specific symbols from the changed file

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -1792,3 +1792,217 @@ class TestImportVisitorTypeChecking:
         visitor.visit(node=tree)
         assert "libs.vm.vm" not in visitor.imports
         assert "libs.fallback" in visitor.imports
+
+
+class TestCheckConftestPathwayTransitive:
+    """Transitive conftest narrowing: conftest -> intermediate -> changed_file."""
+
+    def test_transitive_no_fixture_match_does_not_flag(self, tmp_path: Path) -> None:
+        """When conftest imports an intermediate module that imports the changed file,
+        but no fixture used by the test calls the intermediate's symbols, the test
+        should NOT be flagged.
+        """
+        repo_root = tmp_path
+
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        intermediate_path = tmp_path / "libs" / "net" / "vmspec.py"
+        intermediate_path.parent.mkdir(parents=True, exist_ok=True)
+        # Intermediate module imports BaseVirtualMachine from the changed file
+        intermediate_path.write_text(
+            "from libs.vm.vm import BaseVirtualMachine\n",
+            encoding="utf-8",
+        )
+
+        changed_file = tmp_path / "libs" / "vm" / "vm.py"
+        changed_file.parent.mkdir(parents=True, exist_ok=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_smoke.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_smoke_basic",
+            node_id="tests/test_smoke.py::test_smoke_basic",
+            dependencies={conftest_path, intermediate_path, changed_file},
+            fixtures={"some_unrelated_fixture"},
+            symbol_imports={},
+        )
+
+        # Conftest imports lookup_iface_status from the intermediate (NOT directly from changed_file)
+        conftest_symbol_imports: dict[Path, dict[Path, set[str]]] = {
+            conftest_path: {intermediate_path: {"lookup_iface_status"}},
+        }
+
+        # BaseVirtualMachine was modified in the changed file
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: SymbolClassification(
+                modified_symbols={"BaseVirtualMachine"},
+                new_symbols=set(),
+            ),
+        }
+
+        # The fixture used by the test does NOT call lookup_iface_status
+        fixtures_dict: dict[str, Fixture] = {
+            "some_unrelated_fixture": Fixture(
+                name="some_unrelated_fixture",
+                file_path=conftest_path,
+                function_calls={"other_function"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports=conftest_symbol_imports,
+            conftest_opaque_deps={},
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert not is_affected, (
+            f"Test should NOT be flagged via transitive path when no fixture calls "
+            f"the intermediate module's symbols, but got matching_deps={matching_deps}"
+        )
+        assert matching_deps == []
+
+    def test_transitive_with_fixture_match_flags_test(self, tmp_path: Path) -> None:
+        """When a fixture used by the test calls the intermediate module's symbols,
+        and the intermediate imports modified symbols from the changed file,
+        the test SHOULD be flagged.
+        """
+        repo_root = tmp_path
+
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        intermediate_path = tmp_path / "libs" / "net" / "vmspec.py"
+        intermediate_path.parent.mkdir(parents=True, exist_ok=True)
+        intermediate_path.write_text(
+            "from libs.vm.vm import BaseVirtualMachine\n",
+            encoding="utf-8",
+        )
+
+        changed_file = tmp_path / "libs" / "vm" / "vm.py"
+        changed_file.parent.mkdir(parents=True, exist_ok=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_upgrade.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_upgrade_network",
+            node_id="tests/test_upgrade.py::test_upgrade_network",
+            dependencies={conftest_path, intermediate_path, changed_file},
+            fixtures={"running_vm_upgrade_a"},
+            symbol_imports={},
+        )
+
+        conftest_symbol_imports: dict[Path, dict[Path, set[str]]] = {
+            conftest_path: {intermediate_path: {"lookup_iface_status"}},
+        }
+
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: SymbolClassification(
+                modified_symbols={"BaseVirtualMachine"},
+                new_symbols=set(),
+            ),
+        }
+
+        # This fixture DOES call lookup_iface_status AND the test uses it
+        fixtures_dict: dict[str, Fixture] = {
+            "running_vm_upgrade_a": Fixture(
+                name="running_vm_upgrade_a",
+                file_path=conftest_path,
+                function_calls={"lookup_iface_status", "other_call"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports=conftest_symbol_imports,
+            conftest_opaque_deps={},
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert is_affected, "Test SHOULD be flagged when fixture uses transitive dependency"
+        assert len(matching_deps) == 1
+        assert "lookup_iface_status" in matching_deps[0]
+
+    def test_transitive_no_overlapping_symbols_does_not_flag(self, tmp_path: Path) -> None:
+        """When the intermediate imports from the changed file but none of the
+        modified symbols overlap, the test should NOT be flagged.
+        """
+        repo_root = tmp_path
+
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        intermediate_path = tmp_path / "libs" / "net" / "vmspec.py"
+        intermediate_path.parent.mkdir(parents=True, exist_ok=True)
+        # Intermediate imports BaseVirtualMachine but only container_image was modified
+        intermediate_path.write_text(
+            "from libs.vm.vm import BaseVirtualMachine\n",
+            encoding="utf-8",
+        )
+
+        changed_file = tmp_path / "libs" / "vm" / "vm.py"
+        changed_file.parent.mkdir(parents=True, exist_ok=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_smoke.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_smoke_basic",
+            node_id="tests/test_smoke.py::test_smoke_basic",
+            dependencies={conftest_path, intermediate_path, changed_file},
+            fixtures={"running_vm_upgrade_a"},
+            symbol_imports={},
+        )
+
+        conftest_symbol_imports: dict[Path, dict[Path, set[str]]] = {
+            conftest_path: {intermediate_path: {"lookup_iface_status"}},
+        }
+
+        # Only container_image was modified, NOT BaseVirtualMachine
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: SymbolClassification(
+                modified_symbols={"container_image"},
+                new_symbols=set(),
+            ),
+        }
+
+        fixtures_dict: dict[str, Fixture] = {
+            "running_vm_upgrade_a": Fixture(
+                name="running_vm_upgrade_a",
+                file_path=conftest_path,
+                function_calls={"lookup_iface_status"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports=conftest_symbol_imports,
+            conftest_opaque_deps={},
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert not is_affected, (
+            f"Test should NOT be flagged when modified symbols don't overlap with "
+            f"intermediate imports, but got matching_deps={matching_deps}"
+        )

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from scripts.tests_analyzer.pytest_marker_analyzer import (
     AttributeAccessCollector,
     Fixture,
+    ImportVisitor,
     MarkedTest,
     SymbolClassification,
     _build_intra_class_call_graph,
@@ -1687,3 +1688,107 @@ class TestRenamedFileHandling:
 
         assert modified_fixtures == set(), "Renamed conftest should not flag any fixtures"
         assert modified_functions == set(), "Renamed conftest should not flag any functions"
+
+
+class TestImportVisitorTypeChecking:
+    """Tests for TYPE_CHECKING-guarded import exclusion."""
+
+    def test_regular_imports_collected(self):
+        source = textwrap.dedent("""\
+            from libs.vm.vm import BaseVirtualMachine
+            from libs.net.ip import get_ip
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "libs.vm.vm" in visitor.imports
+        assert "libs.net.ip" in visitor.imports
+
+    def test_type_checking_imports_skipped(self):
+        source = textwrap.dedent("""\
+            from typing import TYPE_CHECKING
+
+            from libs.net.ip import get_ip
+
+            if TYPE_CHECKING:
+                from libs.vm.vm import BaseVirtualMachine
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "libs.net.ip" in visitor.imports
+        assert "libs.vm.vm" not in visitor.imports
+        assert "libs.vm.vm.BaseVirtualMachine" not in visitor.imports
+
+    def test_typing_dot_type_checking_skipped(self):
+        source = textwrap.dedent("""\
+            import typing
+
+            from libs.net.ip import get_ip
+
+            if typing.TYPE_CHECKING:
+                from libs.vm.vm import BaseVirtualMachine
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "libs.net.ip" in visitor.imports
+        assert "libs.vm.vm" not in visitor.imports
+
+    def test_type_checking_does_not_affect_symbol_imports(self):
+        source = textwrap.dedent("""\
+            from typing import TYPE_CHECKING
+            from libs.net.ip import get_ip
+
+            if TYPE_CHECKING:
+                from libs.vm.vm import BaseVirtualMachine
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "libs.net.ip" in visitor.symbol_imports
+        assert "libs.vm.vm" not in visitor.symbol_imports
+
+    def test_bare_import_inside_type_checking_skipped(self):
+        source = textwrap.dedent("""\
+            from typing import TYPE_CHECKING
+
+            if TYPE_CHECKING:
+                import libs.vm.vm
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "libs.vm.vm" not in visitor.imports
+        assert "libs.vm.vm" not in visitor.opaque_imports
+
+    def test_else_branch_of_type_checking_collected(self):
+        source = textwrap.dedent("""\
+            from typing import TYPE_CHECKING
+
+            if TYPE_CHECKING:
+                from typing_extensions import Protocol
+            else:
+                from collections.abc import Protocol
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "typing_extensions" not in visitor.imports
+        assert "collections.abc" in visitor.imports
+
+    def test_elif_after_type_checking_collected(self):
+        source = textwrap.dedent("""\
+            from typing import TYPE_CHECKING
+            import sys
+
+            if TYPE_CHECKING:
+                from libs.vm.vm import BaseVirtualMachine
+            elif sys.version_info >= (3, 11):
+                from libs.fallback import FallbackVM
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "libs.vm.vm" not in visitor.imports
+        assert "libs.fallback" in visitor.imports

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -1854,6 +1854,21 @@ class TestImportVisitorTypeChecking:
         assert "libs.vm.vm" not in visitor.imports
         assert "libs.fallback" in visitor.imports
 
+    def test_non_typing_type_checking_not_skipped(self):
+        source = textwrap.dedent("""\
+            import settings
+
+            from libs.net.ip import get_ip
+
+            if settings.TYPE_CHECKING:
+                from libs.vm.vm import BaseVirtualMachine
+        """)
+        tree = ast.parse(source)
+        visitor = ImportVisitor()
+        visitor.visit(node=tree)
+        assert "libs.net.ip" in visitor.imports
+        assert "libs.vm.vm" in visitor.imports
+
 
 class TestCheckConftestPathwayTransitive:
     """Transitive conftest narrowing: conftest -> intermediate -> changed_file."""
@@ -2134,3 +2149,82 @@ class TestCheckConftestPathwayTransitive:
             f"calls the intermediate module's symbols, but got matching_deps={matching_deps}"
         )
         assert matching_deps == []
+
+    def test_transitive_fixture_chain_flags_test(self, tmp_path: Path) -> None:
+        """When fixture_a depends on fixture_b and fixture_b calls the
+        intermediate module's symbols, the test should be flagged even though
+        the test only directly uses fixture_a.
+        """
+        repo_root = tmp_path
+
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        intermediate_path = tmp_path / "libs" / "net" / "vmspec.py"
+        intermediate_path.parent.mkdir(parents=True, exist_ok=True)
+        intermediate_path.write_text(
+            "from libs.vm.vm import BaseVirtualMachine\n",
+            encoding="utf-8",
+        )
+
+        changed_file = tmp_path / "libs" / "vm" / "vm.py"
+        changed_file.parent.mkdir(parents=True, exist_ok=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_upgrade.py"
+        test_file.touch()
+
+        # Test only directly uses fixture_a, but fixture_a depends on fixture_b
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_upgrade_vm",
+            node_id="tests/test_upgrade.py::test_upgrade_vm",
+            dependencies={conftest_path, intermediate_path, changed_file},
+            fixtures={"fixture_a"},
+            symbol_imports={},
+        )
+
+        conftest_symbol_imports: dict[Path, dict[Path, set[str]]] = {
+            conftest_path: {intermediate_path: {"lookup_iface_status"}},
+        }
+
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: SymbolClassification(
+                modified_symbols={"BaseVirtualMachine"},
+                new_symbols=set(),
+            ),
+        }
+
+        # fixture_a depends on fixture_b, fixture_b calls lookup_iface_status
+        fixtures_dict: dict[str, Fixture] = {
+            "fixture_a": Fixture(
+                name="fixture_a",
+                file_path=conftest_path,
+                function_calls={"some_setup"},
+                fixture_deps={"fixture_b"},
+            ),
+            "fixture_b": Fixture(
+                name="fixture_b",
+                file_path=conftest_path,
+                function_calls={"lookup_iface_status"},
+                fixture_deps=set(),
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports=conftest_symbol_imports,
+            conftest_opaque_deps={},
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert is_affected, (
+            "Test SHOULD be flagged when fixture_b (transitively used via fixture_a) "
+            "calls the intermediate module's symbols"
+        )
+        assert len(matching_deps) == 1
+        assert "lookup_iface_status" in matching_deps[0]

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -2006,3 +2006,70 @@ class TestCheckConftestPathwayTransitive:
             f"Test should NOT be flagged when modified symbols don't overlap with "
             f"intermediate imports, but got matching_deps={matching_deps}"
         )
+
+    def test_transitive_diff_unavailable_no_fixture_match_does_not_flag(self, tmp_path: Path) -> None:
+        """When the diff for the changed file is unavailable but no fixture used
+        by the test calls the intermediate module's symbols, the test should NOT
+        be flagged. Fixture narrowing should still apply even without diff info.
+        """
+        repo_root = tmp_path
+
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        intermediate_path = tmp_path / "libs" / "net" / "vmspec.py"
+        intermediate_path.parent.mkdir(parents=True, exist_ok=True)
+        intermediate_path.write_text(
+            "from libs.vm.vm import BaseVirtualMachine\n",
+            encoding="utf-8",
+        )
+
+        changed_file = tmp_path / "libs" / "vm" / "vm.py"
+        changed_file.parent.mkdir(parents=True, exist_ok=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_smoke.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_smoke_basic",
+            node_id="tests/test_smoke.py::test_smoke_basic",
+            dependencies={conftest_path, intermediate_path, changed_file},
+            fixtures={"some_unrelated_fixture"},
+            symbol_imports={},
+        )
+
+        conftest_symbol_imports: dict[Path, dict[Path, set[str]]] = {
+            conftest_path: {intermediate_path: {"lookup_iface_status"}},
+        }
+
+        # Diff unavailable — classification is None
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: None,
+        }
+
+        fixtures_dict: dict[str, Fixture] = {
+            "some_unrelated_fixture": Fixture(
+                name="some_unrelated_fixture",
+                file_path=conftest_path,
+                function_calls={"other_function"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports=conftest_symbol_imports,
+            conftest_opaque_deps={},
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert not is_affected, (
+            f"Test should NOT be flagged even with diff unavailable when no fixture "
+            f"calls the intermediate module's symbols, but got matching_deps={matching_deps}"
+        )
+        assert matching_deps == []

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -1623,6 +1623,67 @@ class TestCheckConftestPathwayNoFixtureMatch:
             f"Should reference network_fixture, got {matching_deps}"
         )
 
+    def test_diff_unavailable_no_fixture_match_does_not_flag(self, tmp_path: Path) -> None:
+        """When the diff for the changed file is unavailable but no fixture used
+        by the test calls the imported symbols, the test should NOT be flagged.
+        Fixture narrowing should apply even without diff info.
+        """
+        repo_root = tmp_path
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        changed_file = tmp_path / "utilities" / "storage.py"
+        changed_file.parent.mkdir(parents=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_csv.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_csv_properties",
+            node_id="tests/test_csv.py::test_csv_properties",
+            dependencies={conftest_path},
+            fixtures={"csv_scope_session"},
+            symbol_imports={},
+        )
+
+        # Conftest imports wait_for_default_sc from the changed file
+        conftest_symbol_imports: dict[Path, dict[Path, set[str]]] = {
+            conftest_path: {changed_file: {"wait_for_default_sc_in_cdiconfig"}},
+        }
+
+        # Diff unavailable — classification is None
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: None,
+        }
+
+        # The fixture used by the test does NOT call wait_for_default_sc_in_cdiconfig
+        fixtures_dict: dict[str, Fixture] = {
+            "csv_scope_session": Fixture(
+                name="csv_scope_session",
+                file_path=conftest_path,
+                function_calls={"get_csv", "other_function"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports=conftest_symbol_imports,
+            conftest_opaque_deps={},
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert not is_affected, (
+            f"Test should NOT be flagged when diff is unavailable and no fixture "
+            f"calls the imported symbols, but got matching_deps={matching_deps}"
+        )
+        assert matching_deps == []
+
 
 class TestRenamedFileHandling:
     """Tests that renamed files with no content changes do not flag tests as affected.


### PR DESCRIPTION
## Summary

- Skip `TYPE_CHECKING`-guarded imports in `ImportVisitor` — these are never executed at runtime and should not create test dependencies
- Add transitive conftest narrowing — when a changed file is reached through conftest → intermediate → changed_file, apply fixture-level narrowing instead of conservative fallback
- Apply fixture narrowing even when diff is unavailable — the test's fixture usage can still determine if it's affected
- Include root `conftest.py` in fixture graph — `_find_conftest_files` only searched under `tests/`, missing root-level conftest

## Validation

Compared analyzer results against CodeRabbit's smoke test recommendations across 39 merged PRs. Agreement rate ~90% (accounting for cases where CodeRabbit was wrong).

## Test plan

- [ ] `uv run pytest scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py` — 98 tests covering all new behavior
- [ ] `pre-commit run --all-files`
- [ ] Verify on known false-positive PR: `uv run pytest-marker-analyzer --markers smoke --repo RedHatQE/openshift-virtualization-tests --pr 4299 --output json` returns `should_run_tests: false`

Closes #4381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved test-impact analysis with transitive conftest pathway resolution and broader conftest discovery (including repo-root).
  * CLI: checkout enabled by default; add --no-checkout to disable it.
  * Ignore type-checking guarded imports when detecting dependencies to reduce false positives.

* **Tests**
  * Added tests for type-checking import handling, transitive conftest narrowing, and fixture dependency chaining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->