### PR TITLE
infra: align tests to fit multiarch needs 

### DIFF
--- a/tests/global_config_multiarch.py
+++ b/tests/global_config_multiarch.py
@@ -58,6 +58,7 @@ os_matrix = {
         "centos_os_list": ["centos-stream-9"],
         "instance_type_rhel_os_list": [RHEL10_PREFERENCE],
         "instance_type_fedora_os_list": [OS_FLAVOR_FEDORA],
+        "instance_type_centos_os_list": [CENTOS_STREAM10_PREFERENCE],
     },
 }
 

--- a/tests/infrastructure/instance_types/supported_os/conftest.py
+++ b/tests/infrastructure/instance_types/supported_os/conftest.py
@@ -131,7 +131,9 @@ def golden_image_windows_vm(
         vm_instance_type=VirtualMachineClusterInstancetype(client=unprivileged_client, name="u1.large"),
         vm_preference=VirtualMachineClusterPreference(
             client=unprivileged_client,
-            name=windows_os_matrix__module__[os_name][DATA_SOURCE_STR].replace("win", "windows."),
+            name=windows_os_matrix__module__[os_name][DATA_SOURCE_STR]
+            .removesuffix(f"-{py_config.get('cpu_arch', '')}")
+            .replace("win", "windows."),
         ),
         data_volume_template=windows_data_volume_template.res,
         os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -258,7 +258,7 @@ def generate_linux_instance_type_os_matrix(
     os_name: str,
     preferences: list[str],
     arch_suffix: str | None = None,
-    arch_in_preference: bool = True,
+    add_arch_suffix: bool = True,
 ) -> list[dict[str, dict[str, Any]]]:
     """
     Generate a list of dictionaries representing the instance type matrix for a Linux OS type.
@@ -268,8 +268,9 @@ def generate_linux_instance_type_os_matrix(
         os_name (str): The name of the OS.
         preferences (list[str]): A list of preferences for the instance types. Preference format is "<os>.<version>".
         arch_suffix: Optional architecture suffix. Example: "s390x", "arm64" . Omit to keep original preference.
-        arch_in_preference: Set to False for OSes whose ClusterPreferences have no arch suffix
-            (e.g. centos — "centos.stream10" exists, "centos.stream10.arm64" does not).
+        add_arch_suffix: When True, append arch_suffix to the preference name. Set to False for OSes whose
+            ClusterPreferences have no arch suffix (e.g. centos — "centos.stream10" exists,
+            "centos.stream10.arm64" does not).
 
     Returns:
         list[dict[str, dict[str, Any]]]: A list of dictionaries representing the instance type matrix.
@@ -290,7 +291,7 @@ def generate_linux_instance_type_os_matrix(
     instance_types: list[dict[str, dict[str, Any]]] = []
 
     for preference in preferences:
-        arch_preference = f"{preference}.{arch_suffix}" if arch_suffix and arch_in_preference else preference
+        arch_preference = f"{preference}.{arch_suffix}" if arch_suffix and add_arch_suffix else preference
         data_source_name = _format_data_source_name(preference_name=preference)
         preference_config: dict[str, Any] = {
             PREFERENCE_STR: arch_preference,

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -255,7 +255,10 @@ def generate_os_matrix_dict(
 
 
 def generate_linux_instance_type_os_matrix(
-    os_name: str, preferences: list[str], arch_suffix: str | None = None
+    os_name: str,
+    preferences: list[str],
+    arch_suffix: str | None = None,
+    arch_in_preference: bool = True,
 ) -> list[dict[str, dict[str, Any]]]:
     """
     Generate a list of dictionaries representing the instance type matrix for a Linux OS type.
@@ -265,6 +268,8 @@ def generate_linux_instance_type_os_matrix(
         os_name (str): The name of the OS.
         preferences (list[str]): A list of preferences for the instance types. Preference format is "<os>.<version>".
         arch_suffix: Optional architecture suffix. Example: "s390x", "arm64" . Omit to keep original preference.
+        arch_in_preference: Set to False for OSes whose ClusterPreferences have no arch suffix
+            (e.g. centos — "centos.stream10" exists, "centos.stream10.arm64" does not).
 
     Returns:
         list[dict[str, dict[str, Any]]]: A list of dictionaries representing the instance type matrix.
@@ -285,10 +290,11 @@ def generate_linux_instance_type_os_matrix(
     instance_types: list[dict[str, dict[str, Any]]] = []
 
     for preference in preferences:
-        arch_preference = f"{preference}.{arch_suffix}" if arch_suffix else preference
+        arch_preference = f"{preference}.{arch_suffix}" if arch_suffix and arch_in_preference else preference
+        data_source_name = _format_data_source_name(preference_name=preference)
         preference_config: dict[str, Any] = {
             PREFERENCE_STR: arch_preference,
-            DATA_SOURCE_NAME: _format_data_source_name(preference_name=preference),
+            DATA_SOURCE_NAME: f"{data_source_name}-{arch_suffix}" if arch_suffix else data_source_name,
         }
 
         if preference == latest_os:

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -508,22 +508,31 @@ def generate_instance_type_matrix_dicts(os_dict: dict[str, Any], cpu_arch: str |
             "instance_type_rhel_os_list").
         cpu_arch: Optional architecture suffix.
     """
+    arch_in_preference = cpu_arch != AMD_64
+
     if instance_type_rhel_os_list := os_dict.get("instance_type_rhel_os_list"):
         py_config["instance_type_rhel_os_matrix"] = generate_linux_instance_type_os_matrix(
-            os_name="rhel", preferences=instance_type_rhel_os_list, arch_suffix=cpu_arch
+            os_name="rhel",
+            preferences=instance_type_rhel_os_list,
+            arch_suffix=cpu_arch,
+            arch_in_preference=arch_in_preference,
         )
         py_config["latest_instance_type_rhel_os_dict"] = generate_latest_os_dict(
             os_matrix=py_config["instance_type_rhel_os_matrix"]
         )
     if instance_type_fedora_os_list := os_dict.get("instance_type_fedora_os_list"):
         py_config["instance_type_fedora_os_matrix"] = generate_linux_instance_type_os_matrix(
-            os_name="fedora", preferences=instance_type_fedora_os_list, arch_suffix=cpu_arch
+            os_name="fedora",
+            preferences=instance_type_fedora_os_list,
+            arch_suffix=cpu_arch,
+            arch_in_preference=arch_in_preference,
         )
     if instance_type_centos_os_list := os_dict.get("instance_type_centos_os_list"):
         py_config["instance_type_centos_os_matrix"] = generate_linux_instance_type_os_matrix(
             os_name="centos.stream",
             preferences=instance_type_centos_os_list,
-            arch_suffix=None,
+            arch_suffix=cpu_arch,
+            arch_in_preference=False,
         )
 
 

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -508,14 +508,14 @@ def generate_instance_type_matrix_dicts(os_dict: dict[str, Any], cpu_arch: str |
             "instance_type_rhel_os_list").
         cpu_arch: Optional architecture suffix.
     """
-    arch_in_preference = cpu_arch != AMD_64
+    add_arch_suffix = cpu_arch != AMD_64
 
     if instance_type_rhel_os_list := os_dict.get("instance_type_rhel_os_list"):
         py_config["instance_type_rhel_os_matrix"] = generate_linux_instance_type_os_matrix(
             os_name="rhel",
             preferences=instance_type_rhel_os_list,
             arch_suffix=cpu_arch,
-            arch_in_preference=arch_in_preference,
+            add_arch_suffix=add_arch_suffix,
         )
         py_config["latest_instance_type_rhel_os_dict"] = generate_latest_os_dict(
             os_matrix=py_config["instance_type_rhel_os_matrix"]
@@ -525,14 +525,14 @@ def generate_instance_type_matrix_dicts(os_dict: dict[str, Any], cpu_arch: str |
             os_name="fedora",
             preferences=instance_type_fedora_os_list,
             arch_suffix=cpu_arch,
-            arch_in_preference=arch_in_preference,
+            add_arch_suffix=add_arch_suffix,
         )
     if instance_type_centos_os_list := os_dict.get("instance_type_centos_os_list"):
         py_config["instance_type_centos_os_matrix"] = generate_linux_instance_type_os_matrix(
             os_name="centos.stream",
             preferences=instance_type_centos_os_list,
             arch_suffix=cpu_arch,
-            arch_in_preference=False,
+            add_arch_suffix=False,
         )
 
 

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from utilities.constants import ARM_64, CENTOS_STREAM10_PREFERENCE, RHEL10_PREFERENCE
 from utilities.exceptions import OsDictNotFoundError
 from utilities.os_utils import (
     CENTOS_OS_MAPPING,
@@ -331,6 +332,42 @@ class TestGenerateInstanceTypeRhelOsMatrix:
         # RHEL-9 should be latest
         rhel9_item = next(item for item in result if "rhel-9" in item)
         assert rhel9_item["rhel-9"]["latest_released"] is True
+
+    def test_arch_suffix_applied_to_preference_and_data_source(self):
+        """arch_suffix is appended to both the preference name and the DataSource."""
+        result = generate_linux_instance_type_os_matrix(
+            os_name="rhel",
+            preferences=[RHEL10_PREFERENCE],
+            arch_suffix=ARM_64,
+        )
+
+        config = result[0][f"{RHEL10_PREFERENCE}.{ARM_64}"]
+        assert config["preference"] == f"{RHEL10_PREFERENCE}.{ARM_64}"
+        assert config["DATA_SOURCE_NAME"] == f"rhel10-{ARM_64}"
+
+    def test_arch_suffix_omitted_from_preference_when_arch_in_preference_false(self):
+        """arch_in_preference=False keeps the preference plain while the DataSource still gets the arch suffix."""
+        result = generate_linux_instance_type_os_matrix(
+            os_name="centos.stream",
+            preferences=[CENTOS_STREAM10_PREFERENCE],
+            arch_suffix=ARM_64,
+            arch_in_preference=False,
+        )
+
+        config = result[0][CENTOS_STREAM10_PREFERENCE]
+        assert config["preference"] == CENTOS_STREAM10_PREFERENCE, "preference must not include arch suffix"
+        assert config["DATA_SOURCE_NAME"] == f"centos-stream10-{ARM_64}", "DataSource must include arch suffix"
+
+    def test_arch_in_preference_false_no_arch_suffix(self):
+        """arch_in_preference=False with no arch_suffix is a no-op."""
+        result_default = generate_linux_instance_type_os_matrix(
+            os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE]
+        )
+        result_no_arch = generate_linux_instance_type_os_matrix(
+            os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE], arch_in_preference=False
+        )
+
+        assert result_default == result_no_arch
 
 
 class TestOsMappingsConstants:

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -345,26 +345,26 @@ class TestGenerateInstanceTypeRhelOsMatrix:
         assert config["preference"] == f"{RHEL10_PREFERENCE}.{ARM_64}"
         assert config["DATA_SOURCE_NAME"] == f"rhel10-{ARM_64}"
 
-    def test_arch_suffix_omitted_from_preference_when_arch_in_preference_false(self):
-        """arch_in_preference=False keeps the preference plain while the DataSource still gets the arch suffix."""
+    def test_arch_suffix_omitted_from_preference_when_add_arch_suffix_false(self):
+        """add_arch_suffix=False keeps the preference plain while the DataSource still gets the arch suffix."""
         result = generate_linux_instance_type_os_matrix(
             os_name="centos.stream",
             preferences=[CENTOS_STREAM10_PREFERENCE],
             arch_suffix=ARM_64,
-            arch_in_preference=False,
+            add_arch_suffix=False,
         )
 
         config = result[0][CENTOS_STREAM10_PREFERENCE]
         assert config["preference"] == CENTOS_STREAM10_PREFERENCE, "preference must not include arch suffix"
         assert config["DATA_SOURCE_NAME"] == f"centos-stream10-{ARM_64}", "DataSource must include arch suffix"
 
-    def test_arch_in_preference_false_no_arch_suffix(self):
-        """arch_in_preference=False with no arch_suffix is a no-op."""
+    def test_add_arch_suffix_false_no_arch_suffix(self):
+        """add_arch_suffix=False with no arch_suffix is a no-op."""
         result_default = generate_linux_instance_type_os_matrix(
             os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE]
         )
         result_no_arch = generate_linux_instance_type_os_matrix(
-            os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE], arch_in_preference=False
+            os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE], add_arch_suffix=False
         )
 
         assert result_default == result_no_arch

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 import utilities.constants
+from utilities.constants import AMD_64, ARM_64, CENTOS_STREAM9_PREFERENCE, OS_FLAVOR_FEDORA, RHEL9_PREFERENCE, S390X
 from utilities.exceptions import MissingEnvironmentVariableError, UnsupportedCPUArchitectureError
 
 # Circular dependencies are already mocked in conftest.py
