### PR TITLE
Storage Tier2: fix s390x test markers for gating tests

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -100,6 +100,7 @@ def test_successful_clone_of_large_image(
 @pytest.mark.polarion("CNV-2148")
 @pytest.mark.gating()
 @pytest.mark.post_upgrade()
+@pytest.mark.s390x
 def test_successful_vm_restart_with_cloned_dv(
     unprivileged_client,
     namespace,
@@ -211,6 +212,7 @@ def test_successful_vm_from_cloned_dv_windows(
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_successful_snapshot_clone(
     unprivileged_client,
     data_volume_snapshot_capable_storage_scope_function,

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -101,6 +101,7 @@ def test_empty_url(namespace, storage_class_name_scope_module, unprivileged_clie
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_successful_import_image(
     dv_from_http_import,
     storage_class_name_scope_module,
@@ -158,6 +159,7 @@ def test_successful_import_secure_archive(
 )
 @pytest.mark.sno
 @pytest.mark.gating
+@pytest.mark.s390x
 def test_successful_import_secure_image(internal_http_configmap, dv_from_http_import):
     dv_from_http_import.wait_for_dv_success()
 

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -38,6 +38,7 @@ pytestmark = pytest.mark.usefixtures("xfail_if_gcp_storage_class")
     ],
     indirect=True,
 )
+@pytest.mark.s390x
 def test_sequential_disk_expand(
     rhel_dv_for_online_resize,
     rhel_vm_for_online_resize,


### PR DESCRIPTION
##### Short description:
These changes add the `@pytest.mark.s390x` marker to five storage gating tests that are compatible with the s390x architecture. No test logic, parameters, or control flow were modified.

##### More details:
The following five tests were marked for s390x
- test_successful_vm_restart_with_cloned_dv
- test_successful_snapshot_clone
- test_successful_import_image
- test_successful_import_secure_image
- test_sequential_disk_expand


##### What this PR does / why we need it:
This PR aligns s390x storage gating with actual platform support by marking compatible tests and excluding one known unsupported case.

##### Which issue(s) this PR fixes:
None

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
None


Signed-off-by: Alexander Mamani <alexander.mamani@ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Restricted clone-related storage tests to run only on s390x architecture.
  * Restricted import-related storage tests (HTTP import) to run only on s390x architecture.
  * Restricted online-resize storage tests to run only on s390x architecture.
  * No test logic, assertions, or runtime behavior were changed; updates only limit which architecture executes the listed tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->