### PR TITLE
net: Introduce dual-stream linux bridge tests

### DIFF
--- a/libs/net/ip.py
+++ b/libs/net/ip.py
@@ -15,6 +15,48 @@ _IPV6_HEADER_SIZE: Final[int] = 40
 ICMP_HEADER_SIZE: Final[int] = 8
 
 
+def random_cidr_addresses_by_family(net_seed: int, host_address: int) -> list[str]:
+    """Return CIDR-formatted addresses for each IP family supported by the cluster.
+
+    This library uses /24 for IPv4 and /64 for IPv6 VM subnets, matching the
+    subnet definitions in this module. VMs with the same net_seed share the
+    same subnet, allowing direct L2 communication without routing. Only
+    families supported by the cluster are included.
+
+    Args:
+        net_seed: Index into the cached pool of random network prefixes.
+        host_address: Host portion of the address — must be unique per VM in the test.
+
+    Returns:
+        List of CIDR strings (e.g. ["192.168.1.1/24", "fd00::1/64"]).
+    """
+    return [
+        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
+        for ip in random_ip_addresses_by_family(net_seed=net_seed, host_address=host_address)
+    ]
+
+
+def random_ip_addresses_by_family(
+    net_seed: int,
+    host_address: int,
+) -> list[str]:
+    """Generate IP addresses for each IP family supported by the cluster network stack.
+
+    Args:
+        net_seed: Seed index for selecting the random network portion of the address.
+        host_address: Host portion of the address, used to place VMs on the same subnet.
+
+    Returns:
+        List of IP address strings, one per IP family supported by the cluster.
+    """
+    ips = []
+    if ipv4_supported_cluster():
+        ips.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
+    if ipv6_supported_cluster():
+        ips.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
+    return ips
+
+
 def random_ipv4_address(net_seed: int, host_address: int) -> str:
     """Construct a random IPv4 address using a cached list of random third octets.
 
@@ -79,27 +121,6 @@ def _random_hextets(count: int) -> list[int]:
         list[int]: A list of unique random integers representing hextet values.
     """
     return random.sample(range(1, 0xFFFE), count)
-
-
-def random_ip_addresses_by_family(
-    net_seed: int,
-    host_address: int,
-) -> list[str]:
-    """Generate IP addresses for each IP family supported by the cluster network stack.
-
-    Args:
-        net_seed: Seed index for selecting the random network portion of the address.
-        host_address: Host portion of the address, used to place VMs on the same subnet.
-
-    Returns:
-        List of IP address strings, one per IP family supported by the cluster.
-    """
-    ips = []
-    if ipv4_supported_cluster():
-        ips.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
-    if ipv6_supported_cluster():
-        ips.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
-    return ips
 
 
 def filter_link_local_addresses(ip_addresses: list[str]) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:

--- a/libs/vm/affinity.py
+++ b/libs/vm/affinity.py
@@ -6,6 +6,9 @@ from libs.vm.spec import (
     Affinity,
     LabelSelector,
     LabelSelectorRequirement,
+    NodeAffinity,
+    NodeSelectorTerm,
+    NodeSelectorTerms,
     PodAffinity,
     PodAffinityTerm,
     PodAntiAffinity,
@@ -78,5 +81,28 @@ def new_pod_affinity(label: tuple[str, str], namespaces: list[str] | None = None
                     namespaceSelector={} if namespaces is None else None,
                 )
             ]
+        )
+    )
+
+
+def new_node_affinity(key: str, exists: bool) -> Affinity:
+    """Create a node affinity based on whether target nodes must carry the given label.
+
+    Args:
+        key: Node role label key to match.
+        exists: If True, target nodes must carry the label (Exists operator).
+            If False, target nodes must NOT carry the label (DoesNotExist operator).
+
+    Returns:
+        Affinity object with nodeAffinity configured.
+    """
+    operator = "Exists" if exists else "DoesNotExist"
+    return Affinity(
+        nodeAffinity=NodeAffinity(
+            requiredDuringSchedulingIgnoredDuringExecution=NodeSelectorTerms(
+                nodeSelectorTerms=[
+                    NodeSelectorTerm(matchExpressions=[LabelSelectorRequirement(key=key, operator=operator)])
+                ]
+            )
         )
     )

