### PR TITLE
docs: enforce PR template validation via AGENTS.md and CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,23 @@ early_access: true
 enable_free_tier: true
 
 reviews:
+  # Explicit instructions applied to every review, including PR description validation
+  instructions: |
+    ## PR Template Validation
+    Check the PR description for required sections from `.github/pull_request_template.md`.
+    Required sections (must be present, even if empty):
+    - `##### What this PR does / why we need it:` — MUST be present AND have meaningful content.
+      Flag as HIGH if the section is missing, empty, whitespace-only, contains only HTML comments,
+      or contains only placeholder tokens such as `TBD`, `TBA`, `N/A`, `-`, `—`, `none`, or `.`.
+    - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
+    - `##### Special notes for reviewer:` — must be present (may be empty)
+    - `##### jira-ticket:` — must be present (may be empty)
+    Optional sections (may be omitted without issue):
+    - `##### Short description:`
+    - `##### More details:`
+    If any required section is absent, or `What this PR does / why we need it:` has no content,
+    flag it as HIGH severity and ask the author to restore the missing template section(s).
+
   # Assertive profile for strict enforcement of coding standards
   profile: assertive
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,12 @@ This is a test suite - internal APIs have NO backward compatibility requirements
 - **Mark PR as draft** when there are unresolved blockers, failing CI, or open design questions.
 - **NEVER** merge a PR with known unresolved issues — fix or document them first.
 - **DCO (Signed-off-by) REQUIRED** — all commits must include `Signed-off-by` trailer (enforced by CI).
+- **PR template sections REQUIRED** — the PR description MUST preserve these sections from `.github/pull_request_template.md` (even if left empty):
+  - `##### What this PR does / why we need it:` — MUST be present **and have meaningful content** (not blank, whitespace-only, HTML comment only, or a placeholder such as `TBD`, `TBA`, `N/A`, `-`, `none`, or `.`)
+  - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
+  - `##### Special notes for reviewer:` — must be present (may be empty)
+  - `##### jira-ticket:` — must be present (may be empty)
+  - `##### Short description:` and `##### More details:` are optional and may be omitted
 
 ## Essential Commands
 


### PR DESCRIPTION
##### What this PR does / why we need it:
PR authors occasionally delete or rename sections from the pull request template, making reviews harder and breaking coverage tracking (e.g. the `jira-ticket:` field). This PR establishes a two-layer rule to catch that:

1. **`AGENTS.md`** — adds a bullet to the existing _PR Discipline_ section listing which template sections are required (even if left empty) and which are optional. This serves as the human-readable single source of truth consumed by all contributors and AI review tools via `knowledge_base.code_guidelines`.

2. **`.coderabbit.yaml`** — mirrors the same rule explicitly under `reviews.instructions`, the field CodeRabbit is guaranteed to act on for every PR description review (distinct from the knowledge-base context path). Missing required sections or a blank _"What this PR does / why we need it:"_ are flagged as HIGH severity.

Required sections: `What this PR does / why we need it:` (must have content), `Which issue(s) this PR fixes:`, `Special notes for reviewer:`, `jira-ticket:`.
Optional: `Short description:`, `More details:`.

**Follow-up:** The CodeRabbit-based check is best-effort (AI-driven). A dedicated GitHub Actions workflow that parses the PR body and fails CI if required sections are absent or the "why" field is blank would provide a guaranteed gate. That is left as a follow-up PR.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The `reviews.instructions` field in `.coderabbit.yaml` is the explicit per-review instruction path; `knowledge_base.code_guidelines` (pointing to `AGENTS.md`) is the broader context path. Both are needed for consistent enforcement.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced repository review configuration to validate PR descriptions against the required template sections. Missing or placeholder content in the main "What this PR does / why we need it" section now triggers high-severity review flags. Optional sections are allowed to be omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->