### PR TITLE
docs: add missing PYTEST_JIRA_USERNAME to Jira integration section

### DIFF
--- a/docs/RUNNING_TESTS.md
+++ b/docs/RUNNING_TESTS.md
@@ -180,6 +180,7 @@ To use jira plugin, you need to set the following environment variables:
 ```bash
 export PYTEST_JIRA_URL=<url>
 export PYTEST_JIRA_TOKEN=<your_token>
+export PYTEST_JIRA_USERNAME=<email>    # email associated with the Jira account
 ```
 
 ## Additional options


### PR DESCRIPTION
## Summary

Add the missing `PYTEST_JIRA_USERNAME` environment variable to the Jira integration section in `docs/RUNNING_TESTS.md`.

The `utilities/jira.py` module requires all three environment variables (`PYTEST_JIRA_URL`, `PYTEST_JIRA_TOKEN`, and `PYTEST_JIRA_USERNAME`) but the documentation only listed two.

Assisted-by: Claude <noreply@anthropic.com>