### PR TITLE
feat: link design-docs repo for CodeRabbit cross-repo analysis

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -106,6 +106,32 @@ chat:
 knowledge_base:
   opt_out: false
 
+  linked_repositories:
+    # Link to design-docs repo for STP ↔ test traceability
+    - repository: "RedHatQE/openshift-virtualization-tests-design-docs"
+      instructions: |
+        Contains Software Test Plans (STPs) under stps/<sig>/ that define
+        test requirements, scenarios, and acceptance criteria.
+
+        STRICT ENFORCEMENT (applied to STD (Software Test Description)
+        and test implementation PRs):
+        - CRITICAL: Every STD PR MUST cover ALL test scenarios from the
+          referenced STP, except scenarios explicitly excluded with
+          justification and a follow-up Jira link. Any other missing
+          scenario blocks merge.
+        - CRITICAL: Every test MUST link to its STP. The link can be at
+          module, class, or test level docstring — place it at the level
+          that applies. Missing or invalid STP links block merge.
+        - HIGH: STD docstring preconditions, steps, and expected results
+          MUST align with the STP scenario description.
+        - HIGH: If an STP scenario is intentionally excluded, the PR
+          description MUST explain why and include a follow-up Jira link.
+        - HIGH: Every test scenario defined in the STP must have a
+          corresponding STD test implementation.
+        - HIGH: Negative and edge-case scenarios defined in the STP
+          MUST have corresponding tests — do not skip error paths.
+        - Partial coverage without justification blocks merge.
+
   # Enable code guidelines enforcement from AGENTS.md (single source of truth)
   code_guidelines:
     enabled: true


### PR DESCRIPTION
##### What this PR does / why we need it:
Add `linked_repositories` to `.coderabbit.yaml` pointing to
`RedHatQE/openshift-virtualization-tests-design-docs`. This enables
CodeRabbit to cross-reference STPs when reviewing STD and test
implementation PRs.

**Strict enforcement rules:**
- **CRITICAL:** Every STD PR must cover ALL test scenarios from the referenced STP
- **CRITICAL:** Every test must link to its STP (module, class, or test level docstring)
- **HIGH:** STD docstrings must align with STP scenario descriptions
- **HIGH:** Excluded STP scenarios require justification + follow-up Jira
- **HIGH:** Every STP test scenario must have a corresponding STD test
- **HIGH:** Negative/edge-case STP scenarios must have tests

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The design-docs repo should also add a reverse link to this repo for full bidirectional context.

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration to enforce strict STP ↔ test traceability.
  * Requires tests to link to STPs and for STD docstrings (preconditions/steps/expected results) to align with STP scenarios.
  * Mandates full scenario coverage including negative/edge cases; any exclusions require explicit justification and follow-up tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4815)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->