### PR TITLE
docs: allow STP link at module, class, or test level

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,8 @@ New feature tests MUST follow the STD-first workflow:
 
 ### Coverage Tracking
 
-- **STP link REQUIRED** — every new feature test module MUST include an STP link in the module docstring
-- **RFE/Jira link REQUIRED when no STP exists** — if there is no STP, the module docstring MUST include a link to the RFE or Jira epic (not support cases) for coverage tracking
+- **STP link REQUIRED** — every new feature test file MUST include an STP link in the module, class, or test docstring
+- **RFE/Jira link REQUIRED when no STP exists** — if there is no STP, the module, class, or test docstring MUST include a link to the RFE or Jira epic (not support cases) for coverage tracking
 
 ### Test Requirements
 
@@ -122,7 +122,7 @@ When writing or reviewing STD (Software Test Description) test docstrings, follo
 - ❌ **NEVER** use alternative section names.
 - Each test verifies ONE thing with ONE `Expected:` assertion (rare exceptions allowed when multiple assertions verify a single behavior — see STD doc)
 - **No implementation details in STD docstrings** — no fixture names, no code references, no variable names; describe behavior in natural language
-- **STP link REQUIRED** — module docstring must contain the STP (Software Test Plan) link directly, not a reference to a README or other file
+- **STP link REQUIRED** — must appear directly in the module, class, or test docstring (not a reference to a README or other file); place it at the level that applies
 - **Markers can be at any level** — module, class, or test docstring; place them at the level they apply to
 - **Parametrized markers** — parameter values may have inline markers using `[Markers: ...]` syntax (e.g., `- ipv4 [Markers: ipv4]`) to differentiate common markers from parameter-specific ones
 - **Name resources by function** — in Preconditions, name objects by their role (e.g., "client VM", "server VM", "under-test VM"), not generic labels (e.g., "VM-A", "VM-B")

--- a/docs/SOFTWARE_TEST_DESCRIPTION.md
+++ b/docs/SOFTWARE_TEST_DESCRIPTION.md
@@ -30,7 +30,7 @@ This project follows a **two-phase development workflow** that separates test de
 1. **Create test stubs with docstrings only**:
    - Write the test function signature
    - Add the complete STD docstring (Preconditions/Steps/Expected)
-   - Include a link to the approved STP (Software Test Plan) directly in the **module docstring** (top of the test file).  This is needed for a standard format for traceability.
+   - Include a link to the approved STP (Software Test Plan) directly in the **module, class, or test docstring**. Place it at the level that applies (module for all tests in the file, class for all tests in the class, test for a specific test). This is needed for a standard format for traceability.
    - Add applicable pytest markers (architecture markers, etc.)
    - Add `__test__ = False` on unimplemented test(s).  For a single test, add `<test_name>.__test__ = False`
 
@@ -327,7 +327,7 @@ test_<specific_behavior>.__test__ = False
 
 #### Phase 1: Test Description PR
 
-- [ ] STP link in module docstring
+- [ ] STP link in module, class, or test docstring
 - [ ] Tests grouped in class with shared preconditions
 - [ ] Each test has: description, Preconditions, Steps, Expected
 - [ ] Each test verifies ONE thing with ONE Expected
@@ -399,6 +399,8 @@ class TestSnapshotRestore:
 class TestVMLifecycle:
     """
     Tests for VM lifecycle operations.
+
+    STP Reference: https://example.com/stp/vm-lifecycle
 
     Preconditions:
         - VM Running latest Fedora virtual machine


### PR DESCRIPTION
##### What this PR does / why we need it:
Previously, the STP (Software Test Plan) link was required only in the module docstring. This was too restrictive — some test files contain classes that each cover a different STP, or individual tests that reference their own STP.

This update allows the STP link at any docstring level:
- **Module docstring** — covers all tests in the file
- **Class docstring** — covers all tests in the class
- **Test docstring** — covers a specific test

Place the link at the level that applies.

**Changes:**
- `AGENTS.md` — Coverage Tracking section + STD Docstring Format section
- `docs/SOFTWARE_TEST_DESCRIPTION.md` — Phase 1 instructions, checklist, and added class-level STP example in Example 2

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Documentation only — no code changes.

##### jira-ticket:
