### PR TITLE
Quarantine outdated OVS CNI tests until completely removed

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -7,6 +7,7 @@ import pytest
 from libs.net.ip import filter_link_local_addresses
 from libs.net.vmspec import lookup_iface_status, lookup_iface_status_ip
 from tests.network.utils import assert_no_ping
+from utilities.constants import QUARANTINED
 from utilities.network import assert_ping_successful
 
 
@@ -69,6 +70,10 @@ class TestConnectivityLinuxBridge:
         )
 
 
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: OVS CNI tests shouldn't run; will be completely removed by PR-4664",
+    run=False,
+)
 @pytest.mark.usefixtures("hyperconverged_ovs_annotations_enabled_scope_session")
 class TestConnectivityOVSBridge:
     @pytest.mark.post_upgrade


### PR DESCRIPTION
The OVS CNI which is supplied by Openshift Virtualization is not used anymore, and therefore should not be tested. https://github.com/RedHatQE/openshift-virtualization-tests/pull/4664 is intended to remove them entirely, but it requires handling and fixing. Until then, this tests, which occasionally fail, can be quarantined.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * OVS bridge connectivity test suite has been quarantined and is no longer executing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->