### PR TITLE
WIP: Network multiarch marked tests for complete multi-arch cluster)

### DIFF
--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -2,6 +2,8 @@ __test__ = False
 
 import pytest
 
+pytestmark = pytest.mark.multiarch
+
 """
 Markers:
     - IPv4

--- a/tests/network/bgp/test_bgp_connectivity.py
+++ b/tests/network/bgp/test_bgp_connectivity.py
@@ -6,6 +6,7 @@ from utilities.virt import migrate_vm_and_verify
 pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
+    pytest.mark.multiarch,
     pytest.mark.usefixtures("bgp_setup_ready"),
 ]
 

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -84,6 +84,7 @@ def cloud_init_ipv6_network_data(ipv6_primary_interface_cloud_init_data):
             marks=[
                 pytest.mark.polarion("CNV-2332"),
                 pytest.mark.ipv4,
+                pytest.mark.multiarch,
             ],
         ),
         pytest.param(

--- a/tests/network/flat_overlay/test_flat_overlay.py
+++ b/tests/network/flat_overlay/test_flat_overlay.py
@@ -14,6 +14,7 @@ pytestmark = [
         "enable_multi_network_policy_usage",
     ),
     pytest.mark.ipv4,
+    pytest.mark.multiarch,
 ]
 
 

--- a/tests/network/general/test_network_naming.py
+++ b/tests/network/general/test_network_naming.py
@@ -3,6 +3,8 @@ from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
+pytestmark = pytest.mark.multiarch
+
 
 @pytest.fixture()
 def invalid_network_names():

--- a/tests/network/jumbo_frame/test_pod_network_ovn.py
+++ b/tests/network/jumbo_frame/test_pod_network_ovn.py
@@ -14,6 +14,8 @@ pytestmark = [
 ]
 
 
+@pytest.mark.multiarch
+@pytest.mark.single_nic
 class TestJumboPodNetworkOnly:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-9660")

--- a/tests/network/kubemacpool/explicit_range/test_kmp_custom_range.py
+++ b/tests/network/kubemacpool/explicit_range/test_kmp_custom_range.py
@@ -2,6 +2,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.ipv4,
+    pytest.mark.multiarch,
 ]
 
 

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -14,6 +14,8 @@ from tests.network.localnet.liblocalnet import (
 from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
+pytestmark = pytest.mark.multiarch
+
 
 @pytest.mark.gating
 @pytest.mark.single_nic

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -15,6 +15,8 @@ from utilities.virt import (
 
 LOGGER = logging.getLogger(__name__)
 
+pytestmark = pytest.mark.multiarch
+
 
 @pytest.fixture(scope="module")
 def running_vm_static(

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -354,7 +354,7 @@ def test_connectivity_after_migration_and_restart(
 @pytest.mark.parametrize(
     "ip_family",
     [
-        pytest.param("ipv4", marks=[pytest.mark.ipv4, pytest.mark.polarion("CNV-12508")]),
+        pytest.param("ipv4", marks=[pytest.mark.ipv4, pytest.mark.multiarch, pytest.mark.polarion("CNV-12508")]),
         pytest.param("ipv6", marks=[pytest.mark.ipv6, pytest.mark.polarion("CNV-12509")]),
     ],
 )

--- a/tests/network/network_service/test_service_config_manifest.py
+++ b/tests/network/network_service/test_service_config_manifest.py
@@ -9,7 +9,9 @@ class TestServiceConfigurationViaManifest:
     @pytest.mark.parametrize(
         "single_stack_service_ip_family, single_stack_service",
         [
-            pytest.param("IPv4", "IPv4", marks=[pytest.mark.ipv4, pytest.mark.polarion("CNV-5789")]),
+            pytest.param(
+                "IPv4", "IPv4", marks=[pytest.mark.ipv4, pytest.mark.multiarch, pytest.mark.polarion("CNV-5789")]
+            ),
             pytest.param("IPv6", "IPv6", marks=[pytest.mark.ipv6, pytest.mark.polarion("CNV-12557")]),
         ],
         indirect=["single_stack_service"],
@@ -30,6 +32,7 @@ class TestServiceConfigurationViaManifest:
 
     @pytest.mark.polarion("CNV-5831")
     @pytest.mark.single_nic
+    @pytest.mark.multiarch
     @pytest.mark.usefixtures("default_ip_family_policy_service")
     def test_service_with_default_ip_family_policy(
         self,

--- a/tests/network/network_service/test_service_config_virtctl.py
+++ b/tests/network/network_service/test_service_config_virtctl.py
@@ -16,13 +16,13 @@ class TestServiceConfigurationViaVirtctl:
                 SERVICE_IP_FAMILY_POLICY_SINGLE_STACK,
                 SERVICE_IP_FAMILY_POLICY_SINGLE_STACK,
                 SERVICE_IP_FAMILY_POLICY_SINGLE_STACK,
-                marks=(pytest.mark.polarion("CNV-6454")),
+                marks=(pytest.mark.polarion("CNV-6454"), pytest.mark.multiarch),
             ),
             pytest.param(
                 SERVICE_IP_FAMILY_POLICY_PREFER_DUAL_STACK,
                 SERVICE_IP_FAMILY_POLICY_PREFER_DUAL_STACK,
                 SERVICE_IP_FAMILY_POLICY_PREFER_DUAL_STACK,
-                marks=(pytest.mark.polarion("CNV-6481")),
+                marks=(pytest.mark.polarion("CNV-6481"), pytest.mark.multiarch),
             ),
             pytest.param(
                 SERVICE_IP_FAMILY_POLICY_REQUIRE_DUAL_STACK,

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -12,6 +12,8 @@ pytestmark = pytest.mark.service_mesh
 
 
 @pytest.mark.s390x
+@pytest.mark.multiarch
+@pytest.mark.single_nic
 class TestSMTrafficManagement:
     @pytest.mark.polarion("CNV-5782")
     @pytest.mark.single_nic
@@ -46,6 +48,8 @@ class TestSMTrafficManagement:
 
 
 @pytest.mark.s390x
+@pytest.mark.multiarch
+@pytest.mark.single_nic
 class TestSMPeerAuthentication:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-5784")

--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -30,6 +30,7 @@ FIRST_GUEST_IFACE_NAME: Final[str] = "eth0"
 @pytest.mark.ipv4
 @pytest.mark.single_nic
 @pytest.mark.incremental
+@pytest.mark.multiarch
 class TestVMWithExplicitIPAddressSpecification:
     """
     Tests for VM with an IP address explicitly defined for the primary UDN.

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -65,6 +65,8 @@ def client(vma_udn, vmb_udn):
 
 @pytest.mark.ipv4
 @pytest.mark.s390x
+@pytest.mark.multiarch
+@pytest.mark.single_nic
 class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11624")
     @pytest.mark.single_nic

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -16,6 +16,8 @@ from tests.network.libs.vm_factory import udn_vm
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.virt import LOGGER, migrate_vm_and_verify
 
+pytestmark = pytest.mark.multiarch
+
 
 @retry(wait_timeout=400, sleep=10, exceptions_dict={})
 def wait_for_ready_vm_with_restart(vm: BaseVirtualMachine) -> bool:


### PR DESCRIPTION
As opposed to https://github.com/RedHatQE/openshift-virtualization-tests/pull/4495, this PR is intended to execute regression tests not on uni-arch cluster (arm64 or amd64), but rather on cluster that has 3 workers of each arch.