### PR TITLE
[Storage] Fix flakiness of test_virtctl_libguestfs_with_specific_user

### DIFF
--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -6,7 +6,7 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
 from tests.storage.utils import create_cirros_dv
-from utilities.constants import TIMEOUT_1MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
+from utilities.constants import TIMEOUT_1MIN, TIMEOUT_3MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
 from utilities.infra import login_with_user_password
 
 pytestmark = pytest.mark.post_upgrade
@@ -24,7 +24,7 @@ def virtctl_libguestfs_by_user(
     )
 
     guestfs_proc.send("\n\n")
-    guestfs_proc.expect("$", timeout=TIMEOUT_1MIN)
+    guestfs_proc.expect("$", timeout=TIMEOUT_3MIN)
     yield guestfs_proc
     guestfs_proc.send("exit\n")
     guestfs_proc.expect(pexpect.EOF, timeout=TIMEOUT_1MIN)
@@ -92,4 +92,4 @@ def test_virtctl_libguestfs_with_specific_user(
     virtctl_libguestfs_by_user,
 ):
     virtctl_libguestfs_by_user.sendline("libguestfs-test-tool")
-    virtctl_libguestfs_by_user.expect("===== TEST FINISHED OK =====", timeout=TIMEOUT_1MIN)
+    virtctl_libguestfs_by_user.expect("===== TEST FINISHED OK =====", timeout=TIMEOUT_3MIN)

--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -6,7 +6,7 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
 from tests.storage.utils import create_cirros_dv
-from utilities.constants import QUARANTINED, TIMEOUT_1MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
+from utilities.constants import TIMEOUT_1MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
 from utilities.infra import login_with_user_password
 
 pytestmark = pytest.mark.post_upgrade
@@ -85,10 +85,6 @@ def client_for_test(request, admin_client, unprivileged_client):
         ),
     ],
     indirect=True,
-)
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: Timeout exceeded. Tracked in CNV-62312",
-    run=False,
 )
 @pytest.mark.s390x
 def test_virtctl_libguestfs_with_specific_user(


### PR DESCRIPTION
##### Short description:
https://redhat.atlassian.net/browse/CNV-62312

##### More details:

##### What this PR does / why we need it:

The issue was reproduced on a BM cluster.
It looks like the creation of container libguestfs takes more time than 60 seconds.
This PR changed timeout from 60 seconds to 180 seconds (waiting for a shell prompt and waiting for libguestfs-test-tool to complete).

The test was run with the fix 100 times.
openshift-virtualization-tests-runner/5111
The is 1 failure, but it is different reason: dial tcp 10.46.255.201:6443: connect: connection timed out
```
pexpect.exceptions.EOF: End Of File (EOF). Exception style platform.
<pexpect.pty_spawn.spawn object at 0x7f6e5e630410>
command: /tmp/pytest-7ga49GkDtAVCpbnCyoyTV5/bin0/virtctl
args: ['/tmp/pytest-7ga49GkDtAVCpbnCyoyTV5/bin0/virtctl', 'guestfs', 'dv-guestfs-cnv-6566', '-n', 'test-libguestfs', '--fsGroup', '2000']
buffer (last 100 chars): b''
before (last 100 chars): b'=true&stdin=true&stdout=true&tty=true": dial tcp 10.46.255.201:6443: connect: connection timed out\r\n'
after: <class 'pexpect.exceptions.EOF'>
match: None
match_index: None
exitstatus: None
flag_eof: True
pid: 43194
child_fd: 54
closed: False
timeout: 30
delimiter: <class 'pexpect.exceptions.EOF'>
logfile: None
logfile_read: None
logfile_send: None
maxread: 2000
ignorecase: False
searchwindowsize: None
delaybeforesend: 0.05
delayafterclose: 0.1
delayafterterminate: 0.1
searcher: searcher_re:
    0: re.compile(b'===== TEST FINISHED OK =====')
```

##### Which issue(s) this PR fixes:

test_virtctl_libguestfs_with_specific_user was flaky, sometimes failed with:
```
pexpect.exceptions.TIMEOUT: Timeout exceeded.
<pexpect.pty_spawn.spawn object at 0x7fef05c43a70>
command: /tmp/pytest-JzXC8w7hFuAqG8e2gPh6cJ/bin0/virtctl
args: ['/tmp/pytest-JzXC8w7hFuAqG8e2gPh6cJ/bin0/virtctl', 'guestfs', 'dv-guestfs-cnv-6566', '-n', 'test-libguestfs', '--fsGroup', '2000']
buffer (last 100 chars): b'ssage:  \r\nWaiting for container libguestfs still in pending, reason: ContainerCreating, message:  \r\n'
before (last 100 chars): b'ssage:  \r\nWaiting for container libguestfs still in pending, reason: ContainerCreating, message:  \r\n'
after: <class 'pexpect.exceptions.TIMEOUT'>
match: None
match_index: None
exitstatus: None
flag_eof: False
pid: 20005
child_fd: 113
closed: False
timeout: 30
delimiter: <class 'pexpect.exceptions.EOF'>
logfile: None
logfile_read: None
logfile_send: None
maxread: 2000
ignorecase: False
searchwindowsize: None
delaybeforesend: 0.05
delayafterclose: 0.1
delayafterterminate: 0.1
searcher: searcher_re:
    0: re.compile(b'===== TEST FINISHED OK =====')
```


##### Special notes for reviewer:

There is another PR with changes in `test_virtctl_libguestfs_with_specific_user` test https://github.com/RedHatQE/openshift-virtualization-tests/pull/4556  (it switches the test  to use DataSource).
But it does not solve this current issue. (it was reproduced with that chanes as well)

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased timeout durations for libguestfs-related tests to improve reliability and avoid premature timeouts
  * Explicitly marked tests for s390x architecture
  * Removed the previous expected-failure mark so the test is now expected to run normally and report real pass/fail outcomes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->