### PR TITLE
[VIRT] Set CPU topology to cores for Windows WSL2 VMs

### DIFF
--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -10,6 +10,7 @@ import shlex
 import pytest
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from ocp_resources.virtual_machine_instancetype import VirtualMachineInstancetype
+from ocp_resources.virtual_machine_preference import VirtualMachinePreference
 from pyhelper_utils.shell import run_ssh_commands
 
 from tests.utils import verify_wsl2_guest_works
@@ -57,30 +58,50 @@ def wsl2_vm_instance_type(unprivileged_client, namespace):
         client=unprivileged_client,
         namespace=namespace.name,
         name="wsl2-windows-instance-type",
-        cpu={"guest": 8},
+        cpu={"guest": 12},
         memory={"guest": Images.Windows.DEFAULT_MEMORY_SIZE_WSL},
     ) as instance_type:
         yield instance_type
 
 
 @pytest.fixture(scope="class")
+def windows_wsl2_vm_preference(request, unprivileged_client, namespace):
+    """Windows VM preference with CPU topology set to 'cores' for better performance."""
+    windows_preference_name = request.param
+    base_preference = VirtualMachineClusterPreference(client=unprivileged_client, name=windows_preference_name)
+    base_spec = base_preference.instance.to_dict()["spec"]
+
+    with VirtualMachinePreference(
+        client=unprivileged_client,
+        namespace=namespace.name,
+        name=f"wsl2-{windows_preference_name}-preference",
+        cpu={"preferredCPUTopology": "cores"},
+        clock=base_spec.get("clock"),
+        devices=base_spec.get("devices"),
+        features=base_spec.get("features"),
+        firmware=base_spec.get("firmware"),
+        requirements=base_spec.get("requirements"),
+    ) as preference:
+        yield preference
+
+
+@pytest.fixture(scope="class")
 def windows_wsl2_vm(
-    request,
     namespace,
     unprivileged_client,
     wsl2_vm_instance_type,
+    windows_wsl2_vm_preference,
     golden_image_data_volume_template_for_test_scope_class,
     modern_cpu_for_migration,
     vm_cpu_flags,
 ):
     """Create Windows 10/11 VM, Run VM and wait for WSL2 guest to start"""
-    win_ver = request.param["win_ver"]
     with VirtualMachineForTests(
-        name=f"win-{win_ver}-wsl2",
+        name="win-wsl2",
         namespace=namespace.name,
         client=unprivileged_client,
         vm_instance_type=wsl2_vm_instance_type,
-        vm_preference=VirtualMachineClusterPreference(client=unprivileged_client, name=f"windows.{win_ver}"),
+        vm_preference=windows_wsl2_vm_preference,
         data_volume_template=golden_image_data_volume_template_for_test_scope_class,
         cpu_model=modern_cpu_for_migration,
         cpu_flags=vm_cpu_flags,
@@ -100,16 +121,16 @@ def migrated_wsl2_vm(windows_wsl2_vm):
 @pytest.mark.ibm_bare_metal
 @pytest.mark.tier3
 @pytest.mark.parametrize(
-    "golden_image_data_source_for_test_scope_class, windows_wsl2_vm",
+    "golden_image_data_source_for_test_scope_class, windows_wsl2_vm_preference",
     [
         pytest.param(
             {"os_dict": WINDOWS_10_WSL},
-            {"win_ver": "10"},
+            "windows.10",
             id="Windows-10",
         ),
         pytest.param(
             {"os_dict": WINDOWS_11_WSL},
-            {"win_ver": "11"},
+            "windows.11",
             id="Windows-11",
         ),
     ],


### PR DESCRIPTION
##### Short description:
Windows VMs perform better with cores topology instead of sockets. This reduces idle CPU usage from 60%+ to normal levels.

##### More details:

##### What this PR does / why we need it:
  Sets CPU topology to 'cores' for Windows WSL2 VMs.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Windows WSL2 VM test infrastructure to enforce a consistent CPU topology preference, enhancing accuracy of CPU-related validations.
  * Refactored test setup to use centralized VM preference management for Windows WSL2 scenarios, increasing consistency and reliability of test runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4837)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->