### PR TITLE
docs: fix coderabbit reviews.instructions to path_instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,21 +11,23 @@ enable_free_tier: true
 
 reviews:
   # Explicit instructions applied to every review, including PR description validation
-  instructions: |
-    ## PR Template Validation
-    Check the PR description for required sections from `.github/pull_request_template.md`.
-    Required sections (must be present, even if empty):
-    - `##### What this PR does / why we need it:` — MUST be present AND have meaningful content.
-      Flag as HIGH if the section is missing, empty, whitespace-only, contains only HTML comments,
-      or contains only placeholder tokens such as `TBD`, `TBA`, `N/A`, `-`, `—`, `none`, or `.`.
-    - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
-    - `##### Special notes for reviewer:` — must be present (may be empty)
-    - `##### jira-ticket:` — must be present (may be empty)
-    Optional sections (may be omitted without issue):
-    - `##### Short description:`
-    - `##### More details:`
-    If any required section is absent, or `What this PR does / why we need it:` has no content,
-    flag it as HIGH severity and ask the author to restore the missing template section(s).
+  path_instructions:
+    - path: "**"
+      instructions: |
+        ## PR Template Validation
+        Check the PR description for required sections from `.github/pull_request_template.md`.
+        Required sections (must be present, even if empty):
+        - `##### What this PR does / why we need it:` — MUST be present AND have meaningful content.
+          Flag as HIGH if the section is missing, empty, whitespace-only, contains only HTML comments,
+          or contains only placeholder tokens such as `TBD`, `TBA`, `N/A`, `-`, `—`, `none`, or `.`.
+        - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
+        - `##### Special notes for reviewer:` — must be present (may be empty)
+        - `##### jira-ticket:` — must be present (may be empty)
+        Optional sections (may be omitted without issue):
+        - `##### Short description:`
+        - `##### More details:`
+        If any required section is absent, or `What this PR does / why we need it:` has no content,
+        flag it as HIGH severity and ask the author to restore the missing template section(s).
 
   # Assertive profile for strict enforcement of coding standards
   profile: assertive


### PR DESCRIPTION
##### What this PR does / why we need it:
`reviews.instructions` is not a valid field in the CodeRabbit schema v2 and is silently dropped at parse time, meaning the PR template validation rules we defined there were never enforced. This migrates the instructions to `reviews.path_instructions` with a `"**"` glob, which is the correct schema v2 mechanism for applying repo-wide review instructions.

Root cause was surfaced by CodeRabbit itself in PR #4619: the field was silently ignored because the schema defines `reviews` with `additionalProperties: false`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The instruction content is identical — only the enclosing field was changed to comply with the schema.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code review validation to the v2 schema and applied the PR template validation rules repository-wide via a path-based selector to preserve existing enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->