### PR TITLE
docs: clarify pytestmark phase and soften import style rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Before writing ANY new code:
 - **No defensive programming** - fail-fast, don't hide bugs with fake defaults (see exceptions below)
 - **ALWAYS use `uv run`** - NEVER execute `python`, `pip`, or `pytest` directly. Use `uv run python`, `uv run pytest`, `uv add` for package installation.
 - **ALWAYS use absolute imports** - NEVER use relative imports
-- **ALWAYS import specific functions** - use `from module import func`, NEVER `import module`
+- **Prefer specific imports** - use `from module import func` for functions and constants. Use `from package import module` (then `module.Name`) when retaining the module name at the call site meaningfully improves readability (e.g. `libstuntime.ContinuousPing` vs a bare `ContinuousPing` that loses its origin). Never use bare `import module` without a `from` clause.
 - **ALWAYS use named arguments** - for function calls with more than one argument
 - **NEVER use single-letter variable names** - ALWAYS use descriptive, meaningful names
 - **No dead code** - every function, variable, fixture MUST be used or removed. Code marked with `# skip-unused-code` is excluded from dead code analysis (enforced via custom ruff plugin).

--- a/docs/SOFTWARE_TEST_DESCRIPTION.md
+++ b/docs/SOFTWARE_TEST_DESCRIPTION.md
@@ -50,6 +50,11 @@ This project follows a **two-phase development workflow** that separates test de
    - Create any required fixtures
    - Implement helper functions as needed
    - Remove `__test__ = False` from implemented tests
+   - Convert `Markers:` entries from STD docstrings to real pytest expressions:
+     - Module-level markers → `pytestmark = [pytest.mark.<marker>]` at module scope
+     - Class-level markers → `@pytest.mark.<marker>` on the class
+     - Test-level markers → `@pytest.mark.<marker>` on the test function
+     - `pytestmark` is a **Phase 2 addition** — it is intentionally absent from STD placeholders
    - If needed, update the test description. This change must be approved by the team's qe sig owner / lead.
 
 2. **Submit PR for review**:
@@ -340,6 +345,7 @@ test_<specific_behavior>.__test__ = False
 - [ ] Fixtures implement preconditions
 - [ ] Assertions match Expected
 - [ ] No changes to STD docstrings
+- [ ] `Markers:` entries from STD docstrings converted to `pytestmark` or `@pytest.mark` decorators
 
 ---
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Two documentation clarifications surfaced during PR review:

1. **`pytestmark` is a Phase 2 addition** — during STD placeholders (Phase 1), markers live in the `Markers:` docstring section. During implementation (Phase 2), they are converted to `pytestmark` expressions or `@pytest.mark` decorators. This was undocumented, causing reviewers to flag the absence of `pytestmark` in STDs or its presence in implementation PRs as incorrect.

2. **Import style rule was too strict** — the previous rule ("ALWAYS import specific functions, NEVER `import module`") conflicted with cases where retaining the module name at the call site genuinely improves readability (e.g. `libstuntime.ContinuousPing` makes the origin clear; a bare `ContinuousPing` does not). The rule is softened to a context-sensitive guideline.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: