### PR TITLE
ruff: enforce PLC0415 (import-outside-top-level)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ output-format = "grouped"
 exclude = [".git", ".venv", ".mypy_cache", ".tox", "__pycache__"]
 
 [tool.ruff.lint]
+extend-select = ["PLC0415"]
 # TODO: Each ignored rule below should be addressed in a dedicated PR.
 ignore = [
   "SIM102",  # collapsible-if — nested ifs are often more readable

--- a/utilities/architecture.py
+++ b/utilities/architecture.py
@@ -22,7 +22,7 @@ def get_cluster_architecture() -> set[str]:
     """
     # Lazy import to avoid circular dependency
     # TODO: remove when/if utilities modules are refactored
-    from utilities.constants import KUBERNETES_ARCH_LABEL
+    from utilities.constants import KUBERNETES_ARCH_LABEL  # noqa: PLC0415
 
     # Needed for CI
     if arch := os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"):

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -594,7 +594,7 @@ def update_cpu_arch_related_config(cpu_arch_option: str) -> None:
         py_config["cpu_arch"] = arch
 
         # TODO: remove this when utilities modules are refactored
-        import utilities.constants as constants_module
+        import utilities.constants as constants_module  # noqa: PLC0415
 
         # Due to the way the constants module is structured, there's no way to set correctly Images value there
         # This is due to change when constants (and other utilities modules) are refactored

--- a/utilities/unittests/conftest.py
+++ b/utilities/unittests/conftest.py
@@ -55,7 +55,7 @@ utilities.data_collector = mock_data_collector  # type: ignore[attr-defined]
 @pytest.fixture(autouse=True)
 def setup_py_config():
     """Setup py_config for tests that need data_collector configuration"""
-    from pytest_testconfig import config as py_config
+    from pytest_testconfig import config as py_config  # noqa: PLC0415
 
     # Ensure data_collector config is set up
     if "data_collector" not in py_config:
@@ -127,7 +127,7 @@ def mock_vm_no_namespace():
 @pytest.fixture(autouse=True)
 def mock_logger():
     """Auto-mock logger for all tests to prevent logging issues"""
-    import logging
+    import logging  # noqa: PLC0415
 
     # Save original getLogger to avoid recursion
     original_get_logger = logging.getLogger

--- a/utilities/unittests/test_bitwarden.py
+++ b/utilities/unittests/test_bitwarden.py
@@ -204,7 +204,7 @@ class TestGetCnvTestsSecretByName:
     @patch("bitwarden.get_all_cnv_tests_secrets")
     def test_get_cnv_tests_secret_by_name_disabled_bitwarden(self, mock_get_all):
         """Test that --disabled-bitwarden flag returns empty dict without calling Bitwarden"""
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock  # noqa: PLC0415
 
         # Clear cache before test
         get_cnv_tests_secret_by_name.cache_clear()

--- a/utilities/unittests/test_data_collector.py
+++ b/utilities/unittests/test_data_collector.py
@@ -301,7 +301,7 @@ class TestSetDataCollectorDirectory:
         set_data_collector_directory(mock_item, "/output/dir")
 
         mock_prepare_dir.assert_called_once_with(item=mock_item, output_dir="/output/dir")
-        from utilities.data_collector import py_config
+        from utilities.data_collector import py_config  # noqa: PLC0415
 
         assert py_config["data_collector"]["collector_directory"] == "/prepared/dir/path"
 

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -498,7 +498,7 @@ class TestWaitForHcoConditions:
     @patch("utilities.hco.Namespace")
     def test_wait_for_hco_conditions_with_dependent_crs(self, mock_namespace_class, mock_wait_conditions):
         """Test wait_for_hco_conditions with dependent CRs"""
-        from utilities.hco import CDI, KubeVirt
+        from utilities.hco import CDI, KubeVirt  # noqa: PLC0415
 
         mock_admin_client = MagicMock()
         mock_namespace = MagicMock()
@@ -639,7 +639,7 @@ class TestModuleConstants:
 
     def test_default_hco_progressing_conditions(self):
         """Test DEFAULT_HCO_PROGRESSING_CONDITIONS constant"""
-        from utilities.hco import Resource
+        from utilities.hco import Resource  # noqa: PLC0415
 
         assert "Progressing" in DEFAULT_HCO_PROGRESSING_CONDITIONS
         assert DEFAULT_HCO_PROGRESSING_CONDITIONS[Resource.Condition.PROGRESSING] == Resource.Condition.Status.TRUE

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -267,7 +267,7 @@ class TestConfigDefaultStorageClass:
 
         config_default_storage_class(mock_session)
 
-        from utilities.pytest_utils import py_config
+        from utilities.pytest_utils import py_config  # noqa: PLC0415
 
         assert py_config["default_storage_class"] == "new-sc"
         assert py_config["default_volume_mode"] == "Filesystem"
@@ -293,7 +293,7 @@ class TestConfigDefaultStorageClass:
 
         config_default_storage_class(mock_session)
 
-        from utilities.pytest_utils import py_config
+        from utilities.pytest_utils import py_config  # noqa: PLC0415
 
         assert py_config["default_storage_class"] == "first-sc"
         assert py_config["default_volume_mode"] == "Filesystem"
@@ -319,7 +319,7 @@ class TestConfigDefaultStorageClass:
 
         config_default_storage_class(mock_session)
 
-        from utilities.pytest_utils import py_config
+        from utilities.pytest_utils import py_config  # noqa: PLC0415
 
         # Should keep original-sc since it's in the matrix
         assert py_config["default_storage_class"] == "original-sc"
@@ -335,7 +335,7 @@ class TestConfigDefaultStorageClass:
 
         config_default_storage_class(mock_session)
 
-        from utilities.pytest_utils import py_config
+        from utilities.pytest_utils import py_config  # noqa: PLC0415
 
         # Should remain unchanged
         assert py_config["default_storage_class"] == "original-sc"

--- a/utilities/unittests/test_sanity.py
+++ b/utilities/unittests/test_sanity.py
@@ -19,7 +19,7 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_matching_storage_classes(self, mock_logger):
         """Test with matching storage classes - should return True"""
-        from utilities.sanity import storage_sanity_check
+        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1", "sc2", "sc3"]
 
@@ -32,7 +32,7 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_missing_storage_classes(self, mock_logger):
         """Test with missing storage classes - should return False and log error"""
-        from utilities.sanity import storage_sanity_check
+        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1", "sc2"]  # sc3 is missing
 
@@ -48,7 +48,7 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_extra_storage_classes(self, mock_logger):
         """Test with extra storage classes on cluster - should return True (extra classes are allowed)"""
-        from utilities.sanity import storage_sanity_check
+        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         # The function only checks if all expected storage classes exist
         # Extra storage classes on the cluster are allowed
@@ -65,7 +65,7 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_different_order(self, mock_logger):
         """Test with matching storage classes in different order - should return True"""
-        from utilities.sanity import storage_sanity_check
+        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1", "sc2", "sc3"]  # different order from config
 
@@ -78,7 +78,7 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_empty_storage_class_matrix(self, mock_logger):
         """Test with empty storage class matrix - should return True"""
-        from utilities.sanity import storage_sanity_check
+        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = []
 
@@ -91,7 +91,7 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_logging_behavior(self, mock_logger):
         """Test logging behavior for mismatches"""
-        from utilities.sanity import storage_sanity_check
+        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1"]  # sc2 is missing
 
@@ -109,7 +109,7 @@ class TestClusterSanity:
     @patch("utilities.sanity.LOGGER")
     def test_cluster_sanity_skip_cluster_health_check_marker(self, mock_logger):
         """Test skip when '-m cluster_health_check' marker is present"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = "cluster_health_check"
@@ -127,7 +127,7 @@ class TestClusterSanity:
     @patch("utilities.sanity.LOGGER")
     def test_cluster_sanity_skip_check_flag(self, mock_logger):
         """Test skip when --cluster-sanity-skip-check flag is set"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -154,7 +154,7 @@ class TestClusterSanity:
         self, mock_logger, _mock_wait_hco, mock_storage_sanity, _mock_check_vm, _mock_check_webhook
     ):
         """Test skip storage check when --cluster-sanity-skip-storage-check flag is set"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -194,7 +194,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test skip nodes check when --cluster-sanity-skip-nodes-check flag is set"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -236,7 +236,7 @@ class TestClusterSanity:
         mock_check_webhook,
     ):
         """Test successful full sanity check (all checks pass)"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -281,7 +281,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test StorageSanityError raised and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -319,7 +319,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test NodeUnschedulableError caught and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -360,7 +360,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test NodeNotReadyError caught and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -401,7 +401,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test ClusterSanityError caught and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -446,7 +446,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test TimeoutExpiredError during wait_for_pods_running converted to ClusterSanityError"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -492,7 +492,7 @@ class TestClusterSanity:
         mock_check_webhook,
     ):
         """Test all components called in correct order (storage, nodes, webhook, HCO)"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -563,7 +563,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test assert_nodes_in_healthy_condition called with correct parameters"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -602,7 +602,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test assert_nodes_schedulable called"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -642,7 +642,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test wait_for_pods_running called with correct namespace and filter"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -686,7 +686,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test wait_for_hco_conditions called"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -731,7 +731,7 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test junitxml_property passed to exit_pytest_execution"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -762,7 +762,7 @@ class TestClusterSanity:
         self, mock_logger, _mock_wait_hco, mock_storage_sanity, mock_check_vm, mock_check_webhook
     ):
         """Test skip webhook check when --cluster-sanity-skip-webhook-check flag is set"""
