### PR TITLE
[4.21][Storage] Storage Tier2: use DataSource instead of artifactory in test_wffc.py 4.21

### DIFF
--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """
 HonorWaitForFirstConsumer test suite
 """
@@ -11,11 +10,9 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
-from tests.storage.constants import CIRROS_QCOW2_IMG
-from utilities.artifactory import get_artifactory_config_map, get_artifactory_secret, get_test_artifact_server_url
 from utilities.constants import (
+    OS_FLAVOR_RHEL,
     TIMEOUT_2MIN,
-    TIMEOUT_4MIN,
     TIMEOUT_30SEC,
     Images,
 )
@@ -25,7 +22,7 @@ from utilities.storage import (
     check_upload_virtctl_result,
     create_dv,
     create_vm_from_dv,
-    data_volume,
+    data_volume_template_with_source_ref_dict,
     virtctl_upload_dv,
 )
 from utilities.virt import VirtualMachineForTests, running_vm, wait_for_ssh_connectivity
@@ -38,66 +35,46 @@ LOGGER = logging.getLogger(__name__)
 
 
 WFFC_DV_NAME = "wffc-dv-name"
-DV_PARAMS = {
-    "dv_name": "dv-wffc-tests",
-    "image": CIRROS_QCOW2_IMG,
-    "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-}
+DEFAULT_BLANK_DV_SIZE = "1Gi"
 
 
 @pytest.fixture(scope="module")
-def data_volume_multi_wffc_storage_scope_module(
-    request,
-    namespace,
+def wffc_storage_class_name_scope_module(
     storage_class_matrix_wffc_matrix__module__,
 ):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
-        client=namespace.client,
-    )
+    return next(iter(storage_class_matrix_wffc_matrix__module__))
 
 
 @pytest.fixture()
-def data_volume_multi_wffc_storage_scope_function(
-    request,
-    namespace,
-    storage_class_matrix_wffc_matrix__module__,
-):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
-        client=namespace.client,
+def blank_dv_wffc_scope_function(request, unprivileged_client, namespace, wffc_storage_class_name_scope_module):
+    with create_dv(
+        source="blank",
+        dv_name=f"dv-{request.param['dv_name']}",
+        namespace=namespace.name,
+        size=DEFAULT_BLANK_DV_SIZE,
+        storage_class=wffc_storage_class_name_scope_module,
+        consume_wffc=False,
+        client=unprivileged_client,
+    ) as dv:
+        yield dv
+
+
+@pytest.fixture()
+def blank_dv_template_wffc_scope_function(request, namespace, wffc_storage_class_name_scope_module):
+    blank_dv_template = DataVolume(
+        name=f"dv-{request.param['dv_name']}",
+        namespace=namespace.name,
+        source="blank",
+        size=DEFAULT_BLANK_DV_SIZE,
+        storage_class=wffc_storage_class_name_scope_module,
+        api_name="storage",
     )
-
-
-def get_dv_template_dict(namespace, dv_name, storage_class):
-    artifactory_secret = get_artifactory_secret(namespace=namespace)
-    artifactory_config_map = get_artifactory_config_map(namespace=namespace)
-    return {
-        "metadata": {
-            "name": f"{dv_name}",
-        },
-        "spec": {
-            "storage": {
-                "resources": {"requests": {"storage": Images.Cirros.DEFAULT_DV_SIZE}},
-                "storageClassName": storage_class,
-            },
-            "source": {
-                "http": {
-                    "certConfigMap": artifactory_config_map.name,
-                    "secretRef": artifactory_secret.name,
-                    "url": f"{get_test_artifact_server_url()}{CIRROS_QCOW2_IMG}",
-                }
-            },
-        },
-    }
+    blank_dv_template.to_dict()
+    return blank_dv_template.res
 
 
 def validate_vm_and_disk_count(vm):
-    running_vm(vm=vm, wait_for_interfaces=False)
+    running_vm(vm=vm)
     check_disk_count_in_vm(vm=vm)
 
 
@@ -111,7 +88,7 @@ def uploaded_dv_via_virtctl_wffc(
     namespace,
     downloaded_cirros_image_full_path,
     downloaded_cirros_image_scope_class,
-    storage_class_matrix_wffc_matrix__module__,
+    wffc_storage_class_name_scope_module,
 ):
     with virtctl_upload_dv(
         client=namespace.client,
@@ -119,7 +96,7 @@ def uploaded_dv_via_virtctl_wffc(
         name=WFFC_DV_NAME,
         size=Images.Cirros.DEFAULT_DV_SIZE,
         image_path=downloaded_cirros_image_full_path,
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
+        storage_class=wffc_storage_class_name_scope_module,
         insecure=True,
         consume_wffc=False,
     ) as res:
@@ -137,7 +114,8 @@ def vm_from_uploaded_dv(namespace, uploaded_dv_via_virtctl_wffc, uploaded_wffc_d
         pvc = uploaded_wffc_dv.pvc
         vm_dv.start(wait=False)
         if pvc.use_populator:
-            vm_status = VirtualMachineInstance.Status.SCHEDULING
+            # No scheduling status in VirtualMachineInstance.Status, using string literal instead
+            vm_status = "Scheduling"
             bounded_pvc = pvc.prime_pvc
         else:
             vm_status = VirtualMachineInstance.Status.PENDING
@@ -184,7 +162,7 @@ class TestWFFCUploadVirtctl:
         self,
         downloaded_cirros_image_full_path,
         vm_from_uploaded_dv,
-        storage_class_matrix_wffc_matrix__module__,
+        wffc_storage_class_name_scope_module,
     ):
         with virtctl_upload_dv(
             client=vm_from_uploaded_dv.client,
@@ -192,7 +170,7 @@ class TestWFFCUploadVirtctl:
             name=WFFC_DV_NAME,
             size=Images.Cirros.DEFAULT_DV_SIZE,
             image_path=downloaded_cirros_image_full_path,
-            storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
+            storage_class=wffc_storage_class_name_scope_module,
             insecure=True,
             consume_wffc=False,
             cleanup=False,
@@ -204,123 +182,67 @@ class TestWFFCUploadVirtctl:
 
 
 @pytest.mark.sno
-@pytest.mark.polarion("CNV-4739")
 @pytest.mark.s390x
-def test_wffc_import_registry_dv(
-    unprivileged_client,
-    namespace,
-    storage_class_matrix_wffc_matrix__module__,
-):
-    dv_name = "cnv-4739"
-    with create_dv(
-        source="registry",
-        dv_name=dv_name,
-        namespace=namespace.name,
-        url=f"docker://quay.io/kubevirt/{Images.Cirros.DISK_DEMO}",
-        storage_class=[*storage_class_matrix_wffc_matrix__module__][0],
-        consume_wffc=True,
-        client=unprivileged_client,
-    ) as dv:
-        dv.wait_for_dv_success()
-        create_vm_from_dv(client=unprivileged_client, dv=dv, vm_name=dv_name)
-
-
-@pytest.mark.sno
+@pytest.mark.polarion("CNV-4742")
 @pytest.mark.parametrize(
-    "data_volume_multi_wffc_storage_scope_module",
+    "blank_dv_wffc_scope_function",
     [
-        pytest.param(
-            {**DV_PARAMS, **{"consume_wffc": True}},
-            marks=pytest.mark.polarion("CNV-4379"),
-        ),
+        pytest.param({"dv_name": "blank-wffc-4742"}),
     ],
     indirect=True,
 )
-@pytest.mark.s390x
-def test_wffc_clone_dv(unprivileged_client, data_volume_multi_wffc_storage_scope_module):
-    with create_dv(
-        client=unprivileged_client,
-        source="pvc",
-        dv_name="dv-target",
-        namespace=data_volume_multi_wffc_storage_scope_module.namespace,
-        size=data_volume_multi_wffc_storage_scope_module.size,
-        source_pvc=data_volume_multi_wffc_storage_scope_module.name,
-        storage_class=data_volume_multi_wffc_storage_scope_module.storage_class,
-        consume_wffc=True,
-    ) as cdv:
-        cdv.wait_for_dv_success(timeout=TIMEOUT_4MIN)
-        create_vm_from_dv(client=unprivileged_client, dv=cdv, vm_name=cdv.name)
-
-
-@pytest.mark.sno
-@pytest.mark.parametrize(
-    "data_volume_multi_wffc_storage_scope_function",
-    [
-        pytest.param(
-            {
-                "dv_name": "dv-wffc-4742",
-                "image": CIRROS_QCOW2_IMG,
-                "dv_size": Images.Cirros.DEFAULT_DV_SIZE,
-                "consume_wffc": False,
-            },
-            marks=pytest.mark.polarion("CNV-4742"),
-        ),
-    ],
-    indirect=True,
-)
-@pytest.mark.s390x
 def test_wffc_add_dv_to_vm_with_data_volume_template(
     unprivileged_client,
     namespace,
-    data_volume_multi_wffc_storage_scope_function,
+    wffc_storage_class_name_scope_module,
+    rhel10_data_source_scope_module,
+    blank_dv_wffc_scope_function,
 ):
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4742-vm",
         namespace=namespace.name,
-        os_flavor=Images.Cirros.OS_FLAVOR,
-        data_volume_template=get_dv_template_dict(
-            namespace=namespace.name,
-            dv_name="template-dv",
-            storage_class=data_volume_multi_wffc_storage_scope_function.storage_class,
+        os_flavor=OS_FLAVOR_RHEL,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=rhel10_data_source_scope_module,
+            storage_class=wffc_storage_class_name_scope_module,
         ),
-        memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
         validate_vm_and_disk_count(vm=vm)
         # Add DV
         vm.stop(wait=True)
-        add_dv_to_vm(vm=vm, dv_name=data_volume_multi_wffc_storage_scope_function.name)
+        add_dv_to_vm(vm=vm, dv_name=blank_dv_wffc_scope_function.name)
         # Check DV was added
         validate_vm_and_disk_count(vm=vm)
 
 
 @pytest.mark.sno
-@pytest.mark.polarion("CNV-4743")
 @pytest.mark.s390x
+@pytest.mark.polarion("CNV-4743")
+@pytest.mark.parametrize(
+    "blank_dv_template_wffc_scope_function", [pytest.param({"dv_name": "blank-wffc-4743"})], indirect=True
+)
 def test_wffc_vm_with_two_data_volume_templates(
     unprivileged_client,
     namespace,
-    storage_class_matrix_wffc_matrix__module__,
+    wffc_storage_class_name_scope_module,
+    rhel10_data_source_scope_module,
+    blank_dv_template_wffc_scope_function,
 ):
-    storage_class = [*storage_class_matrix_wffc_matrix__module__][0]
     with VirtualMachineForTests(
         client=unprivileged_client,
         name="cnv-4743-vm",
         namespace=namespace.name,
-        os_flavor=Images.Cirros.OS_FLAVOR,
-        data_volume_template=get_dv_template_dict(
-            namespace=namespace.name,
-            dv_name="template-dv-1",
-            storage_class=storage_class,
+        os_flavor=OS_FLAVOR_RHEL,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=rhel10_data_source_scope_module,
+            storage_class=wffc_storage_class_name_scope_module,
         ),
-        memory_guest=Images.Cirros.DEFAULT_MEMORY_SIZE,
+        memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
         add_dv_to_vm(
             vm=vm,
-            template_dv=get_dv_template_dict(
-                namespace=namespace.name,
-                dv_name="template-dv-2",
-                storage_class=storage_class,
-            ),
+            template_dv=blank_dv_template_wffc_scope_function,
         )
         validate_vm_and_disk_count(vm=vm)


### PR DESCRIPTION
##### Short description:
Back patch https://github.com/RedHatQE/openshift-virtualization-tests/pull/4368
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-83360
##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
