### PR TITLE
net, tests, stuntime: Add OVN localnet migration stuntime scenarios 

### DIFF
--- a/tests/network/localnet/migration_stuntime/conftest.py
+++ b/tests/network/localnet/migration_stuntime/conftest.py
@@ -18,14 +18,21 @@ from tests.network.localnet.liblocalnet import (
     libnncp,
     localnet_vm,
 )
-from tests.network.localnet.migration_stuntime.libstuntime import SERVER_VM_LABEL, ContinuousPing
+from tests.network.localnet.migration_stuntime.libstuntime import CLIENT_VM_LABEL, SERVER_VM_LABEL, ContinuousPing
 
 LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="class")
+def ip_family(request: pytest.FixtureRequest) -> int:
+    """IP family for stuntime measurement, activated by per-test parametrize."""
+    return request.param
+
+
+@pytest.fixture(scope="class")
 def localnet_stuntime_server_vm(
     unprivileged_client: DynamicClient,
+    ip_family: int,
     nncp_localnet_on_secondary_node_nic: libnncp.NodeNetworkConfigurationPolicy,
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     namespace_localnet_1: Namespace,
@@ -85,6 +92,7 @@ def localnet_stuntime_client_vm(
             }
         ),
         affinity=new_pod_affinity(label=SERVER_VM_LABEL),
+        vm_labels=dict([CLIENT_VM_LABEL]),
     ) as client_vm:
         client_vm.start(wait=True)
         client_vm.wait_for_agent_connected()
