### PR TITLE
net: Introduce dual-stream udn tests

### DIFF
--- a/tests/network/libs/vm_factory.py
+++ b/tests/network/libs/vm_factory.py
@@ -5,6 +5,7 @@ from kubernetes.dynamic import DynamicClient
 from libs.net.udn import udn_primary_network
 from libs.vm.affinity import new_pod_anti_affinity
 from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import Affinity
 from libs.vm.vm import BaseVirtualMachine
 
 
@@ -15,16 +16,34 @@ def udn_vm(
     binding: str,
     template_labels: dict | None = None,
     anti_affinity_namespaces: list[str] | None = None,
+    affinity: Affinity | None = None,
 ) -> BaseVirtualMachine:
+    """Create a Fedora VM connected to a primary UDN using the specified binding.
+
+    Args:
+        namespace_name: Namespace in which the VM will be created.
+        name: Name of the VM.
+        client: Kubernetes dynamic client.
+        binding: UDN binding plugin name (e.g. UDN_BINDING_DEFAULT_PLUGIN_NAME).
+        template_labels: Optional labels to add to the VM pod template, also used as anti-affinity key.
+        anti_affinity_namespaces: Optional namespaces to scope the pod anti-affinity rule.
+        affinity: Optional explicit affinity rules. When set, takes precedence over auto-generated anti-affinity from template_labels.
+
+    Returns:
+        Configured BaseVirtualMachine object (not yet started).
+    """
     spec = base_vmspec()
     iface, network = udn_primary_network(name="udn-primary", binding=binding)
     spec.template.spec.domain.devices.interfaces = [iface]  # type: ignore
     spec.template.spec.networks = [network]
+    if affinity is not None:
+        spec.template.spec.affinity = affinity
     if template_labels:
         spec.template.metadata.labels = spec.template.metadata.labels or {}  # type: ignore
         spec.template.metadata.labels.update(template_labels)  # type: ignore
-        # Use the first label key and first value as the anti-affinity label to use:
-        label, *_ = template_labels.items()
-        spec.template.spec.affinity = new_pod_anti_affinity(label=label, namespaces=anti_affinity_namespaces)
+        if affinity is None:
+            # Use the first label key and first value as the anti-affinity label to use:
+            label, *_ = template_labels.items()
+            spec.template.spec.affinity = new_pod_anti_affinity(label=label, namespaces=anti_affinity_namespaces)
 
     return fedora_vm(namespace=namespace_name, name=name, client=client, spec=spec)

--- a/tests/network/user_defined_network/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/user_defined_network/rhel9_rhel10_cluster/conftest.py
@@ -1,0 +1,82 @@
+from collections.abc import Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
+
+from libs.net.ip import filter_link_local_addresses
+from libs.net.traffic_generator import TcpServer, VMTcpClient, client_server_active_connection
+from libs.net.udn import UDN_BINDING_DEFAULT_PLUGIN_NAME
+from libs.net.vmspec import lookup_iface_status
+from libs.vm.affinity import new_node_affinity
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from tests.network.libs.vm_factory import udn_vm
+
+_UDN_PRIMARY_IFACE_NAME = "udn-primary"
+
+
+@pytest.fixture(scope="class")
+def udn_server_vm(
+    admin_client: DynamicClient,
+    udn_namespace: Namespace,
+    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
+) -> Generator[BaseVirtualMachine]:
+    with udn_vm(
+        namespace_name=udn_namespace.name,
+        name="server-vm",
+        client=admin_client,
+        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
+        affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        lookup_iface_status(
+            vm=vm,
+            iface_name=_UDN_PRIMARY_IFACE_NAME,
+            predicate=lambda iface: (
+                "guest-agent" in iface["infoSource"]
+                and bool(filter_link_local_addresses(ip_addresses=iface.get("ipAddresses", [])))
+            ),
+        )
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def udn_client_vm(
+    admin_client: DynamicClient,
+    udn_namespace: Namespace,
+    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
+) -> Generator[BaseVirtualMachine]:
+    with udn_vm(
+        namespace_name=udn_namespace.name,
+        name="client-vm",
+        client=admin_client,
+        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
+        affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        lookup_iface_status(
+            vm=vm,
+            iface_name=_UDN_PRIMARY_IFACE_NAME,
+            predicate=lambda iface: (
+                "guest-agent" in iface["infoSource"]
+                and bool(filter_link_local_addresses(ip_addresses=iface.get("ipAddresses", [])))
+            ),
+        )
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def udn_active_tcp_connection(
+    udn_client_vm: BaseVirtualMachine,
+    udn_server_vm: BaseVirtualMachine,
+) -> Generator[tuple[VMTcpClient, TcpServer]]:
+    with client_server_active_connection(
+        client_vm=udn_client_vm,
+        server_vm=udn_server_vm,
+        spec_logical_network=_UDN_PRIMARY_IFACE_NAME,
+    ) as connection:
+        yield connection

--- a/tests/network/user_defined_network/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/user_defined_network/rhel9_rhel10_cluster/test_connectivity.py
@@ -10,9 +10,14 @@ Markers:
 
 import pytest
 
-__test__ = False
+from libs.net.traffic_generator import is_tcp_connection
+from libs.vm.affinity import new_node_affinity
+from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from utilities.virt import migrate_vm_and_verify
 
 
+@pytest.mark.mixed_os_nodes
+@pytest.mark.ipv4
 @pytest.mark.incremental
 class TestConnectivity:
     """
@@ -23,7 +28,12 @@ class TestConnectivity:
     """
 
     @pytest.mark.polarion("CNV-15952")
-    def test_connectivity_preserved_during_server_migration_to_rhcos10(self):
+    def test_connectivity_preserved_during_server_migration_to_rhcos10(
+        self,
+        admin_client,
+        udn_server_vm,
+        udn_active_tcp_connection,
+    ):
         """
         Test that an active TCP connection over a primary UDN
         is preserved when the server VM migrates from an RHCOS 9 node to an RHCOS 10 node.
@@ -39,9 +49,20 @@ class TestConnectivity:
         Expected:
             - The active TCP connection from the client VM to the server VM is preserved during the migration
         """
+        udn_server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=False))
+        migrate_vm_and_verify(vm=udn_server_vm, client=admin_client)
+        client, server = udn_active_tcp_connection
+        assert is_tcp_connection(server=server, client=client), (
+            f"TCP connection lost after migrating {udn_server_vm.name} to RHCOS 10 node"
+        )
 
     @pytest.mark.polarion("CNV-15965")
-    def test_connectivity_preserved_during_server_migration_to_rhcos9(self):
+    def test_connectivity_preserved_during_server_migration_to_rhcos9(
+        self,
+        admin_client,
+        udn_server_vm,
+        udn_active_tcp_connection,
+    ):
         """
         Test that an active TCP connection over a primary UDN
         is preserved when the server VM migrates from an RHCOS 10 node to an RHCOS 9 node.
@@ -57,3 +78,9 @@ class TestConnectivity:
         Expected:
             - The active TCP connection from the client VM to the server VM is preserved during the migration
         """
+        udn_server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True))
+        migrate_vm_and_verify(vm=udn_server_vm, client=admin_client)
+        client, server = udn_active_tcp_connection
+        assert is_tcp_connection(server=server, client=client), (
+            f"TCP connection lost after migrating {udn_server_vm.name} back to RHCOS 9 node"
+        )


### PR DESCRIPTION
##### Short description:
New dual-stream tests: UDN scenarios
This PR adds two tests that verify TCP connection survives migration in both directions (RHCOS 9 -> RHCOS 10 and back). VMs are scheduled using node affinity on the RHCOS 9 worker label rather than hostnames, so the tests are resilient to node replacement.

##### More details:
STD: https://github.com/RedHatQE/openshift-virtualization-tests/pull/4569

##### What this PR does / why we need it:
Added automation for new dual-stream tests


##### Which issue(s) this PR fixes: -

##### Special notes for reviewer:
Follow-up implementation of new tests of primary UDN which is supported in tests only for IPv4.
Due to low availability of dual-stream BMs, the test implemented with IPv4 only. IPv6 will be added in a follow-up.

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-86194
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional VM affinity parameter to allow more control over VM scheduling behavior.
* **Tests**
  * Introduced class-scoped fixtures to provision and coordinate UDN server/client virtual machines and collect active TCP connections.
  * Updated connectivity tests to use shared fixtures and verify TCP connectivity remains intact during live migration between RHCOS 9 and RHCOS 10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->