--- a/libs/vm/oper.py
+++ b/libs/vm/oper.py
@@ -1,0 +1,29 @@
+import logging
+
+from kubernetes.client import ApiException
+
+from libs.vm.vm import BaseVirtualMachine
+
+LOGGER = logging.getLogger(__name__)
+
+
+def run_vms(vms: tuple[BaseVirtualMachine, ...]) -> tuple[BaseVirtualMachine, ...]:
+    """Start all VMs in parallel then wait for each to be ready and agent-connected.
+
+    Args:
+        vms: VMs to start.
+
+    Returns:
+        The same tuple of VMs, all running with guest agent connected.
+    """
+    for vm in vms:
+        try:
+            vm.start()  # type: ignore[no-untyped-call]
+        except ApiException as vm_exception:
+            if "VM is already running" in vm_exception.body:
+                LOGGER.warning(f"VM {vm.name} is already running")
+                continue
+    for vm in vms:
+        vm.wait_for_ready_status(status=True)  # type: ignore[no-untyped-call]
+        vm.wait_for_agent_connected()
+    return vms

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -100,6 +100,22 @@ class Multus:
 class Affinity:
     podAntiAffinity: PodAntiAffinity | None = None  # noqa: N815
     podAffinity: PodAffinity | None = None  # noqa: N815
+    nodeAffinity: NodeAffinity | None = None  # noqa: N815
+
+
+@dataclass
+class NodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution: NodeSelectorTerms  # noqa: N815
+
+
+@dataclass
+class NodeSelectorTerms:
+    nodeSelectorTerms: list[NodeSelectorTerm]  # noqa: N815
+
+
+@dataclass
+class NodeSelectorTerm:
+    matchExpressions: list[LabelSelectorRequirement]  # noqa: N815
 
 
 @dataclass
@@ -129,7 +145,7 @@ class LabelSelector:
 class LabelSelectorRequirement:
     operator: str
     key: str
-    values: list[str]
+    values: list[str] | None = None
 
 
 @dataclass

--- a/pytest.ini
+++ b/pytest.ini
@@ -72,6 +72,7 @@ markers =
     rwx_default_storage: Tests that require RWX storage
     descheduler: Tests that require kube-descheduler on nodes
     remote_cluster: Tests that require a remote cluster
+    mixed_os_nodes: Tests that require a dual-stream cluster with both RHCOS 9 and RHCOS 10 worker nodes
 
     ## Required operators
     mtv: Tests that require the MTV operator to be installed

--- a/tests/network/l2_bridge/bandwidth/conftest.py
+++ b/tests/network/l2_bridge/bandwidth/conftest.py
@@ -21,8 +21,8 @@ from tests.network.l2_bridge.bandwidth.lib_helpers import (
     BANDWIDTH_RATE_BPS,
     BANDWIDTH_SECONDARY_IFACE_NAME,
     GUEST_2ND_IFACE_NAME,
-    secondary_network_vm,
 )
+from tests.network.l2_bridge.libl2bridge import secondary_network_vm
 
 _NAD_NAME: Final[str] = "br-bw-test-nad"
 

--- a/tests/network/l2_bridge/bandwidth/lib_helpers.py
+++ b/tests/network/l2_bridge/bandwidth/lib_helpers.py
@@ -1,14 +1,8 @@
 import json
 from typing import Final
 
-from kubernetes.dynamic import DynamicClient
-
-from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer
-from libs.vm.factory import base_vmspec, fedora_vm
-from libs.vm.spec import CloudInitNoCloud, Interface, Multus, Network
-from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
-from tests.network.libs import cloudinit
+from libs.vm.vm import BaseVirtualMachine
 
 BANDWIDTH_SECONDARY_IFACE_NAME: Final[str] = "secondary"
 BANDWIDTH_RATE_BPS: Final[int] = 10_000_000  # 10 Mbps
@@ -84,64 +78,3 @@ def assert_bidir_throughput_within_limit(
             f"Measured {direction} throughput {throughput_bps:.0f} bps exceeds "
             f"configured limit {rate_bps} bps for {server_ip}"
         )