@@ -1549,127 +1550,136 @@ class TestGenerateInstanceTypeMatrixDicts:
         """Sample instance type OS matrix for testing"""
         return [
             {
-                "rhel.9": {
-                    "preference": "rhel.9",
+                RHEL9_PREFERENCE: {
+                    "preference": RHEL9_PREFERENCE,
                     "latest_released": True,
                 }
             }
         ]
 
+    @pytest.mark.parametrize(
+        ("cpu_arch", "expected_arch_in_preference"),
+        [
+            (None, True),
+            (ARM_64, True),
+            (S390X, True),
+            (AMD_64, False),
+        ],
+        ids=["no_arch", "arm64", "s390x", "amd64"],
+    )
     @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
     @patch("utilities.pytest_utils.generate_latest_os_dict")
     @patch("utilities.pytest_utils.py_config", new_callable=dict)
-    def test_generate_instance_type_rhel_matrix_no_arch(
+    def test_generate_instance_type_rhel_matrix(
         self,
         mock_py_config,
         mock_generate_latest,
         mock_generate_instance_type,
         sample_instance_type_matrix,
+        cpu_arch,
+        expected_arch_in_preference,
     ):
-        """Test generating instance type RHEL matrix without cpu_arch parameter"""
+        """Test RHEL matrix generation across architecture variants."""
         mock_generate_instance_type.return_value = sample_instance_type_matrix
-        mock_generate_latest.return_value = sample_instance_type_matrix[0]["rhel.9"]
+        mock_generate_latest.return_value = sample_instance_type_matrix[0][RHEL9_PREFERENCE]
 
-        os_dict = {"instance_type_rhel_os_list": ["rhel.9"]}
-        generate_instance_type_matrix_dicts(os_dict=os_dict)
-
-        mock_generate_instance_type.assert_called_once_with(os_name="rhel", preferences=["rhel.9"], arch_suffix=None)
-        assert mock_py_config["instance_type_rhel_os_matrix"] == sample_instance_type_matrix
-
-    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
-    @patch("utilities.pytest_utils.generate_latest_os_dict")
-    @patch("utilities.pytest_utils.py_config", new_callable=dict)
-    def test_generate_instance_type_rhel_matrix_with_arch(
-        self,
-        mock_py_config,
-        mock_generate_latest,
-        mock_generate_instance_type,
-        sample_instance_type_matrix,
-    ):
-        """Test generating instance type RHEL matrix with cpu_arch parameter"""
-        mock_generate_instance_type.return_value = sample_instance_type_matrix
-        mock_generate_latest.return_value = sample_instance_type_matrix[0]["rhel.9"]
-
-        os_dict = {"instance_type_rhel_os_list": ["rhel.9"]}
-        generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch="arm64")
-
-        mock_generate_instance_type.assert_called_once_with(os_name="rhel", preferences=["rhel.9"], arch_suffix="arm64")
-        assert mock_py_config["latest_instance_type_rhel_os_dict"] is not None
-
-    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
-    @patch("utilities.pytest_utils.py_config", new_callable=dict)
-    def test_generate_instance_type_fedora_matrix(
-        self,
-        mock_py_config,
-        mock_generate_instance_type,
-    ):
-        """Test generating instance type Fedora matrix"""
-        sample_fedora_instance_type = [{"fedora": {"preference": "fedora"}}]
-        mock_generate_instance_type.return_value = sample_fedora_instance_type
-
-        os_dict = {"instance_type_fedora_os_list": ["fedora"]}
-        generate_instance_type_matrix_dicts(os_dict=os_dict)
-
-        mock_generate_instance_type.assert_called_once_with(os_name="fedora", preferences=["fedora"], arch_suffix=None)
-        assert mock_py_config["instance_type_fedora_os_matrix"] == sample_fedora_instance_type
-
-    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
-    @patch("utilities.pytest_utils.py_config", new_callable=dict)
-    def test_generate_instance_type_centos_matrix(
-        self,
-        mock_py_config,
-        mock_generate_instance_type,
-    ):
-        """Test generating instance type CentOS matrix"""
-        sample_centos_instance_type = [{"centos.stream9": {"preference": "centos.stream9"}}]
-        mock_generate_instance_type.return_value = sample_centos_instance_type
-
-        os_dict = {"instance_type_centos_os_list": ["centos.stream9"]}
-        generate_instance_type_matrix_dicts(os_dict=os_dict)
+        os_dict = {"instance_type_rhel_os_list": [RHEL9_PREFERENCE]}
+        generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch=cpu_arch)
 
         mock_generate_instance_type.assert_called_once_with(
-            os_name="centos.stream", preferences=["centos.stream9"], arch_suffix=None
+            os_name="rhel",
+            preferences=[RHEL9_PREFERENCE],
+            arch_suffix=cpu_arch,
+            arch_in_preference=expected_arch_in_preference,
         )
