### PR TITLE
net, localnet, ipam: Fix localnet ipam test

### DIFF
--- a/libs/net/netattachdef.py
+++ b/libs/net/netattachdef.py
@@ -79,6 +79,7 @@ class CNIPluginOvnK8sConfig(CNIPluginConfig):
     netAttachDefName: str  # noqa: N815
     vlanID: int | None = None  # noqa: N815
     subnets: str | None = None
+    allowPersistentIPs: bool | None = None  # noqa: N815
 
     class Topology(Enum):
         LOCALNET = "localnet"
@@ -121,6 +122,16 @@ class NetConfig:
     name: str
     plugins: list[CNIPluginConfig]
     cniVersion: str = _DEFAULT_CNI_VERSION  # noqa: N815
+    allowPersistentIPs: bool | None = None  # noqa: N815
+
+
+class IPAMClaim(NamespacedResource):
+    """
+    IPAMClaim object — tracks persistent IP allocations for KubeVirt VMs
+    on OVN-K secondary networks with allowPersistentIPs enabled.
+    """
+
+    api_group = NamespacedResource.ApiGroup.K8S_CNI_CNCF_IO
 
 
 class NetworkAttachmentDefinition(NamespacedResource):

--- a/tests/network/localnet/ipam/conftest.py
+++ b/tests/network/localnet/ipam/conftest.py
@@ -7,8 +7,10 @@ from ocp_resources.namespace import Namespace
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
 from libs.net import netattachdef as libnad
 from libs.net.ip import random_ipv4_address
+from libs.net.vmspec import lookup_iface_status_ip
 from libs.vm.spec import Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine
+from tests.network.localnet.ipam.lib_helpers import wait_for_ipam_claim_bound
 from tests.network.localnet.liblocalnet import (
     LOCALNET_IPAM_INTERFACE,
     LOCALNET_OVS_BRIDGE_NETWORK,
@@ -33,8 +35,10 @@ def localnet_ipam_nad(
                 netAttachDefName=f"{namespace_localnet_1.name}/{localnet_ipam_nad_name}",
                 vlanID=vlan_id,
                 subnets=f"{random_ipv4_address(net_seed=0, host_address=0)}/24",
+                allowPersistentIPs=True,
             )
         ],
+        allowPersistentIPs=True,
     )
 
     with libnad.NetworkAttachmentDefinition(
@@ -94,7 +98,12 @@ def vm2_localnet_ipam(
 
 @pytest.fixture()
 def localnet_ipam_running_vms(
-    vm1_localnet_ipam: BaseVirtualMachine, vm2_localnet_ipam: BaseVirtualMachine
+    admin_client: DynamicClient,
+    vm1_localnet_ipam: BaseVirtualMachine,
+    vm2_localnet_ipam: BaseVirtualMachine,
 ) -> tuple[BaseVirtualMachine, BaseVirtualMachine]:
     vm1, vm2 = run_vms(vms=(vm1_localnet_ipam, vm2_localnet_ipam))
+    for vm in (vm1, vm2):
+        wait_for_ipam_claim_bound(vm=vm, iface_name=LOCALNET_IPAM_INTERFACE, client=admin_client)
+        lookup_iface_status_ip(vm=vm, iface_name=LOCALNET_IPAM_INTERFACE, ip_family=4)
     return vm1, vm2

--- a/tests/network/localnet/ipam/lib_helpers.py
+++ b/tests/network/localnet/ipam/lib_helpers.py
@@ -1,0 +1,29 @@
+from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import NotFoundError
+from timeout_sampler import TimeoutSampler
+
+from libs.net.netattachdef import IPAMClaim
+from libs.vm.vm import BaseVirtualMachine
+
+
+def wait_for_ipam_claim_bound(vm: BaseVirtualMachine, iface_name: str, client: DynamicClient) -> None:
+    """Wait until the IPAMClaim for a VM's interface has IP allocations.
+
+    Args:
+        vm: The virtual machine whose IPAMClaim to wait for.
+        iface_name: Logical network interface name as declared in the VM spec.
+        client: Kubernetes dynamic client for resource access.
+    """
+    claim = IPAMClaim(
+        name=f"{vm.name}.{iface_name}",
+        namespace=vm.namespace,
+        client=client,
+    )
+    for sample in TimeoutSampler(
+        wait_timeout=60,
+        sleep=5,
+        func=lambda: claim.instance.status.ips,
+        exceptions_dict={NotFoundError: [], AttributeError: []},
+    ):
+        if sample:
+            break


### PR DESCRIPTION
  The test `tests/network/localnet/ipam/test_connectivity.py`
    fails with error:
    
```
    with VMTcpClient(
             ~~~~~~~~~~~^
            vm=client_vm,
            ^^^^^^^^^^^^^
        ...<2 lines>...
            maximum_segment_size=maximum_segment_size,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        ) as client:
        ^
    File "/openshift-virtualization-tests/libs/net/traffic_generator.py"
       self._ensure_is_running()
    timeout_sampler.TimeoutExpiredError: Timed Out: 30
    Function: libs.net.traffic_generator._ensure_is_running
```
    

Must-gather logs did not show any explicit errors but in test
setup we haven't waited for all conditions for proper TCP
connectivity between the 2 VMs created in test.
   
On this change:
- Set allowPersistentIPs=true on the NAD to match the target SE
   configuration and enable IPAMClaim creation.
    
- Add two readiness checks to localnet_ipam_running_vms before the test
   runs:
   1. Wait for IPAMClaim status.ips  confirms OVN-K control plane has
       allocated the IP and DHCP is configured on the VM's node
   2. Wait for lookup_iface_status_ip  confirms the guest received the
        IP via DHCP and the guest agent has reported it

Together these ensure both the control-plane allocation and data-plane
IP assignment are complete on each VM before TCP connectivity is tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network configurations now support persistent IP allocation through the new `allowPersistentIPs` configuration option, providing stable IP address assignment across interface management operations
  * Introduced new resource for tracking and managing IP address allocations in network environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->