### PR TITLE
WIP: Use PowerShell ProcessorCount for Windows CPU hotplug verification 

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -209,7 +209,7 @@ def clean_up_migration_jobs(client, vm):
 
 def get_os_cpu_count(vm):
     if "windows" in vm.name:
-        cmd = shlex.split("echo %NUMBER_OF_PROCESSORS%")
+        cmd = shlex.split('powershell.exe -command "[Environment]::ProcessorCount"')
     else:
         cmd = shlex.split("nproc")
     return int(run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip())


### PR DESCRIPTION
%NUMBER_OF_PROCESSORS% is an inherited environment variable from the parent process (sshd). After CPU hotplug, sshd retains the stale boot-time value, causing SSH commands to report fewer CPUs than actually available.

Replace with [Environment]::ProcessorCount which queries the kernel directly via GetSystemInfo, reliably reflecting hotplugged CPUs.

This aligns with the Linux scenario  that uses nproc (kernel query) on Linux rather than environment variables.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processor count detection on Windows virtual machines using a more reliable system detection method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->