### PR TITLE
net, tests, stuntime: Add client migration stuntime scenario for OVN localnet

### DIFF
--- a/libs/vm/affinity.py
+++ b/libs/vm/affinity.py
@@ -6,6 +6,7 @@ from libs.vm.spec import (
     Affinity,
     LabelSelector,
     LabelSelectorRequirement,
+    PodAffinity,
     PodAffinityTerm,
     PodAntiAffinity,
 )
@@ -34,6 +35,39 @@ def new_pod_anti_affinity(label: tuple[str, str], namespaces: list[str] | None =
     (key, value) = label
     return Affinity(
         podAntiAffinity=PodAntiAffinity(
+            requiredDuringSchedulingIgnoredDuringExecution=[
+                PodAffinityTerm(
+                    labelSelector=LabelSelector(
+                        matchExpressions=[LabelSelectorRequirement(key=key, values=[value], operator="In")]
+                    ),
+                    topologyKey=f"{Resource.ApiGroup.KUBERNETES_IO}/hostname",
+                    namespaces=namespaces,
+                    namespaceSelector={} if namespaces is None else None,
+                )
+            ]
+        )
+    )
+
+
+def new_pod_affinity(label: tuple[str, str], namespaces: list[str] | None = None) -> Affinity:
+    """Create pod affinity to co-locate with pods matching the label.
+
+    Kubernetes behavior: Omitting both namespaceSelector and namespaces limits
+    affinity to pods in the same namespace. Setting namespaceSelector={} makes the
+    rule cross-namespace.
+
+    Args:
+        label: Tuple of (key, value) to match pods for co-location.
+        namespaces: Optional list of namespaces to search for matching pods.
+            If None, matches pods across all namespaces (cluster-wide).
+            If provided, limits matching to those specific namespaces.
+
+    Returns:
+        Affinity: Affinity object with podAffinity configured.
+    """
+    (key, value) = label
+    return Affinity(
+        podAffinity=PodAffinity(
             requiredDuringSchedulingIgnoredDuringExecution=[
                 PodAffinityTerm(
                     labelSelector=LabelSelector(

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -99,10 +99,16 @@ class Multus:
 @dataclass
 class Affinity:
     podAntiAffinity: PodAntiAffinity | None = None  # noqa: N815
+    podAffinity: PodAffinity | None = None  # noqa: N815
 
 
 @dataclass
 class PodAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution: list[PodAffinityTerm]  # noqa: N815
+
+
+@dataclass
+class PodAffinity:
     requiredDuringSchedulingIgnoredDuringExecution: list[PodAffinityTerm]  # noqa: N815
 
 

--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -12,6 +12,7 @@ from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
 from libs.vm.spec import (
+    Affinity,
     CloudInitNoCloud,
     ContainerDisk,
     Devices,
@@ -112,6 +113,20 @@ class BaseVirtualMachine(VirtualMachine):
         patches = {
             self: {"spec": {"template": {"metadata": {"annotations": self._spec.template.metadata.annotations}}}}
         }
+        ResourceEditor(patches=patches).update()
+
+    def set_template_affinity(self, affinity: Affinity | None) -> None:
+        """Replace the VM template affinity.
+
+        Serializes without dict_factory so that None-valued fields (e.g. podAffinity: None)
+        are preserved as null in the merge patch, ensuring the old affinity type is removed.
+
+        Args:
+            affinity: Affinity object to set, or None to clear.
+        """
+        self._spec.template.spec.affinity = affinity
+        template_affinity = asdict(obj=affinity) if affinity else None
+        patches = {self: {"spec": {"template": {"spec": {"affinity": template_affinity}}}}}
         ResourceEditor(patches=patches).update()
 
     @property

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -2,7 +2,8 @@ import contextlib
 import copy
 import logging
 import uuid
-from typing import Final, Generator
+from collections.abc import Generator
+from typing import Final
 
 from kubernetes.client import ApiException
 from kubernetes.dynamic import DynamicClient
@@ -80,6 +81,7 @@ def localnet_vm(
     interfaces: list[Interface],
     network_data: cloudinit.NetworkData | None = None,
     affinity: Affinity | None = None,
+    vm_labels: dict[str, str] | None = None,
 ) -> BaseVirtualMachine:
     """
     Create a Fedora-based Virtual Machine connected to localnet network(s).
@@ -100,6 +102,9 @@ def localnet_vm(
             configuration for the VM interfaces. If None, no network configuration is applied via cloud-init.
         affinity (Affinity | None): Optional Affinity object for VM scheduling. Controls the VM scheduling
             location. If None, no affinity constraints are applied.
+        vm_labels (dict[str, str] | None): Optional labels to apply to the VM template metadata.
+            These labels are set on the VMI pod and can be used for affinity/anti-affinity matching.
+            If None, no additional labels are applied beyond LOCALNET_TEST_LABEL.
 
     Returns:
         BaseVirtualMachine: The configured VM object ready for creation.
@@ -124,6 +129,8 @@ def localnet_vm(
     spec.template.metadata = spec.template.metadata or Metadata()
     spec.template.metadata.labels = spec.template.metadata.labels or {}
     spec.template.metadata.labels.update(LOCALNET_TEST_LABEL)
+    if vm_labels:
+        spec.template.metadata.labels.update(vm_labels)
 
     vmi_spec = spec.template.spec
     vmi_spec.networks = networks

--- a/tests/network/localnet/migration_stuntime/conftest.py
+++ b/tests/network/localnet/migration_stuntime/conftest.py
@@ -1,0 +1,115 @@
+import logging
+from collections.abc import Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.affinity import new_pod_affinity
+from libs.vm.spec import Interface, Multus, Network
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.libs import cloudinit
+from tests.network.libs import cluster_user_defined_network as libcudn
+from tests.network.localnet.liblocalnet import (
+    GUEST_1ST_IFACE_NAME,
+    LOCALNET_OVS_BRIDGE_INTERFACE,
+    ip_addresses_from_pool,
+    libnncp,
+    localnet_vm,
+)
+from tests.network.localnet.migration_stuntime.libstuntime import SERVER_VM_LABEL, ContinuousPing
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="class")
+def localnet_stuntime_server_vm(
+    unprivileged_client: DynamicClient,
+    nncp_localnet_on_secondary_node_nic: libnncp.NodeNetworkConfigurationPolicy,
+    cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
+    namespace_localnet_1: Namespace,
+    ipv4_localnet_address_pool: Generator[str],
+    ipv6_localnet_address_pool: Generator[str],
+) -> Generator[BaseVirtualMachine]:
+    with localnet_vm(
+        namespace=namespace_localnet_1.name,
+        name="localnet-stuntime-server",
+        client=unprivileged_client,
+        networks=[
+            Network(name=LOCALNET_OVS_BRIDGE_INTERFACE, multus=Multus(networkName=cudn_localnet_ovs_bridge.name))
+        ],
+        interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
+        network_data=cloudinit.NetworkData(
+            ethernets={
+                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                    addresses=ip_addresses_from_pool(
+                        ipv4_pool=ipv4_localnet_address_pool,
+                        ipv6_pool=ipv6_localnet_address_pool,
+                    )
+                )
+            }
+        ),
+        vm_labels=dict([SERVER_VM_LABEL]),
+    ) as server_vm:
+        server_vm.start(wait=True)
+        server_vm.wait_for_agent_connected()
+        yield server_vm
+
+
+@pytest.fixture(scope="class")
+def localnet_stuntime_client_vm(
+    unprivileged_client: DynamicClient,
+    cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
+    namespace_localnet_1: Namespace,
+    ipv4_localnet_address_pool: Generator[str],
+    ipv6_localnet_address_pool: Generator[str],
+    localnet_stuntime_server_vm: BaseVirtualMachine,
+) -> Generator[BaseVirtualMachine]:
+    with localnet_vm(
+        namespace=namespace_localnet_1.name,
+        name="localnet-stuntime-client",
+        client=unprivileged_client,
+        networks=[
+            Network(name=LOCALNET_OVS_BRIDGE_INTERFACE, multus=Multus(networkName=cudn_localnet_ovs_bridge.name))
+        ],
+        interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
+        network_data=cloudinit.NetworkData(
+            ethernets={
+                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                    addresses=ip_addresses_from_pool(
+                        ipv4_pool=ipv4_localnet_address_pool,
+                        ipv6_pool=ipv6_localnet_address_pool,
+                    )
+                )
+            }
+        ),
+        affinity=new_pod_affinity(label=SERVER_VM_LABEL),
+    ) as client_vm:
+        client_vm.start(wait=True)
+        client_vm.wait_for_agent_connected()
+        yield client_vm
+
+
+@pytest.fixture()
+def active_ping(
+    request: pytest.FixtureRequest,
+    localnet_stuntime_server_vm: BaseVirtualMachine,
+    localnet_stuntime_client_vm: BaseVirtualMachine,
+) -> Generator[ContinuousPing]:
+    """Continuous ping session from client to server for stuntime measurement.
+
+    Args (indirect via request.param):
+        ip_family: IP family version - 4 for IPv4, 6 for IPv6.
+    """
+    ip_family = request.param
+    server_ip = str(
+        lookup_iface_status_ip(
+            vm=localnet_stuntime_server_vm,
+            iface_name=LOCALNET_OVS_BRIDGE_INTERFACE,
+            ip_family=ip_family,
+        )
+    )
+
+    with ContinuousPing(source_vm=localnet_stuntime_client_vm, destination_ip=server_ip) as ping:
+        yield ping

--- a/tests/network/localnet/migration_stuntime/libstuntime.py
+++ b/tests/network/localnet/migration_stuntime/libstuntime.py
@@ -1,0 +1,127 @@
+"""Helpers for OVN localnet migration stuntime tests."""
+
+import ipaddress
+import logging
+import re
+from typing import Final, Self
+
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.libs.connectivity import build_ping_command
+
+LOGGER = logging.getLogger(__name__)
+
+SERVER_VM_LABEL: Final[tuple[str, str]] = ("stuntime.test", "server")
+STUNTIME_THRESHOLD_SECONDS: Final[float] = 5.0
+STUNTIME_PING_LOG_PATH: Final[str] = "/tmp/stuntime-ping.log"
+PING_INTERVAL_SECONDS: Final[float] = 0.1
+DEFAULT_COMMAND_TIMEOUT_SECONDS: Final[int] = 10
+
+
+class InsufficientStuntimeDataError(ValueError):
+    """Raised when ping log has too few successful replies to compute stuntime."""
+
+
+def compute_stuntime(lost_packets: int) -> float:
+    """Compute stuntime from lost packet count.
+
+    Args:
+        lost_packets: Number of packets lost during migration.
+
+    Returns:
+        Stuntime in seconds (connectivity gap).
+    """
+    # Add +1 to account for the gap from last successful reply before loss to first successful reply after recovery
+    stuntime = 0.0 if lost_packets == 0 else (lost_packets + 1) * PING_INTERVAL_SECONDS
+    LOGGER.info(f"Stuntime: {stuntime:.1f}s (from {lost_packets} lost packets)")
+    return stuntime
+
+
+class ContinuousPing:
+    """Context manager for continuous ping monitoring during VM operations.
+
+    Example:
+        >>> with ContinuousPing(source_vm=client_vm, destination_ip=server_ip) as ping:
+        ...     migrate_vm_and_verify(vm=client_vm)
+        ...     ping.stop()
+        ...     transmitted, received, lost = ping.report()
+    """
+
+    def __init__(self, source_vm: BaseVirtualMachine, destination_ip: str):
+        """Initialize continuous ping context manager.
+
+        Args:
+            source_vm: The virtual machine from which to initiate the continuous ping.
+            destination_ip: The target IP address (IPv4 or IPv6) to ping continuously.
+        """
+        self._vm = source_vm
+        self._destination_ip = destination_ip
+        self._cmd = self._build_ping_cmd()
+
+    def __enter__(self) -> Self:
+        self._verify_ping_reaches_destination()
+        self._vm.console(
+            commands=[f"{self._cmd} >{STUNTIME_PING_LOG_PATH} 2>&1 &"],
+            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        )
+        LOGGER.info(
+            f"Started continuous ping from {self._vm.name} to {self._destination_ip} (log {STUNTIME_PING_LOG_PATH})"
+        )
+        return self
+
+    def __exit__(
+        self, _exc_type: type[BaseException] | None, _exc_value: BaseException | None, _traceback: object
+    ) -> None:
+        self.stop()
+
+    def stop(self) -> None:
+        # Use SIGINT (not default SIGTERM) to ensure ping flushes statistics summary before exit
+        self._vm.console(
+            commands=[
+                f"pkill -SIGINT -f '{self._cmd}' || true; "
+                f"while pgrep -f '{self._cmd}' >/dev/null 2>&1; do sleep 0.1; done"
+            ],
+            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        )
+
+    def report(self) -> tuple[int, int, int]:
+        """Extract packet statistics from ping log.
+
+        Returns:
+            Tuple of (transmitted_packets, received_packets, lost_packets).
+
+        Raises:
+            InsufficientStuntimeDataError: When ping summary is missing.
+        """
+        cmd_tail = f"tail -n 3 {STUNTIME_PING_LOG_PATH}"
+        result = self._vm.console(commands=[cmd_tail], timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS)
+        ping_summary = "\n".join(result[cmd_tail])
+
+        summary_match = re.search(r"(\d+)\s+packets transmitted,\s+(\d+)\s+received", ping_summary)
+        if not summary_match:
+            raise InsufficientStuntimeDataError(f"Missing ping summary in log (got: {ping_summary})")
+
+        transmitted = int(summary_match.group(1))
+        received = int(summary_match.group(2))
+        lost = transmitted - received
+
+        LOGGER.info(f"Ping report: transmitted={transmitted}, received={received}, lost={lost}")
+        return transmitted, received, lost
+
+    def _build_ping_cmd(self) -> str:
+        """Build the continuous ping command with necessary flags.
+
+        Returns:
+            str: Continuous Ping command string ready to execute.
+        """
+        ip = ipaddress.ip_address(address=self._destination_ip)
+        ping_ipv6_flag = " -6" if ip.version == 6 else ""
+        return f"ping{ping_ipv6_flag} -O -i {PING_INTERVAL_SECONDS} {self._destination_ip}"
+
+    def _verify_ping_reaches_destination(self) -> None:
+        """Verify network connectivity from source VM to destination IP."""
+        self._vm.console(
+            commands=[
+                build_ping_command(dst_ip=self._destination_ip, count=3, timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS)
+            ],
+            timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS + 5,
+        )

--- a/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
@@ -6,8 +6,7 @@ secondary network, for both IPv4 and IPv6, for regression detection.
 Stuntime is defined as the connectivity gap from last successful reply before loss
 to first successful reply after recovery.
 
-Stuntime is measured using ICMP ping from client to server in 0.1s intervals, using ping -D so each
-log line includes a timestamp for gap calculation.
+Stuntime is measured using ICMP ping from client to server in 0.1s intervals.
 The under-test VMs are configured on an OVN localnet secondary network, with a single interface,
 on which IPv4/IPv6 static addresses will be defined according to the environment the test runs on.
 
@@ -20,14 +19,17 @@ https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
 
 import pytest
 
-__test__ = False
+from libs.vm.affinity import new_pod_anti_affinity
+from tests.network.localnet.migration_stuntime.libstuntime import (
+    SERVER_VM_LABEL,
+    STUNTIME_THRESHOLD_SECONDS,
+    compute_stuntime,
+)
+from utilities.virt import migrate_vm_and_verify
+
+pytestmark = [pytest.mark.tier3]
 
 """
-Parametrize:
-    - ip_family:
-        - ipv4 [Markers: ipv4]
-        - ipv6 [Markers: ipv6]
-
 Preconditions:
     - Shared under-test server VM on OVN localnet secondary network, for the IP family from ip_family parametrization.
     - Shared under-test client VM on OVN localnet secondary network, for that same IP family,
@@ -37,11 +39,28 @@ Preconditions:
 
 @pytest.mark.incremental
 class TestMigrationStuntime:
-    @pytest.mark.polarion("CNV-15258")
-    def test_client_migrates_off_server_node(self):
+    @pytest.mark.parametrize(
+        "active_ping",
+        [
+            pytest.param(4, id="ipv4", marks=[pytest.mark.polarion("CNV-15258"), pytest.mark.ipv4]),
+            pytest.param(6, id="ipv6", marks=[pytest.mark.polarion("CNV-15272"), pytest.mark.ipv6]),
+        ],
+        indirect=True,
+    )
+    def test_client_migrates_off_server_node(
+        self,
+        admin_client,
+        localnet_stuntime_client_vm,
+        active_ping,
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the client
         VM migrates from the node hosting the server VM into a different node.
+
+        Parametrize:
+            - active_ping:
+                - ipv4 [Markers: ipv4]
+                - ipv6 [Markers: ipv6]
 
         Preconditions:
             - Under-test server VM on OVN localnet secondary network, for the IP family from ip_family parametrization.
@@ -58,6 +77,14 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        localnet_stuntime_client_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=SERVER_VM_LABEL))
+        migrate_vm_and_verify(vm=localnet_stuntime_client_vm, client=admin_client)
+        active_ping.stop()
+        _, _, lost = active_ping.report()
+        measured_stuntime = compute_stuntime(lost_packets=lost)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15259")
     def test_client_migrates_between_non_server_nodes(self):
@@ -168,3 +195,9 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+
+    test_client_migrates_between_non_server_nodes.__test__ = False
+    test_client_migrates_to_server_node.__test__ = False
+    test_server_migrates_off_client_node.__test__ = False
+    test_server_migrates_between_non_client_nodes.__test__ = False
+    test_server_migrates_to_client_node.__test__ = False


### PR DESCRIPTION
##### Short description:
Implements the first stuntime (connectivity gap during VM live migration) scenario for OVN localnet migration to establish a baseline for performance and regression detection.                                                                                                                     
    
##### More details:
- Add podAffinity support to enable VM co-location for stuntime tests (client VM starts on the same node as server, then migrates off).
- Add `set_template_affinity()` method to dynamically set VM affinity after creation. This function intentionally skips dict_factory: JSON merge patch requires null fields to be explicitly present in the patch to remove the old affinity type (e.g. podAffinity: null), otherwise merge patch merges into the existing affinity and leaves both types set.

##### What this PR does / why we need it: 
Establish a performance baseline and enable regression detection for OVN localnet live migration connectivity gaps (stuntime).  

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
 - For now, the global stuntime threshold is set to a 5s placeholder. Once we finish automating the remaining scenarios and have the baseline data to calibrate our expectations, we’ll replace this with a more precise, data-driven value.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-84379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node selector configuration to constrain VM scheduling
  * Optional pod anti-affinity toggle when provisioning VMs
  * Continuous ping-based stuntime measurement tool for migration monitoring

* **Tests**
  * New stuntime migration test suite with fixtures to run continuous ping, compute stuntime, and validate migration impact
  * Enabled targeted migration test that verifies client migration stuntime (IPv4/IPv6)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->