### PR TITLE
net, 4.21: Manual cherry-pick: Add devs to owners (#4473)

### DIFF
--- a/libs/net/OWNERS
+++ b/libs/net/OWNERS
@@ -7,3 +7,6 @@ reviewers:
   - EdDev
   - servolkov
   - azhivovk
+  - orelmisan
+  - nirdothan
+  - frenzyfriday

--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -7,3 +7,6 @@ reviewers:
   - EdDev
   - servolkov
   - azhivovk
+  - nirdothan
+  - orelmisan
+  - frenzyfriday


### PR DESCRIPTION
Net developers are added to the owners to review and lgtm network tests