### PR TITLE
[IUO] Skip HCO metrics tests when CNV-87184 is open

### DIFF
--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -41,12 +41,16 @@ def workers_rhcos_version(schedulable_nodes):
 
 
 @pytest.fixture(scope="session")
-def is_postcopy_migration_bug_open(workers_rhcos_version) -> bool:  # skip-unused-code
-    """Check if CNV-84023 is open and cluster has RHCOS 10+ nodes.
+def cluster_has_rhcos10_or_above(workers_rhcos_version):
+    return any(Version(ver) >= Version("10") for ver in workers_rhcos_version.values())
 
-    Returns:
-        bool: True if post-copy migration is broken on this cluster.
-    """
-    return any(Version(ver) >= Version("10") for ver in workers_rhcos_version.values()) and is_jira_open(
-        jira_id="CNV-84023"
-    )
+
+@pytest.fixture(scope="session")
+def skip_when_hco_metrics_scraping_bug_open(cluster_has_rhcos10_or_above):
+    if cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-87184"):
+        pytest.xfail(reason="CNV-87184: HCO metrics scraping fails with 401 Unauthorized on RHCOS 10+")
+
+
+@pytest.fixture(scope="session")
+def is_postcopy_migration_bug_open(cluster_has_rhcos10_or_above):
+    return cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-84023")

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -94,6 +94,7 @@ class TestVirtHCOSingleStackIpv6:
     @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11740")
     @pytest.mark.s390x
+    @pytest.mark.usefixtures("skip_when_hco_metrics_scraping_bug_open")
     def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus):
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -59,6 +59,7 @@ class TestMetricsWindows:
 @pytest.mark.polarion("CNV-10438")
 @pytest.mark.s390x
 @pytest.mark.conformance
+@pytest.mark.usefixtures("skip_when_hco_metrics_scraping_bug_open")
 def test_cnv_installation_with_hco_cr_metrics(
     prometheus,
 ):


### PR DESCRIPTION
##### Short description:
HCO metrics scraping fails with 401 Unauthorized on 4.22, causing test_cnv_installation_with_hco_cr_metrics and test_metric_kubevirt_hco_single_stack_ipv6 to timeout.
Signed-off-by: Ohad <orevah@redhat.com>
assisted by: claude code claude-opus-4-6
##### More details:
https://redhat.atlassian.net/browse/CNV-87184
##### What this PR does / why we need it:
Adds conditional xfail for two HCO metrics tests (test_cnv_installation_with_hco_cr_metrics, test_metric_kubevirt_hco_single_stack_ipv6) when CNV-87184 is    
  open and the cluster runs RHCOS 10+. Both Prometheus HCO targets return 401 Unauthorized on RHCOS 10 clusters, making these tests timeout after 240s. Also    
  extracts a shared cluster_has_rhcos10_or_above fixture to eliminate duplicated RHCOS version checks.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a session-scoped RHCOS 10+ cluster check and a session-scoped conditional xfail that marks affected observability tests as expected-to-fail when Jira CNV-87184 is open on RHCOS 10+ clusters.
  * Reused the shared RHCOS 10+ check in existing bug-detection logic (CNV-84023).
  * Applied the conditional xfail to relevant metrics tests to reduce false failures and improve test stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4806)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->