### PR TITLE
net: STD for multi-arch tests

### DIFF
--- a/tests/network/connectivity/test_pod_network_multiarch.py
+++ b/tests/network/connectivity/test_pod_network_multiarch.py
@@ -1,0 +1,49 @@
+"""
+Multi-architecture VM to VM connectivity over pod network
+
+STP Reference:
+https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/multiarch_arm_support.md
+"""
+
+import pytest
+
+
+@pytest.mark.multiarch
+@pytest.mark.single_nic
+@pytest.mark.ipv4
+class TestMultiArchPodNetwork:
+    """
+    Test connectivity between VM on ARM architectures and VM on AMD over pod network.
+    Intended to run on multi-architecture cluster with AMD64 and ARM64 worker nodes
+
+    Preconditions:
+        - VM on ARM64 node
+        - VM on AMD64 node
+    """
+
+    @pytest.mark.polarion("CNV-15968")
+    def test_pod_network_connectivity_arm_to_amd(self):
+        """
+        Test connectivity from VM on ARM architectures to VM on AMD over pod network.
+
+        Steps:
+            1. ICMP (ping) from ARM VM to AMD VM
+
+        Expected:
+            - 0 packet loss
+        """
+
+    @pytest.mark.polarion("CNV-15969")
+    def test_pod_network_connectivity_amd_to_arm(self):
+        """
+        Test connectivity from VM on AMD architectures to VM on ARM over pod network.
+
+        Steps:
+            1. ICMP (ping) from AMD VM to ARM VM
+
+        Expected:
+            - 0 packet loss
+        """
+
+    test_pod_network_connectivity_arm_to_amd.__test__ = False
+    test_pod_network_connectivity_amd_to_arm.__test__ = False

--- a/tests/network/network_service/test_service_multiarch.py
+++ b/tests/network/network_service/test_service_multiarch.py
@@ -1,0 +1,51 @@
+"""
+Multi-architecture Kubernetes Service connectivity tests
+
+STP Reference:
+https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/multiarch_arm_support.md
+"""
+
+import pytest
+
+
+@pytest.mark.multiarch
+@pytest.mark.single_nic
+@pytest.mark.ipv4
+class TestMultiArchService:
+    """
+    Test Kubernetes Service connectivity between VMs on different architectures.
+    Intended to run on multi-architecture cluster with AMD64 and ARM64 worker nodes
+
+    Preconditions:
+        - VM on ARM64 node
+        - VM on AMD64 node
+    """
+
+    @pytest.mark.polarion("CNV-15943")
+    def test_services_between_amd_client_to_arm_server(self):
+        """
+        Preconditions:
+            1. ClusterIP Service exposing the ARM VM
+
+        Steps:
+            1. Establish TCP connection from client on AMD VM to server on ARM VM via the ClusterIP service
+
+        Expected:
+            - TCP connection through the ClusterIP service succeeds
+        """
+
+    @pytest.mark.polarion("CNV-16264")
+    def test_services_between_arm_client_to_amd_server(self):
+        """
+        Preconditions:
+            1. ClusterIP Service exposing the AMD VM
+
+        Steps:
+            1. Establish TCP connection from client on ARM VM to server on AMD VM via the ClusterIP service
+
+        Expected:
+            - TCP connection through the ClusterIP service succeeds
+        """
+
+    test_services_between_amd_client_to_arm_server.__test__ = False
+    test_services_between_arm_client_to_amd_server.__test__ = False

--- a/tests/network/user_defined_network/test_user_defined_network_multiarch.py
+++ b/tests/network/user_defined_network/test_user_defined_network_multiarch.py
@@ -1,0 +1,52 @@
+"""
+Multi-architecture VM connectivity over UserDefinedNetwork
+
+STP Reference:
+https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/multiarch_arm_support.md
+"""
+
+import pytest
+
+
+@pytest.mark.multiarch
+@pytest.mark.single_nic
+@pytest.mark.ipv4
+class TestMultiArchUdn:
+    """
+    Test UDN connectivity between VMs on different architectures.
+    Intended to run on multi-architecture cluster with AMD64 and ARM64 worker nodes
+
+    Preconditions:
+        - User Defined Network configured
+        - VM on AMD64 node
+        - VM on ARM64 node
+        - Both VMs connected to the same User Defined Network
+
+    """
+
+    @pytest.mark.polarion("CNV-15942")
+    def test_udn_connectivity_amd_client_to_arm_server(self):
+        """
+        Test UDN connectivity between VMs on different architectures - client on AMD, server on ARM.
+
+        Steps:
+            1. Establish TCP connection from client on AMD VM to server on ARM VM
+
+        Expected:
+            - TCP connection succeeds
+        """
+
+    @pytest.mark.polarion("CNV-15970")
+    def test_udn_connectivity_arm_client_to_amd_server(self):
+        """
+        Test UDN connectivity between VMs on different architectures - client on ARM, server on AMD.
+
+        Steps:
+            1. Establish TCP connection from client on ARM VM to server on AMD VM
+
+        Expected:
+            - TCP connection succeeds
+        """
+
+    test_udn_connectivity_arm_client_to_amd_server.__test__ = False
+    test_udn_connectivity_amd_client_to_arm_server.__test__ = False


### PR DESCRIPTION
##### Short description:
STD for testing network aspects on multi-arch clusters.

##### More details:
The tests are planned to verify connectivity between VMs which are scheduled on nodes with different architectures - AMD64 and ARM64

##### What this PR does / why we need it:
Adds Software Test Descriptions (STD) for multi-architecture network connectivity tests. These tests verify that VMs scheduled on nodes with different CPU architectures (AMD64 and ARM64) can communicate over Kubernetes Services and User Defined Networks. This coverage is needed to ensure CNV networking features work correctly in heterogeneous multi-arch clusters.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-78200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests to validate TCP connectivity between virtual machines on different CPU architectures (AMD64 client to ARM64 server).
  * Covers both Kubernetes ClusterIP service and user-defined network scenarios.
  * Both tests are included for tracking but are currently disabled and will not run in automated test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->