### PR TITLE
Fix test_d1_instancetype_profile to wait for dv import

### DIFF
--- a/tests/infrastructure/instance_types/conftest.py
+++ b/tests/infrastructure/instance_types/conftest.py
@@ -19,7 +19,13 @@ from utilities.artifactory import (
     get_artifactory_secret,
     get_test_artifact_server_url,
 )
-from utilities.constants import CONTAINER_DISK_IMAGE_PATH_STR, DATA_SOURCE_STR, OS_FLAVOR_WIN_CONTAINER_DISK, Images
+from utilities.constants import (
+    CONTAINER_DISK_IMAGE_PATH_STR,
+    DATA_SOURCE_STR,
+    OS_FLAVOR_WIN_CONTAINER_DISK,
+    TIMEOUT_20MIN,
+    Images,
+)
 from utilities.storage import (
     create_dummy_first_consumer_pod,
     data_volume_template_with_source_ref_dict,
@@ -128,6 +134,7 @@ def latest_windows_data_volume(
     ) as win_dv:
         if sc_volume_binding_mode_is_wffc(sc=default_sc.name, client=win_dv.client):
             create_dummy_first_consumer_pod(pvc=win_dv.pvc)
+        win_dv.wait_for_dv_success(timeout=TIMEOUT_20MIN)
         yield win_dv
     cleanup_artifactory_secret_and_config_map(artifactory_secret=secret, artifactory_config_map=cert)
 


### PR DESCRIPTION
##### Short description:
adding wait_for_dv_success so that tests don't immediately hit 404 

##### More details:
error :

E           HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"persistentvolumeclaims \\"latest-windows\\" not found","reason":"NotFound","details":{"name":"latest-windows","kind":"persistentvolumeclaims"},"code":404}\n'
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
adding 20 mins since it is not iso or qcow but a regular containerdisk image from registry
##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved wait conditions and timeouts for data volume validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->