### PR TITLE
[virt] fix rhel os memory check

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -221,9 +221,9 @@ def get_os_memory_value(vm):
         wmic_total_mem = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip().split()[1]
         return f"{round(float(bitmath.Bit(int(wmic_total_mem)).to_Gib()))}Gi"
     else:
-        cmd = shlex.split("awk \"'{print$2/1024/1024;exit}'\" /proc/meminfo")
-        meminfo = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip()
-        return f"{round(float(meminfo))}Gi"
+        cmd = shlex.split("lsmem | grep 'Total online'")
+        lsmem_total_mem = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip().split()[-1]
+        return f"{lsmem_total_mem}i"
 
 
 def _collect_cpu_diagnostic_info(vm):


### PR DESCRIPTION
##### Short description:
replaced /proc/meminfo with lsmem to get total guest memory available
fixes flakes in memory hotplug tests

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory value retrieval on Linux virtual machines using an alternative system method for more accurate reporting. Windows systems remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->