### PR TITLE
chore: add ruff ignore rules for preview rules needing separate fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,36 @@ output-format = "grouped"
 [tool.ruff.format]
 exclude = [".git", ".venv", ".mypy_cache", ".tox", "__pycache__"]
 
+[tool.ruff.lint]
+# TODO: Each ignored rule below should be addressed in a dedicated PR.
+ignore = [
+  "SIM102",  # collapsible-if — nested ifs are often more readable
+  "SIM114",  # combine if branches using logical or — reduces readability
+  "SIM117",  # nested with statements — existing pattern, keep as-is
+  "C419",    # unnecessary-comprehension-in-call — may change list vs generator semantics
+  "RUF015",  # unnecessary-iterable-allocation-for-first-element — changes exception type
+  "DTZ005",  # datetime.now() without tz — requires careful refactoring
+  "DTZ006",  # datetime.fromtimestamp() without tz
+  "DTZ007",  # naive datetime from strptime()
+  "BLE001",  # blind exception catch — pre-existing, fix separately
+  "PYI036",  # __exit__ parameter annotations
+  "PYI034",  # __enter__ return type annotation
+  "EXE001",  # shebang present but file not executable
+  "EXE002",  # file executable but no shebang
+  "PLE0643", # expression likely to raise IndexError — needs per-case review
+  "PLW0604", # redundant global at module level — used in global_config files
+  "PLW1510", # subprocess.run without check — needs per-call review
+  "B005",    # .strip() with multi-char string — intent-dependent
+  "B018",    # useless expression — intent-dependent
+  "B023",    # loop variable not bound in function — needs careful refactor
+  "G201",    # .error(exc_info=True) vs .exception()
+  "SIM115",  # context manager for file opening — may need structural changes
+]
+
+[tool.ruff.lint.per-file-ignores]
+# F821: undefined name — global_config files use dynamic exec() loading via pytest_testconfig
+"tests/global_config*.py" = ["F821"]
+
 [tool.ruff.lint.isort]
 order-by-type = true
 known-third-party = [


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds ignore rules to `pyproject.toml` for ruff preview rules exposed by `preview = true` that require careful per-file refactoring. Each rule is marked with a TODO to be addressed in a dedicated follow-up PR.

**Rules ignored:**

| Rule | Description | Why ignored |
|------|-------------|-------------|
| SIM102 | collapsible-if | Nested ifs are often more readable |
| SIM114 | combine if branches | Reduces readability |
| SIM117 | nested with statements | Existing pattern, keep as-is |
| C419 | unnecessary comprehension in call | May change list vs generator semantics |
| RUF015 | unnecessary iterable allocation | Changes exception type |
| DTZ005/006/007 | datetime without timezone | Requires careful refactoring |
| BLE001 | blind exception catch | Pre-existing, fix separately |
| PYI034/036 | __enter__/__exit__ annotations | Needs type annotation work |
| EXE001/002 | shebang/executable mismatch | Needs per-file review |
| F821 | undefined name | Used in global_config files (dynamic loading) |
| PLE0643 | likely IndexError | Needs per-case review |
| PLW0604 | redundant global at module level | Used in global_config files |
| PLW1510 | subprocess.run without check | Needs per-call review |
| B005/018/023 | various bugbear rules | Intent-dependent |
| G201 | .error(exc_info=True) vs .exception() | Needs per-call review |
| SIM115 | context manager for file opening | May need structural changes |

Part 2 of a 6-PR series to clean up lint configuration and apply safe fixes:
1. `.flake8` ignore rules (#4703)
2. **This PR** — `pyproject.toml` ruff ignore rules
3. Remove stale `# noqa` comments (depends on PRs 1+2)
4. Remove obsolete utf-8 coding headers
5. Apply safe ruff fixes repo-wide (SIM118, SIM201, PLC0206, etc.)
6. Bump pre-commit hooks (ruff v0.15.12, mypy v1.20.2)

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
No code changes — config only. All pre-commit hooks pass on all files.

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code linting configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->