### PR TITLE
fix: copy cpu_flags to avoid mutating session-scoped fixture dict

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -10,10 +10,11 @@ import secrets
 import shlex
 from collections import defaultdict
 from contextlib import contextmanager
+from copy import deepcopy
 from functools import cache
 from json import JSONDecodeError
 from subprocess import run
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 import bitmath
 import jinja2
@@ -954,7 +955,7 @@ class VirtualMachineForTests(VirtualMachine):
     def update_vm_cpu_configuration(self, template_spec):
         # cpu settings
         if self.cpu_flags:
-            template_spec.setdefault("domain", {})["cpu"] = self.cpu_flags
+            template_spec.setdefault("domain", {})["cpu"] = deepcopy(self.cpu_flags)
 
         if self.cpu_limits:
             template_spec.setdefault("domain", {}).setdefault("resources", {}).setdefault("limits", {})
@@ -1674,7 +1675,7 @@ def generate_dict_from_yaml_template(stream, **kwargs):
     # Find all template variables
     template_vars = [i.split()[1] for i in re.findall(r"{{ .* }}", data)]
     for var in template_vars:
-        if var not in kwargs.keys():
+        if var not in kwargs:
             raise MissingTemplateVariables(var=var, template=data)
     template = jinja2.Template(data)
     out = template.render(**kwargs)
@@ -2601,7 +2602,7 @@ def validate_pause_unpause_linux_vm(vm: VirtualMachineForTests, pre_pause_pid: i
     )
 
 
-def check_vm_xml_smbios(vm: VirtualMachineForTests, cm_values: Dict[str, str], admin_client: DynamicClient) -> None:
+def check_vm_xml_smbios(vm: VirtualMachineForTests, cm_values: dict[str, str], admin_client: DynamicClient) -> None:
     """
     Verify SMBIOS on VM XML [sysinfo type=smbios][system] match kubevirt-config
     config map.
@@ -2632,7 +2633,7 @@ def update_vm_efi_spec_and_restart(
     restart_vm_wait_for_running_vm(vm=vm, wait_for_interfaces=wait_for_interfaces)
 
 
-def delete_guestosinfo_keys(data: Dict[str, Any]) -> Dict[str, Any]:
+def delete_guestosinfo_keys(data: dict[str, Any]) -> dict[str, Any]:
     """
     supportedCommands - removed as the data is used for internal guest agent validations
     fsInfo, userList - checked in validate_fs_info_virtctl_vs_linux_os / validate_user_info_virtctl_vs_linux_os
@@ -2753,7 +2754,7 @@ def guest_reboot(vm: VirtualMachineForTests, os_type: str) -> None:
     run_os_command(vm=vm, command=commands["reboot"][os_type])
 
 
-def run_os_command(vm: VirtualMachineForTests, command: str) -> Optional[str]:
+def run_os_command(vm: VirtualMachineForTests, command: str) -> str | None:
     try:
         return run_ssh_commands(
             host=vm.ssh_exec,
@@ -2782,7 +2783,7 @@ def wait_for_user_agent_down(vm: VirtualMachineForTests, timeout: int) -> None:
             break
 
 
-def get_virt_handler_pods(client: DynamicClient, namespace: Namespace) -> List[Pod]:
+def get_virt_handler_pods(client: DynamicClient, namespace: Namespace) -> list[Pod]:
     return utilities.infra.get_pods(
         client=client,
         namespace=namespace,
@@ -2792,7 +2793,7 @@ def get_virt_handler_pods(client: DynamicClient, namespace: Namespace) -> List[P
 
 def check_virt_handler_pods_for_migration_network(
     client: DynamicClient, namespace: Namespace, network_name: str, migration_network: bool = True
-) -> List[Pod]:
+) -> list[Pod]:
     """
     Checks whether virt-handler pods have migration network.
 


### PR DESCRIPTION
##### Short description:
Add `copy.deepcopy` when `cpu_flags` is used to create a `VirtualMachineForTests`

##### More details:
The current approach copies the object and makes changes to it. this causes pollution as the object is referenced in a `session` scope fixture, thus the next time the fixture is used it gets the changed values

##### What this PR does / why we need it:
When `test_vm_windows_oom` is run it changes `cpu_flags = {cpu_cores: 16, cpu_threads:1}` . after which `TestWSL2` is run with the new values since the fixture is referencing the object and is scoped `session`, causing a failure due to instance type conflict.

##### Special notes for reviewer:
Additional changes were done to the virt.py file due to `ruff` check in pre-commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended shared-state when updating virtual machine CPU configuration to avoid accidental mutations.

* **Refactor**
  * Modernized Python type annotations across utilities for clearer, up-to-date typing.
  * Improved template variable validation logic for more reliable template processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->