### PR TITLE
net: Introduce dual-stream primary network tests

### DIFF
--- a/tests/network/primary_network/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/primary_network/rhel9_rhel10_cluster/conftest.py
@@ -1,0 +1,57 @@
+from collections.abc import Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+from libs.net.vmspec import lookup_iface_status
+from libs.vm.affinity import new_node_affinity
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.libs.connectivity import build_ping_command
+from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from tests.network.primary_network.rhel9_rhel10_cluster.lib_helpers import primary_network_vm
+
+
+@pytest.fixture()
+def primary_network_connectivity(
+    primary_client_vm: BaseVirtualMachine,
+    primary_server_vm: BaseVirtualMachine,
+) -> None:
+    primary_iface_name = primary_server_vm.vmi.interfaces[0].name
+    for ip in lookup_iface_status(vm=primary_server_vm, iface_name=primary_iface_name)["ipAddresses"]:
+        primary_client_vm.console(
+            commands=[build_ping_command(dst_ip=ip, count=10, timeout=10)],
+            timeout=20,
+        )
+
+
+@pytest.fixture(scope="class")
+def primary_server_vm(
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+) -> Generator[BaseVirtualMachine]:
+    with primary_network_vm(
+        namespace=namespace.name,
+        name="server-vm",
+        client=unprivileged_client,
+        affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def primary_client_vm(
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+) -> Generator[BaseVirtualMachine]:
+    with primary_network_vm(
+        namespace=namespace.name,
+        name="client-vm",
+        client=unprivileged_client,
+        affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm

--- a/tests/network/primary_network/rhel9_rhel10_cluster/lib_helpers.py
+++ b/tests/network/primary_network/rhel9_rhel10_cluster/lib_helpers.py
@@ -1,0 +1,45 @@
+from kubernetes.dynamic import DynamicClient
+
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import Affinity, CloudInitNoCloud, Devices, Interface, Network
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import primary_iface_cloud_init
+
+
+def primary_network_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    affinity: Affinity | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM connected to the primary (masquerade) network only.
+
+    Configures a static IPv6 address on the primary interface when the cluster supports IPv6.
+
+    Args:
+        namespace: Namespace in which the VM will be created.
+        name: Name of the VM.
+        client: Kubernetes dynamic client.
+        affinity: Optional affinity rules for scheduling.
+
+    Returns:
+        Configured BaseVirtualMachine object (not yet started).
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.devices = Devices(interfaces=[Interface(name="default", masquerade={})])
+    spec.template.spec.networks = [Network(name="default", pod={})]
+    spec.template.spec.affinity = affinity
+
+    primary = primary_iface_cloud_init()
+    if primary is not None:
+        userdata = cloudinit.UserData(users=[])
+        disk, volume = cloudinitdisk_storage(
+            data=CloudInitNoCloud(
+                networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets={"eth0": primary})),
+                userData=cloudinit.format_cloud_config(userdata=userdata),
+            )
+        )
+        spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)

--- a/tests/network/primary_network/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/primary_network/rhel9_rhel10_cluster/test_connectivity.py
@@ -10,10 +10,16 @@ Markers:
 
 import pytest
 
-__test__ = False
+from libs.net.vmspec import lookup_iface_status
+from libs.vm.affinity import new_node_affinity
+from tests.network.libs.connectivity import build_ping_command
+from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from utilities.virt import migrate_vm_and_verify
 
 
+@pytest.mark.mixed_os_nodes
 @pytest.mark.incremental
+@pytest.mark.usefixtures("primary_network_connectivity")
 class TestConnectivity:
     """
     Preconditions:
@@ -23,7 +29,13 @@ class TestConnectivity:
     """
 
     @pytest.mark.polarion("CNV-15950")
-    def test_primary_connectivity_reestablished_after_server_migration_to_rhcos10(self):
+    def test_primary_connectivity_reestablished_after_server_migration_to_rhcos10(
+        self,
+        subtests,
+        admin_client,
+        primary_client_vm,
+        primary_server_vm,
+    ):
         """
         Test that network connectivity over the primary network can be re-established after
         the server VM migrates from an RHCOS 9 node to an RHCOS 10 node.
@@ -39,9 +51,24 @@ class TestConnectivity:
         Expected:
             - Ping from the client VM to the server VM succeeds after the migration
         """
+        primary_iface_name = primary_server_vm.vmi.interfaces[0].name
+        primary_server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=False))
+        migrate_vm_and_verify(vm=primary_server_vm, client=admin_client)
+        for ip in lookup_iface_status(vm=primary_server_vm, iface_name=primary_iface_name)["ipAddresses"]:
+            with subtests.test(msg=f"Testing {primary_server_vm.name} IP address: {ip}"):
+                primary_client_vm.console(
+                    commands=[build_ping_command(dst_ip=ip, count=10, timeout=10)],
+                    timeout=20,
+                )
 
     @pytest.mark.polarion("CNV-15967")
-    def test_primary_connectivity_reestablished_after_server_migration_to_rhcos9(self):
+    def test_primary_connectivity_reestablished_after_server_migration_to_rhcos9(
+        self,
+        subtests,
+        admin_client,
+        primary_client_vm,
+        primary_server_vm,
+    ):
         """
         Test that network connectivity over the primary network can be re-established after
         the server VM migrates from an RHCOS 10 node to an RHCOS 9 node.
@@ -57,3 +84,12 @@ class TestConnectivity:
         Expected:
             - Ping from the client VM to the server VM succeeds after the migration
         """
+        primary_iface_name = primary_server_vm.vmi.interfaces[0].name
+        primary_server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True))
+        migrate_vm_and_verify(vm=primary_server_vm, client=admin_client)
+        for ip in lookup_iface_status(vm=primary_server_vm, iface_name=primary_iface_name)["ipAddresses"]:
+            with subtests.test(msg=f"Testing {primary_server_vm.name} IP address: {ip}"):
+                primary_client_vm.console(
+                    commands=[build_ping_command(dst_ip=ip, count=10, timeout=10)],
+                    timeout=20,
+                )


### PR DESCRIPTION
##### Short description:
New dual-stream tests: primary network scenarios
This PR adds two tests that verify connectivity post migration in both directions (RHCOS 9 -> RHCOS 10 and back). VMs are scheduled using node affinity on the RHCOS 9 worker label rather than hostnames, so the tests are resilient to node replacement.

##### More details:
STD: https://github.com/RedHatQE/openshift-virtualization-tests/pull/4569

##### What this PR does / why we need it:
Added automation for new dual-stream tests

##### Which issue(s) this PR fixes: -

##### Special notes for reviewer: 
Follow-up implementation of new tests of primary network
RHCOS9_WORKER_LABEL is moved in https://github.com/RedHatQE/openshift-virtualization-tests/pull/4784


##### jira-ticket: https://redhat.atlassian.net/browse/CNV-86194
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end connectivity tests for primary network clusters across mixed OS nodes.
  * Expanded test coverage for server/client VM setup and migration scenarios.

* **Bug Fixes**
  * Verified network connectivity is restored after migrating the server VM between supported worker node types.
  * Improved validation by checking connectivity to all discovered server IPs after migration.

* **Chores**
  * Enabled the new connectivity test suite to run as part of normal test collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->