### PR TITLE
fix: retry bws CLI calls on transient failures

### DIFF
--- a/utilities/bitwarden.py
+++ b/utilities/bitwarden.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from _pytest.main import Session
 from pyhelper_utils.shell import run_command
+from timeout_sampler import retry
 
 from utilities.exceptions import MissingEnvironmentVariableError
 
@@ -15,6 +16,9 @@ LOGGER = logging.getLogger(__name__)
 def _run_bws_command(args: list[str]) -> Any:
     """Run bws CLI command and return parsed JSON output.
 
+    Validates ACCESS_TOKEN then delegates to _run_bws_cli which retries
+    on transient failures for up to 60 seconds.
+
     Args:
         args: Command arguments to pass to bws (e.g., ['secret', 'list'])
 
@@ -23,18 +27,42 @@ def _run_bws_command(args: list[str]) -> Any:
 
     Raises:
         MissingEnvironmentVariableError: If ACCESS_TOKEN not set
+        TimeoutExpiredError: If bws CLI repeatedly fails within the retry window
     """
     access_token = os.getenv("ACCESS_TOKEN")
 
     if not access_token:
         raise MissingEnvironmentVariableError("Bitwarden client needs ACCESS_TOKEN environment variable set up")
 
-    _, stdout, _ = run_command(
-        command=["bws", "--access-token", access_token] + args,
+    return _run_bws_cli(access_token=access_token, args=args)
+
+
+@retry(wait_timeout=60, sleep=10)
+def _run_bws_cli(access_token: str, args: list[str]) -> Any:
+    """Execute bws CLI command with retry on transient failures.
+
+    Retries on any exception for up to 60 seconds with 10-second intervals.
+
+    Args:
+        access_token: Bitwarden access token
+        args: Command arguments to pass to bws
+
+    Returns:
+        Any: Parsed JSON response from bws CLI (always truthy for retry decorator)
+
+    Raises:
+        TimeoutExpiredError: If bws CLI repeatedly fails within the retry window
+    """
+    # hide_log_command=True disables check (CalledProcessError not raised),
+    # so success must be checked explicitly below.
+    success, stdout, stderr = run_command(
+        command=["bws", "--access-token", access_token, *args],
         capture_output=True,
-        check=True,
         hide_log_command=True,
     )
+
+    if not success:
+        raise RuntimeError(f"bws command failed: {stderr}")
 
     return json.loads(stdout)
 

--- a/utilities/bitwarden.py
+++ b/utilities/bitwarden.py
@@ -34,21 +34,23 @@ def _run_bws_command(args: list[str]) -> Any:
     if not access_token:
         raise MissingEnvironmentVariableError("Bitwarden client needs ACCESS_TOKEN environment variable set up")
 
-    return _run_bws_cli(access_token=access_token, args=args)
+    return json.loads(_run_bws_cli(access_token=access_token, args=args))
 
 
 @retry(wait_timeout=60, sleep=10)
-def _run_bws_cli(access_token: str, args: list[str]) -> Any:
+def _run_bws_cli(access_token: str, args: list[str]) -> str:
     """Execute bws CLI command with retry on transient failures.
 
     Retries on any exception for up to 60 seconds with 10-second intervals.
+    Returns raw JSON string (always truthy) so the retry decorator does not
+    discard valid falsy parsed values like [] or {}.
 
     Args:
         access_token: Bitwarden access token
         args: Command arguments to pass to bws
 
     Returns:
-        Any: Parsed JSON response from bws CLI (always truthy for retry decorator)
+        str: Raw JSON response string from bws CLI
 
     Raises:
         TimeoutExpiredError: If bws CLI repeatedly fails within the retry window
@@ -64,7 +66,8 @@ def _run_bws_cli(access_token: str, args: list[str]) -> Any:
     if not success:
         raise RuntimeError(f"bws command failed: {stderr}")
 
-    return json.loads(stdout)
+    json.loads(stdout)  # Validate JSON before returning
+    return stdout
 
 
 @cache

--- a/utilities/unittests/test_bitwarden.py
+++ b/utilities/unittests/test_bitwarden.py
@@ -4,12 +4,12 @@
 
 import json
 import os
-import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 # Add utilities to Python path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -20,6 +20,15 @@ from bitwarden import (
 )
 
 from utilities.exceptions import MissingEnvironmentVariableError
+
+_original_timeout_sampler_init = TimeoutSampler.__init__
+
+
+def _short_timeout_init(self, *args, **kwargs):
+    """Override TimeoutSampler.__init__ to use short timeout for tests."""
+    kwargs["wait_timeout"] = 1
+    kwargs["sleep"] = 0
+    _original_timeout_sampler_init(self, *args, **kwargs)
 
 
 class TestGetAllCnvTestsSecrets:
@@ -51,7 +60,6 @@ class TestGetAllCnvTestsSecrets:
             call_args = mock_run_command.call_args
             assert call_args.kwargs["command"] == ["bws", "--access-token", "test-token", "secret", "list"]
             assert call_args.kwargs["capture_output"] is True
-            assert call_args.kwargs["check"] is True
 
     @patch("bitwarden.run_command")
     def test_get_all_cnv_tests_secrets_command_error(self, mock_run_command):
@@ -60,11 +68,14 @@ class TestGetAllCnvTestsSecrets:
             # Clear cache before test
             get_all_cnv_tests_secrets.cache_clear()
 
-            # Mock bws command failure (run_command raises CalledProcessError when check=True)
-            mock_run_command.side_effect = subprocess.CalledProcessError(1, "bws", stderr="Authentication failed")
+            # Mock bws command failure; run_command returns failure tuple
+            mock_run_command.return_value = (False, "", "503 Service Unavailable")
 
-            with pytest.raises(subprocess.CalledProcessError):
+            with pytest.raises(TimeoutExpiredError), patch.object(TimeoutSampler, "__init__", new=_short_timeout_init):
                 get_all_cnv_tests_secrets()
+
+            # Verify retry happened (called more than once)
+            assert mock_run_command.call_count > 1
 
     @patch("bitwarden.run_command")
     def test_get_all_cnv_tests_secrets_invalid_json(self, mock_run_command):
@@ -73,11 +84,14 @@ class TestGetAllCnvTestsSecrets:
             # Clear cache before test
             get_all_cnv_tests_secrets.cache_clear()
 
-            # Mock run_command with invalid JSON response
-            mock_run_command.return_value = (True, "invalid json {", "")
+            # Mock run_command returning success but empty stdout (causes JSONDecodeError)
+            mock_run_command.return_value = (True, "", "")
 
-            with pytest.raises(json.JSONDecodeError):
+            with pytest.raises(TimeoutExpiredError), patch.object(TimeoutSampler, "__init__", new=_short_timeout_init):
                 get_all_cnv_tests_secrets()
+
+            # Verify retry happened
+            assert mock_run_command.call_count > 1
 
     def test_get_all_cnv_tests_secrets_missing_access_token(self):
         """Test error when ACCESS_TOKEN is not set"""
@@ -178,11 +192,14 @@ class TestGetCnvTestsSecretByName:
                 "secret1": "uuid-1",
             }
 
-            # Mock bws command failure
-            mock_run_command.side_effect = subprocess.CalledProcessError(1, "bws", stderr="Secret not accessible")
+            # Mock bws command failure; run_command returns failure tuple
+            mock_run_command.return_value = (False, "", "Secret not accessible")
 
-            with pytest.raises(subprocess.CalledProcessError):
+            with pytest.raises(TimeoutExpiredError), patch.object(TimeoutSampler, "__init__", new=_short_timeout_init):
                 get_cnv_tests_secret_by_name("secret1")
+
+            # Verify retry happened
+            assert mock_run_command.call_count > 1
 
     @patch("bitwarden.get_all_cnv_tests_secrets")
     def test_get_cnv_tests_secret_by_name_disabled_bitwarden(self, mock_get_all):

--- a/utilities/unittests/test_bitwarden.py
+++ b/utilities/unittests/test_bitwarden.py
@@ -24,10 +24,10 @@ from utilities.exceptions import MissingEnvironmentVariableError
 _original_timeout_sampler_init = TimeoutSampler.__init__
 
 
-def _short_timeout_init(self, *args, **kwargs):
+def _short_timeout_init(self: TimeoutSampler, *args: object, **kwargs: object) -> None:
     """Override TimeoutSampler.__init__ to use short timeout for tests."""
-    kwargs["wait_timeout"] = 1
-    kwargs["sleep"] = 0
+    kwargs["wait_timeout"] = 0.05
+    kwargs["sleep"] = 0.01
     _original_timeout_sampler_init(self, *args, **kwargs)
 
 


### PR DESCRIPTION
## Summary

Add retry logic to `_run_bws_command` in `utilities/bitwarden.py` so transient bws CLI failures (e.g., HTTP 503 Service Unavailable) are retried instead of crashing the test session at `pytest_sessionstart`.

### Problem

Build [cluster-health-check-cnv-for-task #3429](https://jenkins-csb-cnvqe-main.dno.corp.redhat.com/job/cluster-health-check-cnv-for-task/3429/console) failed before any tests ran because Bitwarden Secrets Manager CLI (`bws`) returned HTTP 503. Since `run_command` silently disables `CalledProcessError` when `hide_log_command=True`, the failure surfaced as `JSONDecodeError` on empty stdout.

### Fix

Split `_run_bws_command` into two functions:

- **`_run_bws_command`** — validates `ACCESS_TOKEN` env var (fails fast, no retry)
- **`_run_bws_cli`** — executes the bws CLI with `@retry(wait_timeout=60, sleep=10)`, explicitly checks `run_command` return code and raises `RuntimeError` on failure so the retry decorator can catch and retry it

### Key details

- Only the CLI call is retried; missing `ACCESS_TOKEN` fails immediately
- Explicit `success` check prevents `json.loads` on empty stdout
- Uses the project-standard `@retry` decorator from `timeout_sampler`
- All existing unit tests updated and passing (715/715)

Closes: CNV-83409

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Bitwarden secret retrieval with automatic retry on transient failures.
  * Clearer, explicit error reporting when commands fail and when operations time out.

* **Tests**
  * Updated tests to validate retry behavior, timeout handling, and the revised error reporting for command failures and invalid responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->