### PR TITLE
style: remove stale noqa comments and obsolete utf-8 headers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,10 +11,9 @@ jobs = 0
 #   F821 — undefined name; used in global_config files with dynamic exec() loading
 #
 # Intentionally suppressed (not enforced by either linter):
-#   N815 — mixedCaseVariable in class scope; dataclass fields match Kubernetes API schemas
 #   N802 — function name should be lowercase; method overrides like formatTime from logging.Formatter
 #   N818 — exception name should end with Error; existing names like MissingTemplateVariables
-ignore = N815, N802, E501, F821, E201, W503, N818
+ignore = N802, E501, F821, E201, W503, N818
 exclude =
     doc,
     .tox,

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Pytest conftest file for CNV tests
 """

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env -S uv run python
 
-# flake8: noqa: N802
 
 """
 Pytest Marker Analyzer

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -249,7 +249,7 @@ os_login_param: dict[str, Any] = {}
 vlans = [f"{_id}" for _id in range(1000, 1020)]
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int, set]:

--- a/tests/global_config_amd64.py
+++ b/tests/global_config_amd64.py
@@ -22,7 +22,7 @@ instance_type_fedora_os_list = [OS_FLAVOR_FEDORA]
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -31,4 +31,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -54,7 +54,7 @@ instance_type_rhel_os_list = [RHEL10_PREFERENCE]
 instance_type_fedora_os_list = [OS_FLAVOR_FEDORA]
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -63,4 +63,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_aro.py
+++ b/tests/global_config_aro.py
@@ -25,7 +25,7 @@ storage_class_a = StorageClassNames.CEPH_RBD_VIRTUALIZATION
 storage_class_b = StorageClassNames.CEPH_RBD_VIRTUALIZATION
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -34,4 +34,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -54,7 +54,7 @@ storage_class_a = StorageClassNames.IO2_CSI
 storage_class_b = StorageClassNames.IO2_CSI
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -63,4 +63,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_ibm_spectrum_sc.py
+++ b/tests/global_config_ibm_spectrum_sc.py
@@ -24,7 +24,7 @@ storage_class_a = StorageClassNames.GPFS
 storage_class_b = StorageClassNames.GPFS
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -33,4 +33,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_interop.py
+++ b/tests/global_config_interop.py
@@ -7,7 +7,7 @@ global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", 
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -16,4 +16,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_interop_sno.py
+++ b/tests/global_config_interop_sno.py
@@ -19,7 +19,7 @@ storage_class_matrix = [
 ]
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -28,4 +28,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_lvms.py
+++ b/tests/global_config_lvms.py
@@ -29,7 +29,7 @@ storage_class_a = StorageClassNames.TOPOLVM
 storage_class_b = StorageClassNames.TOPOLVM
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -38,4 +38,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_multiarch.py
+++ b/tests/global_config_multiarch.py
@@ -63,7 +63,7 @@ os_matrix = {
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -72,4 +72,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_nfs.py
+++ b/tests/global_config_nfs.py
@@ -25,7 +25,7 @@ storage_class_a = StorageClassNames.NFS
 storage_class_b = StorageClassNames.NFS
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -34,4 +34,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_oci.py
+++ b/tests/global_config_oci.py
@@ -35,7 +35,7 @@ storage_class_a = StorageClassNames.OCI
 storage_class_b = StorageClassNames.OCI
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -44,4 +44,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_rh_it.py
+++ b/tests/global_config_rh_it.py
@@ -27,7 +27,7 @@ storage_class_a = StorageClassNames.RH_INTERNAL_NFS
 storage_class_b = StorageClassNames.RH_INTERNAL_NFS
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -36,4 +36,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_s390x.py
+++ b/tests/global_config_s390x.py
@@ -25,7 +25,7 @@ instance_type_centos_os_list = [CENTOS_STREAM9_PREFERENCE]
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -34,4 +34,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_sno.py
+++ b/tests/global_config_sno.py
@@ -27,7 +27,7 @@ storage_class_matrix = [
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -36,4 +36,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/global_config_sno_hpp.py
+++ b/tests/global_config_sno_hpp.py
@@ -21,7 +21,7 @@ storage_class_matrix = [
 
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str, int]:
@@ -30,4 +30,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]

--- a/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
+++ b/tests/infrastructure/workload_availability/remediation_fencing_mhc/test_ha_vm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 HA VM reboot and provisioning scenario tests.
 """

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 import os
 import re

--- a/tests/install_upgrade_operators/must_gather/utils.py
+++ b/tests/install_upgrade_operators/must_gather/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import difflib
 import glob
 import logging

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test to verify all HCO deployments have 'openshift.io/required-scc' annotation.
 """

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests to check, HCO Namespace Pod's, Security Context Constraint
 """

--- a/tests/install_upgrade_operators/security/scc/test_default_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_default_scc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Tests to check, the default Security Context Constraint
 """

--- a/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
+++ b/tests/install_upgrade_operators/security/selinux/test_selinux_launcher_type.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Test to check, SELinuxLauncher Type in kubevirt config map
 """

--- a/tests/network/conftest.py
+++ b/tests/network/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV network tests
 """

--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from contextlib import contextmanager
 
 import pytest

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Network Migration test
 """

--- a/tests/network/nmstate/conftest.py
+++ b/tests/network/nmstate/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 
 import pytest

--- a/tests/storage/cdi_config/conftest.py
+++ b/tests/storage/cdi_config/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV CDI Config tests
 """

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Upload tests
 """

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Upload using virtctl
 """

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV CDI tests
 """

--- a/tests/storage/hpp/test_hostpath.py
+++ b/tests/storage/hpp/test_hostpath.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Hostpath Provisioner test suite
 """

--- a/tests/storage/hpp/test_hpp_node_placement.py
+++ b/tests/storage/hpp/test_hpp_node_placement.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 HPP Node Placement test suite
 """

--- a/tests/storage/online_resize/conftest.py
+++ b/tests/storage/online_resize/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Fixtures for online resize tests
 """

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Online resize (PVC expanded while VM running)
 """

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Utility functions and context managers for online resize tests
 """

--- a/tests/storage/snapshots/conftest.py
+++ b/tests/storage/snapshots/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Pytest conftest file for CNV Storage snapshots tests
 """

--- a/tests/storage/snapshots/test_snapshots.py
+++ b/tests/storage/snapshots/test_snapshots.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Snapshots tests
 """

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Automatic refresh of CDI certificates test suite
 """

--- a/tests/storage/test_data_protection.py
+++ b/tests/storage/test_data_protection.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 CDI data protection test suite
 """

--- a/tests/storage/test_disk_preallocation.py
+++ b/tests/storage/test_disk_preallocation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 CDI disk preallocation test suite
 """

--- a/tests/storage/test_local_storage.py
+++ b/tests/storage/test_local_storage.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Test local storage
 """

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 HonorWaitForFirstConsumer test suite
 """

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -78,9 +78,9 @@ class TestCommonTemplatesCentos:
     def test_expose_ssh(self, matrix_centos_os_vm_from_template):
         """CNV common templates access VM via SSH"""
 
-        assert matrix_centos_os_vm_from_template.ssh_exec.executor().is_connective(  # noqa: E501
-            tcp_timeout=120
-        ), "Failed to login via SSH"
+        assert matrix_centos_os_vm_from_template.ssh_exec.executor().is_connective(tcp_timeout=120), (
+            "Failed to login via SSH"
+        )
 
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::vmi_guest_agent_info", depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"]

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -152,9 +152,9 @@ class TestCommonTemplatesFedora:
     def test_expose_ssh(self, matrix_fedora_os_vm_from_template):
         """CNV common templates access VM via SSH"""
 
-        assert matrix_fedora_os_vm_from_template.ssh_exec.executor().is_connective(  # noqa: E501
-            tcp_timeout=120
-        ), "Failed to login via SSH"
+        assert matrix_fedora_os_vm_from_template.ssh_exec.executor().is_connective(tcp_timeout=120), (
+            "Failed to login via SSH"
+        )
 
     @pytest.mark.sno
     @pytest.mark.dependency(

--- a/tests/virt/cluster/common_templates/general/test_template_validator.py
+++ b/tests/virt/cluster/common_templates/general/test_template_validator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Base templates test
 """

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -110,9 +110,9 @@ class TestCommonTemplatesRhel:
     @pytest.mark.polarion("CNV-3320")
     def test_expose_ssh(self, matrix_rhel_os_vm_from_template):
         """CNV common templates access VM via SSH"""
-        assert matrix_rhel_os_vm_from_template.ssh_exec.executor().is_connective(  # noqa: E501
-            tcp_timeout=120
-        ), "Failed to login via SSH"
+        assert matrix_rhel_os_vm_from_template.ssh_exec.executor().is_connective(tcp_timeout=120), (
+            "Failed to login via SSH"
+        )
 
     @pytest.mark.arm64
     @pytest.mark.sno

--- a/utilities/console.py
+++ b/utilities/console.py
@@ -52,10 +52,10 @@ class Console(object):
         self.vm = vm
         # TODO: `BaseVirtualMachine` does not set cloud-init so the VM is using predefined credentials
         self.username = (
-            username or getattr(self.vm, "login_params", {}).get("username") or self.vm.username  # type: ignore[attr-defined]  # noqa: E501
+            username or getattr(self.vm, "login_params", {}).get("username") or self.vm.username  # type: ignore[attr-defined]
         )
         self.password = (
-            password or getattr(self.vm, "login_params", {}).get("password") or self.vm.password  # type: ignore[attr-defined]  # noqa: E501
+            password or getattr(self.vm, "login_params", {}).get("password") or self.vm.password  # type: ignore[attr-defined]
         )
         self.timeout = timeout
         self.child = None

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -872,7 +872,7 @@ POD_CONTAINER_SPEC = {
 
 EXCLUDED_CPU_MODELS_S390X = [
     # Below are deprecated & usable models, but violate RHEL 9 ALS (min z14) causing guest to crash (disable-wait)
-    # Ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/automatically_installing_rhel/preparing-a-rhel-installation-on-64-bit-ibm-z_rhel-installer#planning-for-installation-on-ibm-z_preparing-a-rhel-installation-on-64-bit-ibm-z # noqa: E501
+    # Ref: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/automatically_installing_rhel/preparing-a-rhel-installation-on-64-bit-ibm-z_rhel-installer#planning-for-installation-on-ibm-z_preparing-a-rhel-installation-on-64-bit-ibm-z
     "z114",
     "z114-base",
     "z13",

--- a/utilities/logger.py
+++ b/utilities/logger.py
@@ -27,7 +27,7 @@ class DuplicateFilter(logging.Filter):
 
 
 class TestLogFormatter(ColoredFormatter):
-    def formatTime(self, record, datefmt=None):  # noqa: N802
+    def formatTime(self, record, datefmt=None):
         return datetime.fromtimestamp(record.created).isoformat()
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Two cleanups in one PR:

**1. Remove stale `# noqa` comments** that no linter enforces after .flake8 (#4703) and pyproject.toml (#4720) configuration changes:

| Rule | Reason noqa is stale |
|------|---------------------|
| F821 | Scoped to `tests/global_config*.py` via ruff `per-file-ignores` (#4720) |
| N802 | Flake8 no longer checks this (#4703) |
| E501 | Ruff formatter manages line length |
| E201 | Ruff formatter manages whitespace |

**N815 (`camelCase` in class scope) noqa comments are intentionally kept** — flake8 still enforces N815. The existing `# noqa: N815` comments on dataclass fields matching Kubernetes API schemas remain in place. N815 was also **removed from the flake8 ignore list** to restore enforcement.

`utilities/unittests/` E402 noqa comments are also kept — E402 is not globally ignored and these files use `sys.path` manipulation before imports.

**2. Remove obsolete `# -*- coding: utf-8 -*-` headers** — Python 3 uses UTF-8 by default (PEP 3120), making these headers unnecessary (ruff UP009).

Part 3 of a 5-PR lint cleanup series:
1. `.flake8` ignore rules (#4703) ✅ merged
2. `pyproject.toml` ruff ignore rules (#4720) ✅ merged
3. **This PR** — remove stale noqa + utf-8 headers
4. Apply safe ruff fixes repo-wide (SIM118, SIM201, PLC0206, etc.)
5. Bump pre-commit hooks (ruff v0.15.12, mypy v1.20.2)

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
All changes are comment/header removals — zero behavioral changes. N815 enforcement is restored (removed from flake8 ignore list).

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy UTF-8 encoding declarations from test files.
  * Removed redundant linter-suppression comments across codebase.
  * Updated linting configuration to improve code quality standards.

* **Style**
  * Reformatted test assertions for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->