### PR TITLE
tests, net, l2_bridge: mark interface stability scenarios as t3

### DIFF
--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -12,6 +12,7 @@ STABILITY_PERIOD_IN_SECONDS: Final[int] = 300
 
 
 @pytest.mark.incremental
+@pytest.mark.tier3
 class TestInterfacesStability:
     @pytest.mark.polarion("CNV-14339")
     def test_interfaces_stability(self, running_linux_bridge_vm, stable_ips):


### PR DESCRIPTION
##### Short description:
Relocate Interface Stability scenarios from Tier 2 to Tier 3 to optimize CI pipeline performance.

##### What this PR does / why we need it:
This PR migrates the Interface Stability test suite to the Tier 3 lane to optimize our CI resource allocation. These scenarios require a five-minute monitoring period per test, totaling approximately 15 minutes of execution time. By moving these tests from Tier 2, which runs three times a week, to the weekly Tier 3 cadence, we significantly reduce the execution load on our mid-week lanes. This adjustment ensures that Tier 2 remains lean and focused on providing faster feedback loops for frequent integration checks while still maintaining essential long-term stability coverage on a weekly basis.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The test logic remains identical; only the execution tier/metadata has been updated to reflect the new weekly cadence. This change aligns with our goal to prioritize Tier 2 for faster, high-frequency signals.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked all tests in the interface stability test module as tier3, ensuring uniform classification across contained tests (including those with other markers). This improves test organization, filtering, and execution categorization for stability-related test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->