@@ -93,16 +101,11 @@ def localnet_stuntime_client_vm(
 
 @pytest.fixture()
 def active_ping(
-    request: pytest.FixtureRequest,
+    ip_family: int,
     localnet_stuntime_server_vm: BaseVirtualMachine,
     localnet_stuntime_client_vm: BaseVirtualMachine,
 ) -> Generator[ContinuousPing]:
-    """Continuous ping session from client to server for stuntime measurement.
-
-    Args (indirect via request.param):
-        ip_family: IP family version - 4 for IPv4, 6 for IPv6.
-    """
-    ip_family = request.param
+    """Continuous ping session from client to server for stuntime measurement."""
     server_ip = str(
         lookup_iface_status_ip(
             vm=localnet_stuntime_server_vm,

--- a/tests/network/localnet/migration_stuntime/libstuntime.py
+++ b/tests/network/localnet/migration_stuntime/libstuntime.py
@@ -10,7 +10,9 @@ from tests.network.libs.connectivity import build_ping_command
 
 LOGGER = logging.getLogger(__name__)
 
-SERVER_VM_LABEL: Final[tuple[str, str]] = ("stuntime.test", "server")
+STUNTIME_LABEL_KEY: Final[str] = "stuntime.test"
+SERVER_VM_LABEL: Final[tuple[str, str]] = (STUNTIME_LABEL_KEY, "server")
+CLIENT_VM_LABEL: Final[tuple[str, str]] = (STUNTIME_LABEL_KEY, "client")
 STUNTIME_THRESHOLD_SECONDS: Final[float] = 5.0
 STUNTIME_PING_LOG_PATH: Final[str] = "/tmp/stuntime-ping.log"
 PING_INTERVAL_SECONDS: Final[float] = 0.1
@@ -19,6 +21,20 @@ DEFAULT_COMMAND_TIMEOUT_SECONDS: Final[int] = 10
 
 class InsufficientStuntimeDataError(ValueError):
     """Raised when ping log has too few successful replies to compute stuntime."""
+
+
+def measure_stuntime(active_ping: "ContinuousPing") -> float:
+    """Stop the continuous ping session and compute the measured stuntime.
+
+    Args:
+        active_ping: Active continuous ping session to stop and evaluate.
+
+    Returns:
+        Measured stuntime in seconds.
+    """
+    active_ping.stop()
+    _, _, lost = active_ping.report()
+    return compute_stuntime(lost_packets=lost)
 
 
 def compute_stuntime(lost_packets: int) -> float:

--- a/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
@@ -13,17 +13,18 @@ on which IPv4/IPv6 static addresses will be defined according to the environment
 Client - The connectivity initiator VM that runs continuous ping toward the server VM.
 Server - The connectivity listener VM that receives the ping and responds.
 
-STP Reference:
-https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/stuntime_measurement.md
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
+/stps/sig-network/stuntime_measurement.md
 """
 
 import pytest
 
-from libs.vm.affinity import new_pod_anti_affinity
+from libs.vm.affinity import new_pod_affinity, new_pod_anti_affinity
 from tests.network.localnet.migration_stuntime.libstuntime import (
+    CLIENT_VM_LABEL,
     SERVER_VM_LABEL,
     STUNTIME_THRESHOLD_SECONDS,
-    compute_stuntime,
+    measure_stuntime,
 )
 from utilities.virt import migrate_vm_and_verify
 
@@ -31,36 +32,34 @@ pytestmark = [pytest.mark.tier3]
 
 """
 Preconditions:
-    - Shared under-test server VM on OVN localnet secondary network, for the IP family from ip_family parametrization.
-    - Shared under-test client VM on OVN localnet secondary network, for that same IP family,
+    - Under-test server VM on OVN localnet secondary network, for the IP family from ip_family parametrization.
+    - Under-test client VM on OVN localnet secondary network, for that same IP family,
       initially running on the same node as the server VM.
 """
 
 
 @pytest.mark.incremental
+@pytest.mark.parametrize(
+    "ip_family",
+    [
+        pytest.param(4, marks=pytest.mark.ipv4, id="ipv4"),
+        pytest.param(6, marks=pytest.mark.ipv6, id="ipv6"),
+    ],
+    indirect=True,
+)
 class TestMigrationStuntime:
-    @pytest.mark.parametrize(
-        "active_ping",
-        [
-            pytest.param(4, id="ipv4", marks=[pytest.mark.polarion("CNV-15258"), pytest.mark.ipv4]),
-            pytest.param(6, id="ipv6", marks=[pytest.mark.polarion("CNV-15272"), pytest.mark.ipv6]),
-        ],
-        indirect=True,
-    )
-    def test_client_migrates_off_server_node(
-        self,
-        admin_client,
-        localnet_stuntime_client_vm,
-        active_ping,
-    ):
+    """
+    Parametrize:
+        - ip_family:
+            - ipv4 [Markers: ipv4]
+            - ipv6 [Markers: ipv6]
+    """
+
+    @pytest.mark.polarion("CNV-15258")
+    def test_client_migrates_off_server_node(self, admin_client, ip_family, localnet_stuntime_client_vm, active_ping):
         """
         Test that measured stuntime does not exceed the global threshold when the client
         VM migrates from the node hosting the server VM into a different node.
-
-        Parametrize:
-            - active_ping:
-                - ipv4 [Markers: ipv4]
-                - ipv6 [Markers: ipv6]
 
         Preconditions:
             - Under-test server VM on OVN localnet secondary network, for the IP family from ip_family parametrization.
@@ -79,15 +78,15 @@ class TestMigrationStuntime:
         """
         localnet_stuntime_client_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=SERVER_VM_LABEL))
         migrate_vm_and_verify(vm=localnet_stuntime_client_vm, client=admin_client)
-        active_ping.stop()
-        _, _, lost = active_ping.report()
-        measured_stuntime = compute_stuntime(lost_packets=lost)
+        measured_stuntime = measure_stuntime(active_ping=active_ping)
         assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
             f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
         )
 
     @pytest.mark.polarion("CNV-15259")
-    def test_client_migrates_between_non_server_nodes(self):
+    def test_client_migrates_between_non_server_nodes(
+        self, admin_client, ip_family, localnet_stuntime_client_vm, active_ping
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the client VM migrates between nodes
         while the client and server VMs remain on different nodes.
@@ -107,9 +106,14 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        migrate_vm_and_verify(vm=localnet_stuntime_client_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15260")
-    def test_client_migrates_to_server_node(self):
+    def test_client_migrates_to_server_node(self, admin_client, ip_family, localnet_stuntime_client_vm, active_ping):
         """
         Test that measured stuntime does not exceed the global threshold when the client VM migrates
         from a node other than the node hosting the server VM onto the node hosting the server VM.
@@ -129,9 +133,15 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        localnet_stuntime_client_vm.set_template_affinity(affinity=new_pod_affinity(label=SERVER_VM_LABEL))
+        migrate_vm_and_verify(vm=localnet_stuntime_client_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15261")
-    def test_server_migrates_off_client_node(self):
+    def test_server_migrates_off_client_node(self, admin_client, ip_family, localnet_stuntime_server_vm, active_ping):
         """
         Test that measured stuntime does not exceed the global threshold when the server
         VM migrates from the node hosting the client VM into a different node.
@@ -151,9 +161,17 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        localnet_stuntime_server_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=CLIENT_VM_LABEL))
+        migrate_vm_and_verify(vm=localnet_stuntime_server_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15262")
-    def test_server_migrates_between_non_client_nodes(self):
+    def test_server_migrates_between_non_client_nodes(
+        self, admin_client, ip_family, localnet_stuntime_server_vm, active_ping
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the server VM migrates between nodes
         while the client and server VMs remain on different nodes.
@@ -173,9 +191,15 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        localnet_stuntime_server_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=CLIENT_VM_LABEL))
+        migrate_vm_and_verify(vm=localnet_stuntime_server_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15263")
-    def test_server_migrates_to_client_node(self):
+    def test_server_migrates_to_client_node(self, admin_client, ip_family, localnet_stuntime_server_vm, active_ping):
         """
         Test that measured stuntime does not exceed the global threshold when the server VM migrates from a node
         other than the node hosting the client VM onto the node hosting the client VM.
@@ -195,9 +219,9 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
-
-    test_client_migrates_between_non_server_nodes.__test__ = False
-    test_client_migrates_to_server_node.__test__ = False
-    test_server_migrates_off_client_node.__test__ = False
-    test_server_migrates_between_non_client_nodes.__test__ = False
-    test_server_migrates_to_client_node.__test__ = False
+        localnet_stuntime_server_vm.set_template_affinity(affinity=new_pod_affinity(label=CLIENT_VM_LABEL))
+        migrate_vm_and_verify(vm=localnet_stuntime_server_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )


### PR DESCRIPTION
##### Short description:                                                                                                                                                                                                                            
Complete OVN localnet stuntime coverage for both IP families.                                                                                                                                                               
                                                                                                                                                                                                                                                      
##### More details:                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                      
##### What this PR does / why we need it:                                                                                                                                                                                                           
Add remaining stuntime measurement tests for OVN localnet with both IPv4 and IPv6 coverage, through different migration directions.                                                                                                                                                                                                                                         
                                                            
##### Which issue(s) this PR fixes:                                                                                                                                                                                                                 
                                                            
##### Special notes for reviewer:                                                
- Single parametrized class with class-level ip_family parametrize to group all scenarios per IP family. VMs depend on ip_family so they're recreated per group, giving each IP family fresh VMs with clean network state (4 VMs total).
- The client VM's affinity towards the server (last client migration scenario) is not cleared before server migration tests - server affinity is set independently and the client's affinity has no effect on server scheduling for this matter. 
- measure_stuntime() is also introduced in PR #4867. Whichever merges first takes precedence - the other will rebase and remove the duplicate.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-72773


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Client and server VMs are explicitly labeled; scenarios can enforce client/server co-location or separation before migration.
  * Added a reusable measurement for connectivity gaps; tests now call it and assert against the stuntime threshold.
  * IP family (IPv4/IPv6) is now a class-level parameter for scenarios; ping fixtures and tests accept the injected IP family.
  * Per-scenario test discovery suppression removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->