-
-
-def secondary_network_vm(
-    namespace: str,
-    name: str,
-    client: DynamicClient,
-    nad_name: str,
-    secondary_iface_name: str,
-    secondary_iface_addresses: list[str],
-) -> BaseVirtualMachine:
-    """Create a Fedora VM with a masquerade primary interface and a secondary Linux bridge interface.
-
-    Args:
-        namespace: Namespace to deploy the VM in.
-        name: VM name.
-        client: Kubernetes dynamic client.
-        nad_name: NetworkAttachmentDefinition name for the secondary interface.
-        secondary_iface_name: Name of the secondary network interface in the VM spec.
-        secondary_iface_addresses: CIDR addresses to assign to the secondary interface via cloud-init.
-    """
-    spec = base_vmspec()
-    spec.template.spec.domain.devices.interfaces = [  # type: ignore
-        Interface(name="default", masquerade={}),
-        Interface(name=secondary_iface_name, bridge={}),
-    ]
-    spec.template.spec.networks = [
-        Network(name="default", pod={}),
-        Network(name=secondary_iface_name, multus=Multus(networkName=nad_name)),
-    ]
-
-    ethernets = {}
-    primary = _masquerade_iface_cloud_init()
-    if primary:
-        ethernets["eth0"] = primary
-    ethernets["eth1"] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
-
-    userdata = cloudinit.UserData(users=[])
-    disk, volume = cloudinitdisk_storage(
-        data=CloudInitNoCloud(
-            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)),
-            userData=cloudinit.format_cloud_config(userdata=userdata),
-        )
-    )
-    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
-    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
-
-
-def _masquerade_iface_cloud_init() -> cloudinit.EthernetDevice | None:
-    """Return cloud-init ethernet config for a masquerade (primary) interface.
-
-    Returns:
-        EthernetDevice with static IPv6 and optional DHCP4, or None if IPv6 is not supported.
-    """
-    if not ipv6_supported_cluster():
-        return None
-    return cloudinit.EthernetDevice(
-        addresses=["fd10:0:2::2/120"],
-        gateway6="fd10:0:2::1",
-        dhcp4=ipv4_supported_cluster(),
-        dhcp6=False,
-    )

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -7,6 +7,7 @@ from pyhelper_utils.shell import run_ssh_commands
 
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
 from libs.net.ip import random_ipv4_address
+from libs.net.netattachdef import CNIPluginBridgeConfig, NetConfig, NetworkAttachmentDefinition
 from tests.network.l2_bridge.libl2bridge import DHCP_INTERFACE_NAME, bridge_attached_vm
 from tests.network.libs.dhcpd import (
     DHCP_IP_RANGE_END,
@@ -313,3 +314,22 @@ def bridge_nncp(
     ) as nncp_br:
         nncp_br.wait_for_status_success()
         yield nncp_br
+
+
+@pytest.fixture(scope="class")
+def bridge_nad(
+    admin_client: DynamicClient,
+    namespace,
+    bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
+) -> Generator[NetworkAttachmentDefinition]:
+    config = NetConfig(
+        name="test-bridge-network",
+        plugins=[CNIPluginBridgeConfig(bridge=bridge_nncp.desired_state_spec.interfaces[0].name)],  # type: ignore
+    )
+    with NetworkAttachmentDefinition(
+        name="test-bridge-network",
+        namespace=namespace.name,
+        config=config,
+        client=admin_client,
+    ) as nad:
+        yield nad

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -3,18 +3,25 @@ import logging
 import re
 import time
 from ipaddress import ip_interface
+from typing import Final
 
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status, lookup_iface_status_ip, wait_for_missing_iface_status
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import Affinity, CloudInitNoCloud, Interface, Multus, Network
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
 from tests.network.utils import update_cloud_init_extra_user_data
 from utilities import console
 from utilities.constants import (
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
     LINUX_BRIDGE,
+    NODE_ROLE_KUBERNETES_IO,
     NODE_TYPE_WORKER_LABEL,
     SRIOV,
     TIMEOUT_1MIN,
@@ -359,6 +366,70 @@ def wait_for_no_packet_loss_after_connection(src_vm, dst_ip, interface=None):
     except TimeoutExpiredError:
         LOGGER.error(f"Ping from {src_vm.name} to {dst_ip} failed.")
         raise
+
+
+def secondary_network_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    nad_name: str,
+    secondary_iface_name: str,
+    secondary_iface_addresses: list[str],
+    affinity: Affinity | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with a masquerade primary interface and a secondary Linux bridge interface.
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name.
+        client: Kubernetes dynamic client.
+        nad_name: NetworkAttachmentDefinition name for the secondary interface.
+        secondary_iface_name: Name of the secondary network interface in the VM spec.
+        secondary_iface_addresses: CIDR addresses to assign to the secondary interface via cloud-init.
+        affinity: Optional node or pod affinity rules for scheduling.
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.devices.interfaces = [  # type: ignore
+        Interface(name="default", masquerade={}),
+        Interface(name=secondary_iface_name, bridge={}),
+    ]
+    spec.template.spec.networks = [
+        Network(name="default", pod={}),
+        Network(name=secondary_iface_name, multus=Multus(networkName=nad_name)),
+    ]
+    if affinity:
+        spec.template.spec.affinity = affinity
+
+    ethernets = {}
+    primary = _masquerade_iface_cloud_init()
+    if primary:
+        ethernets["eth0"] = primary
+    ethernets["eth1"] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
+
+    disk, volume = cloudinitdisk_storage(
+        data=CloudInitNoCloud(
+            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)),
+            userData=cloudinit.format_cloud_config(userdata=cloudinit.UserData(users=[])),
+        )
+    )
+    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
+
+
+def _masquerade_iface_cloud_init() -> cloudinit.EthernetDevice | None:
+    """Return cloud-init ethernet config for a masquerade (primary) interface.
+
+    Returns:
+        EthernetDevice with static IPv6 and optional DHCP4, or None if IPv6 is not supported.
+    """
+    if not ipv6_supported_cluster():
+        return None
+    return cloudinit.EthernetDevice(
+        addresses=["fd10:0:2::2/120"],
+        gateway6="fd10:0:2::1",
+        dhcp4=ipv4_supported_cluster(),
+        dhcp6=False,
+    )
 
 
 @contextlib.contextmanager

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -40,6 +40,8 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, prepare_cloud
 
 LOGGER = logging.getLogger(__name__)
 
