### PR TITLE
net, tests, infra: Make localnet_vm affinity configurable via parameter

### DIFF
--- a/libs/vm/affinity.py
+++ b/libs/vm/affinity.py
@@ -16,6 +16,21 @@ def new_label(key_prefix: str) -> tuple[str, str]:
 
 
 def new_pod_anti_affinity(label: tuple[str, str], namespaces: list[str] | None = None) -> Affinity:
+    """Create pod anti-affinity to schedule pods on different nodes.
+
+    Kubernetes behavior: Omitting both namespaceSelector and namespaces limits
+    anti-affinity to pods in the same namespace. Setting namespaceSelector={} makes the
+    rule cross-namespace.
+
+    Args:
+        label: Tuple of (key, value) to match pods for anti-affinity.
+        namespaces: Optional list of namespaces to search for matching pods.
+            If None, matches pods across all namespaces (cluster-wide).
+            If provided, limits matching to those specific namespaces.
+
+    Returns:
+        Affinity: Affinity object with podAntiAffinity configured.
+    """
     (key, value) = label
     return Affinity(
         podAntiAffinity=PodAntiAffinity(
@@ -26,6 +41,7 @@ def new_pod_anti_affinity(label: tuple[str, str], namespaces: list[str] | None =
                     ),
                     topologyKey=f"{Resource.ApiGroup.KUBERNETES_IO}/hostname",
                     namespaces=namespaces,
+                    namespaceSelector={} if namespaces is None else None,
                 )
             ]
         )

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -98,7 +98,7 @@ class Multus:
 
 @dataclass
 class Affinity:
-    podAntiAffinity: PodAntiAffinity  # noqa: N815
+    podAntiAffinity: PodAntiAffinity | None = None  # noqa: N815
 
 
 @dataclass

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -24,6 +24,7 @@ from tests.network.localnet.liblocalnet import (
     LOCALNET_OVS_BRIDGE_INTERFACE,
     LOCALNET_OVS_BRIDGE_NETWORK,
     LOCALNET_TEST_LABEL,
+    LOCALNET_VM_ANTI_AFFINITY,
     create_nncp_localnet_on_secondary_node_nic,
     ip_addresses_from_pool,
     localnet_cudn,
@@ -171,6 +172,7 @@ def vm_localnet_1(
                 ),
             }
         ),
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 
@@ -199,6 +201,7 @@ def vm_localnet_2(
                 )
             }
         ),
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 
@@ -266,6 +269,7 @@ def vm_ovs_bridge_localnet_link_down(
                 )
             }
         ),
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 
@@ -296,6 +300,7 @@ def vm_ovs_bridge_localnet_1(
                 )
             }
         ),
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 
@@ -326,6 +331,7 @@ def vm_ovs_bridge_localnet_2(
                 )
             }
         ),
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 
@@ -473,6 +479,7 @@ def vm1_ovs_bridge_localnet_jumbo_frame(
                 )
             }
         ),
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 
@@ -505,6 +512,7 @@ def vm2_ovs_bridge_localnet_jumbo_frame(
                 )
             }
         ),
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 

--- a/tests/network/localnet/ipam/conftest.py
+++ b/tests/network/localnet/ipam/conftest.py
@@ -12,6 +12,7 @@ from libs.vm.vm import BaseVirtualMachine
 from tests.network.localnet.liblocalnet import (
     LOCALNET_IPAM_INTERFACE,
     LOCALNET_OVS_BRIDGE_NETWORK,
+    LOCALNET_VM_ANTI_AFFINITY,
     localnet_vm,
     run_vms,
 )
