### PR TITLE
chore: bump pre-commit hooks and apply lint cleanup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,14 @@
 jobs = 0
 
 max-line-length = 120
+ignore =
+    N815,
+    N802,
+    E501,
+    F821,
+    E201,
+    W503,
+    N818,
 exclude =
     doc,
     .tox,
@@ -75,6 +83,8 @@ fcn_exclude_functions =
     BeautifulSoup,
     usefixtures,
     find_spec,
+    with_suffix,
+    writelines,
     skip,
     QueueListener,
     requests,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.12
     hooks:
       - id: ruff
         stages: [pre-commit]
@@ -79,7 +79,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.0
+    rev: v1.20.2
     hooks:
       - id: mypy
         exclude: "test_(.*).py$"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,7 @@ When reviewing quarantine PRs, verify the **quarantine mechanism matches the fai
 - **ALWAYS use `timeout_sampler`** - from `timeout_sampler` package for any operation that waits for a condition:
   ```python
   from timeout_sampler import TimeoutSampler
+
   for sample in TimeoutSampler(wait_timeout=60, sleep=5, func=check_condition):
       if sample:
           break

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Pytest conftest file for CNV tests
 """
@@ -704,10 +703,9 @@ def pytest_runtest_makereport(item, call):
 
         elif report.failed:
             if reprcrash := getattr(report.longrepr, "reprcrash", None):
-                if message := getattr(report.longrepr, "message", None):
-                    setattr(report, SETUP_ERROR, message)
-
-                elif message := getattr(reprcrash, "message", None):
+                if (message := getattr(report.longrepr, "message", None)) or (
+                    message := getattr(reprcrash, "message", None)
+                ):
                     setattr(report, SETUP_ERROR, message)
 
 
@@ -737,7 +735,7 @@ def pytest_runtest_setup(item):
     if "incremental" in item.keywords:
         previousfailed = getattr(item.parent, "_previousfailed", None)
         if previousfailed is not None:
-            pytest.xfail("previous test failed (%s)" % previousfailed.name)
+            pytest.xfail(f"previous test failed ({previousfailed.name})")
 
 
 def pytest_runtest_call(item):
@@ -902,7 +900,7 @@ def is_skip_must_gather(node: Node) -> bool:
 
 def get_inspect_command_namespace_string(node: Node, test_name: str) -> str:
     namespace_str = ""
-    components = [key for key in NAMESPACE_COLLECTION.keys() if f"tests/{key}/" in test_name]
+    components = [key for key in NAMESPACE_COLLECTION if f"tests/{key}/" in test_name]
     if not components:
         LOGGER.warning(f"{test_name} does not require special data collection on failure")
     else:

--- a/docs/QUARANTINE_GUIDELINES.md
+++ b/docs/QUARANTINE_GUIDELINES.md
@@ -71,6 +71,7 @@ Conditional skip for product bug:
 ```python
 import pytest
 
+
 @pytest.mark.jira("CNV-12345", run=False)  # Skips if the bug is open
 def test_feature_a():
     pass
@@ -99,8 +100,7 @@ from utilities.constants import QUARANTINED
     reason=f"{QUARANTINED}: VM is going into running state which it shouldn't, CNV-123",
     run=False,
 )
-def test_my_failing_test():
-    ...
+def test_my_failing_test(): ...
 ```
 
 **Benefit**: Provides pytest summary insights:

--- a/docs/SOFTWARE_TEST_DESCRIPTION.md
+++ b/docs/SOFTWARE_TEST_DESCRIPTION.md
@@ -109,9 +109,9 @@ To exclude a whole new module from pytest collection, use:
 # test_module_to_ignore.py
 __test__ = False
 
-def test_abc():
-    assert True # This test will not be collected or run
 
+def test_abc():
+    assert True  # This test will not be collected or run
 ```
 
 To exclude new test classes from pytest collection, use:
@@ -124,8 +124,8 @@ class TestClass:
 To exclude new tests from pytest collection, use:
 
 ```python
-def test_abc():
-    ...
+def test_abc(): ...
+
 
 test_abc.__test__ = False
 ```
@@ -139,6 +139,7 @@ def test_isolated_vms_cannot_communicate():
     """
     [NEGATIVE] Test that VMs on separate networks cannot ping each other.
     """
+
 
 test_isolated_vms_cannot_communicate.__test__ = False
 ```
@@ -352,6 +353,7 @@ VM Snapshot and Restore Tests
 STP Reference: https://example.com/stp/vm-snapshot-restore
 """
 
+
 class TestSnapshotRestore:
     """
     Tests for VM snapshot restore functionality.
@@ -366,6 +368,7 @@ class TestSnapshotRestore:
         - File path="/data/after.txt", content="post-snapshot" (written after snapshot)
         - VM Restored from snapshot, running and SSH accessible
     """
+
     __test__ = False
 
     def test_preserves_original_file(self):
@@ -403,6 +406,7 @@ class TestVMLifecycle:
     Preconditions:
         - VM Running latest Fedora virtual machine
     """
+
     __test__ = False
 
     def test_vm_restart_completes_successfully(self):
@@ -470,6 +474,7 @@ def test_flat_overlay_ping_between_vms():
         - Ping succeeds with 0% packet loss
     """
 
+
 test_flat_overlay_ping_between_vms.__test__ = False
 ```
 
@@ -500,6 +505,7 @@ def test_isolated_vms_cannot_communicate():
     Expected:
         - Ping fails with 100% packet loss
     """
+
 
 test_isolated_vms_cannot_communicate.__test__ = False
 ```
@@ -533,6 +539,7 @@ def test_online_disk_resize():
     Expected:
         - Disk size inside VM is greater than original size
     """
