### PR TITLE
infra: Add test for rhel vm with d1 instance type

### DIFF
--- a/tests/infrastructure/conftest.py
+++ b/tests/infrastructure/conftest.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from ocp_resources.data_source import DataSource
+from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError
 
 from tests.infrastructure.utils import (
@@ -10,6 +12,7 @@ from tests.infrastructure.utils import (
     verify_tekton_operator_installed,
 )
 from tests.utils import verify_cpumanager_workers, verify_hugepages_1gi, verify_rwx_default_storage
+from utilities.constants import DATA_SOURCE_NAME
 from utilities.exceptions import ResourceMissingFieldError, ResourceValueError
 from utilities.pytest_utils import exit_pytest_execution
 
@@ -96,3 +99,13 @@ def infrastructure_special_infra_sanity(
             junitxml_property=junitxml_plugin,
             admin_client=admin_client,
         )
+
+
+@pytest.fixture(scope="module")
+def latest_rhel_data_source(golden_images_namespace):
+    return DataSource(
+        client=golden_images_namespace.client,
+        name=py_config["latest_instance_type_rhel_os_dict"][DATA_SOURCE_NAME],
+        namespace=golden_images_namespace.name,
+        ensure_exists=True,
+    )

--- a/tests/infrastructure/instance_types/conftest.py
+++ b/tests/infrastructure/instance_types/conftest.py
@@ -21,7 +21,7 @@ from utilities.artifactory import (
 )
 from utilities.constants import (
     CONTAINER_DISK_IMAGE_PATH_STR,
-    DATA_SOURCE_STR,
+    OS_FLAVOR_RHEL,
     OS_FLAVOR_WIN_CONTAINER_DISK,
     TIMEOUT_20MIN,
     Images,
@@ -162,15 +162,29 @@ def windows_vm_for_dedicated_cpu(request, unprivileged_client, namespace, latest
         vm_instance_type=VirtualMachineClusterInstancetype(
             client=unprivileged_client, name=request.param["instance_type_name"]
         ),
-        vm_preference=VirtualMachineClusterPreference(
-            client=unprivileged_client,
-            name=py_config["latest_windows_os_dict"][DATA_SOURCE_STR].replace("win", "windows."),
-        ),
+        vm_preference_infer=True,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=latest_windows_data_source,
         ),
         os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
         disk_type=None,
+    ) as vm:
+        vm.start()
+        yield vm
+
+
+@pytest.fixture()
+def rhel_vm_for_dedicated_cpu(unprivileged_client, namespace, latest_rhel_data_source):
+    with VirtualMachineForTests(
+        client=unprivileged_client,
+        name="rhel-d1-vm",
+        namespace=namespace.name,
+        vm_instance_type=VirtualMachineClusterInstancetype(client=unprivileged_client, name="d1.large"),
+        vm_preference_infer=True,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=latest_rhel_data_source,
+        ),
+        os_flavor=OS_FLAVOR_RHEL,
     ) as vm:
         vm.start()
         yield vm

--- a/tests/infrastructure/instance_types/test_common_vm_instancetype.py
+++ b/tests/infrastructure/instance_types/test_common_vm_instancetype.py
@@ -97,3 +97,10 @@ class TestDedicatedInstancetypeProfile:
             f"'windows-vcpu-overcommit-binding' denied request: {WINDOWS_DEDICATED_CPU_MESSAGE}"
         )
         wait_for_condition_message_value(resource=windows_vm_for_dedicated_cpu, expected_message=expected_message)
+
+    @pytest.mark.polarion("CNV-13746")
+    def test_d1_on_rhel_vm(
+        self,
+        rhel_vm_for_dedicated_cpu,
+    ):
+        running_vm(vm=rhel_vm_for_dedicated_cpu)

--- a/tests/infrastructure/vhostmd/test_vhostmd.py
+++ b/tests/infrastructure/vhostmd/test_vhostmd.py
@@ -6,7 +6,6 @@ import pytest
 import requests
 import xmltodict
 from bs4 import BeautifulSoup
-from ocp_resources.data_source import DataSource
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.resource import Resource
 from pyhelper_utils.shell import run_ssh_commands
@@ -14,7 +13,7 @@ from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST_LABELS
 from utilities.artifactory import get_artifactory_header
-from utilities.constants import DATA_SOURCE_NAME, S390X, TIMEOUT_3MIN, TIMEOUT_30SEC
+from utilities.constants import S390X, TIMEOUT_3MIN, TIMEOUT_30SEC
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import get_node_selector_dict, get_node_selector_name
 from utilities.virt import (
@@ -67,16 +66,6 @@ def rpm_file_name(is_s390x_cluster):
     assert rpm_file_names, f"No RPM files found at the URL - {RPMS_REPO_URL}"
 
     return next(file_name for file_name in rpm_file_names if (S390X in file_name) == is_s390x_cluster)
-
-
-@pytest.fixture(scope="module")
-def latest_rhel_data_source(golden_images_namespace):
-    return DataSource(
-        client=golden_images_namespace.client,
-        name=py_config["latest_instance_type_rhel_os_dict"][DATA_SOURCE_NAME],
-        namespace=golden_images_namespace.name,
-        ensure_exists=True,
-    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
##### Short description:
Add test for rhel vm with d1 instance type

##### More details:
 - Adding a test for non windows VM running on a dedicated CPU instance type
 - Update windows_vm_for_dedicated_cpu to use preference inference instead of explicit preference name

##### What this PR does / why we need it:
Add test converge 

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-79339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified VM preference handling for Windows dedicated-CPU tests.
  * Added test coverage for RHEL VMs using a dedicated instance type (d1.large).
  * Introduced a shared RHEL data-source fixture to support RHEL VM tests.
  * Removed a now-redundant RHEL data-source fixture from one test module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->