### PR TITLE
net: Mark localnet tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -72,6 +72,7 @@ markers =
     rwx_default_storage: Tests that require RWX storage
     descheduler: Tests that require kube-descheduler on nodes
     remote_cluster: Tests that require a remote cluster
+    localnet: Tests that use node localnet topology
 
     ## Required operators
     mtv: Tests that require the MTV operator to be installed

--- a/tests/network/localnet/ipam/test_connectivity.py
+++ b/tests/network/localnet/ipam/test_connectivity.py
@@ -4,6 +4,8 @@ from libs.net.traffic_generator import client_server_active_connection, is_tcp_c
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.localnet.liblocalnet import LOCALNET_IPAM_INTERFACE
 
+pytestmark = pytest.mark.localnet
+
 
 @pytest.mark.ipv4
 @pytest.mark.polarion("CNV-14043")

--- a/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
@@ -20,6 +20,8 @@ https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
 
 import pytest
 
+pytestmark = pytest.mark.localnet
+
 __test__ = False
 
 """

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -14,6 +14,8 @@ from tests.network.localnet.liblocalnet import (
 from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
+pytestmark = pytest.mark.localnet
+
 
 @pytest.mark.gating
 @pytest.mark.single_nic

--- a/tests/network/localnet/test_jumbo_frames.py
+++ b/tests/network/localnet/test_jumbo_frames.py
@@ -7,6 +7,7 @@ from tests.network.localnet.liblocalnet import LOCALNET_OVS_BRIDGE_INTERFACE
 from utilities.virt import vm_console_run_commands
 
 pytestmark = [
+    pytest.mark.localnet,
     pytest.mark.special_infra,
     pytest.mark.jumbo_frame,
 ]

--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -13,6 +13,8 @@ from tests.network.localnet.liblocalnet import (
 )
 from utilities.virt import migrate_vm_and_verify
 
+pytestmark = pytest.mark.localnet
+
 
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")


### PR DESCRIPTION
One immediate benefit from marking the localnet tests is that localnet is not supported on cloud-providers clusters, so it makes it easier to filter them out when running on such clusters (for example - heterogeneous multi-arch clusters are currently only applicable such clusters).

Assisted by: Claude Code
