### PR TITLE
[IUO] Fix runbook URL test failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1337,6 +1337,13 @@ def hpp_cr_installed(hostpath_provisioner_scope_session):
     return hostpath_provisioner_scope_session.exists
 
 
+@pytest.fixture(scope="session")
+def aaq_enabled(hyperconverged_resource_scope_session):
+    if not hyperconverged_resource_scope_session:
+        return False
+    return hyperconverged_resource_scope_session.instance.spec.get("enableApplicationAwareQuota", False)
+
+
 @pytest.fixture(scope="module")
 def cnv_pods(admin_client, hco_namespace):
     yield list(Pod.get(client=admin_client, namespace=hco_namespace.name))

--- a/tests/observability/runbook_url/conftest.py
+++ b/tests/observability/runbook_url/conftest.py
@@ -57,8 +57,17 @@ def available_runbook_urls():
             url=runbooks_api_url,
             timeout=TIMEOUT_10SEC,
         ):
-            if sample.status_code == requests.codes.ok:
-                return {entry["html_url"] for entry in sample.json()}
+            if sample:
+                try:
+                    runbook_urls = {entry["html_url"] for entry in sample.json()}
+                except ValueError:
+                    LOGGER.error(
+                        f"Failed to decode JSON from '{runbooks_api_url}', "
+                        f"status: {sample.status_code}, content-type: {sample.headers.get('Content-Type')}"
+                    )
+                    continue
+                if runbook_urls:
+                    return runbook_urls
     except TimeoutExpiredError:
         LOGGER.error(
             f"Failed to fetch runbooks directory listing from '{runbooks_api_url}', "

--- a/tests/observability/runbook_url/test_runbook_url.py
+++ b/tests/observability/runbook_url/test_runbook_url.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from utilities.constants import CNV_PROMETHEUS_RULES
+from utilities.constants import AAQ_PROMETHEUS_RULE, CNV_PROMETHEUS_RULES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ def validate_downstream_runbook_url(
 
 class TestRunbookUrlsAndPrometheusRules:
     @pytest.mark.polarion("CNV-10081")
-    def test_no_new_prometheus_rules(self, cnv_prometheus_rules_names, hpp_cr_installed):
+    def test_no_new_prometheus_rules(self, cnv_prometheus_rules_names, hpp_cr_installed, aaq_enabled):
         """
         Since validations for runbook url of all cnv alerts are done via polarion parameterization of prometheusrules,
         this test has been added to catch any new cnv prometheusrules that is not part of cnv_prometheus_rules_matrix
@@ -38,6 +38,8 @@ class TestRunbookUrlsAndPrometheusRules:
         if not hpp_cr_installed:
             LOGGER.warning("HPP CR is not installed, removing prometheus-hpp-rules from the list of prometheus rules")
             expected_prometheus_rules_names.remove("prometheus-hpp-rules")
+        if aaq_enabled:
+            expected_prometheus_rules_names.append(AAQ_PROMETHEUS_RULE)
         assert sorted(cnv_prometheus_rules_names) == sorted(expected_prometheus_rules_names), (
             f"New cnv prometheusrule found: {set(cnv_prometheus_rules_names) - set(expected_prometheus_rules_names)}"
         )

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -722,6 +722,7 @@ CNV_PROMETHEUS_RULES = [
     f"kubevirt-cnv-{PROMETHEUS_RULES_STR}",
     KUBEMACPOOL_PROMETHEUS_RULE,
 ]
+AAQ_PROMETHEUS_RULE = "prometheus-aaq-rules"
 
 
 class StorageClassNames:


### PR DESCRIPTION
##### Short description:
Replace status code check with data validation in available_runbook_urls fixture to handle non-200 responses that still contain valid data. Add AAQ prometheus rule support to test_no_new_prometheus_rules so clusters with AAQ enabled don't fail the assertion.

Signed-off-by: Ohad Revah <orevah@redhat.com>
assisted by: claude code claude-opus-4-6
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a session-scoped fixture to detect whether Application Aware Quota (AAQ) is enabled.
  * Updated tests to conditionally include the AAQ Prometheus rule when AAQ is enabled.

* **Chores**
  * Improved HTTP/JSON robustness in test utilities to skip/continue on malformed or non-JSON responses.
  * Added a shared constant for the AAQ Prometheus rule name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->