-        assert mock_py_config["instance_type_centos_os_matrix"] == sample_centos_instance_type
-
-    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
-    @patch("utilities.pytest_utils.py_config", new_callable=dict)
-    def test_generate_instance_type_centos_matrix_with_s390x_uses_none(
-        self,
-        mock_py_config,
-        mock_generate_instance_type,
-    ):
-        """Test CentOS instance type with s390x cpu_arch passes None as arch_suffix"""
-        sample_centos_instance_type = [{"centos.stream9": {"preference": "centos.stream9"}}]
-        mock_generate_instance_type.return_value = sample_centos_instance_type
-
-        os_dict = {"instance_type_centos_os_list": ["centos.stream9"]}
-        generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch="s390x")
-
-        mock_generate_instance_type.assert_called_once_with(
-            os_name="centos.stream", preferences=["centos.stream9"], arch_suffix=None
-        )
-        assert mock_py_config["instance_type_centos_os_matrix"] == sample_centos_instance_type
-
-    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
-    @patch("utilities.pytest_utils.generate_latest_os_dict")
-    @patch("utilities.pytest_utils.py_config", new_callable=dict)
-    def test_generate_instance_type_rhel_matrix_with_s390x(
-        self,
-        mock_py_config,
-        mock_generate_latest,
-        mock_generate_instance_type,
-        sample_instance_type_matrix,
-    ):
-        """Test generating instance type RHEL matrix with s390x cpu_arch parameter"""
-        mock_generate_instance_type.return_value = sample_instance_type_matrix
-        mock_generate_latest.return_value = sample_instance_type_matrix[0]["rhel.9"]
-
-        os_dict = {"instance_type_rhel_os_list": ["rhel.9"]}
-        generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch="s390x")
-
-        mock_generate_instance_type.assert_called_once_with(os_name="rhel", preferences=["rhel.9"], arch_suffix="s390x")
         assert mock_py_config["instance_type_rhel_os_matrix"] == sample_instance_type_matrix
