### PR TITLE
[4.18] Remove CNV-63029 quarantine marker and fix migration metrics test

### DIFF
--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -19,6 +19,7 @@ from tests.observability.metrics.utils import (
 )
 from tests.observability.utils import validate_metrics_value
 from utilities.constants import MIGRATION_POLICY_VM_LABEL, TIMEOUT_2MIN, TIMEOUT_3MIN, TIMEOUT_5MIN
+from utilities.infra import is_jira_open
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
@@ -119,6 +120,17 @@ def vm_migration_metrics_vmim(vm_for_migration_metrics_test):
         yield vmim
 
 
+@pytest.fixture()
+def vm_migration_metrics_vmim_scope_function(vm_for_migration_metrics_test):
+    with VirtualMachineInstanceMigration(
+        name="vm-migration-metrics-vmim",
+        namespace=vm_for_migration_metrics_test.namespace,
+        vmi_name=vm_for_migration_metrics_test.vmi.name,
+    ) as vmim:
+        vmim.wait_for_status(status=vmim.Status.RUNNING, timeout=TIMEOUT_3MIN)
+        yield vmim
+
+
 @pytest.fixture(scope="class")
 def vm_migration_metrics_vmim_scope_class(vm_for_migration_metrics_test):
     with VirtualMachineInstanceMigration(
@@ -180,7 +192,6 @@ class TestKubevirtVmiMigrationMetrics:
             ),
         ],
     )
-    @pytest.mark.jira("CNV-63029", run=False)
     def test_kubevirt_vmi_migration_metrics(
         self,
         prometheus,
@@ -188,12 +199,14 @@ class TestKubevirtVmiMigrationMetrics:
         admin_client,
         migration_policy_with_bandwidth_scope_class,
         vm_for_migration_metrics_test,
-        vm_migration_metrics_vmim_scope_class,
+        vm_migration_metrics_vmim_scope_function,
         query,
     ):
+        if query == KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES and is_jira_open(jira_id="CNV-84901"):
+            pytest.xfail(f"CNV-84901: metric {query} not triggered")
         wait_for_non_empty_metrics_value(
             prometheus=prometheus,
-            metric_name=f"last_over_time({query.format(vm_name=vm_for_migration_metrics_test.name)}[8m])",
+            metric_name=query.format(vm_name=vm_for_migration_metrics_test.name),
         )
 
 

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -22,13 +22,14 @@ from tests.observability.metrics.constants import (
 from utilities.constants import (
     CAPACITY,
     TIMEOUT_2MIN,
+    TIMEOUT_3MIN,
     TIMEOUT_4MIN,
     TIMEOUT_5MIN,
+    TIMEOUT_5SEC,
     TIMEOUT_10SEC,
     TIMEOUT_15SEC,
-    TIMEOUT_30SEC,
     USED,
-    VIRT_HANDLER, TIMEOUT_3MIN, TIMEOUT_5SEC,
+    VIRT_HANDLER,
 )
 from utilities.monitoring import get_metrics_value
 from utilities.virt import VirtualMachineForTests

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -28,7 +28,7 @@ from utilities.constants import (
     TIMEOUT_15SEC,
     TIMEOUT_30SEC,
     USED,
-    VIRT_HANDLER,
+    VIRT_HANDLER, TIMEOUT_3MIN, TIMEOUT_5SEC,
 )
 from utilities.monitoring import get_metrics_value
 from utilities.virt import VirtualMachineForTests
@@ -356,8 +356,8 @@ def timestamp_to_seconds(timestamp: str) -> int:
 
 def wait_for_non_empty_metrics_value(prometheus: Prometheus, metric_name: str) -> None:
     samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_5MIN,
-        sleep=TIMEOUT_30SEC,
+        wait_timeout=TIMEOUT_3MIN,
+        sleep=TIMEOUT_5SEC,
         func=get_metrics_value,
         prometheus=prometheus,
         metrics_name=metric_name,


### PR DESCRIPTION
##### Short description:
The bug is fixed, remove the jira marker with the bug and last_over_time query for metric, instead the sampler will query every 5 seconds and not 30 to catch. Added xfail duo to bug with one of the metrics of the migration that still having an issue for 4.18 4.19 and 4.20
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-84902