### PR TITLE
net, libs, vm: Fix console return signature

### DIFF
--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -76,7 +76,7 @@ class BaseVirtualMachine(VirtualMachine):
         self,
         commands: list[str],
         timeout: int,
-    ) -> dict[str, list[str]] | None:
+    ) -> dict[str, list[str]]:
         return vm_console_run_commands(vm=self, commands=commands, timeout=timeout)
 
     def wait_for_agent_connected(self) -> None:

--- a/tests/network/user_defined_network/ip_specification/libipspec.py
+++ b/tests/network/user_defined_network/ip_specification/libipspec.py
@@ -43,12 +43,10 @@ def read_guest_interface_ipv4(
         IPv4 address with prefix length (e.g., 192.168.1.5/24).
 
     Raises:
-        RuntimeError: If command execution fails.
         IpNotFound: If no IPv4 address is found on the specified interface.
     """
     cmd: Final[str] = f"ip -j -4 addr show {interface_name}"
-    if not (out := vm.console(commands=[cmd], timeout=10)):
-        raise RuntimeError(f"Failed to retrieve IP address from {interface_name}")
+    out = vm.console(commands=[cmd], timeout=10)
 
     LOGGER.info(f"Command {cmd} output: {out}")
 


### PR DESCRIPTION
##### Which issue(s) this PR fixes:
The console() signature is incorrect - it always returns a dict, never None.
The change updates both the signature and the one call site that was checking for None incorrectly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable handling of command output when querying guest network interfaces; reduces false-positive command failures and preserves proper IP-not-found errors.

* **Refactor**
  * Console command execution now guarantees a non-null response, improving type predictability and stability of downstream parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->