+        assert mock_py_config["latest_instance_type_rhel_os_dict"] == sample_instance_type_matrix[0][RHEL9_PREFERENCE]
+
+    @pytest.mark.parametrize(
+        ("os_dict", "cpu_arch", "expected_call", "config_key", "matrix_value"),
+        [
+            (
+                {"instance_type_fedora_os_list": [OS_FLAVOR_FEDORA]},
+                None,
+                {
+                    "os_name": OS_FLAVOR_FEDORA,
+                    "preferences": [OS_FLAVOR_FEDORA],
+                    "arch_suffix": None,
+                    "arch_in_preference": True,
+                },
+                "instance_type_fedora_os_matrix",
+                [{OS_FLAVOR_FEDORA: {"preference": OS_FLAVOR_FEDORA}}],
+            ),
+            (
+                {"instance_type_fedora_os_list": [OS_FLAVOR_FEDORA]},
+                AMD_64,
+                {
+                    "os_name": OS_FLAVOR_FEDORA,
+                    "preferences": [OS_FLAVOR_FEDORA],
+                    "arch_suffix": AMD_64,
+                    "arch_in_preference": False,
+                },
+                "instance_type_fedora_os_matrix",
+                [{OS_FLAVOR_FEDORA: {"preference": OS_FLAVOR_FEDORA}}],
+            ),
+            (
+                {"instance_type_centos_os_list": [CENTOS_STREAM9_PREFERENCE]},
+                None,
+                {
+                    "os_name": "centos.stream",
+                    "preferences": [CENTOS_STREAM9_PREFERENCE],
+                    "arch_suffix": None,
+                    "arch_in_preference": False,
+                },
+                "instance_type_centos_os_matrix",
+                [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
+            ),
+            (
+                {"instance_type_centos_os_list": [CENTOS_STREAM9_PREFERENCE]},
+                S390X,
+                {
+                    "os_name": "centos.stream",
+                    "preferences": [CENTOS_STREAM9_PREFERENCE],
+                    "arch_suffix": S390X,
+                    "arch_in_preference": False,
+                },
+                "instance_type_centos_os_matrix",
+                [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
+            ),
+            (
+                {"instance_type_centos_os_list": [CENTOS_STREAM9_PREFERENCE]},
+                ARM_64,
+                {
+                    "os_name": "centos.stream",
+                    "preferences": [CENTOS_STREAM9_PREFERENCE],
+                    "arch_suffix": ARM_64,
+                    "arch_in_preference": False,
+                },
+                "instance_type_centos_os_matrix",
+                [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
+            ),
+        ],
+        ids=["fedora_default", "fedora_amd64", "centos_default", "centos_s390x", "centos_arm64"],
+    )
+    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
+    @patch("utilities.pytest_utils.py_config", new_callable=dict)
+    def test_generate_instance_type_non_rhel_matrix(
+        self,
+        mock_py_config,
+        mock_generate_instance_type,
+        os_dict,
+        cpu_arch,
+        expected_call,
+        config_key,
+        matrix_value,
+    ):
+        """Test Fedora and CentOS matrix generation call signatures."""
+        mock_generate_instance_type.return_value = matrix_value
+
+        generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch=cpu_arch)
+
+        mock_generate_instance_type.assert_called_once_with(**expected_call)
+        assert mock_py_config[config_key] == matrix_value
 
     @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
     @patch("utilities.pytest_utils.generate_latest_os_dict")
@@ -1683,10 +1693,10 @@ class TestGenerateInstanceTypeMatrixDicts:
     ):
         """Test that latest_instance_type_rhel_os_dict is populated correctly"""
         mock_generate_instance_type.return_value = sample_instance_type_matrix
-        expected_latest = {"preference": "rhel.9", "latest_released": True}
+        expected_latest = {"preference": RHEL9_PREFERENCE, "latest_released": True}
         mock_generate_latest.return_value = expected_latest
 
-        os_dict = {"instance_type_rhel_os_list": ["rhel.9"]}
+        os_dict = {"instance_type_rhel_os_list": [RHEL9_PREFERENCE]}
         generate_instance_type_matrix_dicts(os_dict=os_dict)
 
         assert mock_py_config["latest_instance_type_rhel_os_dict"] == expected_latest
@@ -1704,24 +1714,6 @@ class TestGenerateInstanceTypeMatrixDicts:
 
         mock_generate_instance_type.assert_not_called()
         assert mock_py_config == {}
-
-    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
-    @patch("utilities.pytest_utils.py_config", new_callable=dict)
-    def test_generate_instance_type_centos_matrix_with_non_s390x_arch(
-        self,
-        mock_py_config,
-        mock_generate_instance_type,
-    ):
-        """Test CentOS instance type with non-s390x cpu_arch passes arch_suffix"""
-        sample_centos_instance_type = [{"centos.stream9": {"preference": "centos.stream9"}}]
-        mock_generate_instance_type.return_value = sample_centos_instance_type
-
-        os_dict = {"instance_type_centos_os_list": ["centos.stream9"]}
-        generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch="arm64")
-
-        mock_generate_instance_type.assert_called_once_with(
-            os_name="centos.stream", preferences=["centos.stream9"], arch_suffix=None
-        )
 
 
 class TestUpdateLatestOsConfig:

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -1558,7 +1558,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         ]
 
     @pytest.mark.parametrize(
-        ("cpu_arch", "expected_arch_in_preference"),
+        ("cpu_arch", "expected_add_arch_suffix"),
         [
             (None, True),
             (ARM_64, True),
@@ -1577,7 +1577,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         mock_generate_instance_type,
         sample_instance_type_matrix,
         cpu_arch,
-        expected_arch_in_preference,
+        expected_add_arch_suffix,
     ):
         """Test RHEL matrix generation across architecture variants."""
         mock_generate_instance_type.return_value = sample_instance_type_matrix
@@ -1590,7 +1590,7 @@ class TestGenerateInstanceTypeMatrixDicts:
             os_name="rhel",
             preferences=[RHEL9_PREFERENCE],
             arch_suffix=cpu_arch,
-            arch_in_preference=expected_arch_in_preference,
+            add_arch_suffix=expected_add_arch_suffix,
         )
         assert mock_py_config["instance_type_rhel_os_matrix"] == sample_instance_type_matrix
         assert mock_py_config["latest_instance_type_rhel_os_dict"] == sample_instance_type_matrix[0][RHEL9_PREFERENCE]
@@ -1605,7 +1605,7 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": OS_FLAVOR_FEDORA,
                     "preferences": [OS_FLAVOR_FEDORA],
                     "arch_suffix": None,
-                    "arch_in_preference": True,
+                    "add_arch_suffix": True,
                 },
                 "instance_type_fedora_os_matrix",
                 [{OS_FLAVOR_FEDORA: {"preference": OS_FLAVOR_FEDORA}}],
@@ -1617,7 +1617,7 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": OS_FLAVOR_FEDORA,
                     "preferences": [OS_FLAVOR_FEDORA],
                     "arch_suffix": AMD_64,
-                    "arch_in_preference": False,
+                    "add_arch_suffix": False,
                 },
                 "instance_type_fedora_os_matrix",
                 [{OS_FLAVOR_FEDORA: {"preference": OS_FLAVOR_FEDORA}}],
@@ -1629,7 +1629,7 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": "centos.stream",
                     "preferences": [CENTOS_STREAM9_PREFERENCE],
                     "arch_suffix": None,
-                    "arch_in_preference": False,
+                    "add_arch_suffix": False,
                 },
                 "instance_type_centos_os_matrix",
                 [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
@@ -1641,7 +1641,7 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": "centos.stream",
                     "preferences": [CENTOS_STREAM9_PREFERENCE],
                     "arch_suffix": S390X,
-                    "arch_in_preference": False,
+                    "add_arch_suffix": False,
                 },
                 "instance_type_centos_os_matrix",
                 [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
@@ -1653,7 +1653,7 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": "centos.stream",
                     "preferences": [CENTOS_STREAM9_PREFERENCE],
                     "arch_suffix": ARM_64,
-                    "arch_in_preference": False,
+                    "add_arch_suffix": False,
                 },
                 "instance_type_centos_os_matrix",
                 [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2562,8 +2562,8 @@ def wait_for_vmi_relocation_and_running(initial_node, vm, timeout=TIMEOUT_5MIN):
 
 
 def check_qemu_guest_agent_installed(ssh_exec: Host) -> bool:
-    ssh_exec.sudo = True
-    return ssh_exec.package_manager.exist(package="qemu-guest-agent")
+    rc, _, _ = ssh_exec.executor().run_cmd(cmd=shlex.split("rpm -q qemu-guest-agent"))
+    return rc == 0
 
 
 def validate_libvirt_persistent_domain(vm, admin_client):


### PR DESCRIPTION
Update multiarch matrix generation so preference and DataSource names match architecture-specific cluster naming for RHEL, Fedora, and CentOS.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
rrmngmnt's package manager auto-detection uses which to find the package manager binary which is not available in centos-stream10 and hence some of tests didn't work. https://github.com/RedHatQE/openshift-virtualization-tests/commit/8e0f430c65705bc8ec94e92a82448c2d80c2af19 is to fix it.
##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-64577


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for ARM_64 architecture with CentOS Stream 10 preference configuration
  * Enhanced architecture preference handling to provide more flexible configuration options

* **Bug Fixes**
  * Improved QEMU guest agent presence detection methodology

* **Tests**
  * Expanded test coverage for instance-type OS matrix generation with parametrized test cases
  * Added validation for architecture-specific configurations and preference handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->