-        from utilities.sanity import cluster_sanity
+        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -796,7 +796,7 @@ class TestDiscoverWebhookServices:
         self, _mock_logger, mock_mutating_class, mock_validating_class
     ):
         """Test discovery finds services in the HCO namespace"""
-        from utilities.sanity import _discover_webhook_services
+        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -833,7 +833,7 @@ class TestDiscoverWebhookServices:
         self, _mock_logger, mock_mutating_class, mock_validating_class
     ):
         """Test discovery ignores services in other namespaces"""
-        from utilities.sanity import _discover_webhook_services
+        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -862,7 +862,7 @@ class TestDiscoverWebhookServices:
         self, _mock_logger, mock_mutating_class, mock_validating_class
     ):
         """Test discovery skips URL-based webhooks (no service config)"""
-        from utilities.sanity import _discover_webhook_services
+        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -890,7 +890,7 @@ class TestDiscoverWebhookServices:
     @patch("utilities.sanity.LOGGER")
     def test_discover_webhook_services_empty_webhooks(self, _mock_logger, mock_mutating_class, mock_validating_class):
         """Test discovery handles webhook configs with no webhooks"""
-        from utilities.sanity import _discover_webhook_services
+        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -914,7 +914,7 @@ class TestDiscoverWebhookServices:
     @patch("utilities.sanity.LOGGER")
     def test_discover_webhook_services_deduplicates(self, _mock_logger, mock_mutating_class, mock_validating_class):
         """Test discovery deduplicates services referenced by multiple webhooks"""
