### PR TITLE
fix: enable CodeRabbit review for markdown files

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -47,8 +47,8 @@ reviews:
   changed_files_summary: true
 
   # Targeted pre-merge checks - only run on changed files
-  path_filters:
-    - "!**/*.md"  # Skip markdown-only changes for full review
+  # path_filters: markdown files are reviewed (AGENTS.md, docs/*.md contain coding standards)
+  path_filters: []
 
   # Abort review if PR is closed
   abort_on_close: true


### PR DESCRIPTION
##### What this PR does / why we need it:
The `.coderabbit.yaml` had a `path_filters: ["!**/*.md"]` rule that excluded all markdown files from CodeRabbit review. This meant changes to critical project documentation like `AGENTS.md` and `docs/SOFTWARE_TEST_DESCRIPTION.md` (which contain coding standards and test guidelines) were never reviewed by CodeRabbit.

This PR removes that exclusion so markdown files are reviewed like any other file.

Discovered via #4734 where CodeRabbit skipped review entirely.

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Once merged, PR #4734 can be re-reviewed by CodeRabbit.

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to include additional file types in review scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->