### PR TITLE
Revert "Update machine type to pc-q35-rhel9.8.0 (#4415)"

### DIFF
--- a/tests/virt/constants.py
+++ b/tests/virt/constants.py
@@ -43,7 +43,7 @@ class MachineTypesNames:
     pc_q35_rhel7_6 = f"{pc_q35}-rhel7.6.0"
     pc_q35_rhel8_1 = f"{pc_q35}-rhel8.1.0"
     pc_q35_rhel9_4 = f"{pc_q35}-rhel9.4.0"
-    pc_q35_rhel9_8 = f"{pc_q35}-rhel9.8.0"
+    pc_q35_rhel9_6 = f"{pc_q35}-rhel9.6.0"
     pc_q35_rhel7_4 = f"{pc_q35}-rhel7.4.0"
     pc_i440fx = "pc-i440fx"
     pc_i440fx_rhel7_6 = f"{pc_i440fx}-rhel7.6.0"

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -259,11 +259,11 @@ def test_major_release_machine_type(machine_type_from_kubevirt_config):
 
 @pytest.mark.gating
 @pytest.mark.polarion("CNV-8561")
-def test_machine_type_as_rhel_9_8(machine_type_from_kubevirt_config):
-    """Verify that machine type in KubeVirt CR match the value pc-q35-rhel9.8.0"""
-    assert machine_type_from_kubevirt_config == MachineTypesNames.pc_q35_rhel9_8, (
+def test_machine_type_as_rhel_9_6(machine_type_from_kubevirt_config):
+    """Verify that machine type in KubeVirt CR match the value pc-q35-rhel9.6.0"""
+    assert machine_type_from_kubevirt_config == MachineTypesNames.pc_q35_rhel9_6, (
         f"Machine type value is {machine_type_from_kubevirt_config} "
-        f"does not match with {MachineTypesNames.pc_q35_rhel9_8}"
+        f"does not match with {MachineTypesNames.pc_q35_rhel9_6}"
     )
 
 


### PR DESCRIPTION
##### Short description:
Revert PR #4415 which updated machine type from `pc-q35-rhel9.6.0` to `pc-q35-rhel9.8.0`.

##### More details:
This reverts commit 214aad4bd872e52d77a3437477cf6acf776468e8.

The machine type update to `pc-q35-rhel9.8.0` broke OpenShift 4.22. This is a release blocker tracked in [OCPBUGS-83598](https://issues.redhat.com/browse/OCPBUGS-83598).

##### What this PR does / why we need it:
Reverts the machine type change back to `pc-q35-rhel9.6.0` to unblock OpenShift 4.22.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Release blocker — OCPBUGS-83598

##### jira-ticket:
https://issues.redhat.com/browse/OCPBUGS-83598