### PR TITLE
virt, infra: Change xml EFI check to guest OS

### DIFF
--- a/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_fedora_os.py
@@ -4,12 +4,11 @@ from tests.infrastructure.instance_types.supported_os.constants import TEST_CREA
 from tests.infrastructure.instance_types.utils import (
     assert_kernel_lockdown_mode,
     assert_secure_boot_dmesg,
-    assert_secure_boot_mokutil_status,
 )
 from utilities.constants import PREFERENCE_STR, U1_MEDIUM_STR
+from utilities.infra import assert_secure_boot_mokutil_status
 from utilities.virt import (
     assert_linux_efi,
-    assert_vm_xml_efi,
     check_qemu_guest_agent_installed,
     check_vm_xml_smbios,
     running_vm,
@@ -79,16 +78,14 @@ class TestVMFeatures:
     @pytest.mark.polarion("CNV-11834")
     def test_efi_secureboot_disabled_and_enabled(
         self,
-        admin_client,
         golden_image_fedora_vm_with_instance_type,
     ):
         vm = golden_image_fedora_vm_with_instance_type
 
         def _update_and_verify_secure_boot(vm, secure_boot_value):
             update_vm_efi_spec_and_restart(vm=vm, spec={"secureBoot": secure_boot_value})
-            # assert vm config at hypervisor level
-            assert_vm_xml_efi(vm=vm, admin_client=admin_client, secure_boot_enabled=secure_boot_value)
             assert_linux_efi(vm=vm)
+            assert_secure_boot_mokutil_status(vm=vm, expected_enabled=secure_boot_value)
 
         # Disable secureboot
         _update_and_verify_secure_boot(vm=vm, secure_boot_value=False)

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -8,12 +8,11 @@ from tests.infrastructure.instance_types.supported_os.constants import (
 from tests.infrastructure.instance_types.utils import (
     assert_kernel_lockdown_mode,
     assert_secure_boot_dmesg,
-    assert_secure_boot_mokutil_status,
 )
 from utilities.constants import PREFERENCE_STR, U1_MEDIUM_STR
+from utilities.infra import assert_secure_boot_mokutil_status
 from utilities.virt import (
     assert_linux_efi,
-    assert_vm_xml_efi,
     check_qemu_guest_agent_installed,
     check_vm_xml_smbios,
     migrate_vm_and_verify,
@@ -101,16 +100,14 @@ class TestVMFeatures:
     @pytest.mark.polarion("CNV-11834")
     def test_efi_secureboot_disabled_and_enabled(
         self,
-        admin_client,
         golden_image_rhel_vm_with_instance_type,
     ):
         vm = golden_image_rhel_vm_with_instance_type
 
         def _update_and_verify_secure_boot(vm, secure_boot_value):
             update_vm_efi_spec_and_restart(vm=vm, spec={"secureBoot": secure_boot_value})
-            # assert vm config at hypervisor level
-            assert_vm_xml_efi(vm=vm, admin_client=admin_client, secure_boot_enabled=secure_boot_value)
             assert_linux_efi(vm=vm)
+            assert_secure_boot_mokutil_status(vm=vm, expected_enabled=secure_boot_value)
 
         # Disable secureboot
         _update_and_verify_secure_boot(vm=vm, secure_boot_value=False)

--- a/tests/infrastructure/instance_types/utils.py
+++ b/tests/infrastructure/instance_types/utils.py
@@ -54,11 +54,6 @@ def assert_secure_boot_dmesg(vm: VirtualMachineForTests) -> None:
     assert "enabled" in output.lower(), f"Secure Boot was not enabled at boot time. Found: {output}"
 
 
-def assert_secure_boot_mokutil_status(vm: VirtualMachineForTests) -> None:
-    output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("mokutil --sb-state"))[0].lower()
-    assert "enabled" in output, f"Secure Boot is not enabled. Found: {output}"
-
-
 def assert_kernel_lockdown_mode(vm: VirtualMachineForTests) -> None:
     output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("cat /sys/kernel/security/lockdown"))[0]
     assert "[none]" not in output, f"Kernel lockdown mode is not '[none]'. Found: {output}"

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -17,10 +17,9 @@ from tests.virt.cluster.common_templates.utils import (
 from utilities import console
 from utilities.constants import LINUX_STR
 from utilities.guest_support import check_vm_xml_hyperv
-from utilities.infra import validate_os_info_vmi_vs_linux_os
+from utilities.infra import assert_secure_boot_mokutil_status, validate_os_info_vmi_vs_linux_os
 from utilities.virt import (
     assert_linux_efi,
-    assert_vm_xml_efi,
     migrate_vm_and_verify,
     running_vm,
     validate_libvirt_persistent_domain,
@@ -132,9 +131,9 @@ class TestCommonTemplatesFedora:
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-9666")
-    def test_efi_secureboot_enabled_by_default(self, admin_client, matrix_fedora_os_vm_from_template):
-        assert_vm_xml_efi(vm=matrix_fedora_os_vm_from_template, admin_client=admin_client)
+    def test_efi_secureboot_enabled_by_default(self, matrix_fedora_os_vm_from_template):
         assert_linux_efi(vm=matrix_fedora_os_vm_from_template)
+        assert_secure_boot_mokutil_status(vm=matrix_fedora_os_vm_from_template)
 
     @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -15,10 +15,9 @@ from tests.virt.cluster.common_templates.utils import (
 )
 from utilities import console
 from utilities.constants import LINUX_STR
-from utilities.infra import validate_os_info_vmi_vs_linux_os
+from utilities.infra import assert_secure_boot_mokutil_status, validate_os_info_vmi_vs_linux_os
 from utilities.virt import (
     assert_linux_efi,
-    assert_vm_xml_efi,
     check_qemu_guest_agent_installed,
     check_vm_xml_smbios,
     migrate_vm_and_verify,
@@ -61,7 +60,6 @@ class TestCommonTemplatesRhel:
     @pytest.mark.polarion("CNV-3266")
     def test_start_vm(self, matrix_rhel_os_vm_from_template):
         """Test CNV common templates VM initiation"""
-
         running_vm(vm=matrix_rhel_os_vm_from_template)
 
     @pytest.mark.arm64
@@ -88,11 +86,11 @@ class TestCommonTemplatesRhel:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-8712")
     @pytest.mark.usefixtures("xfail_on_rhel_version_below_rhel9")
-    def test_efi_secureboot_enabled_by_default(self, admin_client, matrix_rhel_os_vm_from_template):
+    def test_efi_secureboot_enabled_by_default(self, matrix_rhel_os_vm_from_template):
         """Test CNV common templates EFI secureboot status"""
 
-        assert_vm_xml_efi(vm=matrix_rhel_os_vm_from_template, admin_client=admin_client)
         assert_linux_efi(vm=matrix_rhel_os_vm_from_template)
+        assert_secure_boot_mokutil_status(vm=matrix_rhel_os_vm_from_template)
 
     @pytest.mark.arm64
     @pytest.mark.sno
@@ -221,11 +219,11 @@ class TestCommonTemplatesRhel:
     @pytest.mark.polarion("CNV-6951")
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.usefixtures("xfail_on_rhel_version_below_rhel9")
-    def test_efi_secureboot_disabled(self, admin_client, matrix_rhel_os_vm_from_template):
+    def test_efi_secureboot_disabled(self, matrix_rhel_os_vm_from_template):
         vm = matrix_rhel_os_vm_from_template
         update_vm_efi_spec_and_restart(vm=vm, spec={"secureBoot": False})
-        assert_vm_xml_efi(vm=vm, admin_client=admin_client, secure_boot_enabled=False)
         assert_linux_efi(vm=vm)
+        assert_secure_boot_mokutil_status(vm=vm, expected_enabled=False)
 
     @pytest.mark.arm64
     @pytest.mark.sno

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -17,7 +17,6 @@ from utilities.constants import OS_FLAVOR_WINDOWS, QUARANTINED
 from utilities.guest_support import assert_windows_efi, check_vm_xml_hyperv, check_windows_vm_hvinfo
 from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.virt import (
-    assert_vm_xml_efi,
     check_vm_xml_smbios,
     migrate_vm_and_verify,
     running_vm,
@@ -61,7 +60,6 @@ class TestCommonTemplatesWindows:
     def test_efi_secureboot_enabled_by_default(self, admin_client, matrix_windows_os_vm_from_template):
         """Test CNV common templates EFI secureboot status"""
 
-        assert_vm_xml_efi(vm=matrix_windows_os_vm_from_template, admin_client=admin_client)
         assert_windows_efi(vm=matrix_windows_os_vm_from_template)
 
     @pytest.mark.sno

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -40,7 +40,7 @@ from ocp_resources.resource import Resource, ResourceEditor, get_client
 from ocp_resources.secret import Secret
 from ocp_resources.subscription import Subscription
 from packaging.version import Version
-from pyhelper_utils.shell import run_command
+from pyhelper_utils.shell import run_command, run_ssh_commands
 from pytest_testconfig import config as py_config
 from requests import HTTPError, Timeout, TooManyRedirects
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
@@ -1187,3 +1187,11 @@ def validate_os_info_vmi_vs_linux_os(vm: utilities.virt.VirtualMachineForTests) 
     linux_info = get_linux_os_info(ssh_exec=vm.ssh_exec)["os"]
 
     assert vmi_info == linux_info, f"Data mismatch! VMI: {vmi_info}\nOS: {linux_info}"
+
+
+def assert_secure_boot_mokutil_status(
+    vm: utilities.virt.VirtualMachineForTests, *, expected_enabled: bool = True
+) -> None:
+    output = run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("mokutil --sb-state"))[0].lower()
+    expected = "enabled" if expected_enabled else "disabled"
+    assert expected in output, f"Secure Boot expected {expected}. Found: {output}"

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2623,29 +2623,6 @@ def check_vm_xml_smbios(vm: VirtualMachineForTests, cm_values: Dict[str, str], a
     assert all(results.values())
 
 
-def assert_vm_xml_efi(
-    vm: VirtualMachineForTests, admin_client: DynamicClient, *, secure_boot_enabled: bool = True
-) -> None:
-    LOGGER.info("Verify VM XML - EFI secureBoot values.")
-    xml_dict_os = vm.vmi.get_xml_dict(privileged_client=admin_client)["domain"]["os"]
-    ovmf_path = "/usr/share/OVMF"
-    efi_path = f"{ovmf_path}/OVMF_CODE.secboot.fd"
-    # efi vars path when secure boot is enabled: /usr/share/OVMF/OVMF_VARS.secboot.fd
-    # efi vars path when secure boot is disabled: /usr/share/OVMF/OVMF_VARS.fd
-    efi_vars_path = f"{ovmf_path}/OVMF_VARS.{'secboot.' if secure_boot_enabled else ''}fd"
-    vmi_xml_efi_path = xml_dict_os["loader"]["#text"]
-    vmi_xml_efi_vars_path = xml_dict_os["nvram"]["@template"]
-    vmi_xml_os_secure = xml_dict_os["loader"]["@secure"]
-    os_secure = "yes" if secure_boot_enabled else "no"
-    assert vmi_xml_efi_path == efi_path, f"EFIPath value {vmi_xml_efi_path} does not match expected {efi_path} value"
-    assert vmi_xml_os_secure == os_secure, (
-        f"EFI secure value {vmi_xml_os_secure} does not seem to be set as {os_secure}"
-    )
-    assert vmi_xml_efi_vars_path == efi_vars_path, (
-        f"EFIVarsPath value {vmi_xml_efi_vars_path} does not match expected {efi_vars_path} value"
-    )
-
-
 def update_vm_efi_spec_and_restart(
     vm: VirtualMachineForTests, spec: dict[str, Any] | None = None, wait_for_interfaces: bool = True
 ) -> None:


### PR DESCRIPTION
##### Short description:
Remove XML EFI check in linux related tests and verify secure boot inside the guest OS

##### More details:
This PR updates the secure boot check to verify the guest OS instead of the XML.

##### What this PR does / why we need it:
Fix failing tests related to EFI path change

##### Special notes for reviewer:
 - Relates to https://github.com/RedHatQE/openshift-virtualization-tests/pull/4370
 - A follow up PR should be created for windows tests later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Secure Boot tests now validate guest/OS-level status (mokutil) instead of hypervisor/XML-level checks.
  * Test modules updated to use the consolidated guest-side Secure Boot helper and no longer require elevated hypervisor-side fixtures.
* **Chores**
  * Test utilities reorganized to centralize guest-side Secure Boot verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->