-        from utilities.sanity import _discover_webhook_services
+        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -950,7 +950,7 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_all_healthy(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test successful check when all endpoints are healthy"""
-        from utilities.sanity import check_webhook_endpoints_health
+        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api", "cdi-api", "kubevirt-operator-webhook"}
 
@@ -976,7 +976,7 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_missing_endpoint(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when endpoint does not exist"""
-        from utilities.sanity import check_webhook_endpoints_health
+        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
 
@@ -999,7 +999,7 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_no_subsets(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when endpoint has no subsets"""
-        from utilities.sanity import check_webhook_endpoints_health
+        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
 
@@ -1024,7 +1024,7 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_no_addresses(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when endpoint has no ready addresses"""
-        from utilities.sanity import check_webhook_endpoints_health
+        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
 
@@ -1053,7 +1053,7 @@ class TestCheckWebhookEndpointsHealth:
         self, _mock_logger, mock_endpoints_class, mock_discover
     ):
         """Test that warning is logged when no webhooks are discovered"""
-        from utilities.sanity import check_webhook_endpoints_health
+        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = set()  # No webhooks discovered
 
@@ -1073,9 +1073,9 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_api_exception(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when API exception occurs while checking endpoints"""
-        from kubernetes.client import ApiException
+        from kubernetes.client import ApiException  # noqa: PLC0415
 
-        from utilities.sanity import check_webhook_endpoints_health
+        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
         mock_endpoints_class.side_effect = ApiException(status=500, reason="Internal Server Error")
@@ -1098,7 +1098,7 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_success(self, _mock_logger, mock_vm_class):
         """Test successful dry-run VM creation"""
-        from utilities.sanity import check_vm_creation_capability
+        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm_class.return_value = mock_vm
@@ -1114,9 +1114,9 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_api_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to API error"""
-        from kubernetes.client import ApiException
+        from kubernetes.client import ApiException  # noqa: PLC0415
 
-        from utilities.sanity import check_vm_creation_capability
+        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = ApiException(status=400, reason="Bad Request")
@@ -1135,7 +1135,7 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_unexpected_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to unexpected error"""
-        from utilities.sanity import check_vm_creation_capability
+        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = Exception("Unexpected error")
@@ -1154,7 +1154,7 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_connection_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to connection error"""
-        from utilities.sanity import check_vm_creation_capability
+        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = ConnectionError("Connection refused")
@@ -1173,7 +1173,7 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_timeout_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to timeout"""
-        from utilities.sanity import check_vm_creation_capability
+        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = TimeoutError("Connection timed out")


### PR DESCRIPTION
##### What this PR does / why we need it:

Enables ruff rule **PLC0415** (`import-outside-top-level`), which fails CI
whenever an `import` statement appears inside a function or class body
instead of at the module top-level.

**Why lazy imports are bad:**
- Module-level imports make all dependencies visible at a glance.
- Import errors are surfaced unconditionally, not buried in call paths.
- They typically indicate either forgotten clean-up or an unaddressed
  circular dependency that deserves a proper fix.

**How the rule is enabled:**
`extend-select = ["PLC0415"]` in `[tool.ruff.lint]` adds PLC0415 on top
of the existing default rule set (E + F) without replacing it.

**How to suppress a legitimate exception:**

The project bans blanket `# noqa` and `per-file-ignores` entries because
they silence the rule for every future line in that scope.  When a lazy
import is genuinely required (e.g. to break a circular dependency, or
inside a unit-test that needs the post-patch module binding), suppress
only the specific offending line:

```python
from some.module import Symbol  # noqa: PLC0415
```

This is more precise than a file-level ignore: reviewers can see exactly
which import is exceptional, and new lazy imports elsewhere in the same
file still fail CI.

All pre-existing violations have been annotated with `# noqa: PLC0415`
as a holding measure so that CI passes immediately.  Follow-up PRs are
expected to remove these suppressions by moving imports to the top of the
module (straightforward cases) or by resolving the underlying circular
dependency.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

The `# noqa: PLC0415` suppressions on pre-existing violations are
intentionally temporary.  Each one is a candidate for a dedicated
clean-up PR — either a trivial move-to-top-level or a circular-dep
refactor.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality standards and tooling configuration to improve code consistency across the codebase.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4819)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->