### PR TITLE
fix: add client to StorageProfile resource in virt.py

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1123,7 +1123,9 @@ class VirtualMachineForTests(VirtualMachine):
             else self.pvc.instance.spec.accessModes
             if self.pvc
             else self.data_volume_template["spec"][api_name].get("accessModes")
-            or StorageProfile(name=_sc_name_for_storage_api()).instance.status["claimPropertySets"][0]["accessModes"]
+            or StorageProfile(client=self.client, name=_sc_name_for_storage_api()).instance.status["claimPropertySets"][
+                0
+            ]["accessModes"]
         )
 
     @property


### PR DESCRIPTION
##### Short description:
add client to StorageProfile resource in virt.py

##### More details:
The StorageProfile class is created without a client, which is a must field from the next openshift-wrapper release. 

##### What this PR does / why we need it:
Fix deprecation warning showing

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-68519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced storage configuration handling to properly resolve access modes in fallback scenarios, improving reliability of storage profile initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->