### PR TITLE
[4.19] Remove migration metrics bug marker CNV-64563, simplify query, add CNV-84891 xfail

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -474,6 +474,17 @@ def vm_for_migration_metrics_test(namespace, cpu_for_migration):
 
 
 @pytest.fixture(scope="class")
+def vm_migration_metrics_vmim_scope_function(vm_for_migration_metrics_test):
+    with VirtualMachineInstanceMigration(
+        name="vm-migration-metrics-vmim",
+        namespace=vm_for_migration_metrics_test.namespace,
+        vmi_name=vm_for_migration_metrics_test.vmi.name,
+    ) as vmim:
+        vmim.wait_for_status(status=vmim.Status.RUNNING, timeout=TIMEOUT_3MIN)
+        yield vmim
+
+
+@pytest.fixture(scope="class")
 def vm_migration_metrics_vmim_scope_class(vm_for_migration_metrics_test):
     with VirtualMachineInstanceMigration(
         name="vm-migration-metrics-vmim",

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime, timezone
 
 import pytest
 
@@ -15,6 +14,7 @@ from tests.observability.metrics.utils import (
     wait_for_non_empty_metrics_value,
 )
 from tests.observability.utils import validate_metrics_value
+from utilities.infra import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,6 @@ class TestKubevirtVmiMigrationMetrics:
             ),
         ],
     )
-    @pytest.mark.jira("CNV-64563", run=False)
     def test_kubevirt_vmi_migration_metrics(
         self,
         prometheus,
@@ -50,19 +49,14 @@ class TestKubevirtVmiMigrationMetrics:
         admin_client,
         migration_policy_with_bandwidth_scope_class,
         vm_for_migration_metrics_test,
-        vm_migration_metrics_vmim_scope_class,
+        vm_migration_metrics_vmim_scope_function,
         query,
     ):
-        minutes_passed_since_migration_start = (
-            int(datetime.now(timezone.utc).timestamp())
-            - timestamp_to_seconds(
-                timestamp=vm_for_migration_metrics_test.vmi.instance.status.migrationState.startTimestamp
-            )
-        ) // 60
+        if query == KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES and is_jira_open(jira_id="CNV-84891"):
+            pytest.xfail(f"Bug is still open for metric {query}")
         wait_for_non_empty_metrics_value(
             prometheus=prometheus,
-            metric_name=f"last_over_time({query.format(vm_name=vm_for_migration_metrics_test.name)}"
-            f"[{minutes_passed_since_migration_start if minutes_passed_since_migration_start > 10 else 10}m])",
+            metric_name=query.format(vm_name=vm_for_migration_metrics_test.name),
         )
 
 

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -33,8 +33,10 @@ from utilities.constants import (
     REGISTRY_STR,
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
+    TIMEOUT_3MIN,
     TIMEOUT_4MIN,
     TIMEOUT_5MIN,
+    TIMEOUT_5SEC,
     TIMEOUT_10SEC,
     TIMEOUT_15SEC,
     TIMEOUT_20SEC,
@@ -459,8 +461,8 @@ def timestamp_to_seconds(timestamp: str) -> int:
 
 def wait_for_non_empty_metrics_value(prometheus: Prometheus, metric_name: str) -> None:
     samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_5MIN,
-        sleep=TIMEOUT_30SEC,
+        wait_timeout=TIMEOUT_3MIN,
+        sleep=TIMEOUT_5SEC,
         func=get_metrics_value,
         prometheus=prometheus,
         metrics_name=metric_name,


### PR DESCRIPTION
##### Short description:
The bug is fixed, remove the jira marker with the bug and last_over_time query for metric, instead the sampler will query every 5 seconds and not 30 to catch. Added xfail duo to bug with one of the metrics of the migration that still having an issue for 4.18 4.19 and 4.20
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-84896