+
 
 test_online_disk_resize.__test__ = False
 ```

--- a/libs/net/netattachdef.py
+++ b/libs/net/netattachdef.py
@@ -35,7 +35,7 @@ class IpamStatic(Ipam):
     """
 
     type: str = field(default="static", init=False)
-    addresses: list["IpamStatic.Address"]
+    addresses: list[IpamStatic.Address]
     routes: list[IpamRoute] | None = None
 
     @dataclass
@@ -61,7 +61,7 @@ class CNIPluginBridgeConfig(CNIPluginConfig):
     mtu: int | None = None
     vlan: int | None = None
     macspoofchk: bool | None = None
-    disableContainerInterface: bool | None = None  # noqa: N815
+    disableContainerInterface: bool | None = None
 
 
 @dataclass
@@ -76,8 +76,8 @@ class CNIPluginOvnK8sConfig(CNIPluginConfig):
 
     type: str = field(default="ovn-k8s-cni-overlay", init=False)
     topology: str
-    netAttachDefName: str  # noqa: N815
-    vlanID: int | None = None  # noqa: N815
+    netAttachDefName: str
+    vlanID: int | None = None
     subnets: str | None = None
 
     class Topology(Enum):
@@ -92,10 +92,10 @@ class CNIPluginBandwidthConfig(CNIPluginConfig):
     """
 
     type: str = field(default="bandwidth", init=False)
-    ingressRate: int  # noqa: N815
-    ingressBurst: int  # noqa: N815
-    egressRate: int  # noqa: N815
-    egressBurst: int  # noqa: N815
+    ingressRate: int
+    ingressBurst: int
+    egressRate: int
+    egressBurst: int
 
 
 @dataclass
@@ -120,7 +120,7 @@ class NetConfig:
 
     name: str
     plugins: list[CNIPluginConfig]
-    cniVersion: str = _DEFAULT_CNI_VERSION  # noqa: N815
+    cniVersion: str = _DEFAULT_CNI_VERSION
 
 
 class NetworkAttachmentDefinition(NamespacedResource):

--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -1,7 +1,8 @@
 import contextlib
 import logging
 from abc import ABC, abstractmethod
-from typing import Final, Generator
+from collections.abc import Generator
+from typing import Final
 
 from ocp_resources.pod import Pod
 from ocp_utilities.exceptions import CommandExecFailed
@@ -32,7 +33,7 @@ class BaseTcpClient(ABC):
         return self._server_ip
 
     @abstractmethod
-    def __enter__(self) -> "BaseTcpClient":
+    def __enter__(self) -> BaseTcpClient:
         pass
 
     @abstractmethod
@@ -66,7 +67,7 @@ class TcpServer:
         self._cmd = f"{_IPERF_BIN} --server --port {self._port} --one-off"
         self._cmd += f" --bind {bind_ip}" if bind_ip else ""
 
-    def __enter__(self) -> "TcpServer":
+    def __enter__(self) -> TcpServer:
         self._vm.console(
             commands=[f"{self._cmd} &"],
             timeout=_DEFAULT_CMD_TIMEOUT_SEC,
@@ -113,7 +114,7 @@ class VMTcpClient(BaseTcpClient):
         self._vm = vm
         self._cmd += f" --set-mss {maximum_segment_size}" if maximum_segment_size else ""
 
-    def __enter__(self) -> "VMTcpClient":
+    def __enter__(self) -> VMTcpClient:
         self._vm.console(
             commands=[f"{self._cmd} &"],
             timeout=_DEFAULT_CMD_TIMEOUT_SEC,
@@ -174,7 +175,7 @@ class PodTcpClient(BaseTcpClient):
         self._container = _IPERF_BIN
         self._cmd += f" --bind {bind_interface}" if bind_interface else ""
 
-    def __enter__(self) -> "PodTcpClient":
+    def __enter__(self) -> PodTcpClient:
         # run the command in the background using nohup to ensure it keeps running after the exec session ends
         self._pod.execute(
             command=["sh", "-c", f"nohup {self._cmd} >/tmp/{_IPERF_BIN}.log 2>&1 &"], container=self._container
@@ -204,7 +205,7 @@ def active_tcp_connections(
     client_vm: BaseVirtualMachine,
     server_vm: BaseVirtualMachine,
     iface_name: str,
-) -> Generator[list[tuple[VMTcpClient, TcpServer]], None, None]:
+) -> Generator[list[tuple[VMTcpClient, TcpServer]]]:
     """Start iperf3 client-server connections for all IPs on the server's interface.
        The helper assumed the ip addresses are up.
 
@@ -242,7 +243,7 @@ def client_server_active_connection(
     port: int = IPERF_SERVER_PORT,
     maximum_segment_size: int = 0,
     ip_family: int = 4,
-) -> Generator[tuple[VMTcpClient, TcpServer], None, None]:
+) -> Generator[tuple[VMTcpClient, TcpServer]]:
     """Start iperf3 client-server connection with continuous TCP traffic flow.
 
     Automatically starts an iperf3 server and client, with traffic flowing continuously

--- a/libs/storage/config.py
+++ b/libs/storage/config.py
@@ -26,7 +26,7 @@ class StorageClassConfig:
         self.name = name
         self.storage_config = self.get_storage_config()
 
-    def supported_storage_classes(self) -> list["StorageClass"]:
+    def supported_storage_classes(self) -> list[StorageClass]:
         return [
             StorageClass(
                 name=StorageClassNames.CEPH_RBD_VIRTUALIZATION,

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -9,7 +9,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 @dataclass
 class VMSpec:
     template: Template
-    runStrategy: str = VirtualMachine.RunStrategy.HALTED  # noqa: N815
+    runStrategy: str = VirtualMachine.RunStrategy.HALTED
 
 
 @dataclass
@@ -29,7 +29,7 @@ class VMISpec:
     domain: Domain
     networks: list[Network] | None = None
     volumes: list[Volume] | None = None
-    terminationGracePeriodSeconds: int | None = None  # noqa: N815
+    terminationGracePeriodSeconds: int | None = None
     affinity: Affinity | None = None
 
 
@@ -74,7 +74,7 @@ class Interface:
     masquerade: dict[Any, Any] | None = None
     bridge: dict[Any, Any] | None = None
     sriov: dict[Any, Any] | None = None
-    passtBinding: dict[Any, Any] | None = None  # noqa: N815
+    passtBinding: dict[Any, Any] | None = None
     binding: NetBinding | None = None
     state: str | None = None
 
@@ -93,30 +93,30 @@ class Network:
 
 @dataclass
 class Multus:
-    networkName: str  # noqa: N815
+    networkName: str
 
 
 @dataclass
 class Affinity:
-    podAntiAffinity: PodAntiAffinity  # noqa: N815
+    podAntiAffinity: PodAntiAffinity
 
 
 @dataclass
 class PodAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution: list[PodAffinityTerm]  # noqa: N815
+    requiredDuringSchedulingIgnoredDuringExecution: list[PodAffinityTerm]
 
 
 @dataclass
 class PodAffinityTerm:
-    labelSelector: LabelSelector  # noqa: N815
-    topologyKey: str  # noqa: N815
-    namespaceSelector: dict[str, Any] | None = None  # noqa: N815
+    labelSelector: LabelSelector
+    topologyKey: str
+    namespaceSelector: dict[str, Any] | None = None
     namespaces: list[str] | None = None
 
 
 @dataclass
 class LabelSelector:
-    matchExpressions: list[LabelSelectorRequirement]  # noqa: N815
+    matchExpressions: list[LabelSelectorRequirement]
 
 
 @dataclass
@@ -129,8 +129,8 @@ class LabelSelectorRequirement:
 @dataclass
 class Volume:
     name: str
-    containerDisk: ContainerDisk | None = None  # noqa: N815
-    cloudInitNoCloud: CloudInitNoCloud | None = None  # noqa: N815
+    containerDisk: ContainerDisk | None = None
+    cloudInitNoCloud: CloudInitNoCloud | None = None
 
 
 @dataclass
@@ -140,5 +140,5 @@ class ContainerDisk:
 
 @dataclass
 class CloudInitNoCloud:
-    networkData: str  # noqa: N815
-    userData: str | None = None  # noqa: N815
+    networkData: str
+    userData: str | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,42 @@ output-format = "grouped"
 [tool.ruff.format]
 exclude = [".git", ".venv", ".mypy_cache", ".tox", "__pycache__"]
 
+[tool.ruff.lint]
+ignore = [
+  "SIM102",  # collapsible-if — nested ifs are often more readable
+  "C419",    # unnecessary-comprehension-in-call — may change list vs generator semantics
+  "RUF015",  # unnecessary-iterable-allocation-for-first-element — changes exception type
+  "DTZ005",  # datetime.now() without tz — requires careful refactoring
+  "DTZ006",  # datetime.fromtimestamp() without tz
+  "DTZ007",  # naive datetime from strptime()
+  "BLE001",  # blind exception catch — pre-existing, fix separately
+  "PYI036",  # __exit__ parameter annotations
+  "PYI034",  # __enter__ return type annotation
+  "PLE0643", # expression likely to raise IndexError — needs per-case review
+  "PLW1510", # subprocess.run without check — needs per-call review
+  "B023",    # loop variable not bound in function — needs careful refactor
+  "G201",    # .error(exc_info=True) vs .exception()
+  "SIM115",  # context manager for file opening — may need structural changes
+  "SIM117",  # nested with statements — existing pattern, keep as-is
+  "PLW0604", # redundant global at module level — used in global_config files
+  "B005",    # .strip() with multi-char string — intent-dependent
+  "B018",    # useless expression — intent-dependent
+  "B026",    # star-arg unpacking after keyword arg
+  "DTZ003",  # datetime.utcnow() without tz
+  "EXE001",  # shebang present but file not executable
+  "EXE002",  # file executable but no shebang
+  "F821",    # undefined name — used in global_config files (dynamic loading)
+  "PIE810",  # call startswith/endswith once with tuple
+  "PLE0704", # bare raise not inside exception handler
+  "SIM103",  # return condition directly
+  "SIM113",  # use enumerate() for index variable
+  "SIM114",  # combine if branches using logical or — reduces readability
+  "TRY002",  # create your own exception
+  "TRY201",  # use raise without specifying exception name
+  "TRY203",  # remove exception handler; error immediately re-raised
+  "TRY401",  # redundant exception object in logging.exception
+]
+
 [tool.ruff.lint.isort]
 order-by-type = true
 known-third-party = [

--- a/scripts/quarantine_stats/generate_dashboard.py
+++ b/scripts/quarantine_stats/generate_dashboard.py
@@ -1617,7 +1617,7 @@ class DashboardGenerator:
         first_tab = True
         repo_index = 0
 
-        for _, version_stats_list in self.repo_stats.items():
+        for version_stats_list in self.repo_stats.values():
             repo_index += 1
             repo_id = f"repo{repo_index}"
 

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S uv run python
 
-# flake8: noqa: N802
 
 """
 Pytest Marker Analyzer
@@ -2011,7 +2010,7 @@ def _analyze_single_test_dependencies(
             to_visit = []
 
             for dep_file in current_level:
-                if dep_file in visited or not dep_file.suffix == ".py":
+                if dep_file in visited or dep_file.suffix != ".py":
                     continue
 
                 visited.add(dep_file)

--- a/tests/chaos/oadp/conftest.py
+++ b/tests/chaos/oadp/conftest.py
@@ -76,7 +76,6 @@ def rebooted_vm_source_node(rhel_vm_with_dv_running, oadp_backup_in_progress, wo
 
     LOGGER.info(f"Waiting for node {vm_node.name} to come back online")
     wait_for_node_status(node=vm_node, status=True, wait_timeout=TIMEOUT_10MIN)
-    return
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import subprocess
 import tempfile
 from bisect import bisect_left
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from signal import SIGINT, SIGTERM, getsignal, signal
 
 import bcrypt
@@ -263,7 +263,7 @@ def session_start_time() -> datetime:
     Returns:
         datetime: UTC timestamp when test session began (timezone-naive)
     """
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 @pytest.fixture(scope="session")
@@ -445,7 +445,7 @@ def schedulable_nodes(nodes):
     yield [
         node
         for node in nodes
-        if schedulable_label in node.labels.keys()
+        if schedulable_label in node.labels
         and node.labels[schedulable_label] == "true"
         and not node.instance.spec.unschedulable
         and not kubernetes_taint_exists(node)
@@ -670,7 +670,7 @@ def nodes_active_nics(
 
 @pytest.fixture(scope="session")
 def nodes_available_nics(nodes_active_nics):
-    return {node: nodes_active_nics[node]["available"] for node in nodes_active_nics.keys()}
+    return {node: nodes_active_nics[node]["available"] for node in nodes_active_nics}
 
 
 @pytest.fixture(scope="module")

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -249,7 +249,7 @@ os_login_param: dict[str, Any] = {}
 vlans = [f"{_id}" for _id in range(1000, 1020)]
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int, set]:

--- a/tests/global_config_amd64.py
+++ b/tests/global_config_amd64.py
@@ -22,7 +22,7 @@ instance_type_fedora_os_list = [OS_FLAVOR_FEDORA]
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -31,4 +31,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -54,7 +54,7 @@ instance_type_rhel_os_list = [RHEL10_PREFERENCE]
 instance_type_fedora_os_list = [OS_FLAVOR_FEDORA]
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -63,4 +63,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_aro.py
+++ b/tests/global_config_aro.py
@@ -25,7 +25,7 @@ storage_class_a = StorageClassNames.CEPH_RBD_VIRTUALIZATION
 storage_class_b = StorageClassNames.CEPH_RBD_VIRTUALIZATION
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -34,4 +34,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -54,7 +54,7 @@ storage_class_a = StorageClassNames.IO2_CSI
 storage_class_b = StorageClassNames.IO2_CSI
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -63,4 +63,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_ibm_spectrum_sc.py
+++ b/tests/global_config_ibm_spectrum_sc.py
@@ -24,7 +24,7 @@ storage_class_a = StorageClassNames.GPFS
 storage_class_b = StorageClassNames.GPFS
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -33,4 +33,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_interop.py
+++ b/tests/global_config_interop.py
@@ -7,7 +7,7 @@ global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", 
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -16,4 +16,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_interop_sno.py
+++ b/tests/global_config_interop_sno.py
@@ -19,7 +19,7 @@ storage_class_matrix = [
 ]
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -28,4 +28,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_lvms.py
+++ b/tests/global_config_lvms.py
@@ -29,7 +29,7 @@ storage_class_a = StorageClassNames.TOPOLVM
 storage_class_b = StorageClassNames.TOPOLVM
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -38,4 +38,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_multiarch.py
+++ b/tests/global_config_multiarch.py
@@ -28,15 +28,6 @@ storage_class_matrix = [
             "default": True,
         }
     },
-    {
-        StorageClassNames.CEPH_RBD_VIRTUALIZATION: {
-            "volume_mode": DataVolume.VolumeMode.BLOCK,
-            "access_mode": DataVolume.AccessMode.RWX,
-            "snapshot": True,
-            "online_resize": True,
-            "wffc": False,
-        }
-    },
 ]
 
 storage_class_a = StorageClassNames.IO2_CSI
@@ -63,7 +54,7 @@ os_matrix = {
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -72,4 +63,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_nfs.py
+++ b/tests/global_config_nfs.py
@@ -25,7 +25,7 @@ storage_class_a = StorageClassNames.NFS
 storage_class_b = StorageClassNames.NFS
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -34,4 +34,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_oci.py
+++ b/tests/global_config_oci.py
@@ -35,7 +35,7 @@ storage_class_a = StorageClassNames.OCI
 storage_class_b = StorageClassNames.OCI
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -44,4 +44,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_rh_it.py
+++ b/tests/global_config_rh_it.py
@@ -27,7 +27,7 @@ storage_class_a = StorageClassNames.RH_INTERNAL_NFS
 storage_class_b = StorageClassNames.RH_INTERNAL_NFS
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -36,4 +36,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -25,7 +25,7 @@ instance_type_centos_os_list = [CENTOS_STREAM9_PREFERENCE]
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -34,4 +34,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_sno.py
+++ b/tests/global_config_sno.py
@@ -27,7 +27,7 @@ storage_class_matrix = [
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -36,4 +36,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_sno_hpp.py
+++ b/tests/global_config_sno_hpp.py
@@ -21,7 +21,7 @@ storage_class_matrix = [
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -30,4 +30,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -233,16 +233,16 @@ def data_sources_managed_by_data_import_crons_scope_function(
     return [
         data_source
         for data_source in golden_images_data_sources_scope_function
-        if DATA_SOURCE_MANAGED_BY_CDI_LABEL in data_source.labels.keys()
+        if DATA_SOURCE_MANAGED_BY_CDI_LABEL in data_source.labels
     ]
 
 
 @pytest.fixture()
 def data_sources_names_from_templates_scope_function(base_templates):
-    return set([
+    return {
         get_parameters_from_template(template=template, parameter_subset=DATA_SOURCE_NAME)[DATA_SOURCE_NAME]
         for template in base_templates
-    ])
+    }
 
 
 @pytest.fixture()

--- a/tests/infrastructure/golden_images/update_boot_source/utils.py
+++ b/tests/infrastructure/golden_images/update_boot_source/utils.py
@@ -87,7 +87,7 @@ def get_all_dic_volume_names(client: DynamicClient, namespace: str) -> list[str]
         list[str]: Combined list of PVC and VolumeSnapshot names managed by DataImportCron.
     """
 
-    def _fetch_volume_names(resource_cls: type[PersistentVolumeClaim] | type[VolumeSnapshot]) -> list[str]:
+    def _fetch_volume_names(resource_cls: type[PersistentVolumeClaim | VolumeSnapshot]) -> list[str]:
         return [
             volume.name
             for volume in resource_cls.get(

--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -70,7 +70,7 @@ def vm_cluster_preferences_expected_list():
 
 @pytest.mark.polarion("CNV-9981")
 def test_base_preferences_common_annotation(base_vm_cluster_preferences, vm_cluster_preferences_expected_list):
-    assert set([preference.name for preference in base_vm_cluster_preferences]) == set(
+    assert {preference.name for preference in base_vm_cluster_preferences} == set(
         vm_cluster_preferences_expected_list
     ), "Not all base CNV cluster preferences exist"
 

--- a/tests/infrastructure/vm_console_proxy/utils.py
+++ b/tests/infrastructure/vm_console_proxy/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Type
+from typing import Any
 
 import requests
 from kubernetes.dynamic import DynamicClient
@@ -56,11 +56,11 @@ def create_vnc_console_token(
         response.raise_for_status()  # Raise HTTPError for bad responses <4xx><5xx>
         return response.json()["token"]
     except requests.RequestException as exp:
-        logging.error(f"Request error occurred: {exp}")
+        LOGGER.error(f"Request error occurred: {exp}")
         raise
 
 
-def get_vm_console_proxy_resource(resource_kind: Type, client: DynamicClient, namespace: str | None = None) -> Type:
+def get_vm_console_proxy_resource(resource_kind: type, client: DynamicClient, namespace: str | None = None) -> type:
     if namespace:
         vm_console_proxy_resource_object = resource_kind(
             name=VM_CONSOLE_PROXY,

--- a/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 HA VM reboot and provisioning scenario tests.
 """

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
@@ -72,7 +72,7 @@ def test_hco_overriding_apiserver_crypto_policy(
                 conflicting_resources = {
                     resource.kind: crypto_policy
                     for resource, crypto_policy in sample.items()
-                    if expected_all_managed_crs_crypto_policies[resource] != sample[resource]
+                    if expected_all_managed_crs_crypto_policies[resource] != crypto_policy
                 }
                 assert not conflicting_resources, (
                     "API server crypto policy overrides HCO crypto policy\n"

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -91,7 +91,7 @@ def updated_cr_with_custom_crypto_policy(
             hco_namespace=hco_namespace,
             expected_conditions={
                 **DEFAULT_HCO_CONDITIONS,
-                **{"TaintedConfiguration": Resource.Condition.Status.TRUE},
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
             },
         )
         yield {"resource": resource, "tls_policy": value}

--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -55,7 +55,7 @@ def global_permission_from_csv(cnv_operators_matrix__function__, csv_permissions
 
 @pytest.fixture(scope="module")
 def operators_from_csv(csv_permissions):
-    return {service_account_name for service_account_name, all_permissions in csv_permissions.items()}
+    return {service_account_name for service_account_name in csv_permissions}
 
 
 @pytest.fixture(scope="module")
@@ -88,7 +88,7 @@ def csv_permissions_from_yaml(pytestconfig, admin_client):
 
 @pytest.mark.polarion("CNV-9805")
 def test_new_operator_in_csv(operators_from_csv):
-    assert sorted(list(operators_from_csv)) == sorted(CNV_OPERATORS), (
+    assert sorted(operators_from_csv) == sorted(CNV_OPERATORS), (
         f"Expected cnv operators:{CNV_OPERATORS} does not match operators {operators_from_csv} "
     )
 
@@ -129,7 +129,7 @@ def test_global_csv_permissions(cnv_operators_matrix__function__, global_permiss
             errors[key] = error_list
     if errors:
         LOGGER.error(yaml.dump(errors))
-        if cnv_operators_matrix__function__ in JIRA_LINKS.keys() and is_jira_open(
+        if cnv_operators_matrix__function__ in JIRA_LINKS and is_jira_open(
             jira_id=JIRA_LINKS[cnv_operators_matrix__function__]
         ):
             pytest.xfail(error_message)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
@@ -57,7 +57,7 @@ class TestKubevirtJsonPatch:
             admin_client=admin_client,
             hco_namespace=hco_namespace,
             expected_conditions={
-                **{"TaintedConfiguration": Resource.Condition.Status.TRUE},
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
             },
         )
         validate_cdi_json_patch(

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
@@ -61,7 +61,7 @@ class TestCNAOJsonPatch:
             admin_client=admin_client,
             hco_namespace=hco_namespace,
             expected_conditions={
-                **{"TaintedConfiguration": Resource.Condition.Status.TRUE},
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
             },
         )
         cnao_spec = cnao_resource.instance.spec

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
@@ -54,7 +54,7 @@ class TestKubevirtJsonPatch:
             admin_client=admin_client,
             hco_namespace=hco_namespace,
             expected_conditions={
-                **{"TaintedConfiguration": Resource.Condition.Status.TRUE},
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
             },
         )
         validate_kubevirt_json_patch(kubevirt_resource=kubevirt_resource)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
@@ -91,7 +91,7 @@ class TestMultipleJsonPatch:
             admin_client=admin_client,
             hco_namespace=hco_namespace,
             expected_conditions={
-                **{"TaintedConfiguration": Resource.Condition.Status.TRUE},
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
             },
         )
         validate_cdi_json_patch(
@@ -110,17 +110,17 @@ class TestMultipleJsonPatch:
             )
             for component in [COMPONENT_CDI, COMPONENT_KUBEVIRT]
         }
-        for component_name in component_metrics_dict:
+        for component_name, previous_value in component_metrics_dict.items():
             LOGGER.info(f"Waiting for metrics: {QUERY_STRING} for component: {component_name}")
             wait_for_metrics_value_update(
                 prometheus=prometheus,
                 component_name=component_name,
                 query_string=QUERY_STRING,
-                previous_value=component_metrics_dict[component_name],
+                previous_value=previous_value,
             )
 
     @pytest.mark.polarion("CNV-8813")
     def test_multiple_json_patch_alert(self, prometheus):
-        for component in COMPONENT_DICT.keys():
+        for component in COMPONENT_DICT:
             LOGGER.info(f"Waiting for alert: {ALERT_NAME} for component: {component}")
             wait_for_alert(prometheus=prometheus, alert_name=ALERT_NAME, component_name=component)

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -57,7 +57,7 @@ class TestSSPJsonPatch:
             admin_client=admin_client,
             hco_namespace=hco_namespace,
             expected_conditions={
-                **{"TaintedConfiguration": Resource.Condition.Status.TRUE},
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
             },
         )
         ssp_replicas_current_value = ssp_resource_scope_function.instance.spec.templateValidator.replicas

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 import os
 import re

--- a/tests/install_upgrade_operators/must_gather/utils.py
+++ b/tests/install_upgrade_operators/must_gather/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import difflib
 import glob
 import logging
@@ -54,7 +53,7 @@ FILE_NAMES_TO_CHECK = [
 # To be removed after the issue is fixed in openshift
 
 
-class ResourceFieldEqBugWorkaround(object):
+class ResourceFieldEqBugWorkaround:
     def __enter__(self):
         self.prev_eq_func = ResourceField.__eq__
 
@@ -387,7 +386,7 @@ def validate_must_gather_vm_file_collection(
             admin_client=admin_client,
         )
     assert all(entry in str(exeption_found.value) for entry in not_collected_vm_names + ["path_not_found"]), (
-        f"Failed to find {not_collected_vm_names} in exception message: {str(exeption_found.value)}"
+        f"Failed to find {not_collected_vm_names} in exception message: {exeption_found.value!s}"
     )
 
 

--- a/tests/install_upgrade_operators/node_component/utils.py
+++ b/tests/install_upgrade_operators/node_component/utils.py
@@ -324,7 +324,7 @@ def verify_components_exist_only_on_selected_node(
         admin_client(DynamicClient): DynamicClient object
         hco_namespace(Namespace): Namespace object
     """
-    unselected_nodes = [node_name for node_name in hco_pods_per_nodes.keys() if node_name != selected_node]
+    unselected_nodes = [node_name for node_name in hco_pods_per_nodes if node_name != selected_node]
     verify_all_components_on_node(
         component_list=component_list,
         node_name=selected_node,

--- a/tests/install_upgrade_operators/resource_params/utils.py
+++ b/tests/install_upgrade_operators/resource_params/utils.py
@@ -13,7 +13,7 @@ def assert_status_condition(conditions, field_dict):
     """
 
     for field in field_dict:
-        condition_match = [condition for condition in conditions if field in condition.keys()]
+        condition_match = [condition for condition in conditions if field in condition]
         assert bool(condition_match) == field_dict[field], (
             f"Expected key: {field} to be present:{field_dict[field]} in hyperconverged object's status.condition."
             f" Actual result: {condition_match}"

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test to verify all HCO deployments have 'openshift.io/required-scc' annotation.
 """

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests to check, HCO Namespace Pod's, Security Context Constraint
 """

--- a/tests/install_upgrade_operators/security/scc/test_default_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_default_scc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests to check, the default Security Context Constraint
 """

--- a/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
+++ b/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Test to check, SELinuxLauncher Type in kubevirt config map
 """

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV network tests
 """

--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from contextlib import contextmanager
 
 import pytest

--- a/tests/network/kubemacpool/explicit_range/conftest.py
+++ b/tests/network/kubemacpool/explicit_range/conftest.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 from kubernetes.dynamic import DynamicClient

--- a/tests/network/kubemacpool/utils.py
+++ b/tests/network/kubemacpool/utils.py
@@ -52,8 +52,7 @@ def vm_network_config(mac_pool, all_nads, end_ip_octet, mac_uid):
 def create_vm(name, namespace, iface_config, node_selector, client, mac_pool):
     network_data_data = {}
     _data = {
-        iface: {"addresses": [f"{iface_config[iface].ip_address}/24"]}
-        for iface in ("eth%d" % idx for idx in range(1, 5))
+        iface: {"addresses": [f"{iface_config[iface].ip_address}/24"]} for iface in (f"eth{idx}" for idx in range(1, 5))
     }
     runcmd = [
         # 2 kernel flags are used to disable wrong arp behavior

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -140,7 +140,7 @@ def hot_plug_interface(
 def hot_unplug_interface(vm, hot_plugged_interface_name):
     interfaces = vm.get_interfaces()
     unplugged_interface = next(interface for interface in interfaces if interface["name"] == hot_plugged_interface_name)
-    unplugged_interface.update(dict(state="absent"))
+    unplugged_interface.update({"state": "absent"})
 
     update_hot_plug_config_in_vm(vm=vm, interfaces=interfaces)
 

--- a/tests/network/libs/cluster_user_defined_network.py
+++ b/tests/network/libs/cluster_user_defined_network.py
@@ -49,7 +49,7 @@ class Localnet:
         SECONDARY = "Secondary"
 
     role: str
-    physicalNetworkName: str  # noqa: N815
+    physicalNetworkName: str
     ipam: Ipam
     vlan: Vlan | None = None
     mtu: int | None = None
@@ -58,20 +58,20 @@ class Localnet:
 @dataclass
 class MacVRF:
     vni: int
-    routeTarget: str | None = None  # noqa: N815
+    routeTarget: str | None = None
 
 
 @dataclass
 class IpVRF:
     vni: int
-    routeTarget: str | None = None  # noqa: N815
+    routeTarget: str | None = None
 
 
 @dataclass
 class EvpnConfiguration:
     vtep: str
-    macVRF: MacVRF | None = None  # noqa: N815
-    ipVRF: IpVRF | None = None  # noqa: N815
+    macVRF: MacVRF | None = None
+    ipVRF: IpVRF | None = None
 
 
 class Transport(Enum):

--- a/tests/network/libs/label_selector.py
+++ b/tests/network/libs/label_selector.py
@@ -3,4 +3,4 @@ from dataclasses import dataclass
 
 @dataclass
 class LabelSelector:
-    matchLabels: dict[str, str] | None = None  # noqa: N815
+    matchLabels: dict[str, str] | None = None

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -1,7 +1,8 @@
 import contextlib
 import logging
 import uuid
-from typing import Final, Generator
+from collections.abc import Generator
+from typing import Final
 
 from kubernetes.client import ApiException
 from kubernetes.dynamic import DynamicClient
@@ -198,7 +199,7 @@ def create_nncp_localnet_on_secondary_node_nic(
     node_nic_name: str,
     client: DynamicClient,
     mtu: int | None = None,
-) -> Generator[libnncp.NodeNetworkConfigurationPolicy, None, None]:
+) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
     """Create NNCP to configure an OVS bridge on a secondary NIC across all worker nodes.
 
     Note:

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Network Migration test
 """

--- a/tests/network/nmstate/conftest.py
+++ b/tests/network/nmstate/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 
 import pytest

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -282,11 +282,9 @@ class TestConnectivityAfterNmstateChanged:
                 nmstate_ds=nmstate_ds,
             )
             LOGGER.info(
-                (
-                    f"Check connectivity from {nmstate_linux_bridge_attached_running_vma.name} "
-                    f"to {nmstate_linux_bridge_attached_running_vmb.name} "
-                    f"IP {vmb_dst_ip}. NMstate restart number: {idx + 1}"
-                )
+                f"Check connectivity from {nmstate_linux_bridge_attached_running_vma.name} "
+                f"to {nmstate_linux_bridge_attached_running_vmb.name} "
+                f"IP {vmb_dst_ip}. NMstate restart number: {idx + 1}"
             )
 
             assert_ping_successful(

--- a/tests/network/provider_migration/libprovider.py
+++ b/tests/network/provider_migration/libprovider.py
@@ -114,5 +114,4 @@ def extract_vm_primary_network_data(vm: vim.VirtualMachine) -> tuple[str, str]:
             for net in getattr(vm.guest, "net", []):
                 if net.macAddress == device.macAddress and net.ipAddress:
                     return net.macAddress, net.ipAddress[0]
-    else:
-        raise IfaceNotFoundError("No network interface found in the VM or no IP address assigned.")
+    raise IfaceNotFoundError("No network interface found in the VM or no IP address assigned.")

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -35,7 +35,7 @@ def sriov_vm(
         "cloud_init_data": cloud_init_data,
         "client": unprivileged_client,
         "macs": {sriov_network.name: sriov_mac},
-        "interfaces_types": {name: SRIOV for name in networks.keys()},
+        "interfaces_types": {name: SRIOV for name in networks},
     }
 
     if worker:

--- a/tests/network/user_defined_network/ip_specification/conftest.py
+++ b/tests/network/user_defined_network/ip_specification/conftest.py
@@ -20,7 +20,7 @@ def vm_under_test(
     namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
     udn_affinity_label: tuple[str, str],
     admin_client: DynamicClient,
-) -> Generator[BaseVirtualMachine, None, None]:
+) -> Generator[BaseVirtualMachine]:
     with udn_vm(
         namespace_name=udn_namespace.name,
         name="ip-spec-vm-under-test",
@@ -37,7 +37,7 @@ def vm_for_connectivity_ref(
     namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
     udn_affinity_label: tuple[str, str],
     admin_client: DynamicClient,
-) -> Generator[BaseVirtualMachine, None, None]:
+) -> Generator[BaseVirtualMachine]:
     with udn_vm(
         namespace_name=udn_namespace.name,
         name="vm-for-connectivity-ref",
@@ -77,7 +77,7 @@ def ip_to_request(
 @pytest.fixture(scope="module")
 def client_server_tcp_connectivity_between_vms(
     vm_for_connectivity_ref: BaseVirtualMachine, vm_under_test: BaseVirtualMachine
-) -> Generator[tuple[TcpClient, TcpServer], None, None]:
+) -> Generator[tuple[TcpClient, TcpServer]]:
     with client_server_active_connection(
         client_vm=vm_for_connectivity_ref,
         server_vm=vm_under_test,

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 from kubernetes.dynamic import DynamicClient
@@ -31,7 +31,7 @@ def wait_for_ready_vm_with_restart(vm: BaseVirtualMachine) -> bool:
 @pytest.fixture(scope="module")
 def passt_enabled_in_hco(
     hyperconverged_resource_scope_module: HyperConverged,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     with ResourceEditorValidateHCOReconcile(
         patches={
             hyperconverged_resource_scope_module: {
@@ -51,7 +51,7 @@ def passt_running_vm_pair(
     udn_affinity_label: tuple[str, str],
     admin_client: DynamicClient,
     passt_enabled_in_hco,
-) -> Generator[tuple[BaseVirtualMachine, BaseVirtualMachine], None, None]:
+) -> Generator[tuple[BaseVirtualMachine, BaseVirtualMachine]]:
     with (
         udn_vm(
             namespace_name=udn_namespace.name,

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from urllib.parse import urlparse
 
 import bitmath
@@ -48,9 +48,7 @@ def get_last_transition_time(vm):
     for condition in vm.instance.get("status", {}).get("conditions"):
         if condition.get("type") == vm.Condition.READY:
             last_transition_time = condition.get("lastTransitionTime")
-            return int(
-                (datetime.strptime(last_transition_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)).timestamp()
-            )
+            return int((datetime.strptime(last_transition_time, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)).timestamp())
 
 
 def check_vm_last_transition_metric_value(prometheus, metric, vm):

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -3,9 +3,10 @@ import math
 import re
 import shlex
 import urllib
+from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime, timezone
-from typing import Any, Generator, Optional
+from datetime import UTC, datetime
+from typing import Any
 
 import bitmath
 from kubernetes.dynamic import DynamicClient
@@ -229,7 +230,7 @@ def enable_swap_fedora_vm(vm: VirtualMachineForTests) -> None:
     vm.ssh_exec.executor(sudo=True).run_cmd(cmd=shlex.split("sysctl vm.swappiness=100"))
 
 
-def get_vm_cpu_info_from_prometheus(prometheus: Prometheus, vm_name: str) -> Optional[int]:
+def get_vm_cpu_info_from_prometheus(prometheus: Prometheus, vm_name: str) -> int | None:
     query = urllib.parse.quote_plus(
         f'kubevirt_vmi_node_cpu_affinity{{kubernetes_vmi_label_kubevirt_io_domain="{vm_name}"}}'
     )
@@ -372,9 +373,7 @@ def compare_network_traffic_bytes_and_metrics(
             rx_tx_indicator = True
         else:
             break
-    if rx_tx_indicator:
-        return True
-    return False
+    return rx_tx_indicator
 
 
 def validate_network_traffic_metrics_value(
@@ -463,7 +462,7 @@ def compare_kubevirt_vmi_info_metric_with_vm_info(
 def timestamp_to_seconds(timestamp: str) -> int:
     # Parse the timestamp with UTC timezone and convert to seconds
     dt = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
-    dt = dt.replace(tzinfo=timezone.utc)  # Ensure it is treated as UTC
+    dt = dt.replace(tzinfo=UTC)  # Ensure it is treated as UTC
     return int(dt.timestamp())
 
 

--- a/tests/scale/test_scale_benchmark.py
+++ b/tests/scale/test_scale_benchmark.py
@@ -239,15 +239,15 @@ def vms_info(scale_test_param):
         OS_FLAVOR_FEDORA: {"latest_labels": FEDORA_LATEST_LABELS},
         OS_FLAVOR_WINDOWS: {"latest_labels": WINDOWS_LATEST_LABELS},
     }
-    for os_name in vms_info_dict:
+    for os_name, os_info in vms_info_dict.items():
         for storage_type_key in SCALE_STORAGE_TYPES:
-            vms_info_dict[os_name][storage_type_key] = {
+            os_info[storage_type_key] = {
                 "vms_per_batch": scale_test_param["vms"][os_name][storage_type_key]["vms_per_batch"],
                 "number_of_batches": scale_test_param["vms"][os_name][storage_type_key]["number_of_batches"],
             }
-        vms_info_dict[os_name]["cores"] = int(scale_test_param["vms"][os_name]["cores"])
-        vms_info_dict[os_name]["memory"] = scale_test_param["vms"][os_name]["memory"]
-        vms_info_dict[os_name]["run_strategy"] = scale_test_param["vms"][os_name]["run_strategy"]
+        os_info["cores"] = int(scale_test_param["vms"][os_name]["cores"])
+        os_info["memory"] = scale_test_param["vms"][os_name]["memory"]
+        os_info["run_strategy"] = scale_test_param["vms"][os_name]["run_strategy"]
     return vms_info_dict
 
 

--- a/tests/storage/cdi_config/conftest.py
+++ b/tests/storage/cdi_config/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV CDI Config tests
 """

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Upload tests
 """

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Upload using virtctl
 """
@@ -50,7 +48,7 @@ def get_population_method_by_provisioner(storage_class, cluster_csi_drivers_name
 
 @pytest.fixture(scope="function")
 def skip_no_reencrypt_route(upload_proxy_route):
-    if not upload_proxy_route.termination == "reencrypt":
+    if upload_proxy_route.termination != "reencrypt":
         pytest.skip("Skip testing. The upload proxy route is not re-encrypt.")
 
 

--- a/tests/storage/cdi_upload/utils.py
+++ b/tests/storage/cdi_upload/utils.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.resource import Resource
@@ -8,7 +7,7 @@ from ocp_resources.storage_profile import StorageProfile
 LOGGER = logging.getLogger(__name__)
 
 
-def get_storage_profile_minimum_supported_pvc_size(storage_class_name: str, client: DynamicClient) -> Optional[str]:
+def get_storage_profile_minimum_supported_pvc_size(storage_class_name: str, client: DynamicClient) -> str | None:
     """
     Get the minimum supported PVC size from the storage profile annotations.
 

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV CDI tests
 """

--- a/tests/storage/cross_cluster_live_migration/utils.py
+++ b/tests/storage/cross_cluster_live_migration/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Generator
+from collections.abc import Generator
 
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.hyperconverged import HyperConverged
@@ -22,7 +22,7 @@ def configure_hco_live_migration_network(
     client: DynamicClient,
     hco_namespace: Namespace,
     network_for_live_migration: NetworkAttachmentDefinition | None = None,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """
     Configure HCO live migration network.
 

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -47,7 +47,7 @@ def skip_if_no_storage_profile_with_snapshot_import_cron_format(
     snapshot_storage_class_name_scope_module,
 ):
     sc_storage_profile = StorageProfile(name=snapshot_storage_class_name_scope_module)
-    if not sc_storage_profile.instance.status.get("dataImportCronSourceFormat") == "snapshot":
+    if sc_storage_profile.instance.status.get("dataImportCronSourceFormat") != "snapshot":
         pytest.skip(f"Cant create cached snapshot for {snapshot_storage_class_name_scope_module} storageclass")
 
 

--- a/tests/storage/hpp/test_hostpath.py
+++ b/tests/storage/hpp/test_hostpath.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Hostpath Provisioner test suite
 """

--- a/tests/storage/hpp/test_hpp_node_placement.py
+++ b/tests/storage/hpp/test_hpp_node_placement.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 HPP Node Placement test suite
 """

--- a/tests/storage/online_resize/conftest.py
+++ b/tests/storage/online_resize/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Fixtures for online resize tests
 """

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Online resize (PVC expanded while VM running)
 """

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Utility functions and context managers for online resize tests
 """

--- a/tests/storage/snapshots/conftest.py
+++ b/tests/storage/snapshots/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV Storage snapshots tests
 """

--- a/tests/storage/snapshots/test_snapshots.py
+++ b/tests/storage/snapshots/test_snapshots.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Snapshots tests
 """

--- a/tests/storage/storage_migration/utils.py
+++ b/tests/storage/storage_migration/utils.py
@@ -151,7 +151,7 @@ def build_namespaces_spec_for_storage_migration(
         # Get volume names from VM spec
         target_migration_pvcs = []
         for volume in vm.instance.spec.template.spec.volumes:
-            if "dataVolume" in volume.keys():
+            if "dataVolume" in volume:
                 target_migration_pvcs.append({
                     "volumeName": volume.name,
                     "destinationPVC": {

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Automatic refresh of CDI certificates test suite
 """
@@ -83,9 +81,9 @@ def valid_cdi_certificates(secrets):
 
                 start = secret.certificate_not_before
                 end = secret.certificate_not_after
-                start_dt = datetime.datetime.strptime(start, RFC3339_FORMAT).replace(tzinfo=datetime.timezone.utc)
-                end_dt = datetime.datetime.strptime(end, RFC3339_FORMAT).replace(tzinfo=datetime.timezone.utc)
-                now_dt = datetime.datetime.now(datetime.timezone.utc)
+                start_dt = datetime.datetime.strptime(start, RFC3339_FORMAT).replace(tzinfo=datetime.UTC)
+                end_dt = datetime.datetime.strptime(end, RFC3339_FORMAT).replace(tzinfo=datetime.UTC)
+                now_dt = datetime.datetime.now(datetime.UTC)
                 assert start_dt <= now_dt <= end_dt, f"Certificate of {cdi_secret} not valid at current time"
 
 

--- a/tests/storage/test_cdi_resources.py
+++ b/tests/storage/test_cdi_resources.py
@@ -46,7 +46,7 @@ def verify_label(cdi_resources):
     for rcs in cdi_resources:
         if rcs.name.startswith(CDI_OPERATOR):
             continue
-        if CDI_LABEL not in rcs.labels.keys():
+        if CDI_LABEL not in rcs.labels:
             bad_pods.append(rcs.name)
     assert not bad_pods, " ".join(bad_pods)
 

--- a/tests/storage/test_data_protection.py
+++ b/tests/storage/test_data_protection.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 CDI data protection test suite
 """

--- a/tests/storage/test_disk_preallocation.py
+++ b/tests/storage/test_disk_preallocation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 CDI disk preallocation test suite
 """

--- a/tests/storage/test_local_storage.py
+++ b/tests/storage/test_local_storage.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Test local storage
 """

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 HonorWaitForFirstConsumer test suite
 """

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -1,8 +1,8 @@
 import ast
 import logging
 import shlex
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 import requests
 from kubernetes.dynamic import DynamicClient

--- a/tests/storage/vm_export/utils.py
+++ b/tests/storage/vm_export/utils.py
@@ -5,8 +5,8 @@ Pytest utils file for CNV VMExport tests
 import io
 import logging
 import shlex
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 import yaml
 from kubernetes.dynamic import DynamicClient

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,9 +4,9 @@ import logging
 import re
 import shlex
 import tarfile
+from collections.abc import Generator
 from contextlib import contextmanager
 from io import BytesIO
-from typing import Generator, Optional
 
 import bitmath
 import requests
@@ -338,7 +338,7 @@ def get_numa_cpu_allocation(vm_cpus, numa_nodes):
                 cpus.append(elem)
         return cpus
 
-    for node in numa_nodes.keys():
+    for node in numa_nodes:
         if all(cpu in _parse_ranges_to_list(ranges=numa_nodes[node]) for cpu in vm_cpus):
             return node
 
@@ -538,12 +538,12 @@ def create_cirros_vm(
     client: DynamicClient,
     dv_name: str,
     vm_name: str,
-    node: Optional[str] = None,
-    wait_running: Optional[bool] = True,
-    volume_mode: Optional[str] = None,
-    cpu_model: Optional[str] = None,
-    annotations: Optional[str] = None,
-) -> Generator[VirtualMachineForTests, None, None]:
+    node: str | None = None,
+    wait_running: bool | None = True,
+    volume_mode: str | None = None,
+    cpu_model: str | None = None,
+    annotations: str | None = None,
+) -> Generator[VirtualMachineForTests]:
     artifactory_secret = get_artifactory_secret(namespace=namespace)
     artifactory_config_map = get_artifactory_config_map(namespace=namespace)
 

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -78,9 +78,9 @@ class TestCommonTemplatesCentos:
     def test_expose_ssh(self, matrix_centos_os_vm_from_template):
         """CNV common templates access VM via SSH"""
 
-        assert matrix_centos_os_vm_from_template.ssh_exec.executor().is_connective(  # noqa: E501
-            tcp_timeout=120
-        ), "Failed to login via SSH"
+        assert matrix_centos_os_vm_from_template.ssh_exec.executor().is_connective(tcp_timeout=120), (
+            "Failed to login via SSH"
+        )
 
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::vmi_guest_agent_info", depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"]

--- a/tests/virt/cluster/common_templates/custom_namespace/utils.py
+++ b/tests/virt/cluster/common_templates/custom_namespace/utils.py
@@ -110,7 +110,7 @@ def verify_base_templates_exist_in_namespace(client, original_base_templates, na
 
 def extract_template_labels(template_labels):
     extracted_vm_template_labels = {}
-    for key in template_labels.keys():
+    for key in template_labels:
         label_prefix, label_name = key.split("/")
         if label_prefix in (
             Template.Labels.OS,

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -152,9 +152,9 @@ class TestCommonTemplatesFedora:
     def test_expose_ssh(self, matrix_fedora_os_vm_from_template):
         """CNV common templates access VM via SSH"""
 
-        assert matrix_fedora_os_vm_from_template.ssh_exec.executor().is_connective(  # noqa: E501
-            tcp_timeout=120
-        ), "Failed to login via SSH"
+        assert matrix_fedora_os_vm_from_template.ssh_exec.executor().is_connective(tcp_timeout=120), (
+            "Failed to login via SSH"
+        )
 
     @pytest.mark.sno
     @pytest.mark.dependency(

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -143,7 +143,7 @@ def os_base_templates(request, base_templates):
     os_templates = [
         template
         for template in base_templates
-        if any(label.startswith(f"{Template.Labels.OS}/{os_name}") for label in template.labels.keys())
+        if any(label.startswith(f"{Template.Labels.OS}/{os_name}") for label in template.labels)
     ]
     assert os_templates, f"No {os_name} templates found"
     return os_templates
@@ -367,7 +367,7 @@ def test_common_templates_golden_images_params(base_templates):
             for gi_params in template_parameters_dict
             if gi_params["name"] in [DATA_SOURCE_NAME, DATA_SOURCE_NAMESPACE]
         ]
-        if not len(golden_images_params) == 2:
+        if len(golden_images_params) != 2:
             unmatched_templates.update({template.name: "Missing golden images parameters"})
         for gi_params in golden_images_params:
             # DATA_SOURCE_NAME contains either:
@@ -430,7 +430,7 @@ def test_vm_annotations_in_template(base_templates):
             if not (
                 (
                     annotation_name == Template.VMAnnotations.OS
-                    and [True for label in template_labels.keys() if label_name in label]
+                    and [True for label in template_labels if label_name in label]
                 )
                 or template_labels.get(label_name)
             ):
@@ -514,7 +514,7 @@ def test_hyperv_features_exist_in_windows_templates(os_base_templates):
     templates_with_wrong_hyperv_labels = {}
     for template in os_base_templates:
         template_hyperv_features = template.instance.objects[0].spec.template.spec.domain.features.get("hyperv")
-        if sorted(list(template_hyperv_features.keys())) != sorted(HYPERV_FEATURES_LABELS_VM_YAML):
+        if sorted(template_hyperv_features.keys()) != sorted(HYPERV_FEATURES_LABELS_VM_YAML):
             templates_with_wrong_hyperv_labels[template.name] = list(template_hyperv_features.keys())
     assert not templates_with_wrong_hyperv_labels, (
         f"Windows templates are missing hyperV labels.\n"

--- a/tests/virt/cluster/common_templates/general/test_template_validator.py
+++ b/tests/virt/cluster/common_templates/general/test_template_validator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Base templates test
 """

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -110,9 +110,9 @@ class TestCommonTemplatesRhel:
     @pytest.mark.polarion("CNV-3320")
     def test_expose_ssh(self, matrix_rhel_os_vm_from_template):
         """CNV common templates access VM via SSH"""
-        assert matrix_rhel_os_vm_from_template.ssh_exec.executor().is_connective(  # noqa: E501
-            tcp_timeout=120
-        ), "Failed to login via SSH"
+        assert matrix_rhel_os_vm_from_template.ssh_exec.executor().is_connective(tcp_timeout=120), (
+            "Failed to login via SSH"
+        )
 
     @pytest.mark.arm64
     @pytest.mark.sno

--- a/tests/virt/cluster/common_templates/utils.py
+++ b/tests/virt/cluster/common_templates/utils.py
@@ -2,9 +2,9 @@ import json
 import logging
 import re
 import shlex
-from datetime import datetime, timedelta, timezone
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta, timezone
 from functools import cache
-from typing import Generator, Optional
 
 import bitmath
 import pytest
@@ -178,7 +178,7 @@ def validate_user_info_virtctl_vs_windows_os(vm, admin_client):
     if virtctl_info["userName"].lower() not in windows_info:
         data_mismatch.append("user name mismatch")
     # Windows date format - 11/4/2020 (-m/-d/Y)
-    if datetime.fromtimestamp(timestamp=virtctl_time, tz=timezone.utc).strftime("%-m/%-d/%Y") not in windows_info:
+    if datetime.fromtimestamp(timestamp=virtctl_time, tz=UTC).strftime("%-m/%-d/%Y") not in windows_info:
         data_mismatch.append("login time mismatch")
 
     assert not data_mismatch, (
@@ -480,7 +480,7 @@ def check_vm_xml_tablet_device(vm, admin_client):
 
 def get_matrix_os_golden_image_data_source(
     admin_client: DynamicClient, golden_images_namespace: Namespace, os_matrix: dict[str, dict]
-) -> Generator[DataSource, None, None]:
+) -> Generator[DataSource]:
     """Retrieves or creates a DataSource object in golden image namespace specified in the OS matrix.
 
     Args:
@@ -503,8 +503,8 @@ def matrix_os_vm_from_template(
     data_source_object: DataSource,
     os_matrix: dict[str, dict],
     cpu_model: str | None = None,
-    request: Optional[FixtureRequest] = None,
-    data_volume_template: Optional[dict[str, dict]] = None,
+    request: FixtureRequest | None = None,
+    data_volume_template: dict[str, dict] | None = None,
 ) -> VirtualMachineForTestsFromTemplate:
     param_dict = request.param if request else {}
     os_matrix_key = [*os_matrix][0]

--- a/tests/virt/cluster/general/mass_machine_type_transition_tests/test_mass_machine_type_transition.py
+++ b/tests/virt/cluster/general/mass_machine_type_transition_tests/test_mass_machine_type_transition.py
@@ -18,7 +18,7 @@ def test_nodes_have_machine_type_labels(workers):
     nodes_without_machine_type_label = [
         node.name
         for node in workers
-        if not any(label.startswith("machine-type.node.kubevirt") for label in node.labels.keys())
+        if not any(label.startswith("machine-type.node.kubevirt") for label in node.labels)
     ]
     assert not nodes_without_machine_type_label, (
         f"Nodes {nodes_without_machine_type_label} does not have 'machine-type' label"

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -1,7 +1,6 @@
 import logging
 import shlex
 import shutil
-import socket
 from threading import Thread
 
 from ocp_resources import pod
@@ -138,7 +137,7 @@ def start_win_upgrade_multi_vms(vm_list):
                 timeout=TIMEOUT_40MIN,
             )
             LOGGER.info(f"VM {vm.name}: Finished upgrades download/install stage")
-        except socket.timeout:
+        except TimeoutError:
             LOGGER.warning(f"VM {vm.name}: Finished upgrades download/install stage but the script was stuck")
 
     upgrade_threads_list = []

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -91,7 +91,7 @@ def test_evictionstrategy_not_in_templates(base_templates):
     templates_with_evictionstrategy = [
         template.name
         for template in base_templates
-        if EVICTIONSTRATEGY in template.instance.objects[0].spec.template.spec.keys()
+        if EVICTIONSTRATEGY in template.instance.objects[0].spec.template.spec
     ]
     assert not templates_with_evictionstrategy, (
         f"{EVICTIONSTRATEGY} field present in templates {templates_with_evictionstrategy}"

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -348,9 +348,9 @@ def nodes_taints_before_descheduler_test_run(nodes):
 
     # clean up taints leftovers
     nodes_taints_after = {node: node.instance.spec.taints for node in nodes}
-    for node in nodes_taints_before:
-        if nodes_taints_after[node] != nodes_taints_before[node]:
-            ResourceEditor(patches={node: {"spec": {"taints": nodes_taints_before[node]}}}).update()
+    for node, taints_before in nodes_taints_before.items():
+        if nodes_taints_after[node] != taints_before:
+            ResourceEditor(patches={node: {"spec": {"taints": taints_before}}}).update()
 
 
 @pytest.fixture()

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -48,9 +48,7 @@ def enable_bitlocker(vm):
         try:
             for sample in sampler:
                 if sample:
-                    if all([
-                        True if msg in sample[0] else False for msg in ["100.0%", "Fully Encrypted", "Protection On"]
-                    ]):
+                    if all([msg in sample[0] for msg in ["100.0%", "Fully Encrypted", "Protection On"]]):
                         return
         except TimeoutExpiredError:
             LOGGER.error("Failed to encrypt disk")

--- a/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
@@ -98,7 +98,7 @@ def node_mdevtype_gpu_vm(
 
 @pytest.fixture(scope="class")
 def vm_with_no_gpu(gpu_vma, node_mdevtype_gpu_vm):
-    return [vm.name for vm in [gpu_vma, node_mdevtype_gpu_vm] if not get_num_gpu_devices_in_rhel_vm(vm=vm) == 1]
+    return [vm.name for vm in [gpu_vma, node_mdevtype_gpu_vm] if get_num_gpu_devices_in_rhel_vm(vm=vm) != 1]
 
 
 @pytest.mark.parametrize(
@@ -168,7 +168,7 @@ class TestVGPURHELGPUSSpec:
         """
         Test vGPU is accessible in both the RHEL VMs, using same GPU, using GPUs spec.
         """
-        vm_with_no_gpu = [vm.name for vm in [gpu_vma, gpu_vmb] if not get_num_gpu_devices_in_rhel_vm(vm=vm) == 1]
+        vm_with_no_gpu = [vm.name for vm in [gpu_vma, gpu_vmb] if get_num_gpu_devices_in_rhel_vm(vm=vm) != 1]
         assert not vm_with_no_gpu, f"GPU does not exist in following vms: {vm_with_no_gpu}"
 
 

--- a/tests/virt/node/high_performance_vm/test_numa.py
+++ b/tests/virt/node/high_performance_vm/test_numa.py
@@ -77,7 +77,7 @@ def vm_numa_sriov(namespace, unprivileged_client, sriov_net):
         cpu_placement=True,
         networks=networks,
         interfaces=networks.keys(),
-        interfaces_types={name: SRIOV for name in networks.keys()},
+        interfaces_types={name: SRIOV for name in networks},
     ) as vm:
         vm.start(wait=True)
         vm.vmi.wait_until_running()

--- a/tests/virt/node/hyperv_support/test_hyperv_features_in_vm.py
+++ b/tests/virt/node/hyperv_support/test_hyperv_features_in_vm.py
@@ -44,7 +44,7 @@ def get_hyperv_enabled_labels(instance_labels):
 def verify_evmcs_related_attributes(vmi_xml_dict):
     LOGGER.info("Verify vmx policy 'required' and 'vapic' hyperv feature are added when using evcms feature")
     cpu_feature = vmi_xml_dict["domain"]["cpu"]["feature"]
-    vmx_feature = [feature for feature in cpu_feature for policy, name in feature.items() if name == "vmx"]
+    vmx_feature = [feature for feature in cpu_feature for name in feature.values() if name == "vmx"]
     assert vmx_feature and vmx_feature[0]["@policy"] == "require", (
         f"Wrong vmx policy. Actual: {vmx_feature}, expected: 'require'"
     )

--- a/tests/virt/upgrade/utils.py
+++ b/tests/virt/upgrade/utils.py
@@ -85,7 +85,7 @@ def get_workload_update_migrations_list(
             if migration_job.name.startswith("kubevirt-workload-update"):
                 job_instance = migration_job.instance
                 vmi_name = job_instance.spec.vmiName
-                if vmi_name not in workload_migrations.keys() or datetime.strptime(
+                if vmi_name not in workload_migrations or datetime.strptime(
                     job_instance.metadata.creationTimestamp, TIMESTAMP_FORMAT
                 ) > datetime.strptime(
                     workload_migrations[vmi_name].metadata.creationTimestamp,

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import shlex
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any
 
 import bitmath
 from kubernetes.dynamic import DynamicClient
@@ -87,7 +88,7 @@ def append_feature_gate_to_hco(feature_gate, resource, client, namespace):
             hco_namespace=namespace,
             expected_conditions={
                 **DEFAULT_HCO_CONDITIONS,
-                **{"TaintedConfiguration": Resource.Condition.Status.TRUE},
+                "TaintedConfiguration": Resource.Condition.Status.TRUE,
             },
         )
         yield
@@ -433,7 +434,7 @@ def verify_guest_boot_time(vm_list, initial_boot_time):
 
 def get_or_create_golden_image_data_source(
     admin_client: DynamicClient, golden_images_namespace: Namespace, os_dict: dict[str, Any]
-) -> Generator[DataSource, None, None]:
+) -> Generator[DataSource]:
     """Retrieves or creates a DataSource object in golden image namespace specified in the OS matrix.
 
     Args:

--- a/utilities/console.py
+++ b/utilities/console.py
@@ -16,7 +16,7 @@ from utilities.data_collector import get_data_collector_base_directory
 LOGGER = logging.getLogger(__name__)
 
 
-class Console(object):
+class Console:
     def __init__(
         self,
         vm: VirtualMachine,
@@ -52,10 +52,10 @@ class Console(object):
         self.vm = vm
         # TODO: `BaseVirtualMachine` does not set cloud-init so the VM is using predefined credentials
         self.username = (
-            username or getattr(self.vm, "login_params", {}).get("username") or self.vm.username  # type: ignore[attr-defined]  # noqa: E501
+            username or getattr(self.vm, "login_params", {}).get("username") or self.vm.username  # type: ignore[attr-defined]
         )
         self.password = (
-            password or getattr(self.vm, "login_params", {}).get("password") or self.vm.password  # type: ignore[attr-defined]  # noqa: E501
+            password or getattr(self.vm, "login_params", {}).get("password") or self.vm.password  # type: ignore[attr-defined]
         )
         self.timeout = timeout
         self.child = None

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -872,7 +872,7 @@ POD_CONTAINER_SPEC = {
 
 EXCLUDED_CPU_MODELS_S390X = [
     # Below are deprecated & usable models, but violate RHEL 9 ALS (min z14) causing guest to crash (disable-wait)
-    # Ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/automatically_installing_rhel/preparing-a-rhel-installation-on-64-bit-ibm-z_rhel-installer#planning-for-installation-on-ibm-z_preparing-a-rhel-installation-on-64-bit-ibm-z # noqa: E501
+    # Ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/automatically_installing_rhel/preparing-a-rhel-installation-on-64-bit-ibm-z_rhel-installer#planning-for-installation-on-ibm-z_preparing-a-rhel-installation-on-64-bit-ibm-z
     "z114",
     "z114-base",
     "z13",

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -12,10 +12,11 @@ import tarfile
 import tempfile
 import time
 import zipfile
+from collections.abc import Generator
 from contextlib import contextmanager
 from functools import cache
 from subprocess import PIPE, CalledProcessError, Popen
-from typing import Any, Generator
+from typing import Any
 
 import netaddr
 import requests
@@ -692,8 +693,7 @@ def download_and_extract_file_from_cluster(tmpdir, url):
     with requests.get(url, verify=False, stream=True) as created_request:
         created_request.raise_for_status()
         with open(local_file_name, "wb") as file_downloaded:
-            for chunk in created_request.iter_content(chunk_size=8192):
-                file_downloaded.write(chunk)
+            file_downloaded.writelines(created_request.iter_content(chunk_size=8192))
     LOGGER.info("Extract the downloaded archive.")
     if url.endswith(zip_file_extension):
         archive_file_object = zipfile.ZipFile(file=local_file_name)
@@ -752,7 +752,7 @@ def get_machine_platform():
 
 
 def get_nodes_with_label(nodes, label):
-    return [node for node in nodes if label in node.labels.keys()]
+    return [node for node in nodes if label in node.labels]
 
 
 def get_daemonset_yaml_file_with_image_hash(generated_pulled_secret=None, service_account=None):
@@ -849,7 +849,7 @@ def get_node_audit_log_entries(log: str, node: str, log_entry: str) -> tuple[boo
     return True, lines
 
 
-def get_node_audit_log_line_dict(logs: list[str], node: str, log_entry: str) -> Generator[dict[str, Any], None, None]:
+def get_node_audit_log_line_dict(logs: list[str], node: str, log_entry: str) -> Generator[dict[str, Any]]:
     """
     Parse audit log entries into dictionaries.
 

--- a/utilities/logger.py
+++ b/utilities/logger.py
@@ -27,7 +27,7 @@ class DuplicateFilter(logging.Filter):
 
 
 class TestLogFormatter(ColoredFormatter):
-    def formatTime(self, record, datefmt=None):  # noqa: N802
+    def formatTime(self, record, datefmt=None):
         return datetime.fromtimestamp(record.created).isoformat()
 
 

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -999,8 +999,7 @@ def wait_for_node_marked_by_bridge(bridge_nad: LinuxBridgeNetworkAttachmentDefin
         wait_timeout=TIMEOUT_3MIN,
         sleep=5,
         func=lambda: (
-            bridge_annotation in node.instance.status.capacity.keys()
-            and bridge_annotation in node.instance.status.allocatable.keys()
+            bridge_annotation in node.instance.status.capacity and bridge_annotation in node.instance.status.allocatable
         ),
     )
     try:

--- a/utilities/oadp.py
+++ b/utilities/oadp.py
@@ -122,7 +122,7 @@ class VeleroBackup(Backup):
         self.wait_complete = wait_complete
         self.timeout = timeout
 
-    def __enter__(self) -> "VeleroBackup":
+    def __enter__(self) -> VeleroBackup:
         super().__enter__()
         if self.wait_complete:
             self.wait_for_status(
@@ -148,7 +148,7 @@ def create_rhel_vm(
     client: DynamicClient,
     wait_running: bool = True,
     volume_mode: str | None = None,
-) -> Generator["VirtualMachineForTests", None, None]:
+) -> Generator[VirtualMachineForTests]:
     artifactory_secret = None
     artifactory_config_map = None
 

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -293,7 +293,7 @@ def collect_mcp_data_on_update_timeout(machine_config_pools_list, not_matching_m
     LOGGER.error(
         f"Out of MCPs {mcps_to_check}, following MCPs {not_matching_mcps} were not at desired "
         f"condition {condition_type} before timeout.\n"
-        f"Current MCP status={str({mcp.name: mcp.instance.status.conditions for mcp in machine_config_pools_list})}"
+        f"Current MCP status={ {mcp.name: mcp.instance.status.conditions for mcp in machine_config_pools_list}!s}"
     )
     collect_ocp_must_gather(since_time=since_time)
 
@@ -722,7 +722,7 @@ def get_generated_icsp_idms(
     filter_options: str = "",
 ) -> str:
     pull_secret = None
-    if image_url.startswith(tuple([BREW_REGISTERY_SOURCE, "quay.io"])):
+    if image_url.startswith((BREW_REGISTERY_SOURCE, "quay.io")):
         registry_source = BREW_REGISTERY_SOURCE
         pull_secret = generated_pulled_secret
     cnv_mirror_cmd = create_icsp_idms_command(

--- a/utilities/sanity.py
+++ b/utilities/sanity.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from _pytest.fixtures import FixtureRequest
 from kubernetes.client import ApiException
@@ -22,7 +22,7 @@ from utilities.infra import LOGGER, wait_for_pods_running
 from utilities.pytest_utils import exit_pytest_execution
 
 
-def storage_sanity_check(cluster_storage_classes_names: List[str]) -> bool:
+def storage_sanity_check(cluster_storage_classes_names: list[str]) -> bool:
     """
     Verify cluster has all expected storage classes from pytest configuration.
 
@@ -37,7 +37,7 @@ def storage_sanity_check(cluster_storage_classes_names: List[str]) -> bool:
         True if all expected storage classes from configuration exist on the cluster,
         False otherwise.
     """
-    config_sc = list([[*csc][0] for csc in py_config["storage_class_matrix"]])
+    config_sc = [[*csc][0] for csc in py_config["storage_class_matrix"]]
     exists_sc = [scn for scn in config_sc if scn in cluster_storage_classes_names]
     if sorted(config_sc) != sorted(exists_sc):
         LOGGER.error(f"Expected {config_sc}, On cluster {exists_sc}")
@@ -204,8 +204,8 @@ def check_vm_creation_capability(admin_client: DynamicClient, namespace: str) ->
 def cluster_sanity(
     request: FixtureRequest,
     admin_client: DynamicClient,
-    cluster_storage_classes_names: List[str],
-    nodes: List[Node],
+    cluster_storage_classes_names: list[str],
+    nodes: list[Node],
     hco_namespace: Namespace,
     junitxml_property: Any | None = None,
 ) -> None:

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -2,8 +2,9 @@ import logging
 import math
 import os
 import shlex
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Dict, Generator
+from typing import Any
 
 import cachetools.func
 import kubernetes
@@ -180,13 +181,13 @@ def create_dv(
 def data_volume(
     namespace: Namespace,
     client: DynamicClient,
-    storage_class_matrix: Dict[str, Dict[str, Any]] | None = None,
+    storage_class_matrix: dict[str, dict[str, Any]] | None = None,
     storage_class: str | None = None,
     request: FixtureRequest | None = None,
-    os_matrix: Dict[str, Dict[str, Any]] | None = None,
+    os_matrix: dict[str, dict[str, Any]] | None = None,
     check_dv_exists: bool = False,
     bind_immediate: bool | None = None,
-) -> Generator[DataVolume, None, None]:
+) -> Generator[DataVolume]:
     """
     DV creation using create_dv.
 
@@ -304,8 +305,7 @@ def get_downloaded_artifact(remote_name, local_name):
     with requests.get(url, headers=artifactory_header, verify=False, stream=True) as created_request:
         created_request.raise_for_status()
         with open(local_name, "wb") as file_downloaded:
-            for chunk in created_request.iter_content(chunk_size=8192):
-                file_downloaded.write(chunk)
+            file_downloaded.writelines(created_request.iter_content(chunk_size=8192))
     try:
         assert os.path.isfile(local_name)
         return True
@@ -679,7 +679,10 @@ def run_command_on_cirros_vm_and_check_output(vm, command, expected_result):
         vm_console.expect(expected_result, timeout=20)
 
 
-def assert_disk_serial(vm, command=shlex.split("sudo ls /dev/disk/by-id")):
+_DEFAULT_DISK_SERIAL_COMMAND = shlex.split("sudo ls /dev/disk/by-id")
+
+
+def assert_disk_serial(vm, command=_DEFAULT_DISK_SERIAL_COMMAND):
     assert (
         HOTPLUG_DISK_SERIAL
         in run_ssh_commands(host=vm.ssh_exec, commands=command, wait_timeout=TIMEOUT_2MIN, sleep=TIMEOUT_5SEC)[0]

--- a/utilities/unittests/test_data_collector.py
+++ b/utilities/unittests/test_data_collector.py
@@ -277,7 +277,7 @@ class TestWriteToFile:
         mock_file_open.assert_called_once_with("/test/dir/test.txt", "a")
 
     @patch("os.makedirs")
-    @patch("builtins.open", side_effect=IOError("Permission denied"))
+    @patch("builtins.open", side_effect=OSError("Permission denied"))
     @patch("utilities.data_collector.LOGGER")
     def test_write_to_file_exception_handling(self, mock_logger, mock_file_open, mock_makedirs):
         """Test write_to_file handles exceptions gracefully"""

--- a/utilities/unittests/test_database.py
+++ b/utilities/unittests/test_database.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 # Add utilities to Python path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from database import CNV_TEST_DB, Base, CnvTestTable, Database  # noqa: E402
+from database import CNV_TEST_DB, Base, CnvTestTable, Database
 
 
 class TestCnvTestTable:

--- a/utilities/unittests/test_guest_support.py
+++ b/utilities/unittests/test_guest_support.py
@@ -17,7 +17,7 @@ sys.modules["utilities.virt"] = mock_virt
 utilities.virt = mock_virt
 
 # Import after setting up mocks to avoid circular dependency
-from utilities.guest_support import (  # noqa: E402
+from utilities.guest_support import (
     assert_windows_efi,
     check_vm_xml_hyperv,
     check_windows_vm_hvinfo,

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -39,7 +39,7 @@ if "utilities.hco" in sys.modules:
     del sys.modules["utilities.hco"]
 
 # Import after setting up mocks to avoid circular dependency
-from utilities.hco import (  # noqa: E402
+from utilities.hco import (
     DEFAULT_HCO_PROGRESSING_CONDITIONS,
     HCO_JSONPATCH_ANNOTATION_COMPONENT_DICT,
     ResourceEditorValidateHCOReconcile,

--- a/utilities/unittests/test_oadp.py
+++ b/utilities/unittests/test_oadp.py
@@ -2,7 +2,6 @@
 
 """Unit tests for oadp module"""
 
-# flake8: noqa: E402
 import sys
 from re import escape
 from shlex import quote

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -9,7 +9,7 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from timeout_sampler import TimeoutExpiredError
 
 # Import after setting up mocks to avoid circular dependency
-from utilities.operator import (  # noqa: E402
+from utilities.operator import (
     apply_icsp_idms,
     approve_install_plan,
     cluster_with_icsp,

--- a/utilities/unittests/test_pytest_matrix_utils.py
+++ b/utilities/unittests/test_pytest_matrix_utils.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from utilities.pytest_matrix_utils import (  # noqa: E402
+from utilities.pytest_matrix_utils import (
     hpp_matrix,
     immediate_matrix,
     online_resize_matrix,

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -893,9 +893,7 @@ class TestGetArtifactoryServerUrl:
         mock_session.config.getoption.return_value = False
 
         def mock_secret_side_effect(secret_name, session):
-            if secret_name == "artifactory_servers":
-                return {}
-            elif secret_name == "default_artifactory_server":
+            if secret_name in ("artifactory_servers", "default_artifactory_server"):
                 return {}
 
         mock_get_secret.side_effect = mock_secret_side_effect

--- a/utilities/unittests/test_ssp.py
+++ b/utilities/unittests/test_ssp.py
@@ -28,7 +28,7 @@ if "utilities.ssp" in sys.modules:
     del sys.modules["utilities.ssp"]
 
 # Import after setting up mocks to avoid circular dependency
-from utilities.ssp import (  # noqa: E402
+from utilities.ssp import (
     cluster_instance_type_for_hot_plug,
     create_custom_template_from_url,
     get_cim_instance_json,

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from functools import cache
 from json import JSONDecodeError
 from subprocess import run
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 import bitmath
 import jinja2
@@ -693,7 +693,7 @@ class VirtualMachineForTests(VirtualMachine):
             )
 
     def _is_vm_from_template(self):
-        return f"{self.ApiGroup.VM_KUBEVIRT_IO}/template" in self.res["metadata"].setdefault("labels", {}).keys()
+        return f"{self.ApiGroup.VM_KUBEVIRT_IO}/template" in self.res["metadata"].setdefault("labels", {})
 
     def generate_body(self):
         if self.body:
@@ -1674,7 +1674,7 @@ def generate_dict_from_yaml_template(stream, **kwargs):
     # Find all template variables
     template_vars = [i.split()[1] for i in re.findall(r"{{ .* }}", data)]
     for var in template_vars:
-        if var not in kwargs.keys():
+        if var not in kwargs:
             raise MissingTemplateVariables(var=var, template=data)
     template = jinja2.Template(data)
     out = template.render(**kwargs)
@@ -1848,7 +1848,7 @@ def running_vm(
         "Internal error occurred: unable to complete request: stop/start already underway",
     ]
     vm_dv_volumes_names_list = [
-        volume.dataVolume.name for volume in vm.instance.spec.template.spec.volumes if "dataVolume" in volume.keys()
+        volume.dataVolume.name for volume in vm.instance.spec.template.spec.volumes if "dataVolume" in volume
     ]
 
     try:
@@ -2601,7 +2601,7 @@ def validate_pause_unpause_linux_vm(vm: VirtualMachineForTests, pre_pause_pid: i
     )
 
 
-def check_vm_xml_smbios(vm: VirtualMachineForTests, cm_values: Dict[str, str], admin_client: DynamicClient) -> None:
+def check_vm_xml_smbios(vm: VirtualMachineForTests, cm_values: dict[str, str], admin_client: DynamicClient) -> None:
     """
     Verify SMBIOS on VM XML [sysinfo type=smbios][system] match kubevirt-config
     config map.
@@ -2632,7 +2632,7 @@ def update_vm_efi_spec_and_restart(
     restart_vm_wait_for_running_vm(vm=vm, wait_for_interfaces=wait_for_interfaces)
 
 
-def delete_guestosinfo_keys(data: Dict[str, Any]) -> Dict[str, Any]:
+def delete_guestosinfo_keys(data: dict[str, Any]) -> dict[str, Any]:
     """
     supportedCommands - removed as the data is used for internal guest agent validations
     fsInfo, userList - checked in validate_fs_info_virtctl_vs_linux_os / validate_user_info_virtctl_vs_linux_os
@@ -2753,7 +2753,7 @@ def guest_reboot(vm: VirtualMachineForTests, os_type: str) -> None:
     run_os_command(vm=vm, command=commands["reboot"][os_type])
 
 
-def run_os_command(vm: VirtualMachineForTests, command: str) -> Optional[str]:
+def run_os_command(vm: VirtualMachineForTests, command: str) -> str | None:
     try:
         return run_ssh_commands(
             host=vm.ssh_exec,
@@ -2782,7 +2782,7 @@ def wait_for_user_agent_down(vm: VirtualMachineForTests, timeout: int) -> None:
             break
 
 
-def get_virt_handler_pods(client: DynamicClient, namespace: Namespace) -> List[Pod]:
+def get_virt_handler_pods(client: DynamicClient, namespace: Namespace) -> list[Pod]:
     return utilities.infra.get_pods(
         client=client,
         namespace=namespace,
@@ -2792,7 +2792,7 @@ def get_virt_handler_pods(client: DynamicClient, namespace: Namespace) -> List[P
 
 def check_virt_handler_pods_for_migration_network(
     client: DynamicClient, namespace: Namespace, network_name: str, migration_network: bool = True
-) -> List[Pod]:
+) -> list[Pod]:
     """
     Checks whether virt-handler pods have migration network.
 
@@ -2814,9 +2814,7 @@ def check_virt_handler_pods_for_migration_network(
             f"{Pod.ApiGroup.K8S_V1_CNI_CNCF_IO}/networks", ""
         )
         migration_network_on_pod = pod_network_annotations.split("@")[0] == network_name
-        if migration_network and migration_network_on_pod:
-            verified_pods_list.append(pod)
-        elif not migration_network and not migration_network_on_pod:
+        if migration_network and migration_network_on_pod or not migration_network and not migration_network_on_pod:
             verified_pods_list.append(pod)
     return verified_pods_list
 


### PR DESCRIPTION
##### What this PR does / why we need it:

Replaces #4424 with a cleaner set of pre-commit and lint changes.

**Hook bumps:**
- ruff v0.15.1 → v0.15.12
- mypy v1.20.0 → v1.20.2

**Ignore rules added** to prevent CI failures from pre-existing code:
- *pyproject.toml (ruff)*: preview rules exposed by v0.15.12 that need per-file refactoring (DTZ, BLE001, PYI, SIM, TRY, PLW, EXE, PERF, etc.)
- *.flake8*: rules now handled by ruff (N815, N802, E501, F821, E201, W503, N818) — prevents ruff/flake8 conflicts on `# noqa` comments

**Code fixes applied** (safe, auto-fixable):
- Remove obsolete `# -*- coding: utf-8 -*-` headers (UP009)
- Remove stale `# noqa` comments no longer needed by ruff v0.15.12
- Fix root logger usage: `logging.error()` → `LOGGER.error()` (LOG015)
- Ruff formatting adjustments

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

Replaces #4424

##### Special notes for reviewer:

The ignored rules represent pre-existing issues exposed by ruff v0.15.12 preview mode — each should be addressed in dedicated follow-up PRs. pre-commit.ci runs on ALL files (not just changed), so all pre-existing violations must be either fixed or ignored.

##### jira-ticket:

Signed-off-by: Ruth Netser <rnetser@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exception handling and control flow in backup and network functionality
  * Corrected crypto policy and conflict detection logic in tests
  * Improved HTTP archive download efficiency

* **Chores**
  * Modernized type annotations and imports throughout codebase
  * Updated pre-commit hook versions and linting configuration
  * Removed deprecated encoding declarations and code style comments
  * Simplified dictionary iteration patterns and conditional logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->