### PR TITLE
ci: validate .coderabbit.yaml against CodeRabbit schema in pre-commit

### DIFF
--- a/.github/workflows/validate-coderabbit-schema.yml
+++ b/.github/workflows/validate-coderabbit-schema.yml
@@ -1,0 +1,31 @@
+name: Validate CodeRabbit Schema
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - '.coderabbit.yaml'
+
+  workflow_dispatch:
+
+jobs:
+  validate-coderabbit-schema:
+    name: Validate .coderabbit.yaml against schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Validate .coderabbit.yaml
+        run: uvx check-jsonschema --schemafile "https://coderabbit.ai/integrations/schema.v2.json" .coderabbit.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 default_language_version:
   python: python3.14
 
+ci:
+  skip: [check-jsonschema]
+
 repos:
   - repo: https://github.com/PyCQA/autoflake
     rev: "v2.3.3"
@@ -60,6 +63,15 @@ repos:
     hooks:
       - id: gitlint
         stages: [commit-msg]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: "0.37.1"
+    hooks:
+      - id: check-jsonschema
+        name: Validate .coderabbit.yaml against schema
+        files: ^\.coderabbit\.yaml$
+        args: ["--schemafile", "https://coderabbit.ai/integrations/schema.v2.json"]
+        stages: [pre-commit]
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: "v8.30.0"


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds two complementary mechanisms to validate `.coderabbit.yaml` against the official CodeRabbit schema v2, preventing invalid fields from being silently dropped (the root cause identified in PR #4626):

1. **pre-commit hook** (`check-jsonschema`) — runs locally when `.coderabbit.yaml` is staged. Skipped on pre-commit.ci via `ci.skip` because pre-commit.ci blocks external network access at runtime.
2. **GitHub Actions workflow** — provides the equivalent CI enforcement where external network access is available, triggered only on PRs that touch `.coderabbit.yaml`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Depends logically on PR #4626 (the `.coderabbit.yaml` fix), but can be merged independently — both checks will catch the violation until that PR lands.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated configuration validation to run locally (pre-commit) and in CI for the main config file.
  * Introduced an option to skip the validation in CI runs for exceptional cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->