### PR TITLE
github, pr-template: Drop two redundant sections

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -23,9 +23,6 @@ reviews:
         - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
         - `##### Special notes for reviewer:` — must be present (may be empty)
         - `##### jira-ticket:` — must be present (may be empty)
-        Optional sections (may be omitted without issue):
-        - `##### Short description:`
-        - `##### More details:`
         If any required section is absent, or `What this PR does / why we need it:` has no content,
         flag it as HIGH severity and ask the author to restore the missing template section(s).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
-##### Short description:
-
-##### More details:
-
 ##### What this PR does / why we need it:
 
 ##### Which issue(s) this PR fixes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,6 @@ This is a test suite - internal APIs have NO backward compatibility requirements
   - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
   - `##### Special notes for reviewer:` — must be present (may be empty)
   - `##### jira-ticket:` — must be present (may be empty)
-  - `##### Short description:` and `##### More details:` are optional and may be omitted
 
 ## Essential Commands
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Simplifies the PR description template by removing the redundant `Short description` and `More details` sections. The same information can be provided under the existing `What this PR does / why we need it` section. Also updates `AGENTS.md` to drop the now-stale reference to these removed sections.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: