### PR TITLE
[Storage] Move tests away from test_import_http.py and replace using datasource cloning

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,6 @@ from ocp_resources.network_addons_config import NetworkAddonsConfig
 from ocp_resources.node import Node
 from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.oauth import OAuth
-from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor, get_client
 from ocp_resources.role_binding import RoleBinding
@@ -1021,16 +1020,6 @@ def mac_pool(admin_client, hco_namespace):
             namespace=hco_namespace.name, name=KUBEMACPOOL_MAC_RANGE_CONFIG, client=admin_client
         ).instance["data"]
     )
-
-
-def _skip_access_mode_rwo(storage_class_matrix):
-    if storage_class_matrix[[*storage_class_matrix][0]]["access_mode"] == PersistentVolumeClaim.AccessMode.RWO:
-        pytest.skip(reason="Skipping when access_mode is RWO; possible reason: cannot migrate VMI with non-shared PVCs")
-
-
-@pytest.fixture()
-def skip_access_mode_rwo_scope_function(storage_class_matrix__function__):
-    _skip_access_mode_rwo(storage_class_matrix=storage_class_matrix__function__)
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -71,7 +71,7 @@ def linux_nad(admin_client, namespace, bridge_on_node):
 
 
 @pytest.fixture()
-def cirros_pvc(
+def data_volume_pvc(
     data_volume_template_metadata,
 ):
     """Create a PVC from the data volume template metadata."""
@@ -82,16 +82,16 @@ def cirros_pvc(
 
 
 @pytest.fixture()
-def pvc_original_timestamp(
-    cirros_pvc,
+def data_volume_pvc_creation_timestamp(
+    data_volume_pvc,
 ):
-    """Get the original creation timestamp of the Cirros PVC."""
-    return cirros_pvc.instance.metadata.creationTimestamp
+    """Get the creation timestamp of the data volume PVC."""
+    return data_volume_pvc.instance.metadata.creationTimestamp
 
 
 @pytest.fixture()
 def dv_non_exist_url(namespace, storage_class_name_scope_module):
-    """Create a DV with a non-existent URL to test import failure."""
+    """Create a DV with a non-existent URL"""
     with create_dv(
         dv_name=f"cnv-876-{storage_class_name_scope_module}",
         namespace=namespace.name,

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -20,7 +20,6 @@ from tests.storage.utils import (
     create_pod_for_pvc,
     get_file_url,
 )
-from utilities.artifactory import get_http_image_url
 from utilities.constants import (
     LINUX_BRIDGE,
     OS_FLAVOR_FEDORA,
@@ -244,7 +243,8 @@ def dv_with_annotation(admin_client, namespace, linux_nad):
     with create_dv(
         dv_name="dv-annotation",
         namespace=namespace.name,
-        url=get_http_image_url(image_directory=Images.Fedora.DIR, image_name=Images.Fedora.LATEST_RELEASE_STR),
+        source=REGISTRY_STR,
+        url=QUAY_FEDORA_CONTAINER_IMAGE,
         size=Images.Fedora.DEFAULT_DV_SIZE,
         storage_class=py_config["default_storage_class"],
         multus_annotation=linux_nad.name,

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -11,7 +11,7 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import py_config
 
 from tests.os_params import FEDORA_LATEST
-from tests.storage.cdi_import.test_import_http import wait_dv_and_get_importer
+from tests.storage.cdi_import.utils import wait_dv_and_get_importer
 from tests.storage.constants import (
     HPP_STORAGE_CLASSES,
     HTTP,

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -7,7 +7,6 @@ import logging
 
 import pytest
 from ocp_resources.datavolume import DataVolume
-from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import py_config
 
 from tests.storage.cdi_import.utils import wait_dv_and_get_importer
@@ -67,25 +66,6 @@ def linux_nad(admin_client, namespace, bridge_on_node):
         client=admin_client,
     ) as nad:
         yield nad
-
-
-@pytest.fixture()
-def data_volume_pvc(
-    data_volume_template_metadata,
-):
-    """Create a PVC from the data volume template metadata."""
-    return PersistentVolumeClaim(
-        name=data_volume_template_metadata["name"],
-        namespace=data_volume_template_metadata["namespace"],
-    )
-
-
-@pytest.fixture()
-def data_volume_pvc_creation_timestamp(
-    data_volume_pvc,
-):
-    """Get the creation timestamp of the data volume PVC."""
-    return data_volume_pvc.instance.metadata.creationTimestamp
 
 
 @pytest.fixture()

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -40,12 +40,14 @@ DEFAULT_DV_SIZE = Images.Cirros.DEFAULT_DV_SIZE
 
 @pytest.fixture()
 def skip_non_shared_storage(storage_class_name_scope_function):
+    """Skip tests if the storage class is non-shared."""
     if storage_class_name_scope_function in HPP_STORAGE_CLASSES:
         pytest.skip("Skipping when storage is non-shared")
 
 
 @pytest.fixture()
 def bridge_on_node(admin_client):
+    """Create a Linux Bridge network device and yield it."""
     with network_device(
         interface_type=LINUX_BRIDGE,
         nncp_name=BRIDGE_NAME,
@@ -57,6 +59,7 @@ def bridge_on_node(admin_client):
 
 @pytest.fixture()
 def linux_nad(admin_client, namespace, bridge_on_node):
+    """Create a Linux Bridge Network Attachment Definition (NAD) and yield it."""
     with network_nad(
         namespace=namespace,
         nad_type=LINUX_BRIDGE,
@@ -71,6 +74,7 @@ def linux_nad(admin_client, namespace, bridge_on_node):
 def cirros_pvc(
     data_volume_template_metadata,
 ):
+    """Create a PVC from the data volume template metadata."""
     return PersistentVolumeClaim(
         name=data_volume_template_metadata["name"],
         namespace=data_volume_template_metadata["namespace"],
@@ -81,11 +85,13 @@ def cirros_pvc(
 def pvc_original_timestamp(
     cirros_pvc,
 ):
+    """Get the original creation timestamp of the Cirros PVC."""
     return cirros_pvc.instance.metadata.creationTimestamp
 
 
 @pytest.fixture()
 def dv_non_exist_url(namespace, storage_class_name_scope_module):
+    """Create a DV with a non-existent URL to test import failure."""
     with create_dv(
         dv_name=f"cnv-876-{storage_class_name_scope_module}",
         namespace=namespace.name,
@@ -104,6 +110,7 @@ def dv_from_http_import(
     storage_class_name_scope_module,
     images_internal_http_server,
 ):
+    """Create a DV from HTTP import with parameters from the test function."""
     with create_dv(
         dv_name=f"{request.param.get('dv_name', 'http-dv')}-{storage_class_name_scope_module}",
         namespace=namespace.name,
@@ -127,6 +134,7 @@ def running_pod_with_dv_pvc(
     storage_class_name_scope_module,
     dv_from_http_import,
 ):
+    """Create a running pod with DV's PVC."""
     dv_from_http_import.wait_for_dv_success()
     with create_pod_for_pvc(
         pvc=dv_from_http_import.pvc,
@@ -137,6 +145,7 @@ def running_pod_with_dv_pvc(
 
 @pytest.fixture()
 def created_blank_dv_list(unprivileged_client, namespace, storage_class_name_scope_module, number_of_dvs):
+    """Create a list of blank DVs."""
     dvs_list = []
     try:
         for dv_index in range(number_of_dvs):
@@ -189,6 +198,7 @@ def created_vm_list(unprivileged_client, created_blank_dv_list, storage_class_na
 
 @pytest.fixture()
 def dvs_and_vms_from_public_registry(unprivileged_client, namespace, storage_class_name_scope_function):
+    """Create DVs from public registry and VMs from those DVs."""
     dvs = []
     vms = []
     try:
@@ -230,6 +240,7 @@ def dvs_and_vms_from_public_registry(unprivileged_client, namespace, storage_cla
 
 @pytest.fixture()
 def dv_with_annotation(admin_client, namespace, linux_nad):
+    """Create a DV with multus annotation and yield the importer pod annotations."""
     with create_dv(
         dv_name="dv-annotation",
         namespace=namespace.name,

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -210,7 +210,7 @@ def dvs_and_vms_from_public_registry(unprivileged_client, namespace, storage_cla
 
 
 @pytest.fixture()
-def dv_with_annotation(admin_client, namespace, linux_nad):
+def importer_pod_annotations(admin_client, namespace, linux_nad):
     """Create a DV with multus annotation and yield the importer pod annotations."""
     with create_dv(
         dv_name="dv-annotation",

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -10,7 +10,6 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import py_config
 
-from tests.os_params import FEDORA_LATEST
 from tests.storage.cdi_import.utils import wait_dv_and_get_importer
 from tests.storage.constants import (
     HPP_STORAGE_CLASSES,
@@ -21,7 +20,7 @@ from tests.storage.utils import (
     create_pod_for_pvc,
     get_file_url,
 )
-from utilities.artifactory import get_test_artifact_server_url
+from utilities.artifactory import get_http_image_url
 from utilities.constants import (
     LINUX_BRIDGE,
     OS_FLAVOR_FEDORA,
@@ -234,9 +233,11 @@ def dv_with_annotation(admin_client, namespace, linux_nad):
     with create_dv(
         dv_name="dv-annotation",
         namespace=namespace.name,
-        url=f"{get_test_artifact_server_url()}{FEDORA_LATEST['image_path']}",
+        url=get_http_image_url(image_directory=Images.Fedora.DIR, image_name=Images.Fedora.LATEST_RELEASE_STR),
+        size=Images.Fedora.DEFAULT_DV_SIZE,
         storage_class=py_config["default_storage_class"],
         multus_annotation=linux_nad.name,
         client=namespace.client,
     ) as dv:
-        return wait_dv_and_get_importer(dv=dv, admin_client=admin_client).instance.metadata.annotations
+        importer_pod = wait_dv_and_get_importer(dv=dv, admin_client=admin_client)
+        yield importer_pod.instance.metadata.annotations

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -11,7 +11,6 @@ from pytest_testconfig import py_config
 
 from tests.storage.cdi_import.utils import wait_dv_and_get_importer, wait_for_multus_network_status
 from tests.storage.constants import (
-    HPP_STORAGE_CLASSES,
     HTTP,
     QUAY_FEDORA_CONTAINER_IMAGE,
 )
@@ -34,13 +33,6 @@ from utilities.virt import VirtualMachineForTests
 LOGGER = logging.getLogger(__name__)
 BRIDGE_NAME = "br1-dv"
 DEFAULT_DV_SIZE = Images.Cirros.DEFAULT_DV_SIZE
-
-
-@pytest.fixture()
-def skip_non_shared_storage(storage_class_name_scope_function):
-    """Skip tests if the storage class is non-shared."""
-    if storage_class_name_scope_function in HPP_STORAGE_CLASSES:
-        pytest.skip("Skipping when storage is non-shared")
 
 
 @pytest.fixture()

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from ocp_resources.datavolume import DataVolume
 from pytest_testconfig import py_config
 
-from tests.storage.cdi_import.utils import wait_dv_and_get_importer
+from tests.storage.cdi_import.utils import wait_dv_and_get_importer, wait_for_multus_network_status
 from tests.storage.constants import (
     HPP_STORAGE_CLASSES,
     HTTP,
@@ -231,4 +231,5 @@ def dv_with_annotation(admin_client, namespace, linux_nad):
         client=namespace.client,
     ) as dv:
         importer_pod = wait_dv_and_get_importer(dv=dv, admin_client=admin_client)
+        wait_for_multus_network_status(importer_pod=importer_pod)
         yield importer_pod.instance.metadata.annotations

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -8,7 +8,10 @@ import logging
 import pytest
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from pytest_testconfig import py_config
 
+from tests.os_params import FEDORA_LATEST
+from tests.storage.cdi_import.test_import_http import wait_dv_and_get_importer
 from tests.storage.constants import (
     HPP_STORAGE_CLASSES,
     HTTP,
@@ -18,6 +21,7 @@ from tests.storage.utils import (
     create_pod_for_pvc,
     get_file_url,
 )
+from utilities.artifactory import get_test_artifact_server_url
 from utilities.constants import (
     LINUX_BRIDGE,
     OS_FLAVOR_FEDORA,
@@ -223,3 +227,16 @@ def dvs_and_vms_from_public_registry(unprivileged_client, namespace, storage_cla
             vm.clean_up()
         for dv in dvs:
             dv.clean_up()
+
+
+@pytest.fixture()
+def dv_with_annotation(admin_client, namespace, linux_nad):
+    with create_dv(
+        dv_name="dv-annotation",
+        namespace=namespace.name,
+        url=f"{get_test_artifact_server_url()}{FEDORA_LATEST['image_path']}",
+        storage_class=py_config["default_storage_class"],
+        multus_annotation=linux_nad.name,
+        client=namespace.client,
+    ) as dv:
+        return wait_dv_and_get_importer(dv=dv, admin_client=admin_client).instance.metadata.annotations

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -15,7 +15,6 @@ from tests.os_params import RHEL_LATEST
 from tests.storage.cdi_import.utils import (
     get_importer_pod_node,
     wait_dv_and_get_importer,
-    wait_for_pvc_recreate,
 )
 from tests.storage.constants import (
     ALPINE_QCOW2_IMG,
@@ -31,9 +30,7 @@ from tests.storage.utils import (
     get_importer_pod,
     wait_for_importer_container_message,
 )
-from utilities import console
 from utilities.constants import (
-    OS_FLAVOR_FEDORA,
     OS_FLAVOR_RHEL,
     QUARANTINED,
     TIMEOUT_1MIN,
@@ -45,11 +42,8 @@ from utilities.infra import get_node_selector_dict
 from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.storage import (
     ErrorMsg,
-    create_dummy_first_consumer_pod,
     create_dv,
     create_vm_from_dv,
-    get_dv_size_from_datasource,
-    sc_volume_binding_mode_is_wffc,
 )
 from utilities.virt import running_vm
 
@@ -64,32 +58,6 @@ TAR_IMG = "archive.tar"
 DEFAULT_DV_SIZE = Images.Alpine.DEFAULT_DV_SIZE
 SMALL_DV_SIZE = "200Mi"
 LATEST_WINDOWS_OS_DICT = py_config.get("latest_windows_os_dict", {})
-
-
-@pytest.mark.sno
-@pytest.mark.polarion("CNV-675")
-def test_pvc_recreates_after_deletion(namespace, storage_class_name_scope_function, fedora_data_source_scope_module):
-    with create_dv(
-        dv_name=f"cnv-675-{storage_class_name_scope_function}",
-        namespace=namespace.name,
-        storage_class=storage_class_name_scope_function,
-        size=get_dv_size_from_datasource(fedora_data_source_scope_module),
-        client=namespace.client,
-        source_ref={
-            "kind": fedora_data_source_scope_module.kind,
-            "name": fedora_data_source_scope_module.name,
-            "namespace": fedora_data_source_scope_module.namespace,
-        },
-    ) as dv:
-        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
-        pvc = dv.pvc
-        pvc_original_timestamp = pvc.instance.metadata.creationTimestamp
-        pvc.delete()
-        wait_for_pvc_recreate(pvc=pvc, pvc_original_timestamp=pvc_original_timestamp)
-        storage_class = storage_class_name_scope_function
-        if sc_volume_binding_mode_is_wffc(sc=storage_class, client=namespace.client):
-            create_dummy_first_consumer_pod(pvc=pvc)
-        dv.wait_for_dv_success()
 
 
 @pytest.mark.xfail(
@@ -370,38 +338,6 @@ def test_successful_concurrent_blank_disk_import(
 @pytest.mark.s390x
 def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_function):
     data_volume_multi_storage_scope_function.wait_for_dv_success(timeout=TIMEOUT_5MIN)
-
-
-@pytest.mark.polarion("CNV-3065")
-@pytest.mark.sno
-def test_disk_falloc(
-    storage_class_name_scope_function, unprivileged_client, fedora_data_source_scope_module, namespace
-):
-    size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
-    with create_dv(
-        client=unprivileged_client,
-        dv_name=f"cnv-3065-{storage_class_name_scope_function}",
-        namespace=namespace.name,
-        source_ref={
-            "kind": fedora_data_source_scope_module.kind,
-            "name": fedora_data_source_scope_module.name,
-            "namespace": fedora_data_source_scope_module.namespace,
-        },
-        size=size,
-        storage_class=storage_class_name_scope_function,
-    ) as dv:
-        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
-        with create_vm_from_dv(
-            vm_name="cnv-3065-vm",
-            client=unprivileged_client,
-            dv=dv,
-            os_flavor=OS_FLAVOR_FEDORA,
-            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-        ) as vm_dv:
-            with console.Console(vm=vm_dv) as vm_console:
-                LOGGER.info(f"Fill disk space with size {size}")
-                vm_console.sendline(f"fallocate -l {size} test-file")
-                vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
 
 
 @pytest.mark.destructive

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -392,6 +392,7 @@ def test_disk_falloc(
     ) as dv:
         dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
         with create_vm_from_dv(
+            vm_name="cnv-3065-vm",
             client=unprivileged_client,
             dv=dv,
             os_flavor=OS_FLAVOR_FEDORA,

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -11,7 +11,12 @@ from ocp_resources.resource import Resource
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.os_params import FEDORA_LATEST, RHEL_LATEST
+from tests.os_params import RHEL_LATEST
+from tests.storage.cdi_import.utils import (
+    get_importer_pod_node,
+    wait_dv_and_get_importer,
+    wait_for_pvc_recreate,
+)
 from tests.storage.constants import (
     ALPINE_QCOW2_IMG,
     HTTP,
@@ -27,16 +32,13 @@ from tests.storage.utils import (
     wait_for_importer_container_message,
 )
 from utilities import console
-from utilities.artifactory import get_test_artifact_server_url
 from utilities.constants import (
     OS_FLAVOR_ALPINE,
     OS_FLAVOR_RHEL,
     QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_5MIN,
-    TIMEOUT_5SEC,
     TIMEOUT_12MIN,
-    TIMEOUT_20SEC,
     Images,
 )
 from utilities.infra import get_node_selector_dict
@@ -46,6 +48,7 @@ from utilities.storage import (
     create_dummy_first_consumer_pod,
     create_dv,
     create_vm_from_dv,
+    get_dv_size_from_datasource,
     sc_volume_binding_mode_is_wffc,
 )
 from utilities.virt import running_vm
@@ -60,81 +63,33 @@ ISO_IMG = "Core-current.iso"
 TAR_IMG = "archive.tar"
 DEFAULT_DV_SIZE = Images.Alpine.DEFAULT_DV_SIZE
 SMALL_DV_SIZE = "200Mi"
-
 LATEST_WINDOWS_OS_DICT = py_config.get("latest_windows_os_dict", {})
 
 
-def get_importer_pod_node(importer_pod):
-    for sample in TimeoutSampler(
-        wait_timeout=TIMEOUT_1MIN,
-        sleep=TIMEOUT_5SEC,
-        func=lambda: importer_pod.instance.get("spec", {}).get(
-            "nodeName",
-        ),
-    ):
-        if sample:
-            return sample
-
-
-def wait_for_pvc_recreate(pvc, pvc_original_timestamp):
-    for sample in TimeoutSampler(
-        wait_timeout=TIMEOUT_20SEC,
-        sleep=1,
-        func=lambda: pvc.instance.metadata.creationTimestamp != pvc_original_timestamp,
-    ):
-        if sample:
-            break
-
-
-def wait_dv_and_get_importer(dv, admin_client):
-    dv.wait_for_status(
-        status=DataVolume.Status.IMPORT_IN_PROGRESS,
-        timeout=TIMEOUT_1MIN,
-        stop_status=DataVolume.Status.SUCCEEDED,
-    )
-    return get_importer_pod(client=admin_client, namespace=dv.namespace)
-
-
-@pytest.fixture()
-def dv_with_annotation(admin_client, namespace, linux_nad):
-    with create_dv(
-        dv_name="dv-annotation",
-        namespace=namespace.name,
-        url=f"{get_test_artifact_server_url()}{FEDORA_LATEST['image_path']}",
-        storage_class=py_config["default_storage_class"],
-        multus_annotation=linux_nad.name,
-        client=namespace.client,
-    ) as dv:
-        return wait_dv_and_get_importer(dv=dv, admin_client=admin_client).instance.metadata.annotations
-
-
 @pytest.mark.sno
-@pytest.mark.parametrize(
-    "data_volume_multi_storage_scope_function",
-    [
-        pytest.param(
-            {
-                "dv_name": "import-http-dv",
-                "source": HTTP,
-                "image": ALPINE_QCOW2_IMG,
-                "dv_size": DEFAULT_DV_SIZE,
-            },
-            marks=pytest.mark.polarion("CNV-675"),
-        ),
-    ],
-    indirect=True,
-)
-def test_delete_pvc_after_successful_import(
-    data_volume_multi_storage_scope_function,
-):
-    pvc = data_volume_multi_storage_scope_function.pvc
-    pvc_original_timestamp = pvc.instance.metadata.creationTimestamp
-    pvc.delete()
-    wait_for_pvc_recreate(pvc=pvc, pvc_original_timestamp=pvc_original_timestamp)
-    storage_class = data_volume_multi_storage_scope_function.storage_class
-    if sc_volume_binding_mode_is_wffc(sc=storage_class, client=data_volume_multi_storage_scope_function.client):
-        create_dummy_first_consumer_pod(pvc=pvc)
-    data_volume_multi_storage_scope_function.wait_for_dv_success()
+@pytest.mark.polarion("CNV-675")
+def test_pvc_recreates_after_deletion(namespace, storage_class_name_scope_function, fedora_data_source_scope_module):
+    with create_dv(
+        dv_name=f"cnv-675-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        storage_class=storage_class_name_scope_function,
+        size=get_dv_size_from_datasource(fedora_data_source_scope_module),
+        client=namespace.client,
+        source_ref={
+            "kind": fedora_data_source_scope_module.kind,
+            "name": fedora_data_source_scope_module.name,
+            "namespace": fedora_data_source_scope_module.namespace,
+        },
+    ) as dv:
+        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
+        pvc = dv.pvc
+        pvc_original_timestamp = pvc.instance.metadata.creationTimestamp
+        pvc.delete()
+        wait_for_pvc_recreate(pvc=pvc, pvc_original_timestamp=pvc_original_timestamp)
+        storage_class = storage_class_name_scope_function
+        if sc_volume_binding_mode_is_wffc(sc=storage_class, client=namespace.client):
+            create_dummy_first_consumer_pod(pvc=pvc)
+        dv.wait_for_dv_success()
 
 
 @pytest.mark.xfail(

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -489,6 +489,16 @@ def test_successful_vm_from_imported_dv_windows(
 @pytest.mark.polarion("CNV-5509")
 @pytest.mark.s390x
 def test_importer_pod_annotation(dv_with_annotation, linux_nad):
-    # verify "k8s.v1.cni.cncf.io/networks" can pass to the importer pod
-    assert dv_with_annotation.get(f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks") == linux_nad.name
-    assert '"interface": "net1"' in dv_with_annotation.get(f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status")
+    """Verify "k8s.v1.cni.cncf.io/networks" can pass to the importer pod"""
+    networks_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks"
+    network_status_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status"
+
+    networks_value = dv_with_annotation.get(networks_annotation)
+    assert networks_value == linux_nad.name, (
+        f"DV annotation is not passed to the importer pod. Expected: {linux_nad.name}, Found: {networks_value}"
+    )
+
+    network_status_value = dv_with_annotation.get(network_status_annotation)
+    assert '"interface": "net1"' in network_status_value, (
+        f"DV annotation is not passed to the importer pod. Expected interface: net1, Found: {network_status_value}"
+    )

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -10,9 +10,7 @@ from ocp_resources.datavolume import DataVolume
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.os_params import RHEL_LATEST
 from tests.storage.cdi_import.utils import (
-    get_importer_pod_node,
     wait_dv_and_get_importer,
 )
 from tests.storage.constants import (
@@ -26,23 +24,18 @@ from tests.storage.utils import (
     assert_num_files_in_pod,
     assert_use_populator,
     get_file_url,
-    get_importer_pod,
     wait_for_importer_container_message,
 )
 from utilities.constants import (
-    OS_FLAVOR_RHEL,
     QUARANTINED,
     TIMEOUT_1MIN,
     TIMEOUT_5MIN,
-    TIMEOUT_12MIN,
     Images,
 )
-from utilities.infra import get_node_selector_dict
 from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.storage import (
     ErrorMsg,
     create_dv,
-    create_vm_from_dv,
 )
 from utilities.virt import running_vm
 
@@ -337,56 +330,6 @@ def test_successful_concurrent_blank_disk_import(
 @pytest.mark.s390x
 def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_function):
     data_volume_multi_storage_scope_function.wait_for_dv_success(timeout=TIMEOUT_5MIN)
-
-
-@pytest.mark.destructive
-@pytest.mark.parametrize(
-    "data_volume_multi_storage_scope_function",
-    [
-        pytest.param(
-            {
-                "dv_name": "cnv-3362",
-                "source": HTTP,
-                "image": RHEL_LATEST.get("image_path"),
-                "dv_size": "25Gi",
-                "access_modes": DataVolume.AccessMode.RWX,
-                "wait": False,
-            },
-            marks=pytest.mark.polarion("CNV-3632"),
-        ),
-    ],
-    indirect=True,
-)
-def test_vm_from_dv_on_different_node(
-    admin_client,
-    skip_access_mode_rwo_scope_function,
-    skip_non_shared_storage,
-    schedulable_nodes,
-    data_volume_multi_storage_scope_function,
-):
-    """
-    Test that create and run VM from DataVolume (only use RWX access mode) on different node.
-    It applies to shared storage like Ceph or NFS. It cannot be tested on local storage like HPP.
-    """
-    importer_pod = get_importer_pod(
-        client=admin_client,
-        namespace=data_volume_multi_storage_scope_function.namespace,
-    )
-    importer_node_name = get_importer_pod_node(importer_pod=importer_pod)
-    nodes = list(filter(lambda node: importer_node_name != node.name, schedulable_nodes))
-    data_volume_multi_storage_scope_function.wait_for_dv_success(timeout=TIMEOUT_12MIN)
-    with create_vm_from_dv(
-        client=admin_client,
-        dv=data_volume_multi_storage_scope_function,
-        vm_name="rhel-vm",
-        os_flavor=OS_FLAVOR_RHEL,
-        node_selector=get_node_selector_dict(node_selector=nodes[0].name),
-        memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
-    ) as vm_dv:
-        assert vm_dv.vmi.node.name != importer_node_name, (
-            f"VM is running on the same node as importer pod. Expected different nodes."
-            f" Importer node: {importer_node_name}, VM node: {vm_dv.vmi.node.name}"
-        )
 
 
 @pytest.mark.tier3

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -429,7 +429,7 @@ def test_successful_vm_from_imported_dv_windows(
 @pytest.mark.polarion("CNV-5509")
 @pytest.mark.s390x
 def test_importer_pod_annotation(dv_with_annotation, linux_nad):
-    """Verify "k8s.v1.cni.cncf.io/networks" can pass to the importer pod"""
+    """Verify "k8s.v1.cni.cncf.io/networks" can be passed to the importer pod"""
     networks_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks"
     network_status_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status"
 

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -33,7 +33,7 @@ from tests.storage.utils import (
 )
 from utilities import console
 from utilities.constants import (
-    OS_FLAVOR_ALPINE,
+    OS_FLAVOR_FEDORA,
     OS_FLAVOR_RHEL,
     QUARANTINED,
     TIMEOUT_1MIN,
@@ -372,35 +372,35 @@ def test_blank_disk_import_validate_status(data_volume_multi_storage_scope_funct
     data_volume_multi_storage_scope_function.wait_for_dv_success(timeout=TIMEOUT_5MIN)
 
 
-@pytest.mark.parametrize(
-    "data_volume_multi_storage_scope_function",
-    [
-        pytest.param(
-            {
-                "dv_name": "cnv-3065",
-                "source": HTTP,
-                "image": f"{Images.Alpine.DIR}/{Images.Alpine.QCOW2_IMG}",
-                "dv_size": Images.Alpine.DEFAULT_DV_SIZE,
-                "wait": True,
-            },
-            marks=pytest.mark.polarion("CNV-3065"),
-        ),
-    ],
-    indirect=True,
-)
+@pytest.mark.polarion("CNV-3065")
 @pytest.mark.sno
-def test_disk_falloc(data_volume_multi_storage_scope_function, unprivileged_client):
-    data_volume_multi_storage_scope_function.wait_for_dv_success()
-    with create_vm_from_dv(
+def test_disk_falloc(
+    storage_class_name_scope_function, unprivileged_client, fedora_data_source_scope_module, namespace
+):
+    size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
+    with create_dv(
         client=unprivileged_client,
-        dv=data_volume_multi_storage_scope_function,
-        os_flavor=OS_FLAVOR_ALPINE,
-        memory_guest=Images.Alpine.DEFAULT_MEMORY_SIZE,
-    ) as vm_dv:
-        with console.Console(vm=vm_dv) as vm_console:
-            LOGGER.info("Fill disk space.")
-            vm_console.sendline("dd if=/dev/urandom of=file bs=1M")
-            vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
+        dv_name=f"cnv-3065-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        source_ref={
+            "kind": fedora_data_source_scope_module.kind,
+            "name": fedora_data_source_scope_module.name,
+            "namespace": fedora_data_source_scope_module.namespace,
+        },
+        size=size,
+        storage_class=storage_class_name_scope_function,
+    ) as dv:
+        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
+        with create_vm_from_dv(
+            client=unprivileged_client,
+            dv=dv,
+            os_flavor=OS_FLAVOR_FEDORA,
+            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        ) as vm_dv:
+            with console.Console(vm=vm_dv) as vm_console:
+                LOGGER.info(f"Fill disk space with size {size}")
+                vm_console.sendline(f"fallocate -l {size} test-file")
+                vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
 
 
 @pytest.mark.destructive
@@ -411,7 +411,7 @@ def test_disk_falloc(data_volume_multi_storage_scope_function, unprivileged_clie
             {
                 "dv_name": "cnv-3362",
                 "source": HTTP,
-                "image": RHEL_LATEST["image_path"],
+                "image": RHEL_LATEST.get("image_path"),
                 "dv_size": "25Gi",
                 "access_modes": DataVolume.AccessMode.RWX,
                 "wait": False,

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -447,7 +447,10 @@ def test_vm_from_dv_on_different_node(
         node_selector=get_node_selector_dict(node_selector=nodes[0].name),
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm_dv:
-        assert vm_dv.vmi.node.name != importer_node_name
+        assert vm_dv.vmi.node.name != importer_node_name, (
+            f"VM is running on the same node as importer pod. Expected different nodes."
+            f" Importer node: {importer_node_name}, VM node: {vm_dv.vmi.node.name}"
+        )
 
 
 @pytest.mark.tier3

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -7,7 +7,6 @@ import logging
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.datavolume import DataVolume
-from ocp_resources.resource import Resource
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -423,22 +422,4 @@ def test_successful_vm_from_imported_dv_windows(
 ):
     validate_os_info_vmi_vs_windows_os(
         vm=vm_instance_from_template_multi_storage_scope_function,
-    )
-
-
-@pytest.mark.polarion("CNV-5509")
-@pytest.mark.s390x
-def test_importer_pod_annotation(dv_with_annotation, linux_nad):
-    """Verify "k8s.v1.cni.cncf.io/networks" can be passed to the importer pod"""
-    networks_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks"
-    network_status_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status"
-
-    networks_value = dv_with_annotation.get(networks_annotation)
-    assert networks_value == linux_nad.name, (
-        f"DV annotation is not passed to the importer pod. Expected: {linux_nad.name}, Found: {networks_value}"
-    )
-
-    network_status_value = dv_with_annotation.get(network_status_annotation)
-    assert '"interface": "net1"' in network_status_value, (
-        f"DV annotation is not passed to the importer pod. Expected interface: net1, Found: {network_status_value}"
     )

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -187,17 +187,17 @@ def test_public_registry_data_volume_archive(unprivileged_client, namespace, sto
 
 @pytest.mark.polarion("CNV-5509")
 @pytest.mark.s390x
-def test_importer_pod_annotation(dv_with_annotation, linux_nad):
+def test_importer_pod_annotation(importer_pod_annotations, linux_nad):
     """Verify "k8s.v1.cni.cncf.io/networks" can be passed to the importer pod"""
     networks_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks"
     network_status_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status"
 
-    networks_value = dv_with_annotation.get(networks_annotation)
+    networks_value = importer_pod_annotations.get(networks_annotation)
     assert networks_value == linux_nad.name, (
         f"DV annotation is not passed to the importer pod. Expected: {linux_nad.name}, Found: {networks_value}"
     )
 
-    network_status_value = dv_with_annotation.get(network_status_annotation)
+    network_status_value = importer_pod_annotations.get(network_status_annotation)
     assert '"interface": "net1"' in network_status_value, (
         f"DV annotation is not passed to the importer pod. Expected interface: net1, Found: {network_status_value}"
     )

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from kubernetes.client.rest import ApiException
 from ocp_resources.datavolume import DataVolume
-from referencing import Resource
+from ocp_resources.resource import Resource
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
 from tests.storage.utils import (

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 from kubernetes.client.rest import ApiException
 from ocp_resources.datavolume import DataVolume
+from referencing import Resource
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
 from tests.storage.utils import (
@@ -182,3 +183,21 @@ def test_public_registry_data_volume_archive(unprivileged_client, namespace, sto
             storage_class=[*storage_class_name_scope_function][0],
         ):
             return
+
+
+@pytest.mark.polarion("CNV-5509")
+@pytest.mark.s390x
+def test_importer_pod_annotation(dv_with_annotation, linux_nad):
+    """Verify "k8s.v1.cni.cncf.io/networks" can be passed to the importer pod"""
+    networks_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks"
+    network_status_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status"
+
+    networks_value = dv_with_annotation.get(networks_annotation)
+    assert networks_value == linux_nad.name, (
+        f"DV annotation is not passed to the importer pod. Expected: {linux_nad.name}, Found: {networks_value}"
+    )
+
+    network_status_value = dv_with_annotation.get(network_status_annotation)
+    assert '"interface": "net1"' in network_status_value, (
+        f"DV annotation is not passed to the importer pod. Expected interface: net1, Found: {network_status_value}"
+    )

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import pytest
@@ -198,6 +199,5 @@ def test_importer_pod_annotation(importer_pod_annotations, linux_nad):
     )
 
     network_status_value = importer_pod_annotations.get(network_status_annotation)
-    assert '"interface": "net1"' in network_status_value, (
-        f"DV annotation is not passed to the importer pod. Expected interface: net1, Found: {network_status_value}"
-    )
+    interfaces = [entry["interface"] for entry in json.loads(network_status_value) if "interface" in entry]
+    assert "net1" in interfaces, f"Expected interface: net1, Found: {interfaces}"

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING
 
 from ocp_resources.datavolume import DataVolume
-from timeout_sampler import TimeoutSampler
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.storage.utils import get_importer_pod
 from utilities.constants import TIMEOUT_1MIN, TIMEOUT_5SEC, TIMEOUT_20SEC
@@ -24,18 +24,16 @@ def get_importer_pod_node(importer_pod: Pod) -> str:
         str: The node name where the pod is scheduled.
 
     Raises:
-        TimeoutError: If the importer pod is not scheduled within the timeout period.
+        TimeoutExpiredError: If the importer pod is not scheduled within the timeout period.
     """
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=TIMEOUT_5SEC,
-        func=lambda: importer_pod.instance.get("spec", {}).get(
-            "nodeName",
-        ),
+        func=lambda: importer_pod.instance["spec"].get("nodeName"),
     ):
         if sample:
             return sample
-    raise TimeoutError("Importer pod was not scheduled within the timeout period.")
+    raise TimeoutExpiredError("Importer pod was not scheduled within the timeout period.")
 
 
 def wait_for_pvc_recreate(pvc: PersistentVolumeClaim, pvc_creation_timestamp: str) -> None:
@@ -46,7 +44,7 @@ def wait_for_pvc_recreate(pvc: PersistentVolumeClaim, pvc_creation_timestamp: st
         pvc_creation_timestamp: The original creation timestamp to compare against.
 
     Raises:
-        TimeoutError: If the PVC is not recreated within the timeout period.
+        TimeoutExpiredError: If the PVC is not recreated within the timeout period.
     """
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_20SEC,
@@ -55,7 +53,7 @@ def wait_for_pvc_recreate(pvc: PersistentVolumeClaim, pvc_creation_timestamp: st
     ):
         if sample:
             return
-    raise TimeoutError("PVC was not recreated within the timeout period.")
+    raise TimeoutExpiredError("PVC was not recreated within the timeout period.")
 
 
 def wait_dv_and_get_importer(dv: DataVolume, admin_client: DynamicClient) -> Pod:

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -1,0 +1,61 @@
+"""Helper utilities for CDI import tests."""
+
+from ocp_resources.datavolume import DataVolume
+from timeout_sampler import TimeoutSampler
+
+from tests.storage.utils import get_importer_pod
+from utilities.constants import TIMEOUT_1MIN, TIMEOUT_5SEC, TIMEOUT_20SEC
+
+
+def get_importer_pod_node(importer_pod):
+    """Get the node name where the importer pod is scheduled.
+
+    Args:
+        importer_pod: The importer pod resource.
+
+    Returns:
+        str: The node name where the pod is scheduled.
+    """
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=TIMEOUT_5SEC,
+        func=lambda: importer_pod.instance.get("spec", {}).get(
+            "nodeName",
+        ),
+    ):
+        if sample:
+            return sample
+
+
+def wait_for_pvc_recreate(pvc, pvc_original_timestamp):
+    """Wait for PVC to be recreated with a new timestamp.
+
+    Args:
+        pvc: The PVC resource to monitor.
+        pvc_original_timestamp: The original creation timestamp to compare against.
+    """
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_20SEC,
+        sleep=1,
+        func=lambda: pvc.instance.metadata.creationTimestamp != pvc_original_timestamp,
+    ):
+        if sample:
+            break
+
+
+def wait_dv_and_get_importer(dv, admin_client):
+    """Wait for DataVolume import to start and get the importer pod.
+
+    Args:
+        dv: The DataVolume resource.
+        admin_client: The admin client for accessing cluster resources.
+
+    Returns:
+        Pod: The importer pod resource.
+    """
+    dv.wait_for_status(
+        status=DataVolume.Status.IMPORT_IN_PROGRESS,
+        timeout=TIMEOUT_1MIN,
+        stop_status=DataVolume.Status.SUCCEEDED,
+    )
+    return get_importer_pod(client=admin_client, namespace=dv.namespace)

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -1,5 +1,7 @@
 """Helper utilities for CDI import tests."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from ocp_resources.datavolume import DataVolume

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from ocp_resources.datavolume import DataVolume
+from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.storage.utils import get_importer_pod
@@ -72,3 +73,28 @@ def wait_dv_and_get_importer(dv: DataVolume, admin_client: DynamicClient) -> Pod
         stop_status=DataVolume.Status.SUCCEEDED,
     )
     return get_importer_pod(client=admin_client, namespace=dv.namespace)
+
+
+def wait_for_multus_network_status(importer_pod: Pod) -> None:
+    """Wait for Multus network-status annotation to be populated on the importer pod.
+
+    Multus CNI populates the network-status annotation asynchronously after the pod starts.
+    This function waits for the annotation to appear before proceeding.
+
+    Args:
+        importer_pod: The importer pod resource.
+
+    Raises:
+        TimeoutExpiredError: If the network-status annotation is not populated within the timeout period.
+    """
+    network_status_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status"
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=TIMEOUT_5SEC,
+        func=lambda: importer_pod.instance.metadata.annotations.get(network_status_annotation),
+    ):
+        if sample:
+            return
+    raise TimeoutExpiredError(
+        f"Multus {network_status_annotation} annotation was not populated within the timeout period."
+    )

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -30,7 +30,7 @@ def get_importer_pod_node(importer_pod: Pod) -> str:
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=TIMEOUT_5SEC,
-        func=lambda: importer_pod.instance["spec"].get("nodeName"),
+        func=lambda: importer_pod.instance.spec.nodeName,
     ):
         if sample:
             return sample

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -38,12 +38,12 @@ def get_importer_pod_node(importer_pod: Pod) -> str:
     raise TimeoutError("Importer pod was not scheduled within the timeout period.")
 
 
-def wait_for_pvc_recreate(pvc: PersistentVolumeClaim, pvc_original_timestamp: str) -> None:
+def wait_for_pvc_recreate(pvc: PersistentVolumeClaim, pvc_creation_timestamp: str) -> None:
     """Wait for PVC to be recreated with a new timestamp.
 
     Args:
         pvc: The PVC resource to monitor.
-        pvc_original_timestamp: The original creation timestamp to compare against.
+        pvc_creation_timestamp: The original creation timestamp to compare against.
 
     Raises:
         TimeoutError: If the PVC is not recreated within the timeout period.
@@ -51,7 +51,7 @@ def wait_for_pvc_recreate(pvc: PersistentVolumeClaim, pvc_original_timestamp: st
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_20SEC,
         sleep=1,
-        func=lambda: pvc.instance.metadata.creationTimestamp != pvc_original_timestamp,
+        func=lambda: pvc.instance.metadata.creationTimestamp != pvc_creation_timestamp,
     ):
         if sample:
             return

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -1,13 +1,20 @@
 """Helper utilities for CDI import tests."""
 
+from typing import TYPE_CHECKING
+
 from ocp_resources.datavolume import DataVolume
 from timeout_sampler import TimeoutSampler
 
 from tests.storage.utils import get_importer_pod
 from utilities.constants import TIMEOUT_1MIN, TIMEOUT_5SEC, TIMEOUT_20SEC
 
+if TYPE_CHECKING:
+    from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+    from ocp_resources.pod import Pod
+    from ocp_resources.resource import DynamicClient
 
-def get_importer_pod_node(importer_pod):
+
+def get_importer_pod_node(importer_pod: Pod) -> str:
     """Get the node name where the importer pod is scheduled.
 
     Args:
@@ -15,6 +22,9 @@ def get_importer_pod_node(importer_pod):
 
     Returns:
         str: The node name where the pod is scheduled.
+
+    Raises:
+        TimeoutError: If the importer pod is not scheduled within the timeout period.
     """
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
@@ -25,14 +35,18 @@ def get_importer_pod_node(importer_pod):
     ):
         if sample:
             return sample
+    raise TimeoutError("Importer pod was not scheduled within the timeout period.")
 
 
-def wait_for_pvc_recreate(pvc, pvc_original_timestamp):
+def wait_for_pvc_recreate(pvc: PersistentVolumeClaim, pvc_original_timestamp: str) -> None:
     """Wait for PVC to be recreated with a new timestamp.
 
     Args:
         pvc: The PVC resource to monitor.
         pvc_original_timestamp: The original creation timestamp to compare against.
+
+    Raises:
+        TimeoutError: If the PVC is not recreated within the timeout period.
     """
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_20SEC,
@@ -40,10 +54,11 @@ def wait_for_pvc_recreate(pvc, pvc_original_timestamp):
         func=lambda: pvc.instance.metadata.creationTimestamp != pvc_original_timestamp,
     ):
         if sample:
-            break
+            return
+    raise TimeoutError("PVC was not recreated within the timeout period.")
 
 
-def wait_dv_and_get_importer(dv, admin_client):
+def wait_dv_and_get_importer(dv: DataVolume, admin_client: DynamicClient) -> Pod:
     """Wait for DataVolume import to start and get the importer pod.
 
     Args:

--- a/tests/storage/general/conftest.py
+++ b/tests/storage/general/conftest.py
@@ -54,7 +54,7 @@ def fedora_vm_with_instance_type(
     using a DataVolume template from the provided data source.
     """
     with VirtualMachineForTests(
-        name=f"vm-{storage_class_name_scope_function}",
+        name="fedora-vm",
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_FEDORA,

--- a/tests/storage/general/conftest.py
+++ b/tests/storage/general/conftest.py
@@ -2,13 +2,19 @@
 Storage general tests fixtures
 """
 
+import logging
+
 import pytest
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 
-from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_5MIN, U1_SMALL
+from tests.storage.cdi_import.utils import get_importer_pod_node, wait_dv_and_get_importer
+from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
+from utilities.constants import OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_5MIN, TIMEOUT_12MIN, U1_SMALL, Images
 from utilities.storage import create_dv, data_volume_template_with_source_ref_dict, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture()
@@ -61,3 +67,36 @@ def fedora_vm_with_instance_type(
     ) as vm:
         running_vm(vm=vm)
         yield vm
+
+
+@pytest.fixture()
+def fedora_dv_with_importer_node(
+    admin_client,
+    namespace,
+    storage_class_matrix_rwx_matrix__function__,
+):
+    """
+    Provides a DataVolume imported from Quay registry with importer pod node information.
+
+    Returns:
+        Tuple of (DataVolume, importer_pod_node_name) where the DataVolume is ready
+        and importer_pod_node_name is the node where the import operation ran.
+    """
+    storage_class_name = next(iter(storage_class_matrix_rwx_matrix__function__))
+    with create_dv(
+        dv_name=f"fedora-dv-different-node-{storage_class_name}",
+        namespace=namespace.name,
+        source=REGISTRY_STR,
+        url=QUAY_FEDORA_CONTAINER_IMAGE,
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=storage_class_name,
+        client=admin_client,
+    ) as dv:
+        LOGGER.info(f"Getting importer pod for DataVolume {dv.name}")
+        importer_pod = wait_dv_and_get_importer(dv=dv, admin_client=admin_client)
+        importer_pod_node = get_importer_pod_node(importer_pod=importer_pod)
+        LOGGER.info(f"Importer pod {importer_pod.name} is running on node {importer_pod_node}")
+
+        dv.wait_for_dv_success(timeout=TIMEOUT_12MIN)
+
+        yield dv, importer_pod_node

--- a/tests/storage/general/conftest.py
+++ b/tests/storage/general/conftest.py
@@ -70,8 +70,9 @@ def fedora_vm_with_instance_type(
 
 
 @pytest.fixture()
-def fedora_dv_with_importer_node(
+def fedora_dv_rwx_with_importer_node(
     admin_client,
+    unprivileged_client,
     namespace,
     storage_class_matrix_rwx_matrix__function__,
 ):
@@ -90,7 +91,7 @@ def fedora_dv_with_importer_node(
         url=QUAY_FEDORA_CONTAINER_IMAGE,
         size=Images.Fedora.DEFAULT_DV_SIZE,
         storage_class=storage_class_name,
-        client=admin_client,
+        client=unprivileged_client,
     ) as dv:
         LOGGER.info(f"Getting importer pod for DataVolume {dv.name}")
         importer_pod = wait_dv_and_get_importer(dv=dv, admin_client=admin_client)

--- a/tests/storage/general/conftest.py
+++ b/tests/storage/general/conftest.py
@@ -1,0 +1,63 @@
+"""
+Storage general tests fixtures
+"""
+
+import pytest
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+
+from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_5MIN, U1_SMALL
+from utilities.storage import create_dv, data_volume_template_with_source_ref_dict, get_dv_size_from_datasource
+from utilities.virt import VirtualMachineForTests, running_vm
+
+
+@pytest.fixture()
+def fedora_data_volume(namespace, fedora_data_source_scope_module, storage_class_name_scope_function):
+    """
+    Provides a DataVolume created from Fedora DataSource.
+
+    The DataVolume is created and waits for success before yielding.
+    """
+    with create_dv(
+        dv_name=f"fedora-dv-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        storage_class=storage_class_name_scope_function,
+        size=get_dv_size_from_datasource(fedora_data_source_scope_module),
+        client=namespace.client,
+        source_ref={
+            "kind": fedora_data_source_scope_module.kind,
+            "name": fedora_data_source_scope_module.name,
+            "namespace": fedora_data_source_scope_module.namespace,
+        },
+    ) as dv:
+        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
+        yield dv
+
+
+@pytest.fixture()
+def fedora_vm_with_instance_type(
+    namespace,
+    unprivileged_client,
+    fedora_data_source_scope_module,
+    storage_class_name_scope_function,
+):
+    """
+    Provides a running Fedora VM with instance type and preference.
+
+    The VM is created with U1_SMALL instance type and Fedora preference,
+    using a DataVolume template from the provided data source.
+    """
+    with VirtualMachineForTests(
+        name=f"vm-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        os_flavor=OS_FLAVOR_FEDORA,
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
+        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=fedora_data_source_scope_module,
+            storage_class=storage_class_name_scope_function,
+        ),
+    ) as vm:
+        running_vm(vm=vm)
+        yield vm

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -8,19 +8,8 @@ import pytest
 
 from tests.storage.cdi_import.utils import wait_for_pvc_recreate
 from utilities import console
-from utilities.constants import (
-    OS_FLAVOR_FEDORA,
-    TIMEOUT_1MIN,
-    TIMEOUT_5MIN,
-    Images,
-)
-from utilities.storage import (
-    create_dummy_first_consumer_pod,
-    create_dv,
-    create_vm_from_dv,
-    get_dv_size_from_datasource,
-    sc_volume_binding_mode_is_wffc,
-)
+from utilities.constants import TIMEOUT_1MIN
+from utilities.storage import create_dummy_first_consumer_pod, sc_volume_binding_mode_is_wffc
 
 pytestmark = [
     pytest.mark.post_upgrade,
@@ -28,10 +17,12 @@ pytestmark = [
 
 LOGGER = logging.getLogger(__name__)
 
+ALLOCATION_SIZE_BYTES = 42949672960  # 40GiB in bytes
+
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-675")
-def test_pvc_recreates_after_deletion(namespace, storage_class_name_scope_function, fedora_data_source_scope_module):
+def test_pvc_recreates_after_deletion(fedora_data_volume, namespace, storage_class_name_scope_function):
     """
     Test that a PVC is automatically recreated by CDI after manual deletion.
 
@@ -52,76 +43,33 @@ def test_pvc_recreates_after_deletion(namespace, storage_class_name_scope_functi
         - PVC is recreated automatically
         - DataVolume status is "Succeeded"
     """
-    with create_dv(
-        dv_name=f"cnv-675-{storage_class_name_scope_function}",
-        namespace=namespace.name,
-        storage_class=storage_class_name_scope_function,
-        size=get_dv_size_from_datasource(fedora_data_source_scope_module),
-        client=namespace.client,
-        source_ref={
-            "kind": fedora_data_source_scope_module.kind,
-            "name": fedora_data_source_scope_module.name,
-            "namespace": fedora_data_source_scope_module.namespace,
-        },
-    ) as dv:
-        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
-        pvc = dv.pvc
-        pvc_original_timestamp = pvc.instance.metadata.creationTimestamp
-        pvc.delete()
-        wait_for_pvc_recreate(pvc=pvc, pvc_original_timestamp=pvc_original_timestamp)
-        storage_class = storage_class_name_scope_function
-        if sc_volume_binding_mode_is_wffc(sc=storage_class, client=namespace.client):
-            create_dummy_first_consumer_pod(pvc=pvc)
-        dv.wait_for_dv_success()
+    pvc = fedora_data_volume.pvc
+    pvc_original_timestamp = pvc.instance.metadata.creationTimestamp
+    pvc.delete()
+    wait_for_pvc_recreate(pvc=pvc, pvc_creation_timestamp=pvc_original_timestamp)
+    if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_function, client=namespace.client):
+        create_dummy_first_consumer_pod(pvc=pvc)
+    fedora_data_volume.wait_for_dv_success()
 
 
 @pytest.mark.polarion("CNV-3065")
 @pytest.mark.sno
-def test_disk_falloc(
-    storage_class_name_scope_function, unprivileged_client, fedora_data_source_scope_module, namespace
-):
+def test_disk_falloc(fedora_vm_with_instance_type):
     """
     Test that attempting to allocate more space than available on a disk fails with the expected error.
 
     Preconditions:
-        - Fedora DataSource available
-        - DataVolume created from Fedora DataSource
-        - VM created and started from the DataVolume with console access
+        - VM with instance type and preference created and running with console access
 
     Steps:
         1. Connect to VM console
-        2. Execute fallocate command to allocate a file equal to the disk size
+        2. Execute fallocate command to allocate a file larger than the available disk space
         3. Verify the error message
 
     Expected:
         - fallocate command fails with "No space left on device" error
     """
-    size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
-    with create_dv(
-        client=unprivileged_client,
-        dv_name=f"cnv-3065-{storage_class_name_scope_function}",
-        namespace=namespace.name,
-        source_ref={
-            "kind": fedora_data_source_scope_module.kind,
-            "name": fedora_data_source_scope_module.name,
-            "namespace": fedora_data_source_scope_module.namespace,
-        },
-        size=size,
-        storage_class=storage_class_name_scope_function,
-    ) as dv:
-        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
-        with (
-            (
-                create_vm_from_dv(
-                    vm_name="cnv-3065-vm",
-                    client=unprivileged_client,
-                    dv=dv,
-                    os_flavor=OS_FLAVOR_FEDORA,
-                    memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-                )
-            ) as vm_dv,
-            console.Console(vm=vm_dv) as vm_console,
-        ):
-            LOGGER.info(f"Fill disk space with size {size}")
-            vm_console.sendline(f"fallocate -l {size} test-file")
-            vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
+    with console.Console(vm=fedora_vm_with_instance_type) as vm_console:
+        LOGGER.info(f"Attempting to allocate {ALLOCATION_SIZE_BYTES} bytes to trigger disk full error")
+        vm_console.sendline(f"fallocate -l {ALLOCATION_SIZE_BYTES} test-file")
+        vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -32,6 +32,26 @@ LOGGER = logging.getLogger(__name__)
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-675")
 def test_pvc_recreates_after_deletion(namespace, storage_class_name_scope_function, fedora_data_source_scope_module):
+    """
+    Test that a PVC is automatically recreated by CDI after manual deletion.
+
+    Preconditions:
+        - Fedora DataSource available
+        - Storage class available
+        - DataVolume created from Fedora DataSource
+        - PVC bound and DataVolume import completed
+
+    Steps:
+        1. Record the PVC original creation timestamp
+        2. Delete the PVC
+        3. Wait for PVC to be recreated with a new timestamp
+        4. Create a dummy first consumer pod if storage class uses WaitForFirstConsumer binding mode
+        5. Wait for DataVolume to reach Succeeded status
+
+    Expected:
+        - PVC is recreated automatically
+        - DataVolume status is "Succeeded"
+    """
     with create_dv(
         dv_name=f"cnv-675-{storage_class_name_scope_function}",
         namespace=namespace.name,
@@ -60,6 +80,22 @@ def test_pvc_recreates_after_deletion(namespace, storage_class_name_scope_functi
 def test_disk_falloc(
     storage_class_name_scope_function, unprivileged_client, fedora_data_source_scope_module, namespace
 ):
+    """
+    Test that attempting to allocate more space than available on a disk fails with the expected error.
+
+    Preconditions:
+        - Fedora DataSource available
+        - DataVolume created from Fedora DataSource
+        - VM created and started from the DataVolume with console access
+
+    Steps:
+        1. Connect to VM console
+        2. Execute fallocate command to allocate a file equal to the disk size
+        3. Verify the error message
+
+    Expected:
+        - fallocate command fails with "No space left on device" error
+    """
     size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
     with create_dv(
         client=unprivileged_client,

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -6,10 +6,17 @@ import logging
 
 import pytest
 
-from tests.storage.cdi_import.utils import wait_for_pvc_recreate
+from tests.storage.cdi_import.utils import get_importer_pod_node, wait_dv_and_get_importer, wait_for_pvc_recreate
+from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
 from utilities import console
-from utilities.constants import TIMEOUT_1MIN
-from utilities.storage import create_dummy_first_consumer_pod, sc_volume_binding_mode_is_wffc
+from utilities.constants import OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_1MIN, TIMEOUT_12MIN, Images
+from utilities.infra import get_node_selector_dict
+from utilities.storage import (
+    create_dummy_first_consumer_pod,
+    create_dv,
+    create_vm_from_dv,
+    sc_volume_binding_mode_is_wffc,
+)
 
 pytestmark = [
     pytest.mark.post_upgrade,
@@ -73,3 +80,64 @@ def test_disk_falloc(fedora_vm_with_instance_type):
         LOGGER.info(f"Attempting to allocate {ALLOCATION_SIZE_BYTES} bytes to trigger disk full error")
         vm_console.sendline(f"fallocate -l {ALLOCATION_SIZE_BYTES} test-file")
         vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
+
+
+@pytest.mark.destructive
+@pytest.mark.polarion("CNV-3632")
+def test_vm_from_dv_on_different_node(
+    admin_client,
+    unprivileged_client,
+    schedulable_nodes,
+    namespace,
+    storage_class_matrix_rwx_matrix__function__,
+):
+    """
+    Test that a VM created from a DataVolume runs on a different node than the import operation.
+
+    Preconditions:
+        - Storage class with RWX access mode (shared storage like Ceph or NFS)
+        - Multiple schedulable nodes available
+
+    Steps:
+        1. Create DataVolume from Quay registry without waiting for completion
+        2. Get the importer pod that handles the registry import
+        3. Record the node where the importer pod is running
+        4. Wait for DataVolume to complete successfully
+        5. Create and start a VM from the DataVolume on a different node
+        6. Verify the VM is running on a different node than the importer pod
+
+    Expected:
+        - VM runs successfully on a node different from the import operation node
+    """
+    storage_class_name = next(iter(storage_class_matrix_rwx_matrix__function__))
+    with create_dv(
+        dv_name=f"fedora-dv-different-node-{storage_class_name}",
+        namespace=namespace.name,
+        source=REGISTRY_STR,
+        url=QUAY_FEDORA_CONTAINER_IMAGE,
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=storage_class_name,
+        client=admin_client,
+    ) as dv:
+        LOGGER.info(f"Getting importer pod for DataVolume {dv.name}")
+        importer_pod = wait_dv_and_get_importer(dv=dv, admin_client=admin_client)
+        importer_pod_node = get_importer_pod_node(importer_pod=importer_pod)
+        LOGGER.info(f"Importer pod {importer_pod.name} is running on node {importer_pod_node}")
+
+        nodes = [node for node in schedulable_nodes if node.name != importer_pod_node]
+        assert nodes, f"No available nodes different from importer pod node {importer_pod_node}"
+
+        dv.wait_for_dv_success(timeout=TIMEOUT_12MIN)
+
+        with create_vm_from_dv(
+            client=unprivileged_client,
+            dv=dv,
+            vm_name="fedora-vm-different-node",
+            os_flavor=OS_FLAVOR_FEDORA,
+            node_selector=get_node_selector_dict(node_selector=nodes[0].name),
+            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        ) as vm:
+            assert vm.vmi.node.name != importer_pod_node, (
+                f"VM is running on the same node as importer pod. Expected different nodes. "
+                f"Importer pod node: {importer_pod_node}, VM node: {vm.vmi.node.name}"
+            )

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -6,17 +6,11 @@ import logging
 
 import pytest
 
-from tests.storage.cdi_import.utils import get_importer_pod_node, wait_dv_and_get_importer, wait_for_pvc_recreate
-from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
+from tests.storage.cdi_import.utils import wait_for_pvc_recreate
 from utilities import console
-from utilities.constants import OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_1MIN, TIMEOUT_12MIN, Images
+from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_1MIN, Images
 from utilities.infra import get_node_selector_dict
-from utilities.storage import (
-    create_dummy_first_consumer_pod,
-    create_dv,
-    create_vm_from_dv,
-    sc_volume_binding_mode_is_wffc,
-)
+from utilities.storage import create_dummy_first_consumer_pod, create_vm_from_dv, sc_volume_binding_mode_is_wffc
 
 pytestmark = [
     pytest.mark.post_upgrade,
@@ -84,11 +78,9 @@ def test_disk_falloc(fedora_vm_with_instance_type):
 
 @pytest.mark.polarion("CNV-3632")
 def test_vm_from_dv_on_different_node(
-    admin_client,
     unprivileged_client,
     schedulable_nodes,
-    namespace,
-    storage_class_matrix_rwx_matrix__function__,
+    fedora_dv_with_importer_node,
 ):
     """
     Test that a VM created from a DataVolume runs on a different node than the import operation.
@@ -96,47 +88,31 @@ def test_vm_from_dv_on_different_node(
     Preconditions:
         - Storage class with RWX access mode (shared storage like Ceph or NFS)
         - Multiple schedulable nodes available
+        - DataVolume imported from Quay registry
 
     Steps:
-        1. Create DataVolume from Quay registry without waiting for completion
-        2. Get the importer pod that handles the registry import
-        3. Record the node where the importer pod is running
-        4. Wait for DataVolume to complete successfully
-        5. Create and start a VM from the DataVolume on a different node
-        6. Verify the VM is running on a different node than the importer pod
+        1. Get nodes excluding the importer pod node
+        2. Create and start a VM from the DataVolume on a different node
+        3. Verify the VM is running on a different node than the importer pod
 
     Expected:
         - VM runs successfully on a node different from the import operation node
     """
-    storage_class_name = next(iter(storage_class_matrix_rwx_matrix__function__))
-    with create_dv(
-        dv_name=f"fedora-dv-different-node-{storage_class_name}",
-        namespace=namespace.name,
-        source=REGISTRY_STR,
-        url=QUAY_FEDORA_CONTAINER_IMAGE,
-        size=Images.Fedora.DEFAULT_DV_SIZE,
-        storage_class=storage_class_name,
-        client=admin_client,
-    ) as dv:
-        LOGGER.info(f"Getting importer pod for DataVolume {dv.name}")
-        importer_pod = wait_dv_and_get_importer(dv=dv, admin_client=admin_client)
-        importer_pod_node = get_importer_pod_node(importer_pod=importer_pod)
-        LOGGER.info(f"Importer pod {importer_pod.name} is running on node {importer_pod_node}")
+    dv, importer_pod_node = fedora_dv_with_importer_node
 
-        nodes = [node for node in schedulable_nodes if node.name != importer_pod_node]
-        assert nodes, f"No available nodes different from importer pod node {importer_pod_node}"
+    nodes = [node for node in schedulable_nodes if node.name != importer_pod_node]
+    assert nodes, f"No available nodes different from importer pod node {importer_pod_node}"
 
-        dv.wait_for_dv_success(timeout=TIMEOUT_12MIN)
-
-        with create_vm_from_dv(
-            client=unprivileged_client,
-            dv=dv,
-            vm_name="fedora-vm-different-node",
-            os_flavor=OS_FLAVOR_FEDORA,
-            node_selector=get_node_selector_dict(node_selector=nodes[0].name),
-            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-        ) as vm:
-            assert vm.vmi.node.name != importer_pod_node, (
-                f"VM is running on the same node as importer pod. Expected different nodes. "
-                f"Importer pod node: {importer_pod_node}, VM node: {vm.vmi.node.name}"
-            )
+    with create_vm_from_dv(
+        client=unprivileged_client,
+        dv=dv,
+        vm_name="fedora-vm-different-node",
+        os_flavor=OS_FLAVOR_FEDORA,
+        node_selector=get_node_selector_dict(node_selector=nodes[0].name),
+        memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+    ) as vm:
+        vmi_node_name = vm.vmi.get_node().name
+        assert vmi_node_name != importer_pod_node, (
+            f"VM is running on the same node as importer pod. Expected different nodes. "
+            f"Importer pod node: {importer_pod_node}, VM node: {vmi_node_name}"
+        )

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -82,7 +82,6 @@ def test_disk_falloc(fedora_vm_with_instance_type):
         vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
 
 
-@pytest.mark.destructive
 @pytest.mark.polarion("CNV-3632")
 def test_vm_from_dv_on_different_node(
     admin_client,

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -1,0 +1,87 @@
+"""
+General storage behavior tests
+"""
+
+import logging
+
+import pytest
+
+from tests.storage.cdi_import.utils import wait_for_pvc_recreate
+from utilities import console
+from utilities.constants import (
+    OS_FLAVOR_FEDORA,
+    TIMEOUT_1MIN,
+    TIMEOUT_5MIN,
+    Images,
+)
+from utilities.storage import (
+    create_dummy_first_consumer_pod,
+    create_dv,
+    create_vm_from_dv,
+    get_dv_size_from_datasource,
+    sc_volume_binding_mode_is_wffc,
+)
+
+pytestmark = [
+    pytest.mark.post_upgrade,
+]
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.sno
+@pytest.mark.polarion("CNV-675")
+def test_pvc_recreates_after_deletion(namespace, storage_class_name_scope_function, fedora_data_source_scope_module):
+    with create_dv(
+        dv_name=f"cnv-675-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        storage_class=storage_class_name_scope_function,
+        size=get_dv_size_from_datasource(fedora_data_source_scope_module),
+        client=namespace.client,
+        source_ref={
+            "kind": fedora_data_source_scope_module.kind,
+            "name": fedora_data_source_scope_module.name,
+            "namespace": fedora_data_source_scope_module.namespace,
+        },
+    ) as dv:
+        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
+        pvc = dv.pvc
+        pvc_original_timestamp = pvc.instance.metadata.creationTimestamp
+        pvc.delete()
+        wait_for_pvc_recreate(pvc=pvc, pvc_original_timestamp=pvc_original_timestamp)
+        storage_class = storage_class_name_scope_function
+        if sc_volume_binding_mode_is_wffc(sc=storage_class, client=namespace.client):
+            create_dummy_first_consumer_pod(pvc=pvc)
+        dv.wait_for_dv_success()
+
+
+@pytest.mark.polarion("CNV-3065")
+@pytest.mark.sno
+def test_disk_falloc(
+    storage_class_name_scope_function, unprivileged_client, fedora_data_source_scope_module, namespace
+):
+    size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
+    with create_dv(
+        client=unprivileged_client,
+        dv_name=f"cnv-3065-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        source_ref={
+            "kind": fedora_data_source_scope_module.kind,
+            "name": fedora_data_source_scope_module.name,
+            "namespace": fedora_data_source_scope_module.namespace,
+        },
+        size=size,
+        storage_class=storage_class_name_scope_function,
+    ) as dv:
+        dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
+        with create_vm_from_dv(
+            vm_name="cnv-3065-vm",
+            client=unprivileged_client,
+            dv=dv,
+            os_flavor=OS_FLAVOR_FEDORA,
+            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+        ) as vm_dv:
+            with console.Console(vm=vm_dv) as vm_console:
+                LOGGER.info(f"Fill disk space with size {size}")
+                vm_console.sendline(f"fallocate -l {size} test-file")
+                vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -18,8 +18,6 @@ pytestmark = [
 
 LOGGER = logging.getLogger(__name__)
 
-ALLOCATION_SIZE_BYTES = 42949672960  # 40GiB in bytes
-
 
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-675")
@@ -70,9 +68,10 @@ def test_disk_falloc(fedora_vm_with_instance_type):
     Expected:
         - fallocate command fails with "No space left on device" error
     """
+    allocation_size_bytes = 42949672960  # 40GiB in bytes, assuming DV is about 30Gi
     with console.Console(vm=fedora_vm_with_instance_type) as vm_console:
-        LOGGER.info(f"Attempting to allocate {ALLOCATION_SIZE_BYTES} bytes to trigger disk full error")
-        vm_console.sendline(f"fallocate -l {ALLOCATION_SIZE_BYTES} test-file")
+        LOGGER.info(f"Attempting to allocate {allocation_size_bytes} bytes to trigger disk full error")
+        vm_console.sendline(f"fallocate -l {allocation_size_bytes} test-file")
         vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
 
 
@@ -80,7 +79,7 @@ def test_disk_falloc(fedora_vm_with_instance_type):
 def test_vm_from_dv_on_different_node(
     unprivileged_client,
     schedulable_nodes,
-    fedora_dv_with_importer_node,
+    fedora_dv_rwx_with_importer_node,
 ):
     """
     Test that a VM created from a DataVolume runs on a different node than the import operation.
@@ -98,7 +97,7 @@ def test_vm_from_dv_on_different_node(
     Expected:
         - VM runs successfully on a node different from the import operation node
     """
-    dv, importer_pod_node = fedora_dv_with_importer_node
+    dv, importer_pod_node = fedora_dv_rwx_with_importer_node
 
     nodes = [node for node in schedulable_nodes if node.name != importer_pod_node]
     assert nodes, f"No available nodes different from importer pod node {importer_pod_node}"

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -74,14 +74,18 @@ def test_disk_falloc(
         storage_class=storage_class_name_scope_function,
     ) as dv:
         dv.wait_for_dv_success(timeout=TIMEOUT_5MIN)
-        with create_vm_from_dv(
-            vm_name="cnv-3065-vm",
-            client=unprivileged_client,
-            dv=dv,
-            os_flavor=OS_FLAVOR_FEDORA,
-            memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-        ) as vm_dv:
-            with console.Console(vm=vm_dv) as vm_console:
-                LOGGER.info(f"Fill disk space with size {size}")
-                vm_console.sendline(f"fallocate -l {size} test-file")
-                vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)
+        with (
+            (
+                create_vm_from_dv(
+                    vm_name="cnv-3065-vm",
+                    client=unprivileged_client,
+                    dv=dv,
+                    os_flavor=OS_FLAVOR_FEDORA,
+                    memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
+                )
+            ) as vm_dv,
+            console.Console(vm=vm_dv) as vm_console,
+        ):
+            LOGGER.info(f"Fill disk space with size {size}")
+            vm_console.sendline(f"fallocate -l {size} test-file")
+            vm_console.expect("No space left on device", timeout=TIMEOUT_1MIN)

--- a/utilities/pytest_matrix_utils.py
+++ b/utilities/pytest_matrix_utils.py
@@ -75,9 +75,18 @@ def immediate_matrix(matrix):
     return matrix_to_return
 
 
-def rwx_matrix(matrix):
-    return [
-        storage_class
-        for storage_class in matrix
-        if storage_class[next(iter(storage_class))].get("access_mode") == "ReadWriteMany"
-    ]
+def rwx_matrix(matrix: list[dict[str, dict[str, str]]]) -> list[dict[str, dict[str, str]]]:
+    """Filter storage classes with ReadWriteMany access mode.
+
+    Args:
+        matrix: List of storage class dictionaries.
+
+    Returns:
+        List of storage classes with RWX access mode.
+    """
+    matrix_to_return = []
+    for storage_class in matrix:
+        storage_class_name = [*storage_class][0]
+        if storage_class[storage_class_name]["access_mode"] == "ReadWriteMany":
+            matrix_to_return.append(storage_class)
+    return matrix_to_return

--- a/utilities/pytest_matrix_utils.py
+++ b/utilities/pytest_matrix_utils.py
@@ -73,3 +73,11 @@ def immediate_matrix(matrix):
         if storage_class[storage_class_name]["wffc"] is False:
             matrix_to_return.append(storage_class)
     return matrix_to_return
+
+
+def rwx_matrix(matrix):
+    return [
+        storage_class
+        for storage_class in matrix
+        if storage_class[next(iter(storage_class))].get("access_mode") == "ReadWriteMany"
+    ]

--- a/utilities/unittests/test_pytest_matrix_utils.py
+++ b/utilities/unittests/test_pytest_matrix_utils.py
@@ -2,7 +2,7 @@
 
 """Unit tests for pytest_matrix_utils module"""
 
-import inspect
+from inspect import signature
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -298,41 +298,41 @@ class TestMatrixFunctionSignatures:
     def test_snapshot_matrix_signature(self):
         """Test snapshot_matrix function signature"""
 
-        sig = inspect.signature(snapshot_matrix)
+        sig = signature(snapshot_matrix)
         params = list(sig.parameters.keys())
         assert params == ["matrix"]
 
     def test_without_snapshot_capability_matrix_signature(self):
         """Test without_snapshot_capability_matrix function signature"""
 
-        sig = inspect.signature(without_snapshot_capability_matrix)
+        sig = signature(without_snapshot_capability_matrix)
         params = list(sig.parameters.keys())
         assert params == ["matrix"]
 
     def test_online_resize_matrix_signature(self):
         """Test online_resize_matrix function signature"""
 
-        sig = inspect.signature(online_resize_matrix)
+        sig = signature(online_resize_matrix)
         params = list(sig.parameters.keys())
         assert params == ["matrix"]
 
     def test_hpp_matrix_signature(self):
         """Test hpp_matrix function signature"""
 
-        sig = inspect.signature(hpp_matrix)
+        sig = signature(hpp_matrix)
         params = list(sig.parameters.keys())
         assert params == ["matrix"]
 
     def test_wffc_matrix_signature(self):
         """Test wffc_matrix function signature"""
 
-        sig = inspect.signature(wffc_matrix)
+        sig = signature(wffc_matrix)
         params = list(sig.parameters.keys())
         assert params == ["matrix"]
 
     def test_rwx_matrix_signature(self):
         """Test rwx_matrix function signature"""
 
-        sig = inspect.signature(rwx_matrix)
+        sig = signature(rwx_matrix)
         params = list(sig.parameters.keys())
         assert params == ["matrix"]

--- a/utilities/unittests/test_pytest_matrix_utils.py
+++ b/utilities/unittests/test_pytest_matrix_utils.py
@@ -8,6 +8,7 @@ from utilities.pytest_matrix_utils import (  # noqa: E402
     hpp_matrix,
     immediate_matrix,
     online_resize_matrix,
+    rwx_matrix,
     snapshot_matrix,
     wffc_matrix,
     without_snapshot_capability_matrix,
@@ -241,6 +242,55 @@ class TestImmediateMatrix:
         assert result == []
 
 
+class TestRwxMatrix:
+    """Test cases for rwx_matrix function"""
+
+    def test_rwx_matrix_with_rwx_enabled(self):
+        """Test rwx_matrix filters storage classes with ReadWriteMany access mode"""
+        matrix = [
+            {"sc-with-rwx": {"access_mode": "ReadWriteMany", "other": "value"}},
+            {"sc-with-rwo": {"access_mode": "ReadWriteOnce", "other": "value"}},
+            {"sc-with-rwx-2": {"access_mode": "ReadWriteMany", "other": "value"}},
+        ]
+
+        result = rwx_matrix(matrix)
+
+        assert len(result) == 2
+        assert {"sc-with-rwx": {"access_mode": "ReadWriteMany", "other": "value"}} in result
+        assert {"sc-with-rwx-2": {"access_mode": "ReadWriteMany", "other": "value"}} in result
+        assert {"sc-with-rwo": {"access_mode": "ReadWriteOnce", "other": "value"}} not in result
+
+    def test_rwx_matrix_empty_matrix(self):
+        """Test rwx_matrix with empty matrix"""
+        matrix = []
+
+        result = rwx_matrix(matrix)
+
+        assert result == []
+
+    def test_rwx_matrix_no_rwx_enabled(self):
+        """Test rwx_matrix with no RWX storage classes"""
+        matrix = [
+            {"sc-rwo-1": {"access_mode": "ReadWriteOnce", "other": "value"}},
+            {"sc-rwo-2": {"access_mode": "ReadWriteOnce", "other": "value"}},
+        ]
+
+        result = rwx_matrix(matrix)
+
+        assert result == []
+
+    def test_rwx_matrix_missing_access_mode_key(self):
+        """Test rwx_matrix fails fast when access_mode key is missing"""
+        import pytest
+
+        matrix = [
+            {"sc-no-key": {"other": "value"}},
+        ]
+
+        with pytest.raises(KeyError, match="access_mode"):
+            rwx_matrix(matrix)
+
+
 class TestMatrixFunctionSignatures:
     """Test that all matrix functions accept only matrix argument"""
 
@@ -281,5 +331,13 @@ class TestMatrixFunctionSignatures:
         import inspect
 
         sig = inspect.signature(wffc_matrix)
+        params = list(sig.parameters.keys())
+        assert params == ["matrix"]
+
+    def test_rwx_matrix_signature(self):
+        """Test rwx_matrix function signature"""
+        import inspect
+
+        sig = inspect.signature(rwx_matrix)
         params = list(sig.parameters.keys())
         assert params == ["matrix"]

--- a/utilities/unittests/test_pytest_matrix_utils.py
+++ b/utilities/unittests/test_pytest_matrix_utils.py
@@ -2,7 +2,10 @@
 
 """Unit tests for pytest_matrix_utils module"""
 
+import inspect
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from utilities.pytest_matrix_utils import (  # noqa: E402
     hpp_matrix,
@@ -281,8 +284,6 @@ class TestRwxMatrix:
 
     def test_rwx_matrix_missing_access_mode_key(self):
         """Test rwx_matrix fails fast when access_mode key is missing"""
-        import pytest
-
         matrix = [
             {"sc-no-key": {"other": "value"}},
         ]
@@ -296,7 +297,6 @@ class TestMatrixFunctionSignatures:
 
     def test_snapshot_matrix_signature(self):
         """Test snapshot_matrix function signature"""
-        import inspect
 
         sig = inspect.signature(snapshot_matrix)
         params = list(sig.parameters.keys())
@@ -304,7 +304,6 @@ class TestMatrixFunctionSignatures:
 
     def test_without_snapshot_capability_matrix_signature(self):
         """Test without_snapshot_capability_matrix function signature"""
-        import inspect
 
         sig = inspect.signature(without_snapshot_capability_matrix)
         params = list(sig.parameters.keys())
@@ -312,7 +311,6 @@ class TestMatrixFunctionSignatures:
 
     def test_online_resize_matrix_signature(self):
         """Test online_resize_matrix function signature"""
-        import inspect
 
         sig = inspect.signature(online_resize_matrix)
         params = list(sig.parameters.keys())
@@ -320,7 +318,6 @@ class TestMatrixFunctionSignatures:
 
     def test_hpp_matrix_signature(self):
         """Test hpp_matrix function signature"""
-        import inspect
 
         sig = inspect.signature(hpp_matrix)
         params = list(sig.parameters.keys())
@@ -328,7 +325,6 @@ class TestMatrixFunctionSignatures:
 
     def test_wffc_matrix_signature(self):
         """Test wffc_matrix function signature"""
-        import inspect
 
         sig = inspect.signature(wffc_matrix)
         params = list(sig.parameters.keys())
@@ -336,7 +332,6 @@ class TestMatrixFunctionSignatures:
 
     def test_rwx_matrix_signature(self):
         """Test rwx_matrix function signature"""
-        import inspect
 
         sig = inspect.signature(rwx_matrix)
         params = list(sig.parameters.keys())


### PR DESCRIPTION
##### Short description:
Refactor tests in test_import_http.py by replacing the http import with data sources cloning when possible, and move tests to a more suitable folder (general). Along with these main changes, we are also improving some assertion messages and moving fixtures and helpers to follow already existing test structure.

##### More details:
https://redhat.atlassian.net/browse/CNV-83361

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Assisted by Claude Code

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added storage behavior tests for PVC recreation, disk allocation, and VM placement; added importer-pod annotation test. Removed several redundant import tests and fixtures.
* **Refactor**
  * Centralized import synchronization helpers into a shared utilities module and updated tests to use them; added a fixture exposing importer pod annotations.
* **Chores**
  * Added an RWX storage filtering utility and unit tests; added docstrings and removed obsolete test skips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->