### PR TITLE
CherryPicked: [4.21] [Storage] Test using Windows VMs should have vTPM - test_hotplug.py

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -10,7 +10,7 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
 
-from tests.os_params import WINDOWS_LATEST, WINDOWS_LATEST_LABELS
+from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
 from utilities.constants import HOTPLUG_DISK_SERIAL, Images
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.jira import is_jira_open
@@ -18,7 +18,6 @@ from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,
     create_dv,
-    data_volume,
     virtctl_volume,
     wait_for_vm_volume_ready,
 )
@@ -27,8 +26,6 @@ from utilities.virt import (
     fedora_vm_body,
     migrate_vm_and_verify,
     running_vm,
-    vm_instance_from_template,
-    wait_for_windows_vm,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -74,51 +71,37 @@ def hotplug_volume_windows_scope_class(
 
 
 @pytest.fixture(scope="class")
-def vm_instance_from_template_multi_storage_scope_class(
-    request,
-    unprivileged_client,
-    namespace,
-    data_volume_multi_storage_scope_class,
-    cpu_for_migration,
-):
-    """Calls vm_instance_from_template contextmanager
-
-    Creates a VM from template and starts it (if requested).
-    """
-    with vm_instance_from_template(
-        request=request,
-        unprivileged_client=unprivileged_client,
-        namespace=namespace,
-        existing_data_volume=data_volume_multi_storage_scope_class,
-        vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,
-    ) as vm:
-        yield vm
-
-
-@pytest.fixture(scope="class")
-def started_windows_vm_scope_class(
-    request,
-    vm_instance_from_template_multi_storage_scope_class,
-):
-    wait_for_windows_vm(
-        vm=vm_instance_from_template_multi_storage_scope_class,
-        version=request.param["os_version"],
-    )
-
-
-@pytest.fixture(scope="class")
-def data_volume_multi_storage_scope_class(
-    request,
+def windows_dv_from_registry_scope_class(
     unprivileged_client,
     namespace,
     storage_class_matrix__class__,
 ):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class_matrix=storage_class_matrix__class__,
-        client=namespace.client,
-    )
+    """Creates a Windows 2022 DataVolume from registry container disk."""
+    with create_windows2022_dv_from_registry(
+        dv_name="dv-windows-2022-hotplug",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        storage_class=next(iter(storage_class_matrix__class__)),
+    ) as dv_dict:
+        yield dv_dict
+
+
+@pytest.fixture(scope="class")
+def vm_instance_from_template_multi_storage_scope_class(
+    unprivileged_client,
+    namespace,
+    modern_cpu_for_migration,
+    windows_dv_from_registry_scope_class,
+):
+    """Creates a Windows 2022 VM with vTPM from registry container disk."""
+    with create_windows2022_vm_with_vtpm_from_registry(
+        dv_dict=windows_dv_from_registry_scope_class,
+        namespace=namespace.name,
+        client=unprivileged_client,
+        vm_name="vm-win-2022-hotplug",
+        cpu_model=modern_cpu_for_migration,
+    ) as vm:
+        yield vm
 
 
 @pytest.fixture(scope="class")
@@ -257,22 +240,9 @@ class TestHotPlugWithSerialPersist:
 
 
 @pytest.mark.parametrize(
-    "data_volume_multi_storage_scope_class,"
-    "vm_instance_from_template_multi_storage_scope_class,"
-    "started_windows_vm_scope_class,"
     "hotplug_volume_windows_scope_class",
     [
         pytest.param(
-            {
-                "dv_name": "dv-windows",
-                "image": WINDOWS_LATEST.get("image_path"),
-                "dv_size": WINDOWS_LATEST.get("dv_size"),
-            },
-            {
-                "vm_name": f"vm-win-{WINDOWS_LATEST.get('os_version')}",
-                "template_labels": WINDOWS_LATEST_LABELS,
-            },
-            {"os_version": WINDOWS_LATEST.get("os_version")},
             {"persist": True, "serial": HOTPLUG_DISK_SERIAL},
         ),
     ],
@@ -285,9 +255,7 @@ class TestHotPlugWindows:
     def test_windows_hotplug(
         self,
         blank_disk_dv_multi_storage_scope_class,
-        data_volume_multi_storage_scope_class,
         vm_instance_from_template_multi_storage_scope_class,
-        started_windows_vm_scope_class,
         hotplug_volume_windows_scope_class,
     ):
         wait_for_vm_volume_ready(vm=vm_instance_from_template_multi_storage_scope_class)
@@ -303,9 +271,7 @@ class TestHotPlugWindows:
         self,
         unprivileged_client,
         blank_disk_dv_multi_storage_scope_class,
-        data_volume_multi_storage_scope_class,
         vm_instance_from_template_multi_storage_scope_class,
-        started_windows_vm_scope_class,
         hotplug_volume_windows_scope_class,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,20 +19,25 @@ from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from utilities.artifactory import (
+    cleanup_artifactory_secret_and_config_map,
     get_artifactory_config_map,
     get_artifactory_header,
     get_artifactory_secret,
     get_http_image_url,
+    get_test_artifact_server_url,
 )
 from utilities.constants import (
     DISK_SERIAL,
     NODE_HUGE_PAGES_1GI_KEY,
+    OS_FLAVOR_WIN_CONTAINER_DISK,
     OS_FLAVOR_WINDOWS,
     RHSM_SECRET_NAME,
     TCP_TIMEOUT_30SEC,
@@ -44,6 +49,9 @@ from utilities.constants import (
     TIMEOUT_10SEC,
     TIMEOUT_15SEC,
     TIMEOUT_30MIN,
+    U1_LARGE,
+    WIN_2K22,
+    WINDOWS_2K22_PREFERENCE,
     Images,
 )
 from utilities.data_collector import get_data_collector_dir, write_to_file
@@ -52,6 +60,7 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     ExecCommandOnPod,
 )
+from utilities.os_utils import get_windows_container_disk_path
 from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
@@ -60,6 +69,7 @@ from utilities.virt import (
     running_vm,
     wait_for_migration_finished,
     wait_for_ssh_connectivity,
+    wait_for_windows_vm,
 )
 
 NUM_TEST_VMS = 3
@@ -685,3 +695,83 @@ def verify_rwx_default_storage(client: DynamicClient) -> None:
             f"Default storage class '{storage_class}' doesn't support RWX mode "
             f"(required: RWX, found: {found_mode or 'none'})"
         )
+
+
+@contextmanager
+def create_windows2022_dv_from_registry(
+    dv_name: str,
+    namespace: str,
+    client: DynamicClient,
+    storage_class: str,
+) -> Generator[dict]:
+    """
+    Creates a Windows Server 2022 DataVolume from registry container disk.
+
+    Args:
+        dv_name: Name for the DataVolume
+        namespace: Kubernetes namespace
+        client: Kubernetes client
+        storage_class: Storage class name
+
+    Yields:
+        dict: DataVolume template dictionary with metadata and spec
+    """
+    artifactory_secret = get_artifactory_secret(namespace=namespace)
+    artifactory_config_map = get_artifactory_config_map(namespace=namespace)
+
+    dv = DataVolume(
+        name=dv_name,
+        namespace=namespace,
+        storage_class=storage_class,
+        source="registry",
+        url=f"{get_test_artifact_server_url(schema='registry')}/{get_windows_container_disk_path(os_value=WIN_2K22)}",
+        size=Images.Windows.CONTAINER_DISK_DV_SIZE,
+        client=client,
+        api_name="storage",
+        secret=artifactory_secret,
+        cert_configmap=artifactory_config_map.name,
+    )
+    dv.to_dict()
+
+    try:
+        yield {"metadata": dv.res["metadata"], "spec": dv.res["spec"]}
+    finally:
+        cleanup_artifactory_secret_and_config_map(
+            artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
+        )
+
+
+@contextmanager
+def create_windows2022_vm_with_vtpm_from_registry(
+    dv_dict: dict,
+    namespace: str,
+    client: DynamicClient,
+    vm_name: str,
+    cpu_model: str | None,
+) -> Generator[VirtualMachineForTests]:
+    """
+    Creates a Windows Server 2022 VM with vTPM from registry container disk.
+
+    Args:
+        dv_dict: DataVolume template dictionary with metadata and spec
+        namespace: Kubernetes namespace
+        client: Kubernetes client
+        vm_name: Name for the VirtualMachine
+        cpu_model: CPU model specification (can be None)
+
+    Yields:
+        VirtualMachineForTests: Running Windows 2022 VM with vTPM
+    """
+    with VirtualMachineForTests(
+        name=vm_name,
+        namespace=namespace,
+        client=client,
+        os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_LARGE, client=client),
+        vm_preference=VirtualMachineClusterPreference(name=WINDOWS_2K22_PREFERENCE, client=client),
+        data_volume_template=dv_dict,
+        cpu_model=cpu_model,
+    ) as vm:
+        running_vm(vm=vm)
+        wait_for_windows_vm(vm=vm, version="2022")
+        yield vm

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -898,6 +898,10 @@ WIN_2K22 = "win2k22"
 WIN_2K16 = "win2k16"
 WIN_2K19 = "win2k19"
 
+# Windows VirtualMachine preferences
+WINDOWS_11_PREFERENCE = "windows.11"
+WINDOWS_2K22_PREFERENCE = "windows.2k22"
+
 HYPERV_FEATURES_LABELS_DOM_XML = [
     "relaxed",
     "vapic",


### PR DESCRIPTION
##### Short description:
Backport of #4761 to cnv-4.21: All Windows VMs in storage tests should be Windows 2022 using VTPM.

##### More details:
Added helper functions into `utils.py` that are context managers for DV and VM using Windows 2022 using instance types and preferences. These functions can be used in other modules such as CDI Clone, CDI Upload, Snasphots etc.

##### What this PR does / why we need it:
Backports Windows Server 2022 with vTPM support to cnv-4.21 branch.

##### Which issue(s) this PR fixes:
Backport of #4761

##### Special notes for reviewer:
- Cherry-pick had conflicts, manual replication was performed
- All changes from original PR applied successfully
- Original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/4761
- Co-authored: Claude Code

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-51351