### PR TITLE
net, stability: Fix lookup_iface_status watcher start

### DIFF
--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -59,10 +59,14 @@ def lookup_iface_status(
     Raises:
         VMInterfaceStatusNotFoundError: If the requested interface was not found in the vmi status.
     """
-    if iface := _lookup_iface_status(interfaces=vm.vmi.interfaces, iface_name=iface_name, predicate=predicate):
+    vmi = vm.vmi
+    vmi_instance = vmi.instance
+    if iface := _lookup_iface_status(
+        interfaces=vmi_instance.status.interfaces, iface_name=iface_name, predicate=predicate
+    ):
         return iface
 
-    for event in vm.vmi.watcher(timeout=timeout):
+    for event in vmi.watcher(timeout=timeout, resource_version=vmi_instance.metadata.resourceVersion):
         if event["type"] != "MODIFIED":
             continue
         if interfaces := event["object"].status.interfaces:


### PR DESCRIPTION
Problem:
Events fired between the initial VMI read and the watcher start were silently lost, causing a false
`VMInterfaceStatusNotFoundError` even though the interface was already present in VMI status.

Fix:
On this change `lookup_iface_status` reads the VMI once, checks the interface, then starts the watcher from that same read's resourceVersion so no events are missed.

This change fixes failed test
`test_connectivity_ovs_bridge_jumbo_frames_no_fragmentation` Which failed for missed events by the watcher according to must-gather logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal reliability and performance improvements to how interface status is retrieved and watched; no user-visible changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4671)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->