+RHCOS9_WORKER_LABEL: Final[str] = f"{NODE_ROLE_KUBERNETES_IO}/worker-rhcos9"
+
 NETWORK_MANAGER_UNMANAGE_RUNCMD = [
     'sudo echo -e "[main]\nno-auto-default=*\nignore-carrier=*" > /etc/NetworkManager/conf.d/no-nm-ownership.conf',
     "sudo systemctl restart NetworkManager",

--- a/tests/network/l2_bridge/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/l2_bridge/rhel9_rhel10_cluster/conftest.py
@@ -1,0 +1,88 @@
+import ipaddress
+from collections.abc import Generator
+from typing import Final
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+from libs.net.ip import random_cidr_addresses_by_family
+from libs.net.netattachdef import NetworkAttachmentDefinition
+from libs.net.traffic_generator import TcpServer, VMTcpClient, active_tcp_connections
+from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.affinity import new_node_affinity
+from libs.vm.oper import run_vms
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.l2_bridge.libl2bridge import RHCOS9_WORKER_LABEL, secondary_network_vm
+
+LINUX_BRIDGE_NETWORK_NAME: Final[str] = "linux-bridge-1"
+
+_SERVER_HOST_ADDRESS: Final[int] = 1
+_CLIENT_HOST_ADDRESS: Final[int] = 2
+
+
+@pytest.fixture(scope="class")
+def bridge_active_tcp_connections(
+    bridge_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
+) -> Generator[list[tuple[VMTcpClient, TcpServer]]]:
+    server_vm, client_vm = bridge_running_vms
+    with active_tcp_connections(
+        client_vm=client_vm,
+        server_vm=server_vm,
+        iface_name=LINUX_BRIDGE_NETWORK_NAME,
+    ) as connections:
+        yield connections
+
+
+@pytest.fixture(scope="class")
+def bridge_running_vms(
+    bridge_server_vm: BaseVirtualMachine,
+    bridge_client_vm: BaseVirtualMachine,
+) -> tuple[BaseVirtualMachine, BaseVirtualMachine]:
+    run_vms(vms=(bridge_server_vm, bridge_client_vm))
+    server_addresses = bridge_server_vm.cloud_init_network_data.ethernets["eth1"].addresses or []
+    client_addresses = bridge_client_vm.cloud_init_network_data.ethernets["eth1"].addresses or []
+    for vm, addresses in ((bridge_server_vm, server_addresses), (bridge_client_vm, client_addresses)):
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                LINUX_BRIDGE_NETWORK_NAME: [str(ipaddress.ip_interface(addr).ip) for addr in addresses]
+            },
+        )
+    return bridge_server_vm, bridge_client_vm
+
+
+@pytest.fixture(scope="class")
+def bridge_server_vm(
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    bridge_nad: NetworkAttachmentDefinition,
+) -> Generator[BaseVirtualMachine]:
+    with secondary_network_vm(
+        namespace=namespace.name,
+        name="server-vm",
+        client=unprivileged_client,
+        nad_name=bridge_nad.name,
+        secondary_iface_name=LINUX_BRIDGE_NETWORK_NAME,
+        secondary_iface_addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_SERVER_HOST_ADDRESS),
+        affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
+    ) as vm:
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def bridge_client_vm(
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    bridge_nad: NetworkAttachmentDefinition,
+) -> Generator[BaseVirtualMachine]:
+    with secondary_network_vm(
+        namespace=namespace.name,
+        name="client-vm",
+        client=unprivileged_client,
+        nad_name=bridge_nad.name,
+        secondary_iface_name=LINUX_BRIDGE_NETWORK_NAME,
+        secondary_iface_addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_CLIENT_HOST_ADDRESS),
+        affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
+    ) as vm:
+        yield vm

