### PR TITLE
CherryPicked: [cnv-4.18] [IUO]fix: Catch NotFoundError when pods are deleted during iteration

### DIFF
--- a/tests/install_upgrade_operators/node_component/utils.py
+++ b/tests/install_upgrade_operators/node_component/utils.py
@@ -1,8 +1,7 @@
 import logging
 from collections import defaultdict
 
-from kubernetes.client.rest import ApiException
-from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
+from kubernetes.dynamic.exceptions import NotFoundError
 from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -354,11 +353,8 @@ def get_pod_per_nodes(admin_client, hco_namespace, filter_pods_by_name=None):
                 # to filter out terminating pods, see: https://github.com/kubernetes/kubectl/issues/450
                 if pod.instance.metadata.get("deletionTimestamp") is None:
                     pods_per_nodes[pod.node.name].append(pod)
-            except ApiException as ex:
-                if ex.reason == ResourceNotFoundError:
-                    LOGGER.debug(
-                        f"Ignoring pods that disappeared during the query. node={pod.node.name} pod={pod.name}"
-                    )
+            except NotFoundError:
+                LOGGER.warning(f"Ignoring pods that disappeared during the query. node={pod.node.name} pod={pod.name}")
         return pods_per_nodes
 
     pod_names_per_nodes = {}


### PR DESCRIPTION
4.21 cherry pick (#4376)

Cherry pick of (#3676)
Same problematic code in 4.20, 4.19, 4.18 too

Replace invalid exception handling that attempted to compare ex.reason (string) with ResourceNotFoundError (exception class), causing TypeError.

When pod.instance.metadata is accessed for a deleted pod, the kubernetes dynamic client raises NotFoundError (which inherits from ApiException). The original code had invalid syntax trying to compare the HTTP reason string with an exception class.

Changed from:
  except ApiException as ex:
      if ex.reason == ResourceNotFoundError:

To:
  except NotFoundError:

This correctly catches the NotFoundError when a pod is deleted during iteration and gracefully ignores it, following the established pattern in the codebase (tests/infrastructure/conftest.py).

Also removed unused imports: ApiException and ResourceNotFoundError. Fixes test failures:
- test_change_subscription_on_selected_node_before_workload - test_infrastructure_components_selection_change_allowed_after_workloads -
N/A
N/A
https://redhat.atlassian.net/browse/CNV-83861

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
