### PR TITLE
net: Add devs to owners

### DIFF
--- a/libs/net/OWNERS
+++ b/libs/net/OWNERS
@@ -7,3 +7,6 @@ reviewers:
   - EdDev
   - servolkov
   - azhivovk
+  - orelmisan
+  - nirdothan
+  - frenzyfriday

--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -8,3 +8,5 @@ reviewers:
   - servolkov
   - azhivovk
   - nirdothan
+  - orelmisan
+  - frenzyfriday


### PR DESCRIPTION
Net developers are added to the owners to review and lgtm network tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated reviewer assignments for code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->