### PR TITLE
WIP: [Storgae] [Mian] Drop explicit target size in block-to-fs clone test

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -24,7 +24,6 @@ from utilities.storage import (
     create_vm_from_dv,
     data_volume_template_dict,
     get_dv_size_from_datasource,
-    overhead_size_for_dv,
     sc_volume_binding_mode_is_wffc,
 )
 from utilities.virt import (
@@ -277,7 +276,6 @@ def test_clone_from_block_to_fs_using_dv_template(
     namespace,
     fedora_dv_with_block_volume_mode,
     storage_class_with_filesystem_volume_mode,
-    default_fs_overhead,
 ):
     create_vm_from_clone_dv_template(
         vm_name="vm-5608",
@@ -286,10 +284,5 @@ def test_clone_from_block_to_fs_using_dv_template(
         source_dv=fedora_dv_with_block_volume_mode,
         client=unprivileged_client,
         volume_mode=DataVolume.VolumeMode.FILE,
-        # add fs overhead and round up the result
-        size=overhead_size_for_dv(
-            image_size=int(fedora_dv_with_block_volume_mode.size[:-2]),
-            overhead_value=default_fs_overhead,
-        ),
         storage_class=storage_class_with_filesystem_volume_mode,
     )

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -308,11 +308,6 @@ def skip_block_volumemode_scope_module(storage_class_matrix__module__):
 
 
 @pytest.fixture()
-def default_fs_overhead(cdi_config):
-    return float(cdi_config.instance.status.filesystemOverhead["global"])
-
-
-@pytest.fixture()
 def router_cert_secret(admin_client):
     router_secret = "router-certs-default"
     for secret in Secret.get(

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -561,6 +561,9 @@ def data_volume_template_dict(
     )
     dv.to_dict()
     if not size:
+        # Omitted size parameter signals CDI to auto-detect target capacity
+        # instead of locking to a pre-computed value (required when
+        # minimumSupportedPvcSize causes actual PVC capacity > DV spec size).
         dv.res["spec"][source_dv.api_name]["resources"] = {}
     return dv.res
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -560,6 +560,8 @@ def data_volume_template_dict(
         api_name=source_dv.api_name,
     )
     dv.to_dict()
+    if not size:
+        dv.res["spec"][source_dv.api_name]["resources"] = {}
     return dv.res
 
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import os
 import shlex
 from contextlib import contextmanager
@@ -586,16 +585,6 @@ def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
     # dataVolumeTemplate is not required to have the namespace explicitly set
     dv.res["metadata"].pop("namespace", None)
     return dv.res
-
-
-def overhead_size_for_dv(image_size, overhead_value):
-    """
-    Calculate the size of the dv to include overhead and rounds up
-
-    DV creation can be with a fraction only if the corresponding  mebibyte is an integer
-    """
-    dv_size = image_size / (1 - overhead_value) * 1024
-    return f"{math.ceil(dv_size)}Mi"
 
 
 def cdi_feature_gate_list_with_added_feature(feature):

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -546,6 +546,21 @@ def data_volume_template_dict(
     size=None,
     storage_class=None,
 ):
+    """Build a DataVolume template dict for use in VM dataVolumeTemplates.
+
+    Args:
+        target_dv_name: Name for the target DataVolume.
+        target_dv_namespace: Namespace for the target DataVolume.
+        source_dv: Source DataVolume to clone from.
+        volume_mode: Override volume mode; defaults to source PVC volume mode.
+        size: Explicit target size (e.g. "10Gi"). When omitted, resources is set
+            to {} so CDI auto-detects capacity from the actual PVC size. Required
+            when minimumSupportedPvcSize causes provisioned PVC > DV spec size.
+        storage_class: Override storage class; defaults to source PVC storage class.
+
+    Returns:
+        dict: DataVolume resource dict suitable for dataVolumeTemplates.
+    """
     source_dv_pvc_spec = source_dv.pvc.instance.spec
     dv = DataVolume(
         name=target_dv_name,


### PR DESCRIPTION
## Summary
- Remove explicit target size calculation (filesystem overhead) from `test_clone_from_block_to_fs_using_dv_template`
- Let CDI auto-detect the target size by setting `resources: {}` in the DV template when no size is specified
- Remove now-unused `overhead_size_for_dv`, `default_fs_overhead`, and `import math`
- This fixes failures on environments with `minimumSupportedPvcSize` (e.g. GCP with `sp-balanced-storage`) where the actual PVC capacity (4Gi) exceeds the DV spec size (1Gi), causing "target resources requests storage size is smaller than the source" errors

## Details
This is a test issue, not a CDI bug. When `minimumSupportedPvcSize` is set, the CSI driver rounds up the PVC capacity, but the test was calculating the target size based on the DV spec size rather than the actual PVC capacity. The correct approach (confirmed by CDI devs) is to omit the target size entirely so CDI auto-detects it, including filesystem overhead.

## Changes
- `tests/storage/cdi_clone/test_clone.py`: Remove `size` and `overhead_size_for_dv` from `test_clone_from_block_to_fs_using_dv_template`
- `utilities/storage.py`: In `data_volume_template_dict`, set `resources: {}` when no `size` is provided; remove unused `overhead_size_for_dv` function and `import math`
- `tests/storage/conftest.py`: Remove unused `default_fs_overhead` fixture

## Impacted tests
- `test_clone_from_block_to_fs_using_dv_template` -- directly fixed
- `test_clone_from_fs_to_block_using_dv_template` -- also calls `data_volume_template_dict` without `size`, now gets `resources: {}` (CDI auto-detect); no behavioral change expected

## Test plan
- [x] Run `test_clone_from_block_to_fs_using_dv_template` on an environment with `minimumSupportedPvcSize` (e.g. GCP with `sp-balanced-storage`)
- [x] Run `test_clone_from_block_to_fs_using_dv_template` on a standard environment (e.g. ODF/Ceph)
- [x] Verify `test_clone_from_fs_to_block_using_dv_template` still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Data volume templates no longer inject preset resource requests when size is unspecified, allowing automatic capacity detection instead of relying on precomputed overhead adjustments.
* **Tests**
  * Test suite updated to stop supplying filesystem-overhead-adjusted sizes and no longer depends on the removed filesystem-overhead helper/fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