@@ -65,6 +66,7 @@ def vm1_localnet_ipam(
         interfaces=[
             Interface(name=LOCALNET_IPAM_INTERFACE, bridge={}),
         ],
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 
@@ -88,6 +90,7 @@ def vm2_localnet_ipam(
         interfaces=[
             Interface(name=LOCALNET_IPAM_INTERFACE, bridge={}),
         ],
+        affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
         yield vm
 

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import logging
 import uuid
 from typing import Final, Generator
@@ -9,7 +10,7 @@ from kubernetes.dynamic import DynamicClient
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
-from libs.vm.spec import CloudInitNoCloud, Devices, Interface, Metadata, Network
+from libs.vm.spec import Affinity, CloudInitNoCloud, Devices, Interface, Metadata, Network
 from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
 from tests.network.libs import cloudinit
 from tests.network.libs import cluster_user_defined_network as libcudn
@@ -25,6 +26,7 @@ LOCALNET_BR_EX_INTERFACE_NO_VLAN = "localnet-iface-no-vlan"
 LOCALNET_OVS_BRIDGE_INTERFACE = "localnet-iface-ovs-bridge"
 LOCALNET_IPAM_INTERFACE = "localnet-ipam-iface"
 LOCALNET_TEST_LABEL = {"test": "localnet"}
+LOCALNET_VM_ANTI_AFFINITY = new_pod_anti_affinity(label=next(iter(LOCALNET_TEST_LABEL.items())))
 LINK_STATE_UP = "up"
 LINK_STATE_DOWN = "down"
 NNCP_INTERFACE_TYPE_ETHERNET = "ethernet"
@@ -77,12 +79,13 @@ def localnet_vm(
     networks: list[Network],
     interfaces: list[Interface],
     network_data: cloudinit.NetworkData | None = None,
+    affinity: Affinity | None = None,
 ) -> BaseVirtualMachine:
     """
     Create a Fedora-based Virtual Machine connected to localnet network(s).
 
     The VM will:
-    - Apply a specific label for anti-affinity scheduling.
+    - Apply a specific label for VM scheduling.
     - Based on a standard Fedora VM template.
 
     Args:
@@ -95,6 +98,8 @@ def localnet_vm(
             Each Interface should have a name matching a Network, and additional configuration and state.
         network_data (cloudinit.NetworkData | None): Cloud-init NetworkData object containing the network
             configuration for the VM interfaces. If None, no network configuration is applied via cloud-init.
+        affinity (Affinity | None): Optional Affinity object for VM scheduling. Controls the VM scheduling
+            location. If None, no affinity constraints are applied.
 
     Returns:
         BaseVirtualMachine: The configured VM object ready for creation.
@@ -136,8 +141,8 @@ def localnet_vm(
         )
         vmi_spec = add_volume_disk(vmi_spec=vmi_spec, volume=volume, disk=disk)
 
-    vmi_spec.affinity = new_pod_anti_affinity(label=next(iter(LOCALNET_TEST_LABEL.items())))
-    vmi_spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].namespaceSelector = {}
+    if affinity is not None:
+        vmi_spec.affinity = copy.deepcopy(affinity)
 
     return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
 


### PR DESCRIPTION
  ##### Short description:
  Make VM affinity configurable instead of hardcoded for localnet tests.                                                                                                                                                                                                                                            
                                                                        
  ##### More details:                                                                                                                                                                                                                                                                                               
  Previously, all localnet VMs were forced to use anti-affinity scheduling with cross-namespace selector. This prevented customization for scenarios like stuntime tests that need VMs to co-locate initially before migration.
                                                                                                                                                                                                                               
  Following the same pattern used for network configuration, callers now specify the affinity constraints they need, or none if unconstrained scheduling is acceptable.                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
  Cross-namespace affinity is now configured automatically, eliminating repetitive setup code.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
  Affinity structure now matches Kubernetes semantics—resources can have anti-affinity, affinity, both, or neither.
                                                                                                                                                                                                                                                                                                                    
  ##### What this PR does / why we need it:
  - Replaces hardcoded scheduling behavior with configurable constraints                                                                                                                                                                                                                   
  - Enables future scenarios requiring VM co-location (e.g., stuntime measurement during migration)
  - Eliminates code duplication in affinity configuration                                                                                                                                                                                                                                                           
                                                         
  ##### Which issue(s) this PR fixes:                                                                                                                                                                                                                                                                               
  Addresses code review feedback from #4568.
                                                                                                                                                                                                                                                                                                                    
  ##### Special notes for reviewer:
  - This is part 1 of affinity refactoring - affinity (co-location) support will be added in a separate, stuntime-related PR.                                                                                                                                                                                       
  - All existing test behavior is preserved (VMs still use anti-affinity, just now explicit).                                
  - Follow-up PR will introduce a label constant to clean up verbose extraction pattern.                                                                                                                                                                                                                            
                  
  ##### jira-ticket:     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pod anti-affinity for virtual machines can now be omitted explicitly; helper accepts an optional anti-affinity parameter.
  * Namespace scoping for anti-affinity is now represented explicitly when used.

* **Documentation**
  * Added a detailed docstring describing anti-affinity scoping behavior.

* **Tests**
  * VM test fixtures updated to apply the optional pod anti-affinity across localnet and IPAM scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->