### PR TITLE
ruff: remove easy PLC0415 suppressions by moving imports to top level

### DIFF
--- a/utilities/unittests/conftest.py
+++ b/utilities/unittests/conftest.py
@@ -2,6 +2,7 @@
 
 """Pytest configuration for utilities tests - independent of main project"""
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from ocp_resources import resource
+from pytest_testconfig import config as py_config
 
 import utilities
 
@@ -55,8 +57,6 @@ utilities.data_collector = mock_data_collector  # type: ignore[attr-defined]
 @pytest.fixture(autouse=True)
 def setup_py_config():
     """Setup py_config for tests that need data_collector configuration"""
-    from pytest_testconfig import config as py_config  # noqa: PLC0415
-
     # Ensure data_collector config is set up
     if "data_collector" not in py_config:
         py_config["data_collector"] = {"data_collector_base_directory": "/tmp/data"}
@@ -127,8 +127,6 @@ def mock_vm_no_namespace():
 @pytest.fixture(autouse=True)
 def mock_logger():
     """Auto-mock logger for all tests to prevent logging issues"""
-    import logging  # noqa: PLC0415
-
     # Save original getLogger to avoid recursion
     original_get_logger = logging.getLogger
 

--- a/utilities/unittests/test_bitwarden.py
+++ b/utilities/unittests/test_bitwarden.py
@@ -6,7 +6,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -204,7 +204,6 @@ class TestGetCnvTestsSecretByName:
     @patch("bitwarden.get_all_cnv_tests_secrets")
     def test_get_cnv_tests_secret_by_name_disabled_bitwarden(self, mock_get_all):
         """Test that --disabled-bitwarden flag returns empty dict without calling Bitwarden"""
-        from unittest.mock import MagicMock  # noqa: PLC0415
 
         # Clear cache before test
         get_cnv_tests_secret_by_name.cache_clear()

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -40,8 +40,11 @@ if "utilities.hco" in sys.modules:
 
 # Import after setting up mocks to avoid circular dependency
 from utilities.hco import (  # noqa: E402
+    CDI,
     DEFAULT_HCO_PROGRESSING_CONDITIONS,
     HCO_JSONPATCH_ANNOTATION_COMPONENT_DICT,
+    KubeVirt,
+    Resource,
     ResourceEditorValidateHCOReconcile,
     add_labels_to_nodes,
     apply_np_changes,
@@ -498,7 +501,6 @@ class TestWaitForHcoConditions:
     @patch("utilities.hco.Namespace")
     def test_wait_for_hco_conditions_with_dependent_crs(self, mock_namespace_class, mock_wait_conditions):
         """Test wait_for_hco_conditions with dependent CRs"""
-        from utilities.hco import CDI, KubeVirt  # noqa: PLC0415
 
         mock_admin_client = MagicMock()
         mock_namespace = MagicMock()
@@ -639,7 +641,6 @@ class TestModuleConstants:
 
     def test_default_hco_progressing_conditions(self):
         """Test DEFAULT_HCO_PROGRESSING_CONDITIONS constant"""
-        from utilities.hco import Resource  # noqa: PLC0415
 
         assert "Progressing" in DEFAULT_HCO_PROGRESSING_CONDITIONS
         assert DEFAULT_HCO_PROGRESSING_CONDITIONS[Resource.Condition.PROGRESSING] == Resource.Condition.Status.TRUE

--- a/utilities/unittests/test_sanity.py
+++ b/utilities/unittests/test_sanity.py
@@ -5,11 +5,19 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from kubernetes.client import ApiException
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_utilities.exceptions import NodeNotReadyError, NodeUnschedulableError
 from timeout_sampler import TimeoutExpiredError
 
 from utilities.exceptions import ClusterSanityError
+from utilities.sanity import (
+    _discover_webhook_services,
+    check_vm_creation_capability,
+    check_webhook_endpoints_health,
+    cluster_sanity,
+    storage_sanity_check,
+)
 
 
 class TestStorageSanityCheck:
@@ -19,7 +27,6 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_matching_storage_classes(self, mock_logger):
         """Test with matching storage classes - should return True"""
-        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1", "sc2", "sc3"]
 
@@ -32,7 +39,6 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_missing_storage_classes(self, mock_logger):
         """Test with missing storage classes - should return False and log error"""
-        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1", "sc2"]  # sc3 is missing
 
@@ -48,7 +54,6 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_extra_storage_classes(self, mock_logger):
         """Test with extra storage classes on cluster - should return True (extra classes are allowed)"""
-        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         # The function only checks if all expected storage classes exist
         # Extra storage classes on the cluster are allowed
@@ -65,7 +70,6 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_different_order(self, mock_logger):
         """Test with matching storage classes in different order - should return True"""
-        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1", "sc2", "sc3"]  # different order from config
 
@@ -78,7 +82,6 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_empty_storage_class_matrix(self, mock_logger):
         """Test with empty storage class matrix - should return True"""
-        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = []
 
@@ -91,7 +94,6 @@ class TestStorageSanityCheck:
     @patch("utilities.sanity.LOGGER")
     def test_storage_sanity_check_logging_behavior(self, mock_logger):
         """Test logging behavior for mismatches"""
-        from utilities.sanity import storage_sanity_check  # noqa: PLC0415
 
         cluster_storage_classes = ["sc1"]  # sc2 is missing
 
@@ -109,7 +111,6 @@ class TestClusterSanity:
     @patch("utilities.sanity.LOGGER")
     def test_cluster_sanity_skip_cluster_health_check_marker(self, mock_logger):
         """Test skip when '-m cluster_health_check' marker is present"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = "cluster_health_check"
@@ -127,7 +128,6 @@ class TestClusterSanity:
     @patch("utilities.sanity.LOGGER")
     def test_cluster_sanity_skip_check_flag(self, mock_logger):
         """Test skip when --cluster-sanity-skip-check flag is set"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -154,7 +154,6 @@ class TestClusterSanity:
         self, mock_logger, _mock_wait_hco, mock_storage_sanity, _mock_check_vm, _mock_check_webhook
     ):
         """Test skip storage check when --cluster-sanity-skip-storage-check flag is set"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -194,7 +193,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test skip nodes check when --cluster-sanity-skip-nodes-check flag is set"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -236,7 +234,6 @@ class TestClusterSanity:
         mock_check_webhook,
     ):
         """Test successful full sanity check (all checks pass)"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -281,7 +278,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test StorageSanityError raised and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -319,7 +315,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test NodeUnschedulableError caught and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -360,7 +355,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test NodeNotReadyError caught and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -401,7 +395,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test ClusterSanityError caught and exit_pytest_execution called"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -446,7 +439,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test TimeoutExpiredError during wait_for_pods_running converted to ClusterSanityError"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -492,7 +484,6 @@ class TestClusterSanity:
         mock_check_webhook,
     ):
         """Test all components called in correct order (storage, nodes, webhook, HCO)"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -563,7 +554,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test assert_nodes_in_healthy_condition called with correct parameters"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -602,7 +592,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test assert_nodes_schedulable called"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -642,7 +631,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test wait_for_pods_running called with correct namespace and filter"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -686,7 +674,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test wait_for_hco_conditions called"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -731,7 +718,6 @@ class TestClusterSanity:
         _mock_check_webhook,
     ):
         """Test junitxml_property passed to exit_pytest_execution"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -762,7 +748,6 @@ class TestClusterSanity:
         self, mock_logger, _mock_wait_hco, mock_storage_sanity, mock_check_vm, mock_check_webhook
     ):
         """Test skip webhook check when --cluster-sanity-skip-webhook-check flag is set"""
-        from utilities.sanity import cluster_sanity  # noqa: PLC0415
 
         mock_request = MagicMock()
         mock_request.config.getoption.return_value = ""
@@ -796,7 +781,6 @@ class TestDiscoverWebhookServices:
         self, _mock_logger, mock_mutating_class, mock_validating_class
     ):
         """Test discovery finds services in the HCO namespace"""
-        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -833,7 +817,6 @@ class TestDiscoverWebhookServices:
         self, _mock_logger, mock_mutating_class, mock_validating_class
     ):
         """Test discovery ignores services in other namespaces"""
-        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -862,7 +845,6 @@ class TestDiscoverWebhookServices:
         self, _mock_logger, mock_mutating_class, mock_validating_class
     ):
         """Test discovery skips URL-based webhooks (no service config)"""
-        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -890,7 +872,6 @@ class TestDiscoverWebhookServices:
     @patch("utilities.sanity.LOGGER")
     def test_discover_webhook_services_empty_webhooks(self, _mock_logger, mock_mutating_class, mock_validating_class):
         """Test discovery handles webhook configs with no webhooks"""
