### PR TITLE
[Observability] xfail migration metrics tests on RHCOS 10+ for CNV-84023

### DIFF
--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -1,9 +1,12 @@
 import logging
+import re
 
 import pytest
 from ocp_resources.ssp import SSP
+from packaging.version import Version
 
 from utilities.hco import ResourceEditorValidateHCOReconcile
+from utilities.jira import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
@@ -18,3 +21,32 @@ def paused_ssp_operator(admin_client, hco_namespace, ssp_resource_scope_class):
         list_resource_reconcile=[SSP],
     ):
         yield
+
+
+@pytest.fixture(scope="session")
+def workers_rhcos_version(schedulable_nodes):
+    """Returns a dict mapping each schedulable node name to its RHCOS version.
+
+    Returns:
+        dict[str, str]: Node name to RHCOS version (e.g. {"node-1": "10.2.20260408", ...}).
+    """
+    rhcos_version_re = re.compile(r"CoreOS\s+([\d.]+)")
+    versions = {}
+    for node in schedulable_nodes:
+        os_image = node.instance.status.nodeInfo.osImage
+        match = rhcos_version_re.search(string=os_image)
+        assert match, f"Failed to parse RHCOS version from osImage '{os_image}' on node '{node.name}'"
+        versions[node.name] = match.group(1)
+    return versions
+
+
+@pytest.fixture(scope="session")
+def is_postcopy_migration_bug_open(workers_rhcos_version) -> bool:  # skip-unused-code
+    """Check if CNV-84023 is open and cluster has RHCOS 10+ nodes.
+
+    Returns:
+        bool: True if post-copy migration is broken on this cluster.
+    """
+    return any(Version(ver) >= Version("10") for ver in workers_rhcos_version.values()) and is_jira_open(
+        jira_id="CNV-84023"
+    )

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -470,7 +470,10 @@ def windows_vm_for_test(namespace, unprivileged_client):
 
 
 @pytest.fixture(scope="class")
-def vm_for_migration_metrics_test(namespace, cpu_for_migration):
+def vm_for_migration_metrics_test(namespace, cpu_for_migration, is_postcopy_migration_bug_open):
+    if is_postcopy_migration_bug_open:
+        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
+
     name = "vm-for-migration-metrics-test"
     with VirtualMachineForTests(
         name=name,

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -135,7 +135,10 @@ def vm_metric_1(namespace, unprivileged_client, cluster_common_node_cpu):
 
 
 @pytest.fixture()
-def vm_metric_1_vmim(admin_client, vm_metric_1):
+def vm_metric_1_vmim(admin_client, vm_metric_1, is_postcopy_migration_bug_open):
+    if is_postcopy_migration_bug_open:
+        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
+
     with VirtualMachineInstanceMigration(
         name="vm-metric-1-vmim",
         namespace=vm_metric_1.namespace,


### PR DESCRIPTION
##### Short description:
Add workers_rhel_version fixture that returns a dict mapping each schedulable node name to its RHCOS version string extracted from osImage. Add xfail_cnv_84023_on_rhcos_10 fixture that xfails when CNV-84023 is open and any worker node runs RHCOS 10+, where post-copy migration fails due to missing CAP_SYS_PTRACE for userfaultfd on kernel 6.12.

Affected tests:
- test_kubevirt_vmi_migration_metrics (5 parametrized variants)
- test_metric_kubevirt_vmi_migration_end_time_seconds
- test_vm_migrating_status_metrics

assisted by: claude code claude-opus-4-6
Signed-off-by: Ohad Revah <orevah@redhat.com>
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-84023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test support now detects RHCOS worker node versions and exposes them to the test session.
  * Tests are conditionally marked as expected-to-fail when CNV-84023 applies to detected RHCOS versions.
  * The conditional xfail behavior is applied to several migration and metrics tests so outcomes adapt to the environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->