### PR TITLE
chore: ignore flake8 rules now handled by ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,19 @@
 # UFN plugin must be run in serial
 jobs = 0
 
-max-line-length = 120
+# Ignore rules that conflict with ruff or are intentionally suppressed.
+#
+# Handled by ruff formatter (ruff removes noqa comments for these, causing flake8 failures):
+#   E501 — line too long; ruff formatter manages line length
+#   E201 — whitespace after '('; ruff formatter manages whitespace
+#   W503 — line break before binary operator; PEP 8 reversed this, ruff uses W504 (after)
+#   F821 — undefined name; used in global_config files with dynamic exec() loading
+#
+# Intentionally suppressed (not enforced by either linter):
+#   N815 — mixedCaseVariable in class scope; dataclass fields match Kubernetes API schemas
+#   N802 — function name should be lowercase; method overrides like formatTime from logging.Formatter
+#   N818 — exception name should end with Error; existing names like MissingTemplateVariables
+ignore = N815, N802, E501, F821, E201, W503, N818
 exclude =
     doc,
     .tox,
@@ -75,6 +87,8 @@ fcn_exclude_functions =
     BeautifulSoup,
     usefixtures,
     find_spec,
+    with_suffix,
+    writelines,
     skip,
     QueueListener,
     requests,


### PR DESCRIPTION
##### What this PR does / why we need it:
Ruff v0.15.x handles several rules with better context awareness than flake8 (dataclass fields, method overrides, formatter-managed line length). When ruff removes inline `# noqa` comments it considers unnecessary, flake8 still enforces those rules, causing CI conflicts.

This PR ignores those rules in `.flake8` to prevent conflicts between the two linters:

- **N815**: camelCase in class scope — ruff understands dataclass fields matching API schemas
- **N802**: function name should be lowercase — ruff understands method overrides (e.g. `formatTime`)
- **E501**: line too long — ruff formatter manages line length
- **F821**: undefined name — used in global_config files with dynamic `exec()` loading
- **E201**: whitespace after `(` — ruff formatter manages whitespace
- **W503**: line break before binary operator — PEP 8 reversed this; ruff uses W504 (after)
- **N818**: exception name should end with Error — ruff allows existing names like `MissingTemplateVariables`

Also adds `with_suffix` and `writelines` to `fcn_exclude_functions` to prevent FCN001 false positives on standard library calls.

Part 1 of a 6-PR series to clean up lint configuration and apply safe fixes:
1. **This PR** — `.flake8` ignore rules
2. `pyproject.toml` ruff ignore rules for preview rules
3. Remove stale `# noqa` comments (depends on PRs 1+2)
4. Remove obsolete utf-8 coding headers
5. Apply safe ruff fixes repo-wide (SIM118, SIM201, PLC0206, etc.)
6. Bump pre-commit hooks (ruff v0.15.12, mypy v1.20.2)

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:
Replaces #4701 with a smaller, incremental approach.

##### Special notes for reviewer:
No code changes — config only. All pre-commit hooks pass on all files.

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration: removed hard line-length enforcement in favor of centralized formatting, suppressed a targeted set of stylistic and specific error checks, and added inline notes clarifying that certain rules (including line-length and whitespace checks) are managed by the code formatter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->