-        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -914,7 +895,6 @@ class TestDiscoverWebhookServices:
     @patch("utilities.sanity.LOGGER")
     def test_discover_webhook_services_deduplicates(self, _mock_logger, mock_mutating_class, mock_validating_class):
         """Test discovery deduplicates services referenced by multiple webhooks"""
-        from utilities.sanity import _discover_webhook_services  # noqa: PLC0415
 
         # Set __name__ attributes for the mocks
         mock_mutating_class.__name__ = "MutatingWebhookConfiguration"
@@ -950,7 +930,6 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_all_healthy(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test successful check when all endpoints are healthy"""
-        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api", "cdi-api", "kubevirt-operator-webhook"}
 
@@ -976,7 +955,6 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_missing_endpoint(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when endpoint does not exist"""
-        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
 
@@ -999,7 +977,6 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_no_subsets(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when endpoint has no subsets"""
-        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
 
@@ -1024,7 +1001,6 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_no_addresses(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when endpoint has no ready addresses"""
-        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
 
@@ -1053,7 +1029,6 @@ class TestCheckWebhookEndpointsHealth:
         self, _mock_logger, mock_endpoints_class, mock_discover
     ):
         """Test that warning is logged when no webhooks are discovered"""
-        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = set()  # No webhooks discovered
 
@@ -1073,9 +1048,6 @@ class TestCheckWebhookEndpointsHealth:
     @patch("utilities.sanity.LOGGER")
     def test_check_webhook_endpoints_health_api_exception(self, _mock_logger, mock_endpoints_class, mock_discover):
         """Test error when API exception occurs while checking endpoints"""
-        from kubernetes.client import ApiException  # noqa: PLC0415
-
-        from utilities.sanity import check_webhook_endpoints_health  # noqa: PLC0415
 
         mock_discover.return_value = {"virt-api"}
         mock_endpoints_class.side_effect = ApiException(status=500, reason="Internal Server Error")
@@ -1098,7 +1070,6 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_success(self, _mock_logger, mock_vm_class):
         """Test successful dry-run VM creation"""
-        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm_class.return_value = mock_vm
@@ -1114,9 +1085,6 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_api_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to API error"""
-        from kubernetes.client import ApiException  # noqa: PLC0415
-
-        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = ApiException(status=400, reason="Bad Request")
@@ -1135,7 +1103,6 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_unexpected_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to unexpected error"""
-        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = Exception("Unexpected error")
@@ -1154,7 +1121,6 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_connection_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to connection error"""
-        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = ConnectionError("Connection refused")
@@ -1173,7 +1139,6 @@ class TestCheckVmCreationCapability:
     @patch("utilities.sanity.LOGGER")
     def test_check_vm_creation_capability_timeout_error(self, _mock_logger, mock_vm_class):
         """Test error when VM creation fails due to timeout"""
-        from utilities.sanity import check_vm_creation_capability  # noqa: PLC0415
 
         mock_vm = MagicMock()
         mock_vm.create.side_effect = TimeoutError("Connection timed out")


### PR DESCRIPTION
##### What this PR does / why we need it:

Follow-up to #4819, which enabled ruff rule PLC0415 and annotated all
pre-existing violations with `# noqa: PLC0415` as a holding measure.

This PR removes 40 of those suppressions — the ones where the fix is a
straightforward move to the module top level, with no design changes
required:

- **`test_bitwarden.py`** — `MagicMock` was already imported from
  `unittest.mock`; add it to the existing import line.
- **`test_hco.py`** — `CDI`, `KubeVirt`, `Resource` are not patched in
  any test; add them to the existing top-level `from utilities.hco
  import (...)` block.
- **`conftest.py`** — `import logging` and `from pytest_testconfig
  import config as py_config` have no reason to be lazy; move to the
  module top.
- **`test_sanity.py`** — all imported callables (`storage_sanity_check`,
  `cluster_sanity`, `_discover_webhook_services`,
  `check_webhook_endpoints_health`, `check_vm_creation_capability`,
  `ApiException`) are not themselves patched — only `py_config` is.
  Top-level imports are safe and make dependencies visible.

**Remaining suppressions** (`utilities/architecture.py`,
`utilities/pytest_utils.py`, `test_data_collector.py`,
`test_pytest_utils.py`) require either circular-dependency refactoring
or test restructuring and are left for dedicated follow-up PRs.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

This PR should be merged after #4819. It is branched off
`ruff-add-lazy-import-check` so it applies cleanly on top of that
change.

##### jira-ticket: