### PR TITLE
[VIRT] fix AAQ VmiPodUsage memory calculation using parse_quantity

### DIFF
--- a/tests/virt/cluster/aaq/utils.py
+++ b/tests/virt/cluster/aaq/utils.py
@@ -1,7 +1,7 @@
 import logging
 
-import bitmath
 from kubernetes.dynamic import DynamicClient
+from kubernetes.utils.quantity import parse_quantity
 from ocp_resources.application_aware_applied_cluster_resource_quota import ApplicationAwareAppliedClusterResourceQuota
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -56,13 +56,11 @@ def get_pod_total_cpu_memory(pod_instance):
     for container, status in zip(all_containers, containers_statuses):
         if status.state and status.state.running:
             total_resources["limits"]["cpu"] += _convert_cpu(container.resources.limits.get("cpu", 0))
-            total_resources["limits"]["memory"] += int(
-                bitmath.parse_string_unsafe(container.resources.limits.get("memory", "0B")).to_Byte()
-            )
+            total_resources["limits"]["memory"] += int(parse_quantity(container.resources.limits.get("memory", "0")))
 
             total_resources["requests"]["cpu"] += _convert_cpu(container.resources.requests.get("cpu", 0))
             total_resources["requests"]["memory"] += int(
-                bitmath.parse_string_unsafe(container.resources.requests.get("memory", "0B")).to_Byte()
+                parse_quantity(container.resources.requests.get("memory", "0"))
             )
 
     total_resources["limits"]["cpu"] = f"{total_resources['limits']['cpu']}m"


### PR DESCRIPTION
Replace bitmath with parse_quantity for memory parsing in get_pod_total_cpu_memory.

bitmath misinterprets Kubernetes decimal suffixes ("M") as binary ("MiB"), causing assertion failures with VmiPodUsage allocation.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated memory quantity parsing in test utilities to use Kubernetes parsing standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->