### PR TITLE
docs: add VM network interface domain knowledge to network README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,3 +266,4 @@ tox -e utilities-unittests
 - [`docs/SOFTWARE_TEST_DESCRIPTION.md`](SOFTWARE_TEST_DESCRIPTION.md) — STD docstring format and requirements
 - [`docs/CODING_AND_STYLE_GUIDE.md`](docs/CODING_AND_STYLE_GUIDE.md) — Detailed coding and style conventions
 - [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) — Contribution guidelines
+- [`tests/network/README.md`](tests/network/README.md) — Network domain knowledge: terminology, naming conventions and functionality.

--- a/tests/network/README.md
+++ b/tests/network/README.md
@@ -1,6 +1,41 @@
 # CNV-QE-network
-### General configurations
-#### VLAN
+
+## VM Network Interface Terminology
+
+### Two-Layer Model
+
+A VM network interface involves two distinct, independent layers:
+
+1. **CNI** — the Kubernetes pod-level plugin that configures the pod's network interface
+2. **Network binding** — the KubeVirt mechanism that wires the VM's interface through the pod interface to the node
+
+### Standard Phrasing
+
+When both layers need to be stated explicitly:
+
+```
+<primary/secondary> network using <binding> network binding to connect to the node through <CNI> CNI
+```
+
+### Known Combinations
+
+The following are established combinations in this project. Use the shorthand name in STD docstrings — spelling out binding and CNI is not required unless the test is specifically about that layer.
+
+| Shorthand | Primary/Secondary | Binding | CNI |
+|-----------|-------------------|---------|-----|
+| localnet | secondary | bridge | OVN-K |
+| Linux bridge | secondary | bridge | Linux Bridge |
+| UDN | primary | l2bridge plugin | OVN-K |
+| pod network | primary | masquerade | OVN-K |
+| SR-IOV | secondary | SR-IOV | SR-IOV |
+
+Binding and CNI may be omitted when the combination is unambiguous from context (e.g., the test directory name already implies the CNI). The full standard phrasing is required when the combination is non-standard, novel, or when clarity demands it.
+
+---
+
+## General Configurations
+
+### VLAN
 The current supported vlan tags range in RH labs is 1000-1019.
 
 On IBM clusters the tags can vary they should be transferred as a pytest argument like so:


### PR DESCRIPTION
##### What this PR does / why we need it:
Documents the two-layer model of VM network interfaces (CNI vs. network binding) in `tests/network/README.md`, along with a standard phrasing template and a table of known CNI+binding combinations used in this project. Adds a pointer in `AGENTS.md` so AI tools and contributors automatically load this reference when working on network tests.

This knowledge was previously implicit, leading to incorrect or inconsistent terminology in STD docstrings (e.g., conflating binding names with CNI names).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE