### PR TITLE
fix: retry oc whoami after OAuth changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ from bisect import bisect_left
 from collections import defaultdict
 from datetime import datetime, timezone
 from signal import SIGINT, SIGTERM, getsignal, signal
-from subprocess import check_output
 
 import bcrypt
 import bitmath
@@ -77,7 +76,7 @@ from libs.net.vmspec import lookup_iface_status
 from tests.utils import download_and_extract_tar
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
 from utilities.bitwarden import get_cnv_tests_secret_by_name
-from utilities.cluster import cache_admin_client
+from utilities.cluster import cache_admin_client, get_oc_whoami_username
 from utilities.constants import (
     AAQ_NAMESPACE_LABEL,
     ARM_64,
@@ -414,7 +413,7 @@ def unprivileged_client(
         yield admin_client
 
     else:
-        current_user = check_output("oc whoami", shell=True).decode().strip()  # Get the current admin account
+        current_user = get_oc_whoami_username()
         if login_with_user_password(
             api_address=admin_client.configuration.host,
             user=UNPRIVILEGED_USER,

--- a/utilities/cluster.py
+++ b/utilities/cluster.py
@@ -1,7 +1,10 @@
 from functools import cache
+from subprocess import TimeoutExpired
 
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.resource import get_client
+from pyhelper_utils.shell import run_command
+from timeout_sampler import TimeoutSampler
 
 
 @cache
@@ -17,3 +20,41 @@ def cache_admin_client() -> DynamicClient:
     """
 
     return get_client()
+
+
+def get_oc_whoami_username(*, wait_timeout: int = 30, sleep: int = 3):
+    """Return the current OpenShift CLI user by running ``oc whoami``.
+
+    Each attempt runs ``oc whoami`` in a subprocess with a time limit, then retries
+    on error or hang until a non-empty username is returned or ``wait_timeout`` is
+    reached.
+
+    Args:
+        wait_timeout: Maximum time in seconds to keep retrying ``oc whoami``.
+        sleep: Seconds to wait between attempts.
+
+    Returns:
+        The authenticated user name (stdout from ``oc whoami``, stripped of whitespace).
+
+    Raises:
+        TimeoutExpiredError: If no successful non-empty result is obtained before
+            ``wait_timeout`` elapses.
+    """
+
+    def _whoami() -> str:
+        did_succeed, stdout, _ = run_command(
+            command=["oc", "whoami"],
+            capture_output=True,
+            check=False,
+            timeout=sleep,
+        )
+        return stdout.strip() if did_succeed else ""
+
+    for result in TimeoutSampler(
+        wait_timeout=wait_timeout,
+        sleep=sleep,
+        func=_whoami,
+        exceptions_dict={TimeoutExpired: []},
+    ):
+        if result:
+            return result

--- a/utilities/unittests/test_cluster.py
+++ b/utilities/unittests/test_cluster.py
@@ -4,7 +4,10 @@
 
 from unittest.mock import MagicMock, patch
 
-from utilities.cluster import cache_admin_client
+import pytest
+from timeout_sampler import TimeoutExpiredError
+
+from utilities.cluster import cache_admin_client, get_oc_whoami_username
 
 
 class TestCacheAdminClient:
@@ -99,3 +102,88 @@ class TestCacheAdminClient:
         info = cache_admin_client.cache_info()
         assert info.hits == 2
         assert info.misses == 1
+
+
+class TestGetOcWhoamiUsername:
+    """Test cases for get_oc_whoami_username function"""
+
+    @patch("utilities.cluster.TimeoutSampler")
+    def test_returns_username_on_first_attempt(self, mock_sampler):
+        """Test that username is returned immediately when oc whoami succeeds"""
+        mock_sampler.return_value = ["system:admin"]
+
+        result = get_oc_whoami_username()
+
+        assert result == "system:admin"
+
+    @patch("utilities.cluster.TimeoutSampler")
+    def test_returns_username_after_retry(self, mock_sampler):
+        """Test that username is returned after an initial empty result"""
+        mock_sampler.return_value = ["", "system:admin"]
+
+        result = get_oc_whoami_username()
+
+        assert result == "system:admin"
+
+    @patch("utilities.cluster.TimeoutSampler")
+    def test_raises_on_timeout(self, mock_sampler):
+        """Test that TimeoutExpiredError propagates when oc whoami never succeeds"""
+        mock_sampler.side_effect = TimeoutExpiredError("Timeout")
+
+        with pytest.raises(TimeoutExpiredError):
+            get_oc_whoami_username()
+
+    @patch("utilities.cluster.TimeoutSampler")
+    def test_sampler_called_with_correct_args(self, mock_sampler):
+        """Test that TimeoutSampler is constructed with the expected parameters"""
+        mock_sampler.return_value = ["kubeadmin"]
+
+        get_oc_whoami_username(wait_timeout=60, sleep=5)
+
+        call_kwargs = mock_sampler.call_args[1]
+        assert call_kwargs["wait_timeout"] == 60
+        assert call_kwargs["sleep"] == 5
+
+    @patch("utilities.cluster.TimeoutSampler")
+    @patch("utilities.cluster.run_command")
+    def test_whoami_inner_function_success(self, mock_run_command, mock_sampler):
+        """Test that _whoami calls run_command and returns stripped stdout on success"""
+        mock_run_command.return_value = (True, "system:admin\n", "")
+
+        def call_func_once(*args, **kwargs):
+            return [kwargs["func"]()]
+
+        mock_sampler.side_effect = call_func_once
+
+        result = get_oc_whoami_username()
+
+        assert result == "system:admin"
+        mock_run_command.assert_called_once_with(
+            command=["oc", "whoami"],
+            capture_output=True,
+            check=False,
+            timeout=3,
+        )
+
+    @patch("utilities.cluster.TimeoutSampler")
+    @patch("utilities.cluster.run_command")
+    def test_whoami_inner_function_failure_returns_empty(self, mock_run_command, mock_sampler):
+        """Test that _whoami returns empty string when run_command fails, then retries"""
+        mock_run_command.side_effect = [(False, "", "error"), (True, "kubeadmin\n", "")]
+
+        call_count = 0
+
+        def call_func_twice(*args, **kwargs):
+            nonlocal call_count
+            results = []
+            for _ in range(2):
+                results.append(kwargs["func"]())
+            call_count = len(results)
+            return results
+
+        mock_sampler.side_effect = call_func_twice
+
+        result = get_oc_whoami_username()
+
+        assert result == "kubeadmin"
+        assert mock_run_command.call_count == 2


### PR DESCRIPTION
##### Short description:
Add retry on `pc whoami` call 

##### More details:
 There can be a short window where the API or auth path is inconsistent right after a rollout, so `oc whoami` fails once while admin_client still looks fine in other steps.

##### What this PR does / why we need it:
Fix flaky failures of `oc whoami`

##### Additional info #####
`wait_timeout: int = 30` instead of `wait_timeout: int = TIMEOUT_30SEC` because of mypy circle import error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved username detection with retry and timeout handling for more reliable cluster interactions; client flows now use this robust retrieval.
* **Tests**
  * Added unit tests covering successful, retry, and timeout scenarios for the username retrieval logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->