### PR TITLE
Add tox --collect-only for all folders under tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,17 @@ deps=
     uv
 commands =
     uv run pytest --tc-file=tests/global_config.py --collect-only
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/after_cluster_deploy_sanity
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/chaos
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/data_protection
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/deprecated_api
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/infrastructure
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/install_upgrade_operators
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/network
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/observability
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/scale
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/storage
+    uv run pytest --tc-file=tests/global_config.py --collect-only tests/virt
     uv run pytest --tc-file=tests/global_config.py --upgrade=cnv --cnv-image=NA --cnv-version=NA --collect-only
     uv run pytest --tc-file=tests/global_config.py --upgrade=ocp --ocp-image=NA --collect-only
     uv run pytest --tc-file=tests/global_config.py --upgrade=eus --eus-ocp-images=NA,NA --collect-only

--- a/tox.ini
+++ b/tox.ini
@@ -16,19 +16,10 @@ setenv =
     OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH = amd64
 deps=
     uv
+allowlist_externals =
+    sh
 commands =
     uv run pytest --tc-file=tests/global_config.py --collect-only
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/after_cluster_deploy_sanity
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/chaos
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/data_protection
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/deprecated_api
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/infrastructure
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/install_upgrade_operators
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/network
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/observability
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/scale
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/storage
-    uv run pytest --tc-file=tests/global_config.py --collect-only tests/virt
     uv run pytest --tc-file=tests/global_config.py --upgrade=cnv --cnv-image=NA --cnv-version=NA --collect-only
     uv run pytest --tc-file=tests/global_config.py --upgrade=ocp --ocp-image=NA --collect-only
     uv run pytest --tc-file=tests/global_config.py --upgrade=eus --eus-ocp-images=NA,NA --collect-only
@@ -37,6 +28,8 @@ commands =
     uv run pytest --tc-file=tests/global_config_rh_it.py --collect-only
     uv run pytest --tc-file=tests/global_config.py -m smoke --collect-only
     uv run pytest --tc-file=tests/global_config.py --tc-format=python --setup-plan
+    # Run pytest on each subdirectory in tests directory
+    sh -c 'find tests -mindepth 1 -maxdepth 1 -type d | sort | while read d; do uv run pytest --tc-file=tests/global_config.py --collect-only "$d" || exit 1; done'
 
 [testenv:pytest-check-arm64]
 basepython = python3.14


### PR DESCRIPTION
##### Short description:
Add dynamic tox collect-only discovery for all immediate `tests/*` subdirectories.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

Assisted-by: Claude <noreply@anthropic.com>

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled shell execution in the test environment to support iterative test collection steps.
  * Expanded test collection to iterate through immediate test subdirectories, running collection per module to improve validation coverage and surface collection failures early.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4801)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->