### PR TITLE
Revert "[Storage] Use correct fedora img arch in multi-arch testing"

### DIFF
--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -23,7 +23,6 @@ from utilities.constants import (
     OS_FLAVOR_FEDORA,
     REGISTRY_STR,
     TIMEOUT_1MIN,
-    ArchImages,
     Images,
 )
 from utilities.infra import NON_EXIST_URL
@@ -154,7 +153,7 @@ def created_vm_list(unprivileged_client, created_blank_dv_list, storage_class_na
                 namespace=dv.namespace,
                 os_flavor=OS_FLAVOR_FEDORA,
                 data_volume=dv,
-                image=getattr(ArchImages, py_config["cpu_arch"].upper()).Fedora.FEDORA_CONTAINER_IMAGE,
+                image=Images.Fedora.FEDORA_CONTAINER_IMAGE,
                 memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
             )
             vm.deploy(wait=True)

--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -1,6 +1,4 @@
-from pytest_testconfig import py_config
-
-from utilities.constants import ArchImages, Images, StorageClassNames
+from utilities.constants import Images, StorageClassNames
 from utilities.storage import HppCsiStorageClass
 
 CIRROS_QCOW2_IMG = f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}"
@@ -20,9 +18,7 @@ HTTPS_CONFIG_MAP_NAME = "https-cert"
 HTTP = "http"
 HTTPS = "https"
 
-QUAY_FEDORA_CONTAINER_IMAGE = (
-    f"docker://{getattr(ArchImages, py_config['cpu_arch'].upper()).Fedora.FEDORA_CONTAINER_IMAGE}"
-)
+QUAY_FEDORA_CONTAINER_IMAGE = f"docker://{Images.Fedora.FEDORA_CONTAINER_IMAGE}"
 
 TEST_FILE_NAME = "test-file.txt"
 TEST_FILE_CONTENT = "test-content"


### PR DESCRIPTION
Reverts RedHatQE/openshift-virtualization-tests#4699
the code fails on:
```
 tests/storage/constants.py:24: in <module>
    f"docker://{getattr(ArchImages, py_config['cpu_arch'].upper()).Fedora.FEDORA_CONTAINER_IMAGE}"
E   KeyError: 'cpu_arch'

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified test infrastructure by standardizing container image selection for virtual machine tests. Removed architecture-dependent image selection logic in favor of a consistent fixed image reference across test configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4797)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->