### PR TITLE
Add STD for vnic_info metric NAD swap test

### DIFF
--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -447,6 +447,40 @@ class TestVmVnicInfo:
             metric_name=f"kubevirt_vmi_vnic_info{{name='{windows_vm_for_test.name}'}}",
         )
 
+    @pytest.mark.parametrize(
+        "query",
+        [
+            pytest.param(
+                "kubevirt_vm_vnic_info{{name='{vm_name}', vnic_name='secondary'}}",
+                marks=pytest.mark.polarion("CNV-16018"),
+            ),
+            pytest.param(
+                "kubevirt_vmi_vnic_info{{name='{vm_name}', vnic_name='secondary'}}",
+                marks=pytest.mark.polarion("CNV-16019"),
+            ),
+        ],
+    )
+    def test_metric_kubevirt_vm_vnic_info_after_nad_swap(self, query):
+        """
+        Test that vnic_info metric updates the network label after a NAD swap.
+
+        STP:
+        https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/hotpluggable-nad-ref.md
+
+        Preconditions:
+            - Two Network Attachment Definitions (NAD-A, NAD-B) with different VLANs on the same Linux bridge
+            - Running VM with a secondary bridge interface attached to NAD-A
+
+        Steps:
+            1. Swap the VM secondary network reference from NAD-A to NAD-B
+            2. Query vnic_info metric for the secondary interface
+
+        Expected:
+            - vnic_info labels match the VM spec after NAD swap
+        """
+
+    test_metric_kubevirt_vm_vnic_info_after_nad_swap.__test__ = False
+
 
 class TestVmiPhaseTransitionFromDeletion:
     @pytest.mark.polarion("CNV-12990")


### PR DESCRIPTION
##### Short description:
Add test stub with STD for verifying that
kubevirt_vm_vnic_info and kubevirt_vmi_vnic_info Prometheus metrics update their network label after swapping a VM's secondary NAD reference. Parametrized for both metric variants.

assisted by: claude code claude-opus-4-6
##### More details:
As part of [NAD reference live-update STP ](https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/pull/74#discussion_r3094442348)
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-85546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a parametrized test validating VM vNIC metrics after a network-attachment (NAD) swap. It covers multiple metric variants, includes a documented NAD-swap scenario with preconditions and expected label behavior, and is currently disabled (will not run until explicitly re-enabled).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->