--- a/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
@@ -8,11 +8,17 @@ Markers:
     - mixed_os_nodes
 """
 
+import ipaddress
+
 import pytest
 
-__test__ = False
+from libs.net.traffic_generator import is_tcp_connection
+from libs.vm.affinity import new_node_affinity
+from tests.network.l2_bridge.libl2bridge import RHCOS9_WORKER_LABEL
+from utilities.virt import migrate_vm_and_verify
 
 
+@pytest.mark.mixed_os_nodes
 @pytest.mark.incremental
 class TestConnectivity:
     """
@@ -23,7 +29,12 @@ class TestConnectivity:
     """
 
     @pytest.mark.polarion("CNV-15949")
-    def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos10(self):
+    def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos10(
+        self,
+        subtests,
+        bridge_running_vms,
+        bridge_active_tcp_connections,
+    ):
         """
         Test that an active TCP connection over a secondary Linux bridge network
         is preserved when the server VM migrates from an RHCOS 9 node to an RHCOS 10 node.
@@ -39,9 +50,22 @@ class TestConnectivity:
         Expected:
             - The active TCP connection from the client VM to the server VM is preserved during the migration
         """
+        server_vm, _ = bridge_running_vms
+        server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=False))
+        migrate_vm_and_verify(vm=server_vm)
+        for client, server in bridge_active_tcp_connections:
+            with subtests.test(msg=f"IPv{ipaddress.ip_address(client.server_ip).version} after migration to RHCOS 10"):
+                assert is_tcp_connection(server=server, client=client), (
+                    f"TCP connection lost after migrating {server_vm.name} to RHCOS 10 node"
+                )
 
     @pytest.mark.polarion("CNV-15964")
-    def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos9(self):
+    def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos9(
+        self,
+        subtests,
+        bridge_running_vms,
+        bridge_active_tcp_connections,
+    ):
         """
         Test that an active TCP connection over a secondary Linux bridge network
         is preserved when the server VM migrates from an RHCOS 10 node to an RHCOS 9 node.
