### PR TITLE
Replace except X | Y with comma form for Python 3.14

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/utils.py
+++ b/tests/infrastructure/golden_images/update_boot_source/utils.py
@@ -159,7 +159,7 @@ def get_image_version(image: str) -> str | None:
     try:
         version = Version(version=full_version)
         return f"{version.major}.{version.minor}"
-    except ValueError | AttributeError | TypeError:  # type: ignore[misc]
+    except ValueError, AttributeError, TypeError:
         LOGGER.warning(f"No RHEL version was found from: {image}")
         return None
 

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -147,7 +147,10 @@ def upload_image(token, data, asynchronous=False, client=None):
     try:
         with open(data, "rb") as fd:
             fd_data = fd.read()
-    except OSError, IOError:
+    except OSError as error:
+        LOGGER.error(
+            f"Failed to read upload image (type={type(data).__name__}); treating input as raw data. error={error}"
+        )
         fd_data = data
 
     return requests.post(url=uploadproxy_url, data=fd_data, headers=headers, verify=False).status_code

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -147,7 +147,7 @@ def upload_image(token, data, asynchronous=False, client=None):
     try:
         with open(data, "rb") as fd:
             fd_data = fd.read()
-    except OSError | IOError:
+    except OSError, IOError:
         fd_data = data
 
     return requests.post(url=uploadproxy_url, data=fd_data, headers=headers, verify=False).status_code

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -171,7 +171,7 @@ def verify_pid_after_migrate_multi_vms(vms_with_pids, os_type):
         new_pid = None
         try:
             new_pid = os_dict["fetch_pid"](vm=vms_with_pids[vm_name]["vm"], process_name=os_dict["proc_name"])
-        except AssertionError | ValueError:
+        except AssertionError, ValueError:
             vms_with_wrong_pids_dict[vm_name] = {
                 "orig_pid": orig_pid,
                 "new_pid": new_pid,
@@ -228,7 +228,7 @@ def wait_windows_reboot_multi_vm(vm_list):
             try:
                 wait_for_ssh_connectivity(vm=vm)
                 os_dict["fetch_pid"](vm=vm, process_name=os_dict["proc_name"])
-            except AssertionError | ValueError | TimeoutExpiredError:
+            except AssertionError, ValueError, TimeoutExpiredError:
                 rebooted_vms.append(vm.name)
         return rebooted_vms
 

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -146,7 +146,7 @@ def migrate_and_verify_multi_vms(vm_list):
         vm_sources = vms_dict[vm.name]
         try:
             verify_vm_migrated(vm=vm, node_before=vm_sources["node_before"])
-        except AssertionError | TimeoutExpiredError:
+        except AssertionError, TimeoutExpiredError:
             failed_migrations_list.append(vm.name)
 
     assert not failed_migrations_list, f"Some VMs failed to migrate - {failed_migrations_list}"

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -558,5 +558,5 @@ def enabled_aaq_in_hco(client, hco_namespace, hyperconverged_resource, enable_ac
     except TimeoutExpiredError:
         LOGGER.error(f"Some AAQ pods still present: {sample}")
         raise
-    except NotFoundError | ResourceNotFoundError:
+    except NotFoundError, ResourceNotFoundError:
         LOGGER.info("AAQ system PODs removed.")

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -250,7 +250,7 @@ def get_not_running_pods(pods: list[Pod], filter_pods_by_name: str = "") -> list
                 pods_not_running.append({pod.name: pod.status})
             elif container_status_error := get_pod_container_error_status(pod=pod):
                 pods_not_running.append({pod.name: container_status_error})
-        except ResourceNotFoundError | NotFoundError:
+        except ResourceNotFoundError, NotFoundError:
             LOGGER.warning(f"Ignoring pod {pod.name} that disappeared during cluster sanity check")
             pods_not_running.append({pod.name: "Deleted"})
     return pods_not_running


### PR DESCRIPTION
##### Short description:
On 3.14, except X | Y fails at import time,
because its  evaluates totyping.Union,
which is not a BaseException subclass. Use comma-separated exceptions instead.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-86480