### PR TITLE
net, stability: Wait for client VM iface

### DIFF
--- a/tests/network/localnet/ipam/conftest.py
+++ b/tests/network/localnet/ipam/conftest.py
@@ -7,6 +7,7 @@ from ocp_resources.namespace import Namespace
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
 from libs.net import netattachdef as libnad
 from libs.net.ip import random_ipv4_address
+from libs.net.vmspec import lookup_iface_status_ip
 from libs.vm.spec import Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.localnet.liblocalnet import (
@@ -97,4 +98,6 @@ def localnet_ipam_running_vms(
     vm1_localnet_ipam: BaseVirtualMachine, vm2_localnet_ipam: BaseVirtualMachine
 ) -> tuple[BaseVirtualMachine, BaseVirtualMachine]:
     vm1, vm2 = run_vms(vms=(vm1_localnet_ipam, vm2_localnet_ipam))
+    for vm in (vm1, vm2):
+        lookup_iface_status_ip(vm=vm, iface_name=LOCALNET_IPAM_INTERFACE, ip_family=4)
     return vm1, vm2


### PR DESCRIPTION
On this change we wait for both VM's interfaces IPs up on the
running VMs' setup, similarly to other localnet setups.

The change will fix
`test_tcp_connectivity_between_vms_with_localnet_ipam_nic`
failures on CI.

When establishing client-server connections in
`client_server_active_connection` we wait for the server
VM's secondary interface to get its DHCP-assigned IP.

If the client VM's DHCP hadn't completed yet, iperf3 had no
route to the server and exited immediately, causing
`_ensure_is_running` to time out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixture validation to verify interface status and IP assignment before executing tests, improving test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->