### PR TITLE
net, evpn: add stretched L2 connectivity tests

### DIFF
--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -166,12 +166,20 @@ class PodTcpClient(BaseTcpClient):
         server_port (int): The port on which the server listens for connections.
         bind_interface (str): The interface or IP address to bind the client to (optional).
             If not specified, the client will use the default interface.
+        container (str): Container name to execute commands in.
     """
 
-    def __init__(self, pod: Pod, server_ip: str, server_port: int, bind_interface: str | None = None):
+    def __init__(
+        self,
+        pod: Pod,
+        server_ip: str,
+        server_port: int,
+        bind_interface: str | None = None,
+        container: str | None = None,
+    ) -> None:
         super().__init__(server_ip=server_ip, server_port=server_port)
         self._pod = pod
-        self._container = _IPERF_BIN
+        self._container = container or _IPERF_BIN
         self._cmd += f" --bind {bind_interface}" if bind_interface else ""
 
     def __enter__(self) -> "PodTcpClient":

--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -22,6 +22,7 @@ from tests.network.libs import cluster_user_defined_network as libcudn
 from tests.network.libs import nodenetworkconfigurationpolicy as libnncp
 from tests.network.libs.bgp import (
     EXTERNAL_FRR_POD_LABEL,
+    NET_TOOLS_CONTAINER_NAME,
     POD_SECONDARY_IFACE_NAME,
     ExternalFrrPodInfo,
     create_cudn_route_advertisements,
@@ -244,5 +245,6 @@ def tcp_client_external_network(
         ),
         server_port=IPERF3_SERVER_PORT,
         bind_interface=EXTERNAL_PROVIDER_IP_V4.split("/")[0],
+        container=NET_TOOLS_CONTAINER_NAME,
     ) as client:
         yield client

--- a/tests/network/bgp/evpn/conftest.py
+++ b/tests/network/bgp/evpn/conftest.py
@@ -11,9 +11,20 @@ from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.vtep import VTEP
 
+from libs.net.ip import random_ipv4_address, random_ipv6_address
+from libs.net.traffic_generator import TcpServer
 from libs.net.udn import UDN_BINDING_DEFAULT_PLUGIN_NAME, create_udn_namespace
 from libs.vm.vm import BaseVirtualMachine
-from tests.network.bgp.evpn.libevpn import cudn_evpn_subnets
+from tests.network.bgp.evpn.libevpn import (
+    EndpointTcpClient,
+    EvpnEndpoint,
+    cudn_evpn_subnets,
+    deploy_evpn_bridge,
+    deploy_evpn_l2_endpoint,
+    evpn_workloads_active_connections,
+    teardown_evpn_bridge,
+    teardown_evpn_l2_endpoint,
+)
 from tests.network.libs import cluster_user_defined_network as libcudn
 from tests.network.libs.bgp import (
     EXTERNAL_FRR_POD_LABEL,
@@ -28,6 +39,8 @@ from tests.network.libs.vm_factory import udn_vm
 EVPN_ADVERTISE_LABEL: Final[dict] = {"advertise": "evpn"}
 APP_EVPN_CUDN_LABEL: Final[dict] = {**EVPN_ADVERTISE_LABEL, "app": "cudn-evpn"}
 CUDN_EVPN_BGP_LABEL: Final[dict] = {"cudn-bgp": "evpn"}
+EXTERNAL_L2_ENDPOINT_IPV4: Final[str] = f"{random_ipv4_address(net_seed=5, host_address=250)}/24"
+EXTERNAL_L2_ENDPOINT_IPV6: Final[str] = f"{random_ipv6_address(net_seed=5, host_address=250)}/64"
 EVPN_MAC_VRF_VNI: Final[int] = 10100
 EVPN_IP_VRF_VNI: Final[int] = 20102
 
@@ -165,7 +178,7 @@ def vm_evpn_target(
         yield vm
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def vm_evpn_reference(
     namespace_evpn: Namespace,
     cudn_evpn_layer2: libcudn.ClusterUserDefinedNetwork,
@@ -183,3 +196,46 @@ def vm_evpn_reference(
         vm.start(wait=True)
         vm.wait_for_agent_connected()
         yield vm
+
+
+@pytest.fixture(scope="module")
+def evpn_bridge(
+    frr_external_pod: ExternalFrrPodInfo,
+    workers: list[Node],
+) -> Generator[None]:
+    worker_ips = []
+    for worker in workers:
+        host_cidrs = json.loads(worker.instance.metadata.annotations["k8s.ovn.org/host-cidrs"])
+        host_ip = next(cidr.split("/")[0] for cidr in host_cidrs if "." in cidr)
+        worker_ips.append(host_ip)
+
+    deploy_evpn_bridge(
+        pod=frr_external_pod.pod,
+        local_vtep_ip=frr_external_pod.ipv4,
+        remote_vtep_ips=worker_ips,
+    )
+    yield
+    teardown_evpn_bridge(pod=frr_external_pod.pod)
+
+
+@pytest.fixture(scope="module")
+def external_l2_endpoint(
+    evpn_bridge: None,
+    frr_external_pod: ExternalFrrPodInfo,
+) -> Generator[EvpnEndpoint]:
+    endpoint = deploy_evpn_l2_endpoint(
+        pod=frr_external_pod.pod,
+        vni=EVPN_MAC_VRF_VNI,
+        endpoint_ips=[EXTERNAL_L2_ENDPOINT_IPV4, EXTERNAL_L2_ENDPOINT_IPV6],
+    )
+    yield endpoint
+    teardown_evpn_l2_endpoint(pod=frr_external_pod.pod)
+
+
+@pytest.fixture()
+def evpn_stretched_l2_active_connections(
+    external_l2_endpoint: EvpnEndpoint,
+    vm_evpn_target: BaseVirtualMachine,
+) -> Generator[list[tuple[EndpointTcpClient, TcpServer]]]:
+    with evpn_workloads_active_connections(endpoint=external_l2_endpoint, vm=vm_evpn_target) as connections:
+        yield connections

--- a/tests/network/bgp/evpn/libevpn.py
+++ b/tests/network/bgp/evpn/libevpn.py
@@ -1,8 +1,71 @@
+import contextlib
+import logging
+import shlex
+from collections.abc import Generator
+from dataclasses import dataclass
+
+from ocp_resources.pod import Pod
+
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
-from libs.net.ip import random_ipv4_address, random_ipv6_address
+from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
+from libs.net.traffic_generator import IPERF_SERVER_PORT, PodTcpClient, TcpServer
+from libs.net.vmspec import lookup_iface_status, lookup_primary_network
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.libs.bgp import NET_TOOLS_CONTAINER_NAME
+
+LOGGER = logging.getLogger(__name__)
 
 CUDN_EVPN_SUBNET_IPV4: str = f"{random_ipv4_address(net_seed=5, host_address=0)}/24"
 CUDN_EVPN_SUBNET_IPV6: str = f"{random_ipv6_address(net_seed=5, host_address=0)}/64"
+
+_BRIDGE_NAME: str = "br0"
+_VXLAN_NAME: str = "vxlan0"
+_VXLAN_DEST_PORT: int = 4789
+
+_L2_VID: int = 100
+_L2_ENDPOINT_NETNS: str = "l2-ep"
+_L2_VETH_POD_SIDE: str = "veth-l2-frr"
+_L2_VETH_EP_SIDE: str = "veth-l2-ep"
+
+
+@dataclass
+class EvpnEndpoint:
+    """External EVPN endpoint in a network namespace inside the FRR pod."""
+
+    pod: Pod
+    ip_addresses: list[str]
+    netns_name: str
+
+
+class EndpointTcpClient(PodTcpClient):
+    """PodTcpClient that runs iperf3 inside a network namespace.
+
+    'ip netns exec' replaces itself with iperf3 via execvp,
+    so pgrep/pkill match by the bare iperf3 cmdline.
+
+    Args:
+        netns: Network namespace to run iperf3 in.
+    """
+
+    def __init__(
+        self,
+        pod: Pod,
+        server_ip: str,
+        server_port: int,
+        netns: str,
+        container: str | None = None,
+    ) -> None:
+        super().__init__(pod=pod, server_ip=server_ip, server_port=server_port, container=container)
+        self._netns = netns
+
+    def __enter__(self) -> "EndpointTcpClient":
+        run_cmd = f"ip netns exec {self._netns} {self._cmd}"
+        self._pod.execute(
+            command=["sh", "-c", f"nohup {run_cmd} >/tmp/iperf3.log 2>&1 &"],
+            container=self._container,
+        )
+        self._ensure_is_running()
+        return self
 
 
 def cudn_evpn_subnets() -> list[str]:
@@ -17,3 +80,153 @@ def cudn_evpn_subnets() -> list[str]:
     if ipv6_supported_cluster():
         subnets.append(CUDN_EVPN_SUBNET_IPV6)
     return subnets
+
+
+def deploy_evpn_bridge(
+    pod: Pod,
+    local_vtep_ip: str,
+    remote_vtep_ips: list[str],
+) -> None:
+    """Creates the shared SVD bridge inside the FRR pod.
+
+    Sets up a VLAN-filtering bridge with a single VXLAN device (SVD mode).
+    Both L2 and L3 VNIs share this VXLAN via per-VLAN VNI mappings.
+
+    Args:
+        pod: The FRR pod.
+        local_vtep_ip: FRR pod's IP used as local VTEP.
+        remote_vtep_ips: Cluster node IPs for BUM traffic forwarding.
+    """
+    commands = _build_bridge_commands(local_vtep_ip=local_vtep_ip, remote_vtep_ips=remote_vtep_ips)
+    for command in commands:
+        pod.execute(command=shlex.split(command), container=NET_TOOLS_CONTAINER_NAME)
+
+    LOGGER.info(f"EVPN SVD bridge deployed: {_BRIDGE_NAME} + {_VXLAN_NAME}")
+
+
+def _build_bridge_commands(local_vtep_ip: str, remote_vtep_ips: list[str]) -> list[str]:
+    return [
+        f"ip link add {_BRIDGE_NAME} type bridge vlan_filtering 1 vlan_default_pvid 0",
+        f"ip link set {_BRIDGE_NAME} up",
+        f"ip link add {_VXLAN_NAME} type vxlan dstport {_VXLAN_DEST_PORT} local {local_vtep_ip}"
+        " nolearning external vnifilter",
+        f"ip link set {_VXLAN_NAME} master {_BRIDGE_NAME}",
+        f"bridge link set dev {_VXLAN_NAME} vlan_tunnel on neigh_suppress on learning off",
+        f"ip link set {_VXLAN_NAME} up",
+        *(f"bridge fdb append 00:00:00:00:00:00 dev {_VXLAN_NAME} dst {ip}" for ip in remote_vtep_ips),
+    ]
+
+
+def teardown_evpn_bridge(pod: Pod) -> None:
+    """Removes the EVPN bridge from the FRR pod."""
+    pod.execute(command=shlex.split(f"ip link delete {_BRIDGE_NAME}"), container=NET_TOOLS_CONTAINER_NAME)
+    LOGGER.info(f"EVPN bridge removed: {_BRIDGE_NAME}")
+
+
+def deploy_evpn_l2_endpoint(
+    pod: Pod,
+    vni: int,
+    endpoint_ips: list[str],
+) -> EvpnEndpoint:
+    """Creates a stretched L2 endpoint on the shared SVD bridge.
+
+    Adds VLAN/VNI mapping for MAC-VRF, then creates a veth pair with the
+    pod-side as an access port on the L2 VLAN, and the endpoint-side in a netns.
+
+    Data path: VM -> OVN VXLAN (VNI) -> vxlan0 -> br0 (VLAN) -> veth -> l2-ep namespace.
+
+    Args:
+        pod: The FRR pod hosting the endpoint.
+        vni: MAC-VRF VNI (must match CUDN's macVRF VNI).
+        endpoint_ips: IPs with prefix length (e.g. ["10.0.5.250/24", "fd00::fa/64"]).
+
+    Returns:
+        EvpnEndpoint.
+    """
+    commands = _build_l2_endpoint_commands(vni=vni, endpoint_ips=endpoint_ips)
+    for command in commands:
+        pod.execute(command=shlex.split(command), container=NET_TOOLS_CONTAINER_NAME)
+
+    bare_ips = [ip.split("/")[0] for ip in endpoint_ips]
+    LOGGER.info(f"EVPN L2 endpoint deployed: {bare_ips} in namespace {_L2_ENDPOINT_NETNS}")
+
+    return EvpnEndpoint(pod=pod, ip_addresses=bare_ips, netns_name=_L2_ENDPOINT_NETNS)
+
+
+def teardown_evpn_l2_endpoint(pod: Pod) -> None:
+    """Removes the EVPN L2 endpoint (netns, veth) from the FRR pod."""
+    for cmd in [
+        f"ip netns delete {_L2_ENDPOINT_NETNS}",
+        f"ip link delete {_L2_VETH_POD_SIDE}",
+    ]:
+        pod.execute(command=shlex.split(cmd), container=NET_TOOLS_CONTAINER_NAME, ignore_rc=True)
+
+    LOGGER.info(f"EVPN L2 endpoint removed: namespace={_L2_ENDPOINT_NETNS}")
+
+
+def _build_l2_endpoint_commands(vni: int, endpoint_ips: list[str]) -> list[str]:
+    return [
+        f"bridge vlan add dev {_BRIDGE_NAME} vid {_L2_VID} self",
+        f"bridge vlan add dev {_VXLAN_NAME} vid {_L2_VID}",
+        f"bridge vni add dev {_VXLAN_NAME} vni {vni}",
+        f"bridge vlan add dev {_VXLAN_NAME} vid {_L2_VID} tunnel_info id {vni}",
+        f"ip link add {_L2_VETH_POD_SIDE} type veth peer name {_L2_VETH_EP_SIDE}",
+        f"ip link set {_L2_VETH_POD_SIDE} master {_BRIDGE_NAME}",
+        f"bridge vlan add dev {_L2_VETH_POD_SIDE} vid {_L2_VID} pvid untagged",
+        f"ip link set {_L2_VETH_POD_SIDE} up",
+        f"ip netns add {_L2_ENDPOINT_NETNS}",
+        f"ip link set {_L2_VETH_EP_SIDE} netns {_L2_ENDPOINT_NETNS}",
+        *(f"ip netns exec {_L2_ENDPOINT_NETNS} ip addr add {ip} dev {_L2_VETH_EP_SIDE}" for ip in endpoint_ips),
+        f"ip netns exec {_L2_ENDPOINT_NETNS} ip link set {_L2_VETH_EP_SIDE} up",
+        f"ip netns exec {_L2_ENDPOINT_NETNS} ip link set lo up",
+    ]
+
+
+@contextlib.contextmanager
+def evpn_workloads_active_connections(
+    endpoint: EvpnEndpoint,
+    vm: BaseVirtualMachine,
+) -> Generator[list[tuple[EndpointTcpClient, TcpServer]]]:
+    """Opens TCP connections for all IP families between an EVPN endpoint and a VM.
+
+    Args:
+        endpoint: EVPN endpoint (L2 or L3) running the TCP client (sends traffic).
+        vm: VM running the TCP server (receives traffic).
+
+    Yields:
+        List of (EndpointTcpClient, TcpServer) tuples, one per IP family.
+    """
+    iface_name = lookup_primary_network(vm=vm).name
+    iface = lookup_iface_status(vm=vm, iface_name=iface_name)
+    server_ips = list(filter_link_local_addresses(ip_addresses=iface.ipAddresses))
+
+    with contextlib.ExitStack() as stack:
+        active_conns = []
+        for server_ip in server_ips:
+            active_conns.append(
+                stack.enter_context(
+                    cm=_evpn_workloads_connection(
+                        endpoint=endpoint,
+                        vm=vm,
+                        server_ip=str(server_ip),
+                    ),
+                )
+            )
+        yield active_conns
+
+
+@contextlib.contextmanager
+def _evpn_workloads_connection(
+    endpoint: EvpnEndpoint,
+    vm: BaseVirtualMachine,
+    server_ip: str,
+) -> Generator[tuple[EndpointTcpClient, TcpServer]]:
+    with TcpServer(vm=vm, port=IPERF_SERVER_PORT, bind_ip=server_ip) as tcp_server:
+        with EndpointTcpClient(
+            pod=endpoint.pod,
+            server_ip=server_ip,
+            server_port=IPERF_SERVER_PORT,
+            netns=endpoint.netns_name,
+            container=NET_TOOLS_CONTAINER_NAME,
+        ) as tcp_client:
+            yield tcp_client, tcp_server

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -22,12 +22,14 @@ import pytest
 
 from libs.net.traffic_generator import active_tcp_connections, is_tcp_connection
 from libs.net.vmspec import lookup_primary_network
+from tests.network.bgp.evpn.libevpn import evpn_workloads_active_connections
+from utilities.virt import migrate_vm_and_verify
 
 pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
     pytest.mark.usefixtures("evpn_setup_ready"),
-    pytest.mark.jira("CORENET-6861", run=False),
+    pytest.mark.jira("CNV-86961", run=False),
 ]
 
 
@@ -55,7 +57,7 @@ def test_connectivity_between_udn_vms(vm_evpn_target, vm_evpn_reference, subtest
 
 
 @pytest.mark.polarion("CNV-15228")
-def test_stretched_l2_connectivity_udn_vm_and_external_provider():
+def test_stretched_l2_connectivity_udn_vm_and_external_provider(external_l2_endpoint, vm_evpn_target, subtests):
     """
     Preconditions:
     - External Source Provider L2 endpoint.
@@ -67,13 +69,18 @@ def test_stretched_l2_connectivity_udn_vm_and_external_provider():
     Expected:
     - The VM successfully communicates with the external L2 endpoint.
     """
-
-
-test_stretched_l2_connectivity_udn_vm_and_external_provider.__test__ = False
+    with evpn_workloads_active_connections(endpoint=external_l2_endpoint, vm=vm_evpn_target) as connections:
+        for client, server in connections:
+            with subtests.test(f"IPv{ipaddress.ip_address(client.server_ip).version}"):
+                assert is_tcp_connection(server=server, client=client)
 
 
 @pytest.mark.polarion("CNV-15229")
-def test_stretched_l2_connectivity_is_preserved_over_live_migration():
+def test_stretched_l2_connectivity_is_preserved_over_live_migration(
+    evpn_stretched_l2_active_connections,
+    vm_evpn_target,
+    subtests,
+):
     """
     Preconditions:
     - External Source Provider L2 endpoint.
@@ -86,9 +93,10 @@ def test_stretched_l2_connectivity_is_preserved_over_live_migration():
     Expected:
     - The initial TCP connection is preserved (no disconnection).
     """
-
-
-test_stretched_l2_connectivity_is_preserved_over_live_migration.__test__ = False
+    migrate_vm_and_verify(vm=vm_evpn_target)
+    for client, server in evpn_stretched_l2_active_connections:
+        with subtests.test(f"IPv{ipaddress.ip_address(client.server_ip).version}"):
+            assert is_tcp_connection(server=server, client=client)
 
 
 @pytest.mark.polarion("CNV-15230")

--- a/tests/network/libs/bgp.py
+++ b/tests/network/libs/bgp.py
@@ -26,6 +26,7 @@ _EXTERNAL_FRR_ASN: Final[int] = 64000
 _EXTERNAL_FRR_IMAGE: Final[str] = "quay.io/frrouting/frr:10.6.0"
 _FRR_DEPLOYMENT_NAME: Final[str] = "frr-k8s-statuscleaner"
 POD_SECONDARY_IFACE_NAME: Final[str] = "net1"
+NET_TOOLS_CONTAINER_NAME: Final[str] = "net-tools"
 EXTERNAL_FRR_POD_LABEL: Final[dict] = {"role": "frr-external"}
 
 
@@ -281,7 +282,7 @@ def deploy_external_frr_pod(
             "volumeMounts": [{"name": frr_configmap_name, "mountPath": "/etc/frr"}],
         },
         {
-            "name": "iperf3",
+            "name": NET_TOOLS_CONTAINER_NAME,
             "image": NET_UTIL_CONTAINER_IMAGE,
             "securityContext": {"privileged": True, "capabilities": {"add": ["NET_ADMIN"]}},
             "command": ["sleep", "infinity"],
@@ -306,9 +307,11 @@ def deploy_external_frr_pod(
 
 
 def _acquire_dhcp_ipv4(pod: Pod, iface_name: str) -> str:
-    pod.execute(command=shlex.split(f"dhclient {iface_name}"), container="iperf3")
+    pod.execute(command=shlex.split(f"dhclient {iface_name}"), container=NET_TOOLS_CONTAINER_NAME)
 
-    iface_info = json.loads(pod.execute(command=shlex.split(f"ip -j -4 addr show {iface_name}")))
+    iface_info = json.loads(
+        pod.execute(command=shlex.split(f"ip -j -4 addr show {iface_name}"), container=NET_TOOLS_CONTAINER_NAME)
+    )
     if iface_info and "addr_info" in iface_info[0]:
         for addr in iface_info[0]["addr_info"]:
             if addr["family"] == "inet":


### PR DESCRIPTION
  ##### What this PR does / why we need it:                                                                                                                                                                         
  Add stretched L2 connectivity tests for EVPN, including live migration verification.                                                                                                                              
                                                                                                                                                                                                                    
  - Rename the misleadingly named "iperf3" container in the external FRR pod to "net-tools" and extract `NET_TOOLS_CONTAINER_NAME` constant                                                                                                                                                         
  - Add EVPN L2 endpoint emulation inside the external FRR pod (bridge, VXLAN, veth, netns) and implement stretched L2 connectivity and live migration tests                                                        
                                                                                                                                                                                                                    
  ##### Which issue(s) this PR fixes:                                                                                                                                                                               
                                                                                                                                                                                                                    
  ##### Special notes for reviewer:                          
  - Reference VM (`vm_evpn_reference`) is function-scoped — it is used by a single test, ensuring proper teardown and freeing a node for migration

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-80611

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fixtures and helpers to deploy EVPN bridges and stretched L2 endpoints for end-to-end validation.
  * Enabled stretched-L2 connectivity tests to run active per-IP-family TCP checks and verify preservation across live migration.

* **Chores**
  * Made TCP traffic clients runnable inside a selectable test container/netns so connectivity checks execute in the intended environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->