### PR TITLE
docs: add DCO requirement to CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,5 +14,16 @@ If you find a problem with the code, [search if an issue already exists](https:/
 If you open a pull request to fix the problem, an issue will be automatically created.
 If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/RedHatQE/openshift-virtualization-tests/issues/new/choose).
 
+## Developer Certificate of Origin (DCO)
+
+All commits must be signed off to certify that you wrote or have the right to submit the contribution.
+Add a `Signed-off-by` trailer to every commit:
+
+```
+Signed-off-by: Your Name <your@email.com>
+```
+
+Use `git commit -s` to add this automatically. Commits without a valid `Signed-off-by` will be rejected by CI.
+
 ## Pull requests
 Follow the guidelines in [Developer guide](DEVELOPER_GUIDE.md)


### PR DESCRIPTION
##### What this PR does / why we need it:
The DCO (Developer Certificate of Origin) is enforced by CI, but
CONTRIBUTING.md had no mention of it. New contributors hitting a DCO
failure have no guidance in the contributing docs on what it is or how
to fix it. This adds a dedicated section explaining the Signed-off-by
requirement and how to use `git commit -s`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE