### PR TITLE
IUO: featuregates tests should consider multiarch and v1beta1 api

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -13,7 +13,11 @@ from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
+    DISABLE_MDEV_CONFIGURATION,
+    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
     EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
+    FG_ENABLED,
+    HCO_DEFAULT_FEATUREGATES,
     RESOURCE_NAME_STR,
     RESOURCE_NAMESPACE_STR,
     RESOURCE_TYPE_STR,
@@ -24,7 +28,7 @@ from tests.install_upgrade_operators.utils import (
     get_resource_by_name,
     get_resource_from_module_name,
 )
-from utilities.constants import HOSTPATH_PROVISIONER_CSI, HPP_POOL
+from utilities.constants import HOSTPATH_PROVISIONER_CSI, HPP_POOL, MULTIARCH
 from utilities.hco import ResourceEditorValidateHCOReconcile, get_hco_version
 from utilities.infra import (
     get_daemonset_by_name,
@@ -149,6 +153,11 @@ def kubevirt_resource(admin_client, hco_namespace):
 @pytest.fixture()
 def cdi_resource_scope_function(admin_client):
     return get_hyperconverged_cdi(admin_client=admin_client)
+
+
+@pytest.fixture()
+def cdi_feature_gates(cdi_resource_scope_function):
+    return cdi_resource_scope_function.instance.spec.config.get("featureGates")
 
 
 @pytest.fixture()
@@ -280,8 +289,19 @@ def jira_86102_open():
     return is_jira_open(jira_id="CNV-86102")
 
 
+@pytest.fixture(scope="session")
+def jira_86639_open():
+    return is_jira_open(jira_id="CNV-86639")
+
+
 @pytest.fixture()
-def expected_value(request, is_s390x_cluster):
-    if request.param == EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES and is_s390x_cluster:
-        return request.param | S390X_SPECIFIC_KUBEVIRT_FEATUREGATES
-    return request.param
+def expected_value(request, is_s390x_cluster, jira_86639_open):
+    expected = request.param.copy()
+    if expected == EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES and is_s390x_cluster:
+        expected |= S390X_SPECIFIC_KUBEVIRT_FEATUREGATES
+    if expected == HCO_DEFAULT_FEATUREGATES:
+        if py_config["cluster_type"] == MULTIARCH:
+            expected[ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT] = FG_ENABLED
+        if jira_86639_open:
+            expected[DISABLE_MDEV_CONFIGURATION] = FG_ENABLED
+    return expected

--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -13,6 +13,7 @@ DEVELOPER_CONFIGURATION = "developerConfiguration"
 # featuregates:
 DEPLOY_KUBE_SECONDARY_DNS = "deployKubeSecondaryDNS"
 DISABLE_MDEV_CONFIGURATION = "disableMDevConfiguration"
+ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT = "enableMultiArchBootImageImport"
 PERSISTENT_RESERVATION = "persistentReservation"
 FG_DISABLED = False
 FG_ENABLED = True
@@ -34,6 +35,7 @@ EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
     "VideoConfig",
     "HotplugVolumes",
     "DecentralizedLiveMigration",
+    "LiveUpdateNADRef",
 }
 S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
 EXPECTED_CDI_HARDCODED_FEATUREGATES = {
@@ -47,12 +49,13 @@ HCO_DEFAULT_FEATUREGATES = {
     PERSISTENT_RESERVATION: FG_DISABLED,
     "alignCPUs": FG_DISABLED,
     "downwardMetrics": FG_DISABLED,
-    "enableMultiArchBootImageImport": FG_DISABLED,
+    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_DISABLED,
     "decentralizedLiveMigration": FG_ENABLED,
     "declarativeHotplugVolumes": FG_DISABLED,
     "videoConfig": FG_ENABLED,
     "objectGraph": FG_DISABLED,
     "incrementalBackup": FG_DISABLED,
+    "containerPathVolumes": FG_DISABLED,
 }
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"

--- a/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
+++ b/tests/install_upgrade_operators/feature_gates/test_default_featuregates.py
@@ -1,89 +1,50 @@
-import logging
-
 import pytest
-from ocp_resources.cdi import CDI
-from ocp_resources.hyperconverged import HyperConverged
-from ocp_resources.kubevirt import KubeVirt
-from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.constants import (
-    DEVELOPER_CONFIGURATION,
     EXPECTED_CDI_HARDCODED_FEATUREGATES,
     EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
     FEATUREGATES,
     HCO_DEFAULT_FEATUREGATES,
-    KEY_NAME_STR,
-    KEY_PATH_SEPARATOR,
-    RESOURCE_NAME_STR,
-    RESOURCE_NAMESPACE_STR,
-    RESOURCE_TYPE_STR,
 )
-from tests.install_upgrade_operators.utils import (
-    get_resource_by_name,
-    get_resource_key_value,
-)
-from utilities.constants import CDI_KUBEVIRT_HYPERCONVERGED, KUBEVIRT_HCO_NAME
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x, pytest.mark.skip_must_gather_collection]
 
-LOGGER = logging.getLogger(__name__)
-
 
 @pytest.fixture()
-def resource_object_value_by_key(request, admin_client):
-    resource_obj = get_resource_by_name(
-        resource_kind=request.param.get(RESOURCE_TYPE_STR),
-        name=request.param.get(RESOURCE_NAME_STR),
-        admin_client=admin_client,
-        namespace=request.param.get(RESOURCE_NAMESPACE_STR),
-    )
-    return get_resource_key_value(resource=resource_obj, key_name=request.param.get(KEY_NAME_STR))
+def hco_featuregates(hco_spec):
+    return hco_spec[FEATUREGATES]
 
 
 @pytest.mark.parametrize(
-    ("expected_value", "resource_object_value_by_key"),
+    ("expected_value", "featuregates_fixture"),
     [
         pytest.param(
             HCO_DEFAULT_FEATUREGATES,
-            {
-                RESOURCE_TYPE_STR: HyperConverged,
-                RESOURCE_NAME_STR: py_config["hco_cr_name"],
-                RESOURCE_NAMESPACE_STR: py_config["hco_namespace"],
-                KEY_NAME_STR: FEATUREGATES,
-            },
+            "hco_featuregates",
             marks=(pytest.mark.polarion("CNV-6115"),),
             id="verify_default_featuregates_hco_cr",
         ),
         pytest.param(
             EXPECTED_CDI_HARDCODED_FEATUREGATES,
-            {
-                RESOURCE_TYPE_STR: CDI,
-                RESOURCE_NAME_STR: CDI_KUBEVIRT_HYPERCONVERGED,
-                KEY_NAME_STR: f"config{KEY_PATH_SEPARATOR}{FEATUREGATES}",
-            },
+            "cdi_feature_gates",
             marks=(pytest.mark.polarion("CNV-6448"),),
             id="verify_defaults_featuregates_cdi_cr",
         ),
         pytest.param(
             EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
-            {
-                RESOURCE_TYPE_STR: KubeVirt,
-                RESOURCE_NAME_STR: KUBEVIRT_HCO_NAME,
-                RESOURCE_NAMESPACE_STR: py_config["hco_namespace"],
-                KEY_NAME_STR: f"configuration{KEY_PATH_SEPARATOR}{DEVELOPER_CONFIGURATION}"
-                f"{KEY_PATH_SEPARATOR}{FEATUREGATES}",
-            },
+            "kubevirt_feature_gates",
             marks=(pytest.mark.polarion("CNV-6426"),),
             id="verify_defaults_featuregates_kubevirt_cr",
         ),
     ],
-    indirect=["resource_object_value_by_key", "expected_value"],
+    indirect=["expected_value"],
 )
 def test_default_featuregates_by_resource(
+    request,
     expected_value,
-    resource_object_value_by_key,
+    featuregates_fixture,
 ):
-    if isinstance(resource_object_value_by_key, list):
-        resource_object_value_by_key = set(resource_object_value_by_key)
-    error_message = f"Expected featuregates: {expected_value}, actual: {resource_object_value_by_key}"
-    assert expected_value == resource_object_value_by_key, error_message
+    actual = request.getfixturevalue(featuregates_fixture)
+    if isinstance(actual, list):
+        actual = set(actual)
+    assert expected_value == actual, f"Expected featuregates: {expected_value}, actual: {actual}"


### PR DESCRIPTION
##### Short description:
Fix featuregates failuers

##### More details:
1. Use v1beta1.
2. Align with multiarch FG enabled by multiarch deployments.
3. Add jira reference for misconfiguration in deployments.
##### What this PR does / why we need it:
Green runs on iuo lanes
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-86648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored feature gate validation infrastructure for improved test clarity and maintainability.
  * Added support for validating feature gates in multi-architecture cluster configurations.
  * Enhanced test fixtures to dynamically validate feature gate settings based on cluster configuration and known issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4744)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->