### PR TITLE
[IUO] Apply new Lazy IDMS strategy for upgrade and install lanes

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import pkgutil
+import re
 
 import pytest
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
@@ -29,16 +30,42 @@ from utilities.infra import (
     get_daemonset_by_name,
     get_deployment_by_name,
     get_pod_by_name_prefix,
+    wait_for_version_explorer_response,
 )
 from utilities.jira import is_jira_open
 from utilities.operator import (
     disable_default_sources_in_operatorhub,
     get_machine_config_pools_conditions,
 )
+from utilities.pytest_utils import exit_pytest_execution
 from utilities.storage import get_hyperconverged_cdi
 from utilities.virt import get_hyperconverged_kubevirt
 
 LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def iib_build_info(cnv_source, cnv_image_url, admin_client):
+    """Queries Version Explorer for IIB build info.
+
+    Returns:
+        Build info dict for osbs/fbc sources, empty dict for other sources.
+    """
+    if cnv_source in ("osbs", "fbc"):
+        iib_format_match = re.search(r"/iib:(\d+)$", cnv_image_url)
+        assert iib_format_match, f"Cannot extract IIB number from: {cnv_image_url} (expected format: .../iib:<number>)"
+        iib_number = iib_format_match.group(1)
+
+        if build_info := wait_for_version_explorer_response(
+            api_end_point="GetBuildByIIB",
+            query_string=f"iib_number={iib_number}",
+        ):
+            return build_info
+        exit_pytest_execution(
+            admin_client=admin_client,
+            log_message=f"Version Explorer returned empty response for IIB {iib_number}.",
+        )
+    return {}
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -57,3 +57,9 @@ HCO_DEFAULT_FEATUREGATES = {
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"
 KUBEMACPOOL_SERVICE = "kubemacpool-service"
+
+KONFLUX_IDMS_NAME = "zz-cnv-icsp-fallback"
+KONFLUX_MIRROR_BASE_URL = "quay.io/openshift-virtualization/konflux-builds"
+RH_IDMS_SOURCE = "registry.redhat.io/container-native-virtualization"
+KONFLUX_PIPELINE = "Konflux"
+BREW_MIRROR_BASE_URL = "brew.registry.redhat.io/container-native-virtualization"

--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -13,14 +13,15 @@ from packaging.version import Version
 from pytest_testconfig import py_config
 from timeout_sampler import TimeoutSampler
 
+from tests.install_upgrade_operators.constants import (
+    KONFLUX_IDMS_NAME,
+    KONFLUX_MIRROR_BASE_URL,
+)
 from tests.install_upgrade_operators.product_install.constants import (
     HCO_NOT_INSTALLED_ALERT,
 )
 from tests.install_upgrade_operators.utils import (
-    KONFLUX_IDMS_NAME,
-    KONFLUX_MIRROR_BASE_URL,
     apply_konflux_idms,
-    idms_has_all_mirrors,
 )
 from utilities.constants import (
     CRITICAL_STR,
@@ -80,10 +81,6 @@ def installed_konflux_idms(
     required_mirrors = [f"{KONFLUX_MIRROR_BASE_URL}/v{version.major}-{version.minor}"]
 
     idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
-    if idms.exists and idms_has_all_mirrors(idms=idms, required_mirrors=required_mirrors):
-        LOGGER.info(f"IDMS {KONFLUX_IDMS_NAME} already contains required mirrors.")
-        return
-
     apply_konflux_idms(
         idms=idms,
         required_mirrors=required_mirrors,

--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -5,23 +5,14 @@ import pytest
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.hostpath_provisioner import HostPathProvisioner
 from ocp_resources.hyperconverged import HyperConverged
-from ocp_resources.image_digest_mirror_set import ImageDigestMirrorSet
 from ocp_resources.installplan import InstallPlan
 from ocp_resources.persistent_volume import PersistentVolume
 from ocp_resources.storage_class import StorageClass
-from packaging.version import Version
 from pytest_testconfig import py_config
 from timeout_sampler import TimeoutSampler
 
-from tests.install_upgrade_operators.constants import (
-    KONFLUX_IDMS_NAME,
-    KONFLUX_MIRROR_BASE_URL,
-)
 from tests.install_upgrade_operators.product_install.constants import (
     HCO_NOT_INSTALLED_ALERT,
-)
-from tests.install_upgrade_operators.utils import (
-    apply_konflux_idms,
 )
 from utilities.constants import (
     CRITICAL_STR,
@@ -62,32 +53,6 @@ from utilities.storage import (
 INSTALLATION_VERSION_MISMATCH = "98"
 LOCAL_BLOCK_HPP = "local-block-hpp"
 LOGGER = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="module")
-def installed_konflux_idms(
-    admin_client,
-    is_production_source,
-    cnv_version_to_install_info,
-    nodes,
-    machine_config_pools,
-    machine_config_pools_conditions_scope_module,
-):
-    if is_production_source:
-        LOGGER.info("Production source install, IDMS update not needed.")
-        return
-
-    version = Version(version=cnv_version_to_install_info["version"])
-    required_mirrors = [f"{KONFLUX_MIRROR_BASE_URL}/v{version.major}-{version.minor}"]
-
-    idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
-    apply_konflux_idms(
-        idms=idms,
-        required_mirrors=required_mirrors,
-        machine_config_pools=machine_config_pools,
-        mcp_conditions=machine_config_pools_conditions_scope_module,
-        nodes=nodes,
-    )
 
 
 @pytest.fixture(scope="module")
@@ -181,7 +146,6 @@ def cnv_install_plan_installed(
 def installed_openshift_virtualization(
     admin_client,
     disabled_default_sources_in_operatorhub_scope_module,
-    installed_konflux_idms,
     hyperconverged_catalog_source,
     created_cnv_namespace,
     created_cnv_operator_group,

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -425,7 +425,7 @@ def eus_updated_konflux_idms(
     idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
     apply_konflux_idms(
         idms=idms,
-        required_mirrors=required_mirrors,
+        required_mirrors=required_mirrors if idms.exists else required_mirrors + [BREW_MIRROR_BASE_URL],
         machine_config_pools=machine_config_pools,
         mcp_conditions=machine_config_pools_conditions_scope_module,
         nodes=nodes,

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 
 import pytest
 from ocp_resources.cluster_version import ClusterVersion
@@ -56,7 +55,6 @@ from utilities.infra import (
     get_prometheus_k8s_token,
     get_related_images_name_and_version,
     get_subscription,
-    wait_for_version_explorer_response,
 )
 from utilities.operator import (
     get_machine_config_pool_by_name,
@@ -71,30 +69,6 @@ from utilities.virt import get_oc_image_info
 LOGGER = logging.getLogger(__name__)
 POD_STR_NOT_MANAGED_BY_HCO = "hostpath-"
 EUS_ERROR_CODE = 98
-
-
-@pytest.fixture(scope="session")
-def iib_build_info(cnv_source, cnv_image_url, admin_client):
-    """Queries Version Explorer for IIB build info.
-
-    Returns:
-        Build info dict for osbs/fbc sources, empty dict for other sources.
-    """
-    if cnv_source in ("osbs", "fbc"):
-        iib_format_match = re.search(r"/iib:(\d+)$", cnv_image_url)
-        assert iib_format_match, f"Cannot extract IIB number from: {cnv_image_url} (expected format: .../iib:<number>)"
-        iib_number = iib_format_match.group(1)
-
-        if build_info := wait_for_version_explorer_response(
-            api_end_point="GetBuildByIIB",
-            query_string=f"iib_number={iib_number}",
-        ):
-            return build_info
-        exit_pytest_execution(
-            admin_client=admin_client,
-            log_message=f"Version Explorer returned empty response for IIB {iib_number}.",
-        )
-    return {}
 
 
 @pytest.fixture(scope="session")
@@ -123,8 +97,8 @@ def required_konflux_mirrors(cnv_target_version, cnv_current_version):
 
 @pytest.fixture()
 def updated_konflux_idms(
+    request,
     admin_client,
-    iib_build_info,
     nodes,
     required_konflux_mirrors,
     is_disconnected_cluster,
@@ -136,6 +110,7 @@ def updated_konflux_idms(
         LOGGER.warning("Skip applying IDMS in a disconnected setup.")
         return
 
+    iib_build_info = request.getfixturevalue("iib_build_info")
     if iib_build_info.get("pipeline") != KONFLUX_PIPELINE:
         LOGGER.warning(f"Pipeline is '{iib_build_info.get('pipeline')}', not Konflux. Skipping IDMS.")
         return
@@ -421,12 +396,24 @@ def eus_unpaused_workload_update(
 
 @pytest.fixture(scope="module")
 def eus_updated_konflux_idms(
+    request,
     admin_client,
     eus_cnv_upgrade_path,
     nodes,
+    is_disconnected_cluster,
     machine_config_pools,
     machine_config_pools_conditions_scope_module,
 ):
+    """Ensures Konflux IDMS mirrors are set up for all EUS upgrade path versions."""
+    if is_disconnected_cluster:
+        LOGGER.warning("Skip applying IDMS in a disconnected setup.")
+        return
+
+    iib_build_info = request.getfixturevalue("iib_build_info")
+    if iib_build_info.get("pipeline") != KONFLUX_PIPELINE:
+        LOGGER.warning(f"Pipeline is '{iib_build_info.get('pipeline')}', not Konflux. Skipping IDMS.")
+        return
+
     required_mirrors = []
     for phase in eus_cnv_upgrade_path:
         for version in eus_cnv_upgrade_path[phase]:

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -10,7 +10,14 @@ from ocp_utilities.monitoring import Prometheus
 from packaging.version import Version
 from pytest_testconfig import py_config
 
-from tests.install_upgrade_operators.constants import WORKLOAD_UPDATE_STRATEGY_KEY_NAME, WORKLOADUPDATEMETHODS
+from tests.install_upgrade_operators.constants import (
+    BREW_MIRROR_BASE_URL,
+    KONFLUX_IDMS_NAME,
+    KONFLUX_MIRROR_BASE_URL,
+    KONFLUX_PIPELINE,
+    WORKLOAD_UPDATE_STRATEGY_KEY_NAME,
+    WORKLOADUPDATEMETHODS,
+)
 from tests.install_upgrade_operators.product_upgrade.utils import (
     approve_cnv_upgrade_install_plan,
     extract_ocp_version_from_ocp_image,
@@ -31,16 +38,12 @@ from tests.install_upgrade_operators.product_upgrade.utils import (
     wait_for_pods_replacement_by_type,
 )
 from tests.install_upgrade_operators.utils import (
-    KONFLUX_IDMS_NAME,
-    KONFLUX_MIRROR_BASE_URL,
     apply_konflux_idms,
-    idms_has_all_mirrors,
     wait_for_operator_condition,
 )
 from tests.upgrade_params import EUS
 from utilities.constants import (
     HCO_CATALOG_SOURCE,
-    HOTFIX_STR,
     TIMEOUT_10MIN,
     NamespacesNames,
 )
@@ -53,6 +56,7 @@ from utilities.infra import (
     get_prometheus_k8s_token,
     get_related_images_name_and_version,
     get_subscription,
+    wait_for_version_explorer_response,
 )
 from utilities.operator import (
     get_machine_config_pool_by_name,
@@ -70,14 +74,27 @@ EUS_ERROR_CODE = 98
 
 
 @pytest.fixture(scope="session")
-def cnv_image_name(cnv_image_url):
-    # Image name format example osbs: registry-proxy.engineering.redhat.com/rh-osbs/iib:45131
-    match = re.match(".*/(.*):", cnv_image_url)
-    assert match, (
-        f"Can not find CNV image name from: {cnv_image_url} "
-        f"(example: registry-proxy.engineering.redhat.com/rh-osbs/iib:45131 should find 'iib')"
-    )
-    return match.group(1)
+def iib_build_info(cnv_source, cnv_image_url, admin_client):
+    """Queries Version Explorer for IIB build info.
+
+    Returns:
+        Build info dict for osbs/fbc sources, empty dict for other sources.
+    """
+    if cnv_source in ("osbs", "fbc"):
+        iib_format_match = re.search(r"/iib:(\d+)$", cnv_image_url)
+        assert iib_format_match, f"Cannot extract IIB number from: {cnv_image_url} (expected format: .../iib:<number>)"
+        iib_number = iib_format_match.group(1)
+
+        if build_info := wait_for_version_explorer_response(
+            api_end_point="GetBuildByIIB",
+            query_string=f"iib_number={iib_number}",
+        ):
+            return build_info
+        exit_pytest_execution(
+            admin_client=admin_client,
+            log_message=f"Version Explorer returned empty response for IIB {iib_number}.",
+        )
+    return {}
 
 
 @pytest.fixture(scope="session")
@@ -107,31 +124,26 @@ def required_konflux_mirrors(cnv_target_version, cnv_current_version):
 @pytest.fixture()
 def updated_konflux_idms(
     admin_client,
-    cnv_image_name,
+    iib_build_info,
     nodes,
-    cnv_source,
     required_konflux_mirrors,
     is_disconnected_cluster,
     active_machine_config_pools,
     machine_config_pools_conditions,
 ):
-    """Ensures the Konflux IDMS contains the required mirror entries for the CNV upgrade target version."""
+    """Ensures Konflux IDMS mirrors are set up if the IIB was built by Konflux pipeline."""
     if is_disconnected_cluster:
         LOGGER.warning("Skip applying IDMS in a disconnected setup.")
         return
 
-    if cnv_source == HOTFIX_STR:
-        LOGGER.info("IDMS updates skipped as upgrading using production source/upgrade to hotfix")
+    if iib_build_info.get("pipeline") != KONFLUX_PIPELINE:
+        LOGGER.warning(f"Pipeline is '{iib_build_info.get('pipeline')}', not Konflux. Skipping IDMS.")
         return
 
     idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
-    if idms.exists and idms_has_all_mirrors(idms=idms, required_mirrors=required_konflux_mirrors):
-        LOGGER.info(f"IDMS {KONFLUX_IDMS_NAME} already contains all required mirrors.")
-        return
-
     apply_konflux_idms(
         idms=idms,
-        required_mirrors=required_konflux_mirrors,
+        required_mirrors=required_konflux_mirrors if idms.exists else required_konflux_mirrors + [BREW_MIRROR_BASE_URL],
         machine_config_pools=active_machine_config_pools,
         mcp_conditions=machine_config_pools_conditions,
         nodes=nodes,
@@ -424,10 +436,6 @@ def eus_updated_konflux_idms(
                 required_mirrors.append(mirror)
 
     idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
-    if idms.exists and idms_has_all_mirrors(idms=idms, required_mirrors=required_mirrors):
-        LOGGER.info(f"IDMS {KONFLUX_IDMS_NAME} already has all EUS mirrors.")
-        return
-
     apply_konflux_idms(
         idms=idms,
         required_mirrors=required_mirrors,

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -3,17 +3,12 @@ import os
 
 import pytest
 from ocp_resources.cluster_version import ClusterVersion
-from ocp_resources.image_digest_mirror_set import ImageDigestMirrorSet
 from ocp_resources.resource import ResourceEditor
 from ocp_utilities.monitoring import Prometheus
 from packaging.version import Version
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
-    BREW_MIRROR_BASE_URL,
-    KONFLUX_IDMS_NAME,
-    KONFLUX_MIRROR_BASE_URL,
-    KONFLUX_PIPELINE,
     WORKLOAD_UPDATE_STRATEGY_KEY_NAME,
     WORKLOADUPDATEMETHODS,
 )
@@ -38,6 +33,8 @@ from tests.install_upgrade_operators.product_upgrade.utils import (
 )
 from tests.install_upgrade_operators.utils import (
     apply_konflux_idms,
+    is_konflux_pipeline,
+    konflux_mirror_url,
     wait_for_operator_condition,
 )
 from tests.upgrade_params import EUS
@@ -91,34 +88,31 @@ def required_konflux_mirrors(cnv_target_version, cnv_current_version):
     target = Version(version=cnv_target_version)
     current = Version(version=cnv_current_version)
     return [
-        f"{KONFLUX_MIRROR_BASE_URL}/v{target.major}-{minor}" for minor in range(target.minor, current.minor - 1, -1)
+        konflux_mirror_url(version=Version(version=f"{target.major}.{minor}"))
+        for minor in range(target.minor, current.minor - 1, -1)
     ]
 
 
 @pytest.fixture()
 def updated_konflux_idms(
-    request,
     admin_client,
     nodes,
     required_konflux_mirrors,
     is_disconnected_cluster,
     active_machine_config_pools,
     machine_config_pools_conditions,
+    iib_build_info,
 ):
     """Ensures Konflux IDMS mirrors are set up if the IIB was built by Konflux pipeline."""
     if is_disconnected_cluster:
         LOGGER.warning("Skip applying IDMS in a disconnected setup.")
         return
-
-    iib_build_info = request.getfixturevalue("iib_build_info")
-    if iib_build_info.get("pipeline") != KONFLUX_PIPELINE:
-        LOGGER.warning(f"Pipeline is '{iib_build_info.get('pipeline')}', not Konflux. Skipping IDMS.")
+    if not is_konflux_pipeline(build_info=iib_build_info):
         return
 
-    idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
     apply_konflux_idms(
-        idms=idms,
-        required_mirrors=required_konflux_mirrors if idms.exists else required_konflux_mirrors + [BREW_MIRROR_BASE_URL],
+        admin_client=admin_client,
+        required_mirrors=required_konflux_mirrors,
         machine_config_pools=active_machine_config_pools,
         mcp_conditions=machine_config_pools_conditions,
         nodes=nodes,
@@ -396,36 +390,31 @@ def eus_unpaused_workload_update(
 
 @pytest.fixture(scope="module")
 def eus_updated_konflux_idms(
-    request,
     admin_client,
     eus_cnv_upgrade_path,
     nodes,
     is_disconnected_cluster,
     machine_config_pools,
     machine_config_pools_conditions_scope_module,
+    iib_build_info,
 ):
     """Ensures Konflux IDMS mirrors are set up for all EUS upgrade path versions."""
     if is_disconnected_cluster:
         LOGGER.warning("Skip applying IDMS in a disconnected setup.")
         return
-
-    iib_build_info = request.getfixturevalue("iib_build_info")
-    if iib_build_info.get("pipeline") != KONFLUX_PIPELINE:
-        LOGGER.warning(f"Pipeline is '{iib_build_info.get('pipeline')}', not Konflux. Skipping IDMS.")
+    if not is_konflux_pipeline(build_info=iib_build_info):
         return
 
     required_mirrors = []
     for phase in eus_cnv_upgrade_path:
         for version in eus_cnv_upgrade_path[phase]:
-            ver = Version(version=version)
-            mirror = f"{KONFLUX_MIRROR_BASE_URL}/v{ver.major}-{ver.minor}"
+            mirror = konflux_mirror_url(version=Version(version=version))
             if mirror not in required_mirrors:
                 required_mirrors.append(mirror)
 
-    idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
     apply_konflux_idms(
-        idms=idms,
-        required_mirrors=required_mirrors if idms.exists else required_mirrors + [BREW_MIRROR_BASE_URL],
+        admin_client=admin_client,
+        required_mirrors=required_mirrors,
         machine_config_pools=machine_config_pools,
         mcp_conditions=machine_config_pools_conditions_scope_module,
         nodes=nodes,

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -303,15 +303,20 @@ def _get_entries_with_missing_mirrors(
     mirror_entries = idms.instance.to_dict()["spec"]["imageDigestMirrors"]
     has_changes = False
     for entry in mirror_entries:
-        if entry["source"].startswith(f"{RH_IDMS_SOURCE}/"):
-            image_name = entry["source"].removeprefix(f"{RH_IDMS_SOURCE}/")
-            mirrors = entry.get("mirrors", [])
+        source = entry["source"]
+        mirrors = entry.get("mirrors", [])
+        if source == RH_IDMS_SOURCE:
+            missing = [url for url in required_mirrors if url not in mirrors]
+        elif source.startswith(f"{RH_IDMS_SOURCE}/"):
+            image_name = source.removeprefix(f"{RH_IDMS_SOURCE}/")
             missing = [
                 expected_mirror for url in required_mirrors if (expected_mirror := f"{url}/{image_name}") not in mirrors
             ]
-            if missing:
-                entry["mirrors"] = mirrors + missing
-                has_changes = True
+        else:
+            continue
+        if missing:
+            entry["mirrors"] = mirrors + missing
+            has_changes = True
     return mirror_entries if has_changes else []
 
 

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -14,10 +14,15 @@ from ocp_resources.network_addons_config import NetworkAddonsConfig
 from ocp_resources.node import Node
 from ocp_resources.operator_condition import OperatorCondition
 from ocp_resources.resource import Resource, ResourceEditor
+from packaging.version import Version
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.install_upgrade_operators.constants import (
+    BREW_MIRROR_BASE_URL,
     KEY_PATH_SEPARATOR,
+    KONFLUX_IDMS_NAME,
+    KONFLUX_MIRROR_BASE_URL,
+    KONFLUX_PIPELINE,
     RH_IDMS_SOURCE,
 )
 from utilities.constants import (
@@ -290,6 +295,18 @@ def get_resource_key_value(resource: Resource, key_name: str) -> Any:
     ).get(key_name)
 
 
+def is_konflux_pipeline(build_info: dict[str, Any]) -> bool:
+    pipeline = build_info.get("pipeline")
+    if pipeline != KONFLUX_PIPELINE:
+        LOGGER.warning(f"Pipeline is '{pipeline}', not Konflux. Skipping IDMS.")
+        return False
+    return True
+
+
+def konflux_mirror_url(version: Version) -> str:
+    return f"{KONFLUX_MIRROR_BASE_URL}/v{version.major}-{version.minor}"
+
+
 def _get_entries_with_missing_mirrors(
     idms: ImageDigestMirrorSet,
     required_mirrors: list[str],
@@ -304,16 +321,14 @@ def _get_entries_with_missing_mirrors(
     has_changes = False
     for entry in mirror_entries:
         source = entry["source"]
-        mirrors = entry.get("mirrors", [])
         if source == RH_IDMS_SOURCE:
-            missing = [url for url in required_mirrors if url not in mirrors]
+            suffix = ""
         elif source.startswith(f"{RH_IDMS_SOURCE}/"):
-            image_name = source.removeprefix(f"{RH_IDMS_SOURCE}/")
-            missing = [
-                expected_mirror for url in required_mirrors if (expected_mirror := f"{url}/{image_name}") not in mirrors
-            ]
+            suffix = source.removeprefix(RH_IDMS_SOURCE)
         else:
             continue
+        mirrors = entry.get("mirrors", [])
+        missing = [f"{url}{suffix}" for url in required_mirrors if f"{url}{suffix}" not in mirrors]
         if missing:
             entry["mirrors"] = mirrors + missing
             has_changes = True
@@ -321,7 +336,7 @@ def _get_entries_with_missing_mirrors(
 
 
 def apply_konflux_idms(
-    idms: ImageDigestMirrorSet,
+    admin_client: DynamicClient,
     required_mirrors: list[str],
     machine_config_pools: list[MachineConfigPool],
     mcp_conditions: dict[str, list[dict[str, str]]],
@@ -331,34 +346,35 @@ def apply_konflux_idms(
 
     For an existing IDMS with per-image entries, adds missing version mirrors
     to each entry while preserving the existing structure.
-    For a new IDMS, creates it with the provided mirrors.
+    For a new IDMS, creates it with the provided mirrors plus the brew fallback.
 
     Args:
-        idms: The Konflux IDMS resource to create or patch.
+        admin_client: Kubernetes client for IDMS operations.
         required_mirrors: Konflux mirror base URLs (e.g. quay.io/.../v4-22).
         machine_config_pools: Active machine config pools to pause/wait.
         mcp_conditions: Initial MCP conditions for tracking update progress.
         nodes: Cluster nodes to verify readiness after MCP update.
     """
-    if idms.exists:
+    idms = ImageDigestMirrorSet(name=KONFLUX_IDMS_NAME, client=admin_client)
+    if not idms.exists:
+        all_mirrors = required_mirrors + [BREW_MIRROR_BASE_URL]
+        image_digest_mirrors = [{"source": RH_IDMS_SOURCE, "mirrors": all_mirrors}]
+        LOGGER.info(f"Creating IDMS {idms.name} with mirrors: {all_mirrors}")
+        with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in machine_config_pools}):
+            ImageDigestMirrorSet(
+                name=KONFLUX_IDMS_NAME,
+                client=admin_client,
+                image_digest_mirrors=image_digest_mirrors,
+                teardown=False,
+            ).deploy(wait=True)
+    else:
         updated_entries = _get_entries_with_missing_mirrors(idms=idms, required_mirrors=required_mirrors)
         if not updated_entries:
             LOGGER.warning(f"IDMS {idms.name} already contains all required mirrors.")
             return
-
-    with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in machine_config_pools}):
-        if idms.exists:
-            LOGGER.info(f"Patching IDMS {idms.name} with missing mirrors for: {required_mirrors}")
+        LOGGER.info(f"Patching IDMS {idms.name} with missing mirrors for: {required_mirrors}")
+        with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in machine_config_pools}):
             ResourceEditor(patches={idms: {"spec": {"imageDigestMirrors": updated_entries}}}).update()
-        else:
-            image_digest_mirrors = [{"source": RH_IDMS_SOURCE, "mirrors": required_mirrors}]
-            LOGGER.info(f"Creating IDMS {idms.name} with mirrors: {required_mirrors}")
-            ImageDigestMirrorSet(
-                name=idms.name,
-                client=idms.client,
-                image_digest_mirrors=image_digest_mirrors,
-                teardown=False,
-            ).deploy(wait=True)
     LOGGER.info("Wait for MCP update after IDMS modification.")
     wait_for_mcp_update_completion(
         machine_config_pools_list=machine_config_pools,

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -16,7 +16,10 @@ from ocp_resources.operator_condition import OperatorCondition
 from ocp_resources.resource import Resource, ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.install_upgrade_operators.constants import KEY_PATH_SEPARATOR
+from tests.install_upgrade_operators.constants import (
+    KEY_PATH_SEPARATOR,
+    RH_IDMS_SOURCE,
+)
 from utilities.constants import (
     HCO_SUBSCRIPTION,
     PRODUCTION_CATALOG_SOURCE,
@@ -30,9 +33,6 @@ from utilities.infra import get_subscription
 from utilities.operator import wait_for_mcp_update_completion
 
 LOGGER = logging.getLogger(__name__)
-KONFLUX_IDMS_NAME = "zz-cnv-icsp-fallback"
-KONFLUX_MIRROR_BASE_URL = "quay.io/openshift-virtualization/konflux-builds"
-KONFLUX_IDMS_SOURCE = "registry.redhat.io/container-native-virtualization"
 
 
 def wait_for_operator_condition(client, hco_namespace, name, upgradable):
@@ -290,6 +290,29 @@ def get_resource_key_value(resource: Resource, key_name: str) -> Any:
     ).get(key_name)
 
 
+def _get_entries_with_missing_mirrors(
+    idms: ImageDigestMirrorSet,
+    required_mirrors: list[str],
+) -> list[dict[str, Any]]:
+    """Returns updated IDMS entries with missing Konflux mirrors added, or empty list if all present.
+
+    Each required mirror is a base URL (e.g. quay.io/.../konflux-builds/v4-22).
+    For each CNV entry, checks if a mirror starting with that base URL exists,
+    and appends the per-image mirror (e.g. quay.io/.../v4-22/aaq-controller-rhel9) if missing.
+    """
+    mirror_entries = idms.instance.to_dict()["spec"]["imageDigestMirrors"]
+    has_changes = False
+    for entry in mirror_entries:
+        if entry["source"].startswith(RH_IDMS_SOURCE):
+            image_name = entry["source"].removeprefix(f"{RH_IDMS_SOURCE}/")
+            mirrors = entry.get("mirrors", [])
+            missing = [f"{url}/{image_name}" for url in required_mirrors if not any(m.startswith(url) for m in mirrors)]
+            if missing:
+                entry["mirrors"] = mirrors + missing
+                has_changes = True
+    return mirror_entries if has_changes else []
+
+
 def apply_konflux_idms(
     idms: ImageDigestMirrorSet,
     required_mirrors: list[str],
@@ -299,23 +322,32 @@ def apply_konflux_idms(
 ) -> None:
     """Creates or patches the Konflux IDMS with the required mirror entries.
 
+    For an existing IDMS with per-image entries, adds missing version mirrors
+    to each entry while preserving the existing structure.
+    For a new IDMS, creates it with the provided mirrors.
+
     Args:
         idms: The Konflux IDMS resource to create or patch.
-        required_mirrors: Konflux mirror URLs to set on the IDMS.
+        required_mirrors: Konflux mirror base URLs (e.g. quay.io/.../v4-22).
         machine_config_pools: Active machine config pools to pause/wait.
         mcp_conditions: Initial MCP conditions for tracking update progress.
         nodes: Cluster nodes to verify readiness after MCP update.
     """
-    image_digest_mirrors = [{"source": KONFLUX_IDMS_SOURCE, "mirrors": required_mirrors}]
-    LOGGER.info("Pausing MCP updates while modifying IDMS.")
+    if idms.exists:
+        updated_entries = _get_entries_with_missing_mirrors(idms=idms, required_mirrors=required_mirrors)
+        if not updated_entries:
+            LOGGER.warning(f"IDMS {idms.name} already contains all required mirrors.")
+            return
+
     with ResourceEditor(patches={mcp: {"spec": {"paused": True}} for mcp in machine_config_pools}):
         if idms.exists:
-            LOGGER.info(f"Patching IDMS {KONFLUX_IDMS_NAME} with mirrors: {required_mirrors}")
-            ResourceEditor(patches={idms: {"spec": {"imageDigestMirrors": image_digest_mirrors}}}).update()
+            LOGGER.info(f"Patching IDMS {idms.name} with missing mirrors for: {required_mirrors}")
+            ResourceEditor(patches={idms: {"spec": {"imageDigestMirrors": updated_entries}}}).update()
         else:
-            LOGGER.info(f"Creating IDMS {KONFLUX_IDMS_NAME} with mirrors: {required_mirrors}")
+            image_digest_mirrors = [{"source": RH_IDMS_SOURCE, "mirrors": required_mirrors}]
+            LOGGER.info(f"Creating IDMS {idms.name} with mirrors: {required_mirrors}")
             ImageDigestMirrorSet(
-                name=KONFLUX_IDMS_NAME,
+                name=idms.name,
                 client=idms.client,
                 image_digest_mirrors=image_digest_mirrors,
                 teardown=False,
@@ -326,20 +358,3 @@ def apply_konflux_idms(
         initial_mcp_conditions=mcp_conditions,
         nodes=nodes,
     )
-
-
-def idms_has_all_mirrors(idms: ImageDigestMirrorSet, required_mirrors: list[str]) -> bool:
-    """Returns True if the IDMS already contains all required Konflux mirror entries."""
-    existing_mirrors = idms.instance.spec.imageDigestMirrors
-    source_entry = next(
-        (entry for entry in existing_mirrors if entry["source"] == KONFLUX_IDMS_SOURCE),
-        None,
-    )
-    if not source_entry:
-        LOGGER.info(
-            f"IDMS {idms.name} has no entry for source {KONFLUX_IDMS_SOURCE}, mirrors need to be added."
-            f" Current IDMS mirrors: {existing_mirrors}"
-        )
-        return False
-    existing_urls = {str(mirror) for mirror in source_entry["mirrors"]}
-    return all(mirror in existing_urls for mirror in required_mirrors)

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -303,10 +303,12 @@ def _get_entries_with_missing_mirrors(
     mirror_entries = idms.instance.to_dict()["spec"]["imageDigestMirrors"]
     has_changes = False
     for entry in mirror_entries:
-        if entry["source"].startswith(RH_IDMS_SOURCE):
+        if entry["source"].startswith(f"{RH_IDMS_SOURCE}/"):
             image_name = entry["source"].removeprefix(f"{RH_IDMS_SOURCE}/")
             mirrors = entry.get("mirrors", [])
-            missing = [f"{url}/{image_name}" for url in required_mirrors if not any(m.startswith(url) for m in mirrors)]
+            missing = [
+                expected_mirror for url in required_mirrors if (expected_mirror := f"{url}/{image_name}") not in mirrors
+            ]
             if missing:
                 entry["mirrors"] = mirrors + missing
                 has_changes = True

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -267,7 +267,7 @@ def get_artifactory_server_url(cluster_host_url, session):
 
 
 def get_cnv_version_explorer_url(pytest_config):
-    if pytest_config.getoption("install") or pytest_config.getoption("upgrade") == "eus":
+    if pytest_config.getoption("install") or pytest_config.getoption("upgrade") in ("eus", "cnv"):
         LOGGER.info("Checking for cnv version explorer url:")
         version_explorer_url = os.environ.get("CNV_VERSION_EXPLORER_URL")
         if not version_explorer_url:


### PR DESCRIPTION
##### Short description:
This PR modifies the IDMS patching logic to follow a per-image strategy, aligning with Konflux build requirements.

##### More details:
This change aligns the code with the DevOps per-image IDMS strategy to reduce execution time and avoid unnecessary VM migrations that cause PSI execution failures. 

* **For Konflux builds:** The code checks if the upgrade target version image (e.g., v4.22) already exists in the IDMS per related image; if it does, no action is taken. 
* **Missing versions:** If the version is missing, the existing IDMS is patched. 
* **Fallback:** If no IDMS exists at all, a new namespaced IDMS is created.

##### What this PR does / why we need it:
* **Improves CI Stability:** Minimizes VM migrations by avoiding redundant IDMS patching, leading to more reliable test results.
* **DevOps Alignment:** Ensures registry mirroring logic follows the current per-image strategy.

##### Special notes for reviewer:
Review the logic in the IDMS patching helper functions to ensure the image version check is robust.

##### jira-ticket:

🤖 Assisted with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized Konflux/IDMS constants and simplified mirror setup logic.
  * Removed automatic mirror application during some test setups; Konflux mirror application is now gated to relevant pipeline builds.
  * Mirror updates now add only missing entries instead of requiring full replacements.
  * Added session-scoped build-info retrieval from Version Explorer and extended version-explorer requirements to additional upgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->