### PR TITLE
chore: remove qwang1 from OWNERS files

### DIFF
--- a/tests/chaos/OWNERS
+++ b/tests/chaos/OWNERS
@@ -1,3 +1,2 @@
 reviewers:
-  - qwang1
   - sarahbx

--- a/tests/scale/OWNERS
+++ b/tests/scale/OWNERS
@@ -1,4 +1,3 @@
 reviewers:
   - guchen11
   - sarahbx
-  - qwang1


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove qwang1 from reviewers in OWNERS files:
- `tests/chaos/OWNERS`
- `tests/scale/OWNERS`

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
