### PR TITLE
net, 4.20: Manual cherry-pick: Add devs to owners (#4473)

### DIFF
--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -7,3 +7,6 @@ reviewers:
   - EdDev
   - servolkov
   - azhivovk
+  - nirdothan
+  - orelmisan
+  - frenzyfriday


### PR DESCRIPTION
Net developers are added to the owners to review and lgtm network tests