### PR TITLE
[libs/vm] Add OWNERS file for sig-network ownership

### DIFF
--- a/libs/vm/OWNERS
+++ b/libs/vm/OWNERS
@@ -1,0 +1,12 @@
+root-approvers: False
+approvers:
+  - EdDev
+reviewers:
+  - yossisegev
+  - Anatw
+  - EdDev
+  - servolkov
+  - azhivovk
+  - orelmisan
+  - nirdothan
+  - frenzyfriday


### PR DESCRIPTION
##### What this PR does / why we need it:
`libs/vm` is de-facto managed by sig-network but had no OWNERS file. This PR adds one identical to `libs/net` to make the ownership explicit and consistent.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code governance configuration.

**Note:** This release contains no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4823)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->