### PR TITLE
Retrieve guest interface name dynamically

### DIFF
--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -90,13 +90,11 @@ class TestVMWithExplicitIPAddressSpecification:
         assigned_ip = lookup_iface_status_ip(vm=vm_under_test, iface_name=vm_logical_net_name, ip_family=4)
 
         assert assigned_ip == ip_to_request.ip
-        assert (
-            read_guest_interface_ipv4(
-                vm=vm_under_test,
-                interface_name=vm_under_test.vmi.interfaces[0].interfaceName,
-            )
-            == ip_to_request
+        guest_ip = read_guest_interface_ipv4(
+            vm=vm_under_test,
+            interface_name=vm_under_test.vmi.interfaces[0].interfaceName,
         )
+        assert guest_ip == ip_to_request
 
         with client_server_active_connection(
             client_vm=vm_for_connectivity_ref,
@@ -176,10 +174,8 @@ class TestVMWithExplicitIPAddressSpecification:
         assigned_ip = lookup_iface_status_ip(vm=vm_under_test, iface_name=vm_logical_net_name, ip_family=4)
 
         assert assigned_ip == ip_to_request.ip
-        assert (
-            read_guest_interface_ipv4(
-                vm=vm_under_test,
-                interface_name=vm_under_test.vmi.interfaces[0].interfaceName,
-            )
-            == ip_to_request
+        guest_ip = read_guest_interface_ipv4(
+            vm=vm_under_test,
+            interface_name=vm_under_test.vmi.interfaces[0].interfaceName,
         )
+        assert guest_ip == ip_to_request

--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -90,7 +90,13 @@ class TestVMWithExplicitIPAddressSpecification:
         assigned_ip = lookup_iface_status_ip(vm=vm_under_test, iface_name=vm_logical_net_name, ip_family=4)
 
         assert assigned_ip == ip_to_request.ip
-        assert read_guest_interface_ipv4(vm=vm_under_test, interface_name=FIRST_GUEST_IFACE_NAME) == ip_to_request
+        assert (
+            read_guest_interface_ipv4(
+                vm=vm_under_test,
+                interface_name=vm_under_test.vmi.interfaces[0].interfaceName,
+            )
+            == ip_to_request
+        )
 
         with client_server_active_connection(
             client_vm=vm_for_connectivity_ref,
@@ -170,4 +176,10 @@ class TestVMWithExplicitIPAddressSpecification:
         assigned_ip = lookup_iface_status_ip(vm=vm_under_test, iface_name=vm_logical_net_name, ip_family=4)
 
         assert assigned_ip == ip_to_request.ip
-        assert read_guest_interface_ipv4(vm=vm_under_test, interface_name=FIRST_GUEST_IFACE_NAME) == ip_to_request
+        assert (
+            read_guest_interface_ipv4(
+                vm=vm_under_test,
+                interface_name=vm_under_test.vmi.interfaces[0].interfaceName,
+            )
+            == ip_to_request
+        )


### PR DESCRIPTION
Instead of assuming what the name of the primary guest interface is - retrieve it from the interface status in the VMI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test flexibility and reliability by dynamically selecting the guest network interface when validating IPv4 addresses. Assertions now compare the retrieved guest IP to the requested IP, reducing brittleness from hardcoded interface names and making IPv4 preservation checks more robust across different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->