### PR TITLE
fix: move multiprocessing_start_method_fork fixture to shared conftest

### DIFF
--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -406,14 +406,3 @@ def deleted_pod_by_name_prefix(admin_client, cnv_pod_deletion_test_matrix__class
         namespace=pod_deletion_config["namespace_name"],
         pod_prefix=pod_deletion_config["pod_prefix"],
     )
-
-
-@pytest.fixture(scope="module")
-def multiprocessing_start_method_fork():
-    # Use fork context to avoid pickling issues with nested functions
-    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process
-    # https://github.com/python/cpython/issues/132898
-    original_start_method = multiprocessing.get_start_method()
-    multiprocessing.set_start_method("fork", force=True)
-    yield
-    multiprocessing.set_start_method(original_start_method, force=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ Pytest conftest file for CNV tests
 
 import copy
 import logging
+import multiprocessing
 import os
 import os.path
 import re
@@ -225,6 +226,22 @@ RWX_FS_STORAGE_CLASS_NAMES_LIST = [
 
 # Pre-compiled regex for audit log filename parsing: captures date and time components
 AUDIT_LOG_PATTERN = re.compile(r"audit-(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2}\.\d{3})\.log")
+
+
+@pytest.fixture(scope="module")
+def multiprocessing_start_method_fork():
+    """Temporarily set multiprocessing start method to ``fork``.
+
+    Side effects:
+        Changes the process-global multiprocessing start method to ``fork``
+        for the module lifetime, then restores the previous method on teardown.
+    """
+    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process
+    # https://github.com/python/cpython/issues/132898
+    original_start_method = multiprocessing.get_start_method()
+    multiprocessing.set_start_method("fork", force=True)
+    yield
+    multiprocessing.set_start_method(original_start_method, force=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -284,6 +284,7 @@ def _upload_image(dv_name, namespace, storage_class, local_name, client):
 @pytest.mark.sno
 @pytest.mark.s390x
 @pytest.mark.polarion("CNV-2015")
+@pytest.mark.usefixtures("multiprocessing_start_method_fork")
 @pytest.mark.parametrize(
     "upload_file_path",
     [


### PR DESCRIPTION
##### Short description:
Move multiprocessing_start_method_fork fixture to shared conftest for reuse across test directories

##### More details:
Python 3.14 changed the default multiprocessing start method from fork to forkserver, requiring all Process arguments to be picklable. test_successful_concurrent_uploads passes unprivileged_client to child processes, which contains unpicklable thread locks, causing PicklingError.

##### What this PR does / why we need it:
- Moves multiprocessing_start_method_fork fixture from tests/chaos/conftest.py to tests/conftest.py
- Applies it to test_successful_concurrent_uploads via usefixtures
- Existing chaos test consumers are unaffected (fixture resolves from parent conftest)

##### Which issue(s) this PR fixes:
Fixes PicklingError in test_successful_concurrent_uploads on Python 3.14+

##### Special notes for reviewer:
The multiprocessing import in tests/chaos/conftest.py is kept — it is still used by chaos_worker_background_process.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized multiprocessing start-method configuration in the shared test setup.
  * Removed the duplicate fork-mocking fixture from chaos test setup.
  * Updated concurrent upload tests to explicitly use the fork-based start method for more consistent, reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->