@@ -57,3 +81,13 @@ class TestConnectivity:
         Expected:
             - The active TCP connection from the client VM to the server VM is preserved during the migration
         """
+        server_vm, _ = bridge_running_vms
+        server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True))
+        migrate_vm_and_verify(vm=server_vm)
+        for client, server in bridge_active_tcp_connections:
+            with subtests.test(
+                msg=f"IPv{ipaddress.ip_address(client.server_ip).version} after migration back to RHCOS 9"
+            ):
+                assert is_tcp_connection(server=server, client=client), (
+                    f"TCP connection lost after migrating {server_vm.name} back to RHCOS 9 node"
+                )

--- a/tests/network/l2_bridge/vmi_interfaces_stability/conftest.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/conftest.py
@@ -4,8 +4,7 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 
-import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
-from libs.net.netattachdef import CNIPluginBridgeConfig, NetConfig, NetworkAttachmentDefinition
+from libs.net.netattachdef import NetworkAttachmentDefinition
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.l2_bridge.vmi_interfaces_stability.lib_helpers import (
     secondary_network_vm,
@@ -29,25 +28,6 @@ def running_linux_bridge_vm(
         vm.wait_for_agent_connected()
         wait_for_stable_ifaces(vm=vm)
         yield vm
-
-
-@pytest.fixture(scope="class")
-def bridge_nad(
-    admin_client: DynamicClient,
-    namespace: Namespace,
-    bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
-) -> Generator[NetworkAttachmentDefinition]:
-    config = NetConfig(
-        name="test-bridge-network",
-        plugins=[CNIPluginBridgeConfig(bridge=bridge_nncp.desired_state_spec.interfaces[0].name)],  # type: ignore
-    )
-    with NetworkAttachmentDefinition(
-        name="test-bridge-network",
-        namespace=namespace.name,
-        config=config,
-        client=admin_client,
-    ) as nad:
-        yield nad
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -9,6 +9,7 @@ from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
 from libs.net.traffic_generator import TcpServer, VMTcpClient, active_tcp_connections
 from libs.net.vmspec import lookup_iface_status
+from libs.vm.oper import run_vms
 from libs.vm.spec import Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cloudinit
@@ -29,7 +30,6 @@ from tests.network.localnet.liblocalnet import (
     ip_addresses_from_pool,
     localnet_cudn,
     localnet_vm,
-    run_vms,
 )
 from utilities.constants import (
     WORKER_NODE_LABEL_KEY,

--- a/tests/network/localnet/ipam/conftest.py
+++ b/tests/network/localnet/ipam/conftest.py
@@ -7,6 +7,7 @@ from ocp_resources.namespace import Namespace
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
 from libs.net import netattachdef as libnad
 from libs.net.ip import random_ipv4_address
+from libs.vm.oper import run_vms
 from libs.vm.spec import Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.localnet.liblocalnet import (
@@ -14,7 +15,6 @@ from tests.network.localnet.liblocalnet import (
     LOCALNET_OVS_BRIDGE_NETWORK,
     LOCALNET_VM_ANTI_AFFINITY,
     localnet_vm,
-    run_vms,
 )
 
 

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -5,7 +5,6 @@ import uuid
 from collections.abc import Generator
 from typing import Final
 
-from kubernetes.client import ApiException
 from kubernetes.dynamic import DynamicClient
 
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
@@ -57,20 +56,6 @@ def ip_addresses_from_pool(
     if ipv6_supported_cluster():
         addresses.append(next(ipv6_pool))
     return addresses
-
-
-def run_vms(vms: tuple[BaseVirtualMachine, ...]) -> tuple[BaseVirtualMachine, ...]:
-    for vm in vms:
-        try:
-            vm.start()  # type: ignore[no-untyped-call]
-        except ApiException as vm_exception:
-            if "VM is already running" in vm_exception.body:
-                LOGGER.warning(f"VM {vm.name} is already running")
-                continue
-    for vm in vms:
-        vm.wait_for_ready_status(status=True)  # type: ignore[no-untyped-call]
-        vm.wait_for_agent_connected()
-    return vms
 
 
 def localnet_vm(


### PR DESCRIPTION
##### Short description:
Dual-stream clusters run worker nodes with a mix of RHCOS 9 and RHCOS 10.
Live migration across OS versions can expose compatibility issues: kernel bridge drivers, OVN flow tables, and binding plugins all behave differently between RHCOS releases, that would only manifest during cross-OS migration and not in homogeneous OS nodes clusters. 

##### More details: STD: https://github.com/RedHatQE/openshift-virtualization-tests/pull/4569

##### What this PR does / why we need it:
This PR adds the shared infrastructure layer needed by all network migration tests in this series, plus Linux bridge connectivity tests.                        
The shared layer registers the mixed_os_nodes marker to gate tests to compatible clusters, and introduces helpers to direct a running VM to a specific OS node before triggering migration.

The Linux bridge tests verify that an active TCP connection over a secondary Linux bridge network survives live migration of the server VM in both directions (RHCOS 9 -> 10 and back). 
The client VM remains on RHCOS 9 throughout, so the test isolates the impact of the server-side OS change on the forwarding path.

##### Which issue(s) this PR fixes: -

##### Special notes for reviewer:
This is the first PR in a series. Localnet, primary network, and primary UDN are covered in separate PRs that depend on the same infra commits.  

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-86194
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added testing framework for virtual machine migrations between RHEL9 and RHEL10 worker nodes.
  * Enhanced L2 bridge network configuration and testing across mixed-OS clusters.

* **Tests**
  * Implemented comprehensive test fixtures for L2 bridge integration testing.
  * Added automated network connectivity verification during VM migrations across operating system versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4772)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->