### PR TITLE
[Storage] Refactor test_clone tests to remove DV wait usage

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -14,7 +14,6 @@ from tests.storage.utils import (
 from utilities.constants import (
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
-    TIMEOUT_1MIN,
     TIMEOUT_40MIN,
     Images,
 )
@@ -107,13 +106,11 @@ def test_successful_vm_restart_with_cloned_dv(
     cluster_csi_drivers_names,
 ):
     size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
-
-    with DataVolume(
-        name="dv-target",
+    with create_dv(
+        dv_name="dv-target",
         namespace=namespace.name,
         client=unprivileged_client,
         size=size,
-        api_name="storage",
         storage_class=storage_class_name_scope_module,
         source_ref={
             "kind": fedora_data_source_scope_module.kind,
@@ -121,9 +118,7 @@ def test_successful_vm_restart_with_cloned_dv(
             "namespace": fedora_data_source_scope_module.namespace,
         },
     ) as cdv:
-        cdv.wait(timeout=TIMEOUT_1MIN, wait_for_exists_only=True)
-        cdv.pvc.wait()
-
+        cdv.wait_for_dv_success()
         with create_vm_from_dv(
             client=unprivileged_client,
             dv=cdv,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -14,6 +14,7 @@ from tests.storage.utils import (
 from utilities.constants import (
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
+    TIMEOUT_1MIN,
     TIMEOUT_40MIN,
     Images,
 )
@@ -24,6 +25,7 @@ from utilities.storage import (
     data_volume_template_dict,
     get_dv_size_from_datasource,
     overhead_size_for_dv,
+    sc_volume_binding_mode_is_wffc,
 )
 from utilities.virt import (
     VirtualMachineForTests,
@@ -112,13 +114,17 @@ def test_successful_vm_restart_with_cloned_dv(
         client=unprivileged_client,
         size=size,
         storage_class=storage_class_name_scope_module,
+        consume_wffc=False,
         source_ref={
             "kind": fedora_data_source_scope_module.kind,
             "name": fedora_data_source_scope_module.name,
             "namespace": fedora_data_source_scope_module.namespace,
         },
     ) as cdv:
-        cdv.wait_for_dv_success()
+        if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_module, client=unprivileged_client):
+            cdv.wait_for_status(status=DataVolume.Status.PENDING_POPULATION, timeout=TIMEOUT_1MIN)
+        else:
+            cdv.wait_for_dv_success()
         with create_vm_from_dv(
             client=unprivileged_client,
             dv=cdv,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -123,6 +123,7 @@ def test_successful_vm_restart_with_cloned_dv(
     ) as cdv:
         if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_module, client=unprivileged_client):
             cdv.wait_for_status(status=DataVolume.Status.PENDING_POPULATION, timeout=TIMEOUT_1MIN)
+            cdv.pvc.wait()
         else:
             cdv.wait_for_dv_success()
         with create_vm_from_dv(


### PR DESCRIPTION
##### Short description:
Removing DataVolume wait usage to allow us to remove it from the wrapper. Using `wait_for_dv_success()` instead.

##### More details:
Part of this task's work https://redhat.atlassian.net/browse/CNV-73197


##### What this PR does / why we need it:
To abandon DataVolume wait(), which will be deprecated.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

> once DV.wait() is removed from the wrapper, we need to go back to

        cdv.wait(timeout=TIMEOUT_1MIN)
        cdv.pvc.wait()

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test efficiency and reliability for data volume operations during VM restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->