### PR TITLE
net, hot-plug: reuse bridge_nncp in hot plug NAD fixture

### DIFF
--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -46,21 +46,12 @@ def running_vm_for_nic_hot_plug(namespace, unprivileged_client):
 
 
 @pytest.fixture(scope="module")
-def bridge_interface_for_hot_plug(nmstate_dependent_placeholder, admin_client, hosts_common_available_ports):
-    yield from create_bridge_interface_for_hot_plug(
-        bridge_name=f"{HOT_PLUG_STR}-br",
-        bridge_port=hosts_common_available_ports[-1],
-        client=admin_client,
-    )
-
-
-@pytest.fixture(scope="module")
 def network_attachment_definition_for_hot_plug(
     admin_client,
     namespace,
-    bridge_interface_for_hot_plug,
+    bridge_nncp,
 ):
-    bridge_name = bridge_interface_for_hot_plug.bridge_name
+    bridge_name = bridge_nncp.desired_state_spec.interfaces[0].name
     with netattachdef.NetworkAttachmentDefinition(
         namespace=namespace.name,
         name=f"{bridge_name}-nad",


### PR DESCRIPTION
##### What this PR does / why we need it:
`bridge_interface_for_hot_plug` creates a module-scoped NNCP on the same NIC that the package-scoped `bridge_nncp` already uses. Two NNCPs targeting the same NIC cannot coexist, leading to conflicts when both are active in the same session. Since `bridge_nncp` provides an equivalent Linux bridge, this PR removes the duplicate fixture and reuses `bridge_nncp` directly in `network_attachment_definition_for_hot_plug`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
    
##### jira-ticket: NONE

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified bridge hot-plug test provisioning by using externally-provided network configuration instead of local fixture-based creation.

* **Refactor**
  * Streamlined test fixture dependencies to reduce overhead in test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->