### PR TITLE
net, evpn: implement VM reboot connectivity test

### DIFF
--- a/tests/network/bgp/evpn/libevpn.py
+++ b/tests/network/bgp/evpn/libevpn.py
@@ -1,15 +1,23 @@
 import contextlib
+import ipaddress
 import logging
 import shlex
 from collections.abc import Generator
 from dataclasses import dataclass
 
 from ocp_resources.pod import Pod
+from pytest import Subtests
 from timeout_sampler import retry
 
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
-from libs.net.traffic_generator import IPERF_SERVER_PORT, PodTcpClient, TcpServer
+from libs.net.traffic_generator import (
+    IPERF_SERVER_PORT,
+    PodTcpClient,
+    TcpServer,
+    active_tcp_connections,
+    is_tcp_connection,
+)
 from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs.bgp import CLUSTER_FRR_ASN, EXTERNAL_FRR_ASN, NET_TOOLS_CONTAINER_NAME
@@ -361,3 +369,41 @@ def _evpn_workloads_connection(
             container=NET_TOOLS_CONTAINER_NAME,
         ) as tcp_client:
             yield tcp_client, tcp_server
+
+
+def assert_evpn_workloads_connectivity(
+    target_vm: BaseVirtualMachine,
+    ref_vm: BaseVirtualMachine,
+    l2_endpoint: EvpnEndpoint,
+    l3_endpoint: EvpnEndpoint,
+    subtests: Subtests,
+) -> None:
+    """Verifies EVPN connectivity: VM-to-VM, stretched L2, and routed L3.
+
+    Args:
+        target_vm: The under-test VM (server).
+        ref_vm: The reference VM (client for VM-to-VM check).
+        l2_endpoint: External L2 endpoint (client for stretched L2 check).
+        l3_endpoint: External L3 endpoint (client for routed L3 check).
+        subtests: pytest-subtests fixture for per-check reporting.
+    """
+    iface_name = lookup_primary_network(vm=target_vm).name
+
+    with active_tcp_connections(
+        client_vm=ref_vm,
+        server_vm=target_vm,
+        iface_name=iface_name,
+    ) as vm_connections:
+        for vm_client, vm_server in vm_connections:
+            with subtests.test(f"VM-to-VM IPv{ipaddress.ip_address(vm_client.server_ip).version}"):
+                assert is_tcp_connection(server=vm_server, client=vm_client)
+
+    with evpn_workloads_active_connections(endpoint=l2_endpoint, vm=target_vm) as l2_connections:
+        for l2_client, l2_server in l2_connections:
+            with subtests.test(f"stretched-L2 IPv{ipaddress.ip_address(l2_client.server_ip).version}"):
+                assert is_tcp_connection(server=l2_server, client=l2_client)
+
+    with evpn_workloads_active_connections(endpoint=l3_endpoint, vm=target_vm) as l3_connections:
+        for l3_client, l3_server in l3_connections:
+            with subtests.test(f"routed-L3 IPv{ipaddress.ip_address(l3_client.server_ip).version}"):
+                assert is_tcp_connection(server=l3_server, client=l3_client)

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -22,7 +22,7 @@ import pytest
 
 from libs.net.traffic_generator import active_tcp_connections, is_tcp_connection
 from libs.net.vmspec import lookup_primary_network
-from tests.network.bgp.evpn.libevpn import evpn_workloads_active_connections
+from tests.network.bgp.evpn.libevpn import assert_evpn_workloads_connectivity, evpn_workloads_active_connections
 from utilities.virt import migrate_vm_and_verify
 
 pytestmark = [
@@ -143,7 +143,13 @@ def test_routed_l3_connectivity_is_preserved_over_live_migration(
 
 
 @pytest.mark.polarion("CNV-15232")
-def test_connectivity_after_udn_vm_cold_reboot():
+def test_connectivity_after_udn_vm_cold_reboot(
+    vm_evpn_target,
+    vm_evpn_reference,
+    external_l2_endpoint,
+    external_l3_endpoint,
+    subtests,
+):
     """
     Preconditions:
     - External Source Provider L2 and L3 endpoints.
@@ -152,14 +158,21 @@ def test_connectivity_after_udn_vm_cold_reboot():
 
     Steps:
     1. Restart the target under-test VM.
-    3. Initiate TCP traffic between target under-test VM and the external endpoints/connectivity reference VM.
+    2. Initiate TCP traffic between target under-test VM and the external endpoints/connectivity reference VM.
 
     Expected:
     - New connections are established after the cold reboot.
     """
+    vm_evpn_target.restart(wait=True)
+    vm_evpn_target.wait_for_agent_connected()
 
-
-test_connectivity_after_udn_vm_cold_reboot.__test__ = False
+    assert_evpn_workloads_connectivity(
+        target_vm=vm_evpn_target,
+        ref_vm=vm_evpn_reference,
+        l2_endpoint=external_l2_endpoint,
+        l3_endpoint=external_l3_endpoint,
+        subtests=subtests,
+    )
 
 
 @pytest.mark.polarion("CNV-15233")


### PR DESCRIPTION
##### What this PR does / why we need it:

Verify TCP connectivity to all EVPN endpoints (VM-to-VM, stretched L2, routed L3) is re-established after restarting the target VM.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-87077

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
