### PR TITLE
Update machine type to pc-q35-rhel9.8.0

### DIFF
--- a/tests/virt/constants.py
+++ b/tests/virt/constants.py
@@ -43,7 +43,7 @@ class MachineTypesNames:
     pc_q35_rhel7_6 = f"{pc_q35}-rhel7.6.0"
     pc_q35_rhel8_1 = f"{pc_q35}-rhel8.1.0"
     pc_q35_rhel9_4 = f"{pc_q35}-rhel9.4.0"
-    pc_q35_rhel9_6 = f"{pc_q35}-rhel9.6.0"
+    pc_q35_rhel9_8 = f"{pc_q35}-rhel9.8.0"
     pc_q35_rhel7_4 = f"{pc_q35}-rhel7.4.0"
     pc_i440fx = "pc-i440fx"
     pc_i440fx_rhel7_6 = f"{pc_i440fx}-rhel7.6.0"

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -259,11 +259,11 @@ def test_major_release_machine_type(machine_type_from_kubevirt_config):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8561")
-def test_machine_type_as_rhel_9_6(machine_type_from_kubevirt_config):
-    """Verify that machine type in KubeVirt CR match the value pc-q35-rhel9.6.0"""
-    assert machine_type_from_kubevirt_config == MachineTypesNames.pc_q35_rhel9_6, (
+def test_machine_type_as_rhel_9_8(machine_type_from_kubevirt_config):
+    """Verify that machine type in KubeVirt CR match the value pc-q35-rhel9.8.0"""
+    assert machine_type_from_kubevirt_config == MachineTypesNames.pc_q35_rhel9_8, (
         f"Machine type value is {machine_type_from_kubevirt_config} "
-        f"does not match with {MachineTypesNames.pc_q35_rhel9_6}"
+        f"does not match with {MachineTypesNames.pc_q35_rhel9_8}"
     )
 
 


### PR DESCRIPTION
##### Short description:
Update machine type to pc-q35-rhel9.8.0
##### More details:

##### What this PR does / why we need it:
Kubevirt now uses pc-q35-rhel9.8.0 machine type
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated KubeVirt machine type compatibility tests for RHEL 9.8

* **Chores**
  * Updated machine type configuration constants, transitioning support from RHEL 9.6 to RHEL 9.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->