### PR TITLE
cno: Check CNO network CRD status

### DIFF
--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -2,6 +2,7 @@ import logging
 import random
 
 import pytest
+from ocp_resources.cluster_operator import ClusterOperator
 from ocp_resources.multi_network_policy import MultiNetworkPolicy
 from ocp_resources.resource import ResourceEditor
 
@@ -20,10 +21,9 @@ from tests.network.flat_overlay.utils import (
     get_vm_kubevirt_domain_label,
     is_port_number_available,
     start_nc_response_on_vm,
-    wait_for_multi_network_policy_resources,
 )
-from utilities.constants import FLAT_OVERLAY_STR
-from utilities.infra import create_ns
+from utilities.constants import DEFAULT_RESOURCE_CONDITIONS, FLAT_OVERLAY_STR
+from utilities.infra import create_ns, wait_for_consistent_resource_conditions
 from utilities.network import assert_ping_successful, network_nad
 from utilities.virt import migrate_vm_and_verify
 
@@ -44,11 +44,24 @@ SPECIFIC_HOST_MASK = "32"
 
 
 @pytest.fixture(scope="module")
-def enable_multi_network_policy_usage(admin_client, network_operator):
-    with ResourceEditor(patches={network_operator: {"spec": {"useMultiNetworkPolicy": True}}}):
-        wait_for_multi_network_policy_resources(admin_client=admin_client, deploy_mnp_crd=True)
+def multi_network_policy_enabled(admin_client, network_operator):
+    if network_operator.instance.spec.get("useMultiNetworkPolicy"):
         yield
-    wait_for_multi_network_policy_resources(admin_client=admin_client, deploy_mnp_crd=False)
+        return
+    with ResourceEditor(patches={network_operator: {"spec": {"useMultiNetworkPolicy": True}}}):
+        wait_for_consistent_resource_conditions(
+            dynamic_client=admin_client,
+            resource_kind=ClusterOperator,
+            resource_name="network",
+            expected_conditions=DEFAULT_RESOURCE_CONDITIONS,
+        )
+        yield
+    wait_for_consistent_resource_conditions(
+        dynamic_client=admin_client,
+        resource_kind=ClusterOperator,
+        resource_name="network",
+        expected_conditions=DEFAULT_RESOURCE_CONDITIONS,
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/network/flat_overlay/test_flat_overlay.py
+++ b/tests/network/flat_overlay/test_flat_overlay.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
     pytest.mark.usefixtures(
-        "enable_multi_network_policy_usage",
+        "multi_network_policy_enabled",
     ),
     pytest.mark.ipv4,
 ]

--- a/tests/network/flat_overlay/test_multi_network_policy.py
+++ b/tests/network/flat_overlay/test_multi_network_policy.py
@@ -29,7 +29,6 @@ def test_positive_egress_multi_network_policy(
 
 @pytest.mark.polarion("CNV-10645")
 @pytest.mark.s390x
-@pytest.mark.jira("CNV-88747", run=False)
 def test_negative_ingress_multi_network_policy(
     vma_flat_overlay,
     vmb_flat_overlay_ip_address,

--- a/tests/network/flat_overlay/test_multi_network_policy.py
+++ b/tests/network/flat_overlay/test_multi_network_policy.py
@@ -7,7 +7,7 @@ from utilities.network import assert_ping_successful
 
 pytestmark = [
     pytest.mark.usefixtures(
-        "enable_multi_network_policy_usage",
+        "multi_network_policy_enabled",
         "flat_l2_port",
     ),
     pytest.mark.ipv4,

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -1,15 +1,12 @@
 import logging
 import shlex
 
-from ocp_resources.custom_resource_definition import CustomResourceDefinition
-from ocp_resources.resource import NamespacedResource, Resource
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+from ocp_resources.resource import Resource
 
 from libs.net.ip import random_ipv4_address
 from tests.network.flat_overlay.constants import (
     HTTP_SUCCESS_RESPONSE_STR,
 )
-from utilities.constants import TIMEOUT_3MIN, TIMEOUT_5SEC
 from utilities.exceptions import ResourceValueError
 from utilities.infra import ExecCommandOnPod, get_node_selector_dict
 from utilities.network import compose_cloud_init_data_dict
@@ -64,31 +61,6 @@ def get_vm_kubevirt_domain_label(vm):
 def create_ip_block(ip_address, ingress=True):
     network_direction = "from" if ingress else "to"
     return [{network_direction: [{"ipBlock": {"cidr": ip_address}}]}]
-
-
-def wait_for_multi_network_policy_resources(admin_client, deploy_mnp_crd=False):
-    sample = None
-    consecutive_check = 0
-    mnp_crd = CustomResourceDefinition(
-        name=f"multi-networkpolicies.{NamespacedResource.ApiGroup.K8S_CNI_CNCF_IO}", client=admin_client
-    )
-    try:
-        sampler = TimeoutSampler(
-            wait_timeout=TIMEOUT_3MIN,
-            sleep=TIMEOUT_5SEC,
-            func=lambda: mnp_crd.exists,
-        )
-        for sample in sampler:
-            if deploy_mnp_crd == bool(sample):
-                # We should make sure that the change in the MNP CRD is stable
-                consecutive_check += 1
-                if consecutive_check == 3:
-                    return
-    except TimeoutExpiredError:
-        LOGGER.error(
-            f"Value for deploying the multi-networkpolicies crd is {deploy_mnp_crd}, but the CRD status doesn't match."
-        )
-        raise
 
 
 def get_vm_connection_reply(


### PR DESCRIPTION
##### Short description:
Replace the multi-network-policy CRD existence check with a Cluster Network Operator (CNO) status check when toggling `useMultiNetworkPolicy`.

##### More details:
The previous wait only verified the `multi-networkpolicies.k8s.cni.cncf.io` CRD existed/disappeared. That signal is insufficient: enabling/disabling `useMultiNetworkPolicy` triggers a CNO reconcile that restarts ovn-kubernetes pods, and the CRD can flip ahead of the operator finishing its rollout. Tests proceeded while the cluster network was still converging, leading to flakes.

##### What this PR does / why we need it:
When multi network policy is activated the tests were just checking that the CRD exists. This is not enough since ovn-kubernetes pods get restarted; the proper way is to wait for the cluster network operator to finish reconciling via its status conditions.

##### Which issue(s) this PR fixes:
NONE

##### Special notes for reviewer:
NONE

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-83350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure to enable/disable multi-network policy handling more reliably and to wait for network operator stability using explicit reference timestamps and operator status checks.
* **Tests**
  * Updated fixtures and utilities to coordinate operator reconciliation before and after changes; adjusted test markers for related scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4770)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->