### PR TITLE
CherryPicked: [4.20] [Storage] Test using Windows VMs should have vTPM - test_hotplug.py

### DIFF
--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -64,7 +64,7 @@ class Windows:
     WIN2022_ISO_IMG: str | None = None
     WIN2025_ISO_IMG: str | None = None
     DIR: str = f"{BASE_IMAGES_DIR}/windows-images"
-    DOCKER_IMAGE_DIR = "docker/kubevirt-common-instancetypes"
+    DOCKER_IMAGE_DIR: str = "docker-local/kubevirt-common-instancetypes"
     UEFI_WIN_DIR: str = f"{DIR}/uefi"
     HA_DIR: str = f"{DIR}/HA-images"
     ISO_BASE_DIR = f"{DIR}/install_iso"

--- a/libs/infra/images.py
+++ b/libs/infra/images.py
@@ -72,6 +72,7 @@ class Windows:
     ISO_WIN11_DIR: str = f"{ISO_BASE_DIR}/win11"
     ISO_WIN2022_DIR: str = f"{ISO_BASE_DIR}/win2022"
     ISO_WIN2025_DIR: str = f"{ISO_BASE_DIR}/win2025"
+    CONTAINER_DISK_DV_SIZE: str = "40Gi"
     DEFAULT_DV_SIZE: str = "70Gi"
     DEFAULT_MEMORY_SIZE: str = "8Gi"
     DEFAULT_MEMORY_SIZE_WSL: str = "12Gi"

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -132,7 +132,7 @@ def fedora_vm_for_hotplug_scope_class(unprivileged_client, namespace, param_subs
     memory_requests = None
     cpu_requests = None
 
-    if is_jira_open(jira_id="CNV-76658"):
+    if is_jira_open(jira_id="CNV-71599"):
         memory_requests = f"{float(Images.Fedora.DEFAULT_MEMORY_SIZE[:-2]) * 2}Gi"
         cpu_requests = 1
 

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -189,9 +189,7 @@ class TestHotPlugWithPersist:
         fedora_vm_for_hotplug_scope_class,
         expected_bus,
     ):
-        wait_for_vm_volume_ready(
-            vm=fedora_vm_for_hotplug_scope_class, volume_name=blank_disk_dv_multi_storage_scope_class.name
-        )
+        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class)
         assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class)
         assert_disk_bus(
             vm=fedora_vm_for_hotplug_scope_class,
@@ -232,9 +230,7 @@ class TestHotPlugWithSerialPersist:
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
     ):
-        wait_for_vm_volume_ready(
-            vm=fedora_vm_for_hotplug_scope_class, volume_name=blank_disk_dv_multi_storage_scope_class.name
-        )
+        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class)
         assert_disk_serial(vm=fedora_vm_for_hotplug_scope_class)
         assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class)
 
@@ -269,10 +265,7 @@ class TestHotPlugWindows:
         blank_disk_dv_multi_storage_scope_class,
         vm_instance_from_template_multi_storage_scope_class,
     ):
-        wait_for_vm_volume_ready(
-            vm=vm_instance_from_template_multi_storage_scope_class,
-            volume_name=blank_disk_dv_multi_storage_scope_class.name,
-        )
+        wait_for_vm_volume_ready(vm=vm_instance_from_template_multi_storage_scope_class)
         assert_disk_serial(
             command=shlex.split("wmic diskdrive get SerialNumber"),
             vm=vm_instance_from_template_multi_storage_scope_class,

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -9,12 +9,12 @@ import pytest
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
-from utilities.jira import is_jira_open
 
 from tests.storage.utils import assert_disk_bus
 from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
 from utilities.constants import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS, Images
 from utilities.hco import ResourceEditorValidateHCOReconcile
+from utilities.infra import is_jira_open
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist_optional_restart,

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -9,15 +9,16 @@ import pytest
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
+from utilities.jira import is_jira_open
 
-from tests.os_params import WINDOWS_LATEST, WINDOWS_LATEST_LABELS
-from utilities.constants import HOTPLUG_DISK_SERIAL
+from tests.storage.utils import assert_disk_bus
+from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
+from utilities.constants import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS, Images
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist_optional_restart,
     create_dv,
-    data_volume,
     virtctl_volume,
     wait_for_vm_volume_ready,
 )
@@ -26,8 +27,6 @@ from utilities.virt import (
     fedora_vm_body,
     migrate_vm_and_verify,
     running_vm,
-    vm_instance_from_template,
-    wait_for_windows_vm,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -73,51 +72,37 @@ def hotplug_volume_windows_scope_class(
 
 
 @pytest.fixture(scope="class")
-def vm_instance_from_template_multi_storage_scope_class(
-    request,
+def windows_dv_from_registry_scope_class(
     unprivileged_client,
     namespace,
-    data_volume_multi_storage_scope_class,
-    cpu_for_migration,
+    storage_class_matrix__class__,
 ):
-    """Calls vm_instance_from_template contextmanager
+    """Creates a Windows 2022 DataVolume from registry container disk."""
+    with create_windows2022_dv_from_registry(
+        dv_name="dv-windows-2022-hotplug",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        storage_class=next(iter(storage_class_matrix__class__)),
+    ) as dv_dict:
+        yield dv_dict
 
-    Creates a VM from template and starts it (if requested).
-    """
-    with vm_instance_from_template(
-        request=request,
-        unprivileged_client=unprivileged_client,
-        namespace=namespace,
-        existing_data_volume=data_volume_multi_storage_scope_class,
-        vm_cpu_model=cpu_for_migration if request.param.get("set_vm_common_cpu") else None,
+
+@pytest.fixture(scope="class")
+def vm_instance_from_template_multi_storage_scope_class(
+    unprivileged_client,
+    namespace,
+    modern_cpu_for_migration,
+    windows_dv_from_registry_scope_class,
+):
+    """Creates a Windows 2022 VM with vTPM from registry container disk."""
+    with create_windows2022_vm_with_vtpm_from_registry(
+        dv_dict=windows_dv_from_registry_scope_class,
+        namespace=namespace.name,
+        client=unprivileged_client,
+        vm_name="vm-win-2022-hotplug",
+        cpu_model=modern_cpu_for_migration,
     ) as vm:
         yield vm
-
-
-@pytest.fixture(scope="class")
-def started_windows_vm_scope_class(
-    request,
-    vm_instance_from_template_multi_storage_scope_class,
-):
-    wait_for_windows_vm(
-        vm=vm_instance_from_template_multi_storage_scope_class,
-        version=request.param["os_version"],
-    )
-
-
-@pytest.fixture(scope="class")
-def data_volume_multi_storage_scope_class(
-    request,
-    namespace,
-    storage_class_matrix__class__,
-    schedulable_nodes,
-):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class_matrix=storage_class_matrix__class__,
-        schedulable_nodes=schedulable_nodes,
-    )
 
 
 @pytest.fixture(scope="class")
@@ -142,21 +127,36 @@ def param_substring_scope_class(storage_class_name_scope_class):
 
 
 @pytest.fixture(scope="class")
-def fedora_vm_for_hotplug_scope_class(namespace, param_substring_scope_class, cpu_for_migration):
+def fedora_vm_for_hotplug_scope_class(unprivileged_client, namespace, param_substring_scope_class, cpu_for_migration):
     name = f"fedora-hotplug-{param_substring_scope_class}"
+    memory_requests = None
+    cpu_requests = None
+
+    if is_jira_open(jira_id="CNV-76658"):
+        memory_requests = f"{float(Images.Fedora.DEFAULT_MEMORY_SIZE[:-2]) * 2}Gi"
+        cpu_requests = 1
+
     with VirtualMachineForTests(
+        client=unprivileged_client,
         name=name,
+        memory_requests=memory_requests,
+        memory_limits=memory_requests,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
         cpu_model=cpu_for_migration,
+        cpu_limits=cpu_requests,
+        cpu_requests=cpu_requests,
     ) as vm:
         running_vm(vm=vm)
         yield vm
 
 
 @pytest.fixture(scope="class")
-def blank_disk_dv_multi_storage_scope_class(namespace, param_substring_scope_class, storage_class_name_scope_class):
+def blank_disk_dv_multi_storage_scope_class(
+    unprivileged_client, namespace, param_substring_scope_class, storage_class_name_scope_class
+):
     with create_dv(
+        client=unprivileged_client,
         source="blank",
         dv_name=f"blank-dv-{param_substring_scope_class}",
         namespace=namespace.name,
@@ -168,36 +168,45 @@ def blank_disk_dv_multi_storage_scope_class(namespace, param_substring_scope_cla
 
 
 @pytest.mark.parametrize(
-    "hotplug_volume_scope_class",
+    ("hotplug_volume_scope_class", "expected_bus"),
     [
-        pytest.param({"persist": True}),
+        pytest.param({"persist": True, "bus": HOTPLUG_DISK_VIRTIO_BUS}, HOTPLUG_DISK_VIRTIO_BUS, id="virtio-bus"),
+        pytest.param({"persist": True, "bus": HOTPLUG_DISK_SCSI_BUS}, HOTPLUG_DISK_SCSI_BUS, id="scsi-bus"),
     ],
-    indirect=True,
+    indirect=["hotplug_volume_scope_class"],
 )
 @pytest.mark.conformance
 @pytest.mark.gating
+@pytest.mark.usefixtures("hotplug_volume_scope_class")
 class TestHotPlugWithPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6014")
-    @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
+    @pytest.mark.dependency(name="test_hotplug_volume_with_bus_and_persist")
     @pytest.mark.s390x
-    def test_hotplug_volume_with_persist(
+    def test_hotplug_volume_with_bus_and_persist(
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
-        hotplug_volume_scope_class,
+        expected_bus,
     ):
-        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class)
-        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class, restart=True)
+        wait_for_vm_volume_ready(
+            vm=fedora_vm_for_hotplug_scope_class, volume_name=blank_disk_dv_multi_storage_scope_class.name
+        )
+        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class)
+        assert_disk_bus(
+            vm=fedora_vm_for_hotplug_scope_class,
+            volume=blank_disk_dv_multi_storage_scope_class,
+            expected_bus=expected_bus,
+        )
 
     @pytest.mark.polarion("CNV-11390")
-    @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
+    @pytest.mark.dependency(depends=["test_hotplug_volume_with_bus_and_persist"])
     @pytest.mark.s390x
-    def test_hotplug_volume_with_persist_migrate(
+    def test_hotplug_volume_with_bus_and_persist_migrate(
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
-        hotplug_volume_scope_class,
+        expected_bus,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
@@ -212,6 +221,7 @@ class TestHotPlugWithPersist:
 )
 @pytest.mark.conformance
 @pytest.mark.gating
+@pytest.mark.usefixtures("hotplug_volume_scope_class")
 class TestHotPlugWithSerialPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6425")
@@ -221,11 +231,12 @@ class TestHotPlugWithSerialPersist:
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
-        hotplug_volume_scope_class,
     ):
-        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class)
+        wait_for_vm_volume_ready(
+            vm=fedora_vm_for_hotplug_scope_class, volume_name=blank_disk_dv_multi_storage_scope_class.name
+        )
         assert_disk_serial(vm=fedora_vm_for_hotplug_scope_class)
-        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class, restart=True)
+        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class)
 
     @pytest.mark.polarion("CNV-6425b")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
@@ -234,34 +245,21 @@ class TestHotPlugWithSerialPersist:
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
-        hotplug_volume_scope_class,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
 
 
 @pytest.mark.parametrize(
-    "data_volume_multi_storage_scope_class,"
-    "vm_instance_from_template_multi_storage_scope_class,"
-    "started_windows_vm_scope_class,"
     "hotplug_volume_windows_scope_class",
     [
         pytest.param(
-            {
-                "dv_name": "dv-windows",
-                "image": WINDOWS_LATEST.get("image_path"),
-                "dv_size": WINDOWS_LATEST.get("dv_size"),
-            },
-            {
-                "vm_name": f"vm-win-{WINDOWS_LATEST.get('os_version')}",
-                "template_labels": WINDOWS_LATEST_LABELS,
-            },
-            {"os_version": WINDOWS_LATEST.get("os_version")},
             {"persist": True, "serial": HOTPLUG_DISK_SERIAL},
         ),
     ],
     indirect=True,
 )
+@pytest.mark.usefixtures("hotplug_volume_windows_scope_class")
 @pytest.mark.tier3
 class TestHotPlugWindows:
     @pytest.mark.polarion("CNV-6525")
@@ -269,20 +267,17 @@ class TestHotPlugWindows:
     def test_windows_hotplug(
         self,
         blank_disk_dv_multi_storage_scope_class,
-        data_volume_multi_storage_scope_class,
         vm_instance_from_template_multi_storage_scope_class,
-        started_windows_vm_scope_class,
-        hotplug_volume_windows_scope_class,
     ):
-        wait_for_vm_volume_ready(vm=vm_instance_from_template_multi_storage_scope_class)
+        wait_for_vm_volume_ready(
+            vm=vm_instance_from_template_multi_storage_scope_class,
+            volume_name=blank_disk_dv_multi_storage_scope_class.name,
+        )
         assert_disk_serial(
             command=shlex.split("wmic diskdrive get SerialNumber"),
             vm=vm_instance_from_template_multi_storage_scope_class,
         )
-        assert_hotplugvolume_nonexist_optional_restart(
-            vm=vm_instance_from_template_multi_storage_scope_class,
-            restart=True,
-        )
+        assert_hotplugvolume_nonexist_optional_restart(vm=vm_instance_from_template_multi_storage_scope_class)
 
     @pytest.mark.polarion("CNV-11391")
     @pytest.mark.dependency(depends=["test_windows_hotplug"])
@@ -290,10 +285,7 @@ class TestHotPlugWindows:
         self,
         unprivileged_client,
         blank_disk_dv_multi_storage_scope_class,
-        data_volume_multi_storage_scope_class,
         vm_instance_from_template_multi_storage_scope_class,
-        started_windows_vm_scope_class,
-        hotplug_volume_windows_scope_class,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -10,11 +10,9 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
 
-from tests.storage.utils import assert_disk_bus
 from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
-from utilities.constants import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS, Images
+from utilities.constants import HOTPLUG_DISK_SERIAL
 from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.infra import is_jira_open
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist_optional_restart,
@@ -127,36 +125,21 @@ def param_substring_scope_class(storage_class_name_scope_class):
 
 
 @pytest.fixture(scope="class")
-def fedora_vm_for_hotplug_scope_class(unprivileged_client, namespace, param_substring_scope_class, cpu_for_migration):
+def fedora_vm_for_hotplug_scope_class(namespace, param_substring_scope_class, cpu_for_migration):
     name = f"fedora-hotplug-{param_substring_scope_class}"
-    memory_requests = None
-    cpu_requests = None
-
-    if is_jira_open(jira_id="CNV-71599"):
-        memory_requests = f"{float(Images.Fedora.DEFAULT_MEMORY_SIZE[:-2]) * 2}Gi"
-        cpu_requests = 1
-
     with VirtualMachineForTests(
-        client=unprivileged_client,
         name=name,
-        memory_requests=memory_requests,
-        memory_limits=memory_requests,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
         cpu_model=cpu_for_migration,
-        cpu_limits=cpu_requests,
-        cpu_requests=cpu_requests,
     ) as vm:
         running_vm(vm=vm)
         yield vm
 
 
 @pytest.fixture(scope="class")
-def blank_disk_dv_multi_storage_scope_class(
-    unprivileged_client, namespace, param_substring_scope_class, storage_class_name_scope_class
-):
+def blank_disk_dv_multi_storage_scope_class(namespace, param_substring_scope_class, storage_class_name_scope_class):
     with create_dv(
-        client=unprivileged_client,
         source="blank",
         dv_name=f"blank-dv-{param_substring_scope_class}",
         namespace=namespace.name,
@@ -168,43 +151,36 @@ def blank_disk_dv_multi_storage_scope_class(
 
 
 @pytest.mark.parametrize(
-    ("hotplug_volume_scope_class", "expected_bus"),
+    "hotplug_volume_scope_class",
     [
-        pytest.param({"persist": True, "bus": HOTPLUG_DISK_VIRTIO_BUS}, HOTPLUG_DISK_VIRTIO_BUS, id="virtio-bus"),
-        pytest.param({"persist": True, "bus": HOTPLUG_DISK_SCSI_BUS}, HOTPLUG_DISK_SCSI_BUS, id="scsi-bus"),
+        pytest.param({"persist": True}),
     ],
-    indirect=["hotplug_volume_scope_class"],
+    indirect=True,
 )
 @pytest.mark.conformance
 @pytest.mark.gating
-@pytest.mark.usefixtures("hotplug_volume_scope_class")
 class TestHotPlugWithPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6014")
-    @pytest.mark.dependency(name="test_hotplug_volume_with_bus_and_persist")
+    @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
     @pytest.mark.s390x
-    def test_hotplug_volume_with_bus_and_persist(
+    def test_hotplug_volume_with_persist(
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
-        expected_bus,
+        hotplug_volume_scope_class,
     ):
         wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class)
-        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class)
-        assert_disk_bus(
-            vm=fedora_vm_for_hotplug_scope_class,
-            volume=blank_disk_dv_multi_storage_scope_class,
-            expected_bus=expected_bus,
-        )
+        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class, restart=True)
 
     @pytest.mark.polarion("CNV-11390")
-    @pytest.mark.dependency(depends=["test_hotplug_volume_with_bus_and_persist"])
+    @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
     @pytest.mark.s390x
-    def test_hotplug_volume_with_bus_and_persist_migrate(
+    def test_hotplug_volume_with_persist_migrate(
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
-        expected_bus,
+        hotplug_volume_scope_class,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
@@ -219,7 +195,6 @@ class TestHotPlugWithPersist:
 )
 @pytest.mark.conformance
 @pytest.mark.gating
-@pytest.mark.usefixtures("hotplug_volume_scope_class")
 class TestHotPlugWithSerialPersist:
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6425")
@@ -229,10 +204,11 @@ class TestHotPlugWithSerialPersist:
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
+        hotplug_volume_scope_class,
     ):
         wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class)
         assert_disk_serial(vm=fedora_vm_for_hotplug_scope_class)
-        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class)
+        assert_hotplugvolume_nonexist_optional_restart(vm=fedora_vm_for_hotplug_scope_class, restart=True)
 
     @pytest.mark.polarion("CNV-6425b")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
@@ -241,6 +217,7 @@ class TestHotPlugWithSerialPersist:
         self,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
+        hotplug_volume_scope_class,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
@@ -270,7 +247,10 @@ class TestHotPlugWindows:
             command=shlex.split("wmic diskdrive get SerialNumber"),
             vm=vm_instance_from_template_multi_storage_scope_class,
         )
-        assert_hotplugvolume_nonexist_optional_restart(vm=vm_instance_from_template_multi_storage_scope_class)
+        assert_hotplugvolume_nonexist_optional_restart(
+            vm=vm_instance_from_template_multi_storage_scope_class,
+            restart=True,
+        )
 
     @pytest.mark.polarion("CNV-11391")
     @pytest.mark.dependency(depends=["test_windows_hotplug"])

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -10,7 +10,7 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
 
-from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
+from tests.utils import create_windows2022_dv_template_from_registry, create_windows2022_vm_with_vtpm
 from utilities.constants import HOTPLUG_DISK_SERIAL
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import (
@@ -76,7 +76,7 @@ def windows_dv_from_registry_scope_class(
     storage_class_matrix__class__,
 ):
     """Creates a Windows 2022 DataVolume from registry container disk."""
-    with create_windows2022_dv_from_registry(
+    with create_windows2022_dv_template_from_registry(
         dv_name="dv-windows-2022-hotplug",
         namespace=namespace.name,
         client=unprivileged_client,
@@ -93,8 +93,8 @@ def vm_instance_from_template_multi_storage_scope_class(
     windows_dv_from_registry_scope_class,
 ):
     """Creates a Windows 2022 VM with vTPM from registry container disk."""
-    with create_windows2022_vm_with_vtpm_from_registry(
-        dv_dict=windows_dv_from_registry_scope_class,
+    with create_windows2022_vm_with_vtpm(
+        dv_template=windows_dv_from_registry_scope_class,
         namespace=namespace.name,
         client=unprivileged_client,
         vm_name="vm-win-2022-hotplug",

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -462,3 +462,27 @@ def create_windows_directory(windows_vm: VirtualMachineForTests, directory_path:
         windows_vm=windows_vm,
         directory_path=directory_path,
     )
+
+
+def assert_disk_bus(vm: VirtualMachineForTests, volume: DataVolume, expected_bus: str) -> None:
+    """Assert that a hotplugged volume has the expected disk bus type.
+
+    Args:
+        vm: Virtual machine instance.
+        volume: DataVolume expected to be hotplugged.
+        expected_bus: Expected bus type (e.g., "virtio", "scsi")
+
+    Raises:
+        AssertionError: If disk is not found or bus type does not match.
+    """
+    disk = next(
+        (
+            disk_entry
+            for disk_entry in vm.vmi.instance.spec.domain.devices.disks
+            if disk_entry.get("name") == volume.name
+        ),
+        None,
+    )
+    assert disk is not None, f"Disk {volume.name} not found in VM {vm.name}"
+    actual_bus = disk.get("disk", {}).get("bus")
+    assert actual_bus == expected_bus, f"Disk {volume.name} has bus '{actual_bus}' but expected '{expected_bus}'"

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -439,3 +439,27 @@ def create_windows_directory(windows_vm: VirtualMachineForTests, directory_path:
         windows_vm=windows_vm,
         directory_path=directory_path,
     )
+
+
+def assert_disk_bus(vm: VirtualMachineForTests, volume: DataVolume, expected_bus: str) -> None:
+    """Assert that a hotplugged volume has the expected disk bus type.
+
+    Args:
+        vm: Virtual machine instance.
+        volume: DataVolume expected to be hotplugged.
+        expected_bus: Expected bus type (e.g., "virtio", "scsi")
+
+    Raises:
+        AssertionError: If disk is not found or bus type does not match.
+    """
+    disk = next(
+        (
+            disk_entry
+            for disk_entry in vm.vmi.instance.spec.domain.devices.disks
+            if disk_entry.get("name") == volume.name
+        ),
+        None,
+    )
+    assert disk is not None, f"Disk {volume.name} not found in VM {vm.name}"
+    actual_bus = disk.get("disk", {}).get("bus")
+    assert actual_bus == expected_bus, f"Disk {volume.name} has bus '{actual_bus}' but expected '{expected_bus}'"

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -439,27 +439,3 @@ def create_windows_directory(windows_vm: VirtualMachineForTests, directory_path:
         windows_vm=windows_vm,
         directory_path=directory_path,
     )
-
-
-def assert_disk_bus(vm: VirtualMachineForTests, volume: DataVolume, expected_bus: str) -> None:
-    """Assert that a hotplugged volume has the expected disk bus type.
-
-    Args:
-        vm: Virtual machine instance.
-        volume: DataVolume expected to be hotplugged.
-        expected_bus: Expected bus type (e.g., "virtio", "scsi")
-
-    Raises:
-        AssertionError: If disk is not found or bus type does not match.
-    """
-    disk = next(
-        (
-            disk_entry
-            for disk_entry in vm.vmi.instance.spec.domain.devices.disks
-            if disk_entry.get("name") == volume.name
-        ),
-        None,
-    )
-    assert disk is not None, f"Disk {volume.name} not found in VM {vm.name}"
-    actual_bus = disk.get("disk", {}).get("bus")
-    assert actual_bus == expected_bus, f"Disk {volume.name} has bus '{actual_bus}' but expected '{expected_bus}'"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http
 import logging
 import re
 import shlex
@@ -11,6 +12,7 @@ from typing import Generator, Optional
 import bitmath
 import requests
 import xmltodict
+from bs4 import BeautifulSoup
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.datavolume import DataVolume
@@ -146,6 +148,27 @@ def wait_for_cr_labels_change(expected_value, component, timeout=TIMEOUT_10MIN):
         raise
 
 
+def validate_runbook_url_exists(url, alert_name=None, production=False):
+    response = requests.get(url, allow_redirects=False)
+    LOGGER.info(response)
+    if response.status_code != http.HTTPStatus.OK:
+        return f"{url} validation failed: {response}"
+    if production:
+        assert alert_name
+        url_link = f"#virt-runbook-{alert_name}"
+        if NOT_PUBLISHED_MESSAGE in response.text:
+            LOGGER.error(f"{url} found with message {NOT_PUBLISHED_MESSAGE}: {response.content}")
+            return f"{url} not published yet."
+        soup = BeautifulSoup(response.content)
+        for link in soup.findAll("a"):
+            url_str = link.get("href")
+            if url_str and url_str.endswith(url_link):
+                LOGGER.info(f"Alert link is found : {link}")
+                return
+        LOGGER.warning(f"Alert url {url} not found for alert {alert_name}")
+        return f"Alert url {url} not found"
+
+
 def get_image_from_csv(image_string, csv_related_images):
     for image in csv_related_images:
         if image_string in image["image"]:
@@ -279,6 +302,13 @@ def wait_for_guest_os_cpu_count(vm, spec_cpu_amount):
             f"Timed out waiting for guest OS CPU count to match VMI spec. Guest: {sample}; VMI: {spec_cpu_amount}"
         )
         raise
+
+
+def assert_guest_os_cpu_count(vm, spec_cpu_amount):
+    guest_os_cpu_amount = get_os_cpu_count(vm=vm)
+    assert guest_os_cpu_amount == spec_cpu_amount, (
+        f"Wrong amount of CPUs! Guest: {guest_os_cpu_amount}; VMI: {spec_cpu_amount}"
+    )
 
 
 def assert_guest_os_memory_amount(vm, spec_memory_amount):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -665,8 +665,7 @@ def create_windows2022_dv_from_registry(
     Yields:
         dict: DataVolume template dictionary with metadata and spec
     """
-    from utilities.artifactory import cleanup_artifactory_secret_and_config_map, get_test_artifact_server_url
-
+    from utilities.infra import cleanup_artifactory_secret_and_config_map, get_test_artifact_server_url
     from utilities.os_utils import get_windows_container_disk_path
 
     artifactory_secret = get_artifactory_secret(namespace=namespace)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import http
 import logging
 import re
 import shlex
@@ -12,20 +11,24 @@ from typing import Generator, Optional
 import bitmath
 import requests
 import xmltodict
-from bs4 import BeautifulSoup
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
+from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from pyhelper_utils.shell import run_ssh_commands
+from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from utilities.constants import (
     DISK_SERIAL,
     HCO_DEFAULT_CPU_MODEL_KEY,
+    OS_FLAVOR_WIN_CONTAINER_DISK,
+    OS_FLAVOR_WINDOWS,
     RHSM_SECRET_NAME,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
@@ -36,8 +39,13 @@ from utilities.constants import (
     TIMEOUT_10SEC,
     TIMEOUT_15SEC,
     TIMEOUT_30MIN,
+    U1_LARGE,
+    WIN_2K22,
+    WINDOWS_2K22_PREFERENCE,
     Images,
 )
+from utilities.data_collector import get_data_collector_dir, write_to_file
+from utilities.exceptions import ResourceValueError
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     ExecCommandOnPod,
@@ -72,6 +80,7 @@ def create_vms(
     client=None,
     ssh=True,
     node_selector_labels=None,
+    cpu_model=None,
 ):
     """
     Create n number of fedora vms.
@@ -83,6 +92,7 @@ def create_vms(
         node_selector_labels (str): Labels for node selector.
         client (DynamicClient): DynamicClient object
         ssh (bool): enable SSH on the VM
+        cpu_model (str): CPU model to be used for the VMs
 
     Returns:
         list: List of VirtualMachineForTests
@@ -99,6 +109,7 @@ def create_vms(
             run_strategy=VirtualMachine.RunStrategy.ALWAYS,
             ssh=ssh,
             client=client,
+            cpu_model=cpu_model,
         ) as vm:
             vms_list.append(vm)
     return vms_list
@@ -133,27 +144,6 @@ def wait_for_cr_labels_change(expected_value, component, timeout=TIMEOUT_10MIN):
             f" current value:'{label}'"
         )
         raise
-
-
-def validate_runbook_url_exists(url, alert_name=None, production=False):
-    response = requests.get(url, allow_redirects=False)
-    LOGGER.info(response)
-    if response.status_code != http.HTTPStatus.OK:
-        return f"{url} validation failed: {response}"
-    if production:
-        assert alert_name
-        url_link = f"#virt-runbook-{alert_name}"
-        if NOT_PUBLISHED_MESSAGE in response.text:
-            LOGGER.error(f"{url} found with message {NOT_PUBLISHED_MESSAGE}: {response.content}")
-            return f"{url} not published yet."
-        soup = BeautifulSoup(response.content)
-        for link in soup.findAll("a"):
-            url_str = link.get("href")
-            if url_str and url_str.endswith(url_link):
-                LOGGER.info(f"Alert link is found : {link}")
-                return
-        LOGGER.warning(f"Alert url {url} not found for alert {alert_name}")
-        return f"Alert url {url} not found"
 
 
 def get_image_from_csv(image_string, csv_related_images):
@@ -224,7 +214,7 @@ def update_vm_instancetype_name(vm, instance_type_name):
 
 
 def clean_up_migration_jobs(client, vm):
-    for migration_job in VirtualMachineInstanceMigration.get(dyn_client=client, namespace=vm.namespace):
+    for migration_job in VirtualMachineInstanceMigration.get(client=client, namespace=vm.namespace):
         migration_job.clean_up()
 
 
@@ -232,7 +222,7 @@ def get_os_cpu_count(vm):
     if "windows" in vm.name:
         cmd = shlex.split("echo %NUMBER_OF_PROCESSORS%")
     else:
-        cmd = shlex.split("nproc --all")
+        cmd = shlex.split("nproc")
     return int(run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip())
 
 
@@ -247,11 +237,48 @@ def get_os_memory_value(vm):
         return f"{round(float(meminfo))}Gi"
 
 
-def assert_guest_os_cpu_count(vm, spec_cpu_amount):
-    guest_os_cpu_amount = get_os_cpu_count(vm=vm)
-    assert guest_os_cpu_amount == spec_cpu_amount, (
-        f"Wrong amount of CPUs! Guest: {guest_os_cpu_amount}; VMI: {spec_cpu_amount}"
+def _collect_cpu_diagnostic_info(vm):
+    """Collect CPU diagnostic information when CPU count mismatch occurs."""
+    base_dir = get_data_collector_dir()
+    LOGGER.info(f"Collecting CPU diagnostic information for VM {vm.name}")
+
+    if vm.os_flavor == OS_FLAVOR_WINDOWS:
+        cmd = shlex.split('powershell.exe -command "Get-WinEvent -LogName System -MaxEvents 30 | Format-List"')
+    else:
+        cmd = shlex.split("bash -c 'dmesg | tail -n 30'")
+
+    output = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0]
+    write_to_file(base_directory=base_dir, file_name=f"{vm.name}_cpu_diagnostic.txt", content=output)
+
+
+def wait_for_guest_os_cpu_count(vm, spec_cpu_amount):
+    """Wait for the guest OS CPU count to match the VMI spec.
+
+    Args:
+        vm (VirtualMachineForTests): Target VM.
+        spec_cpu_amount (int): Expected CPU socket count from VMI spec.
+
+    Raises:
+        TimeoutExpiredError: If the guest OS CPU count does not match within the timeout.
+    """
+    sampler = TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=TIMEOUT_5SEC,
+        func=get_os_cpu_count,
+        vm=vm,
     )
+    sample = None
+    try:
+        for sample in sampler:
+            if sample == spec_cpu_amount:
+                LOGGER.info(f"Guest OS CPU count matches VMI spec: {spec_cpu_amount}")
+                return
+    except TimeoutExpiredError:
+        _collect_cpu_diagnostic_info(vm=vm)
+        LOGGER.error(
+            f"Timed out waiting for guest OS CPU count to match VMI spec. Guest: {sample}; VMI: {spec_cpu_amount}"
+        )
+        raise
 
 
 def assert_guest_os_memory_amount(vm, spec_memory_amount):
@@ -478,8 +505,8 @@ def download_and_extract_tar(tarfile_url, dest_path):
     """Download and Extract the tar file."""
     artifactory_header = get_artifactory_header()
     request = requests.get(tarfile_url, verify=False, headers=artifactory_header, timeout=10)
-    thetarfile = tarfile.open(fileobj=BytesIO(request.content), mode="r|xz")
-    thetarfile.extractall(path=dest_path)
+    tar_file = tarfile.open(fileobj=BytesIO(request.content), mode="r|xz")
+    tar_file.extractall(path=dest_path)
 
     return True
 
@@ -575,15 +602,15 @@ def create_cirros_vm(
         yield vm
 
 
-def start_stress_on_vm(vm, stress_command):
+def start_stress_on_vm(vm: VirtualMachineForTests, stress_command: str) -> None:
     LOGGER.info(f"Running memory load in VM {vm.name}")
     if "windows" in vm.name:
         verify_wsl2_guest_running(vm=vm)
         verify_wsl2_guest_works(vm=vm)
         command = f"wsl nohup bash -c '{stress_command}'"
     else:
-        run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("sudo dnf install -y stress-ng"))
-        command = stress_command
+        command = f"sudo dnf install stress-ng -y; {stress_command}"
+
     run_ssh_commands(
         host=vm.ssh_exec,
         commands=shlex.split(command),
@@ -591,33 +618,7 @@ def start_stress_on_vm(vm, stress_command):
     )
 
 
-def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
-    """
-    Verifies that WSL2 is functioning on windows vm.
-    Args:
-        vm: An instance of `VirtualMachineForTests`
-    Raises:
-        TimeoutExpiredError: If WSL2 fails to return the expected output within
-            the specified timeout period.
-    """
-    echo_string = "TEST"
-    samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_1MIN,
-        sleep=TIMEOUT_15SEC,
-        func=run_ssh_commands,
-        host=vm.ssh_exec,
-        commands=shlex.split(f"wsl echo {echo_string}"),
-    )
-    try:
-        for sample in samples:
-            if sample and echo_string in sample[0]:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(f"VM {vm.name} failed to start WSL2")
-        raise
-
-
-def verify_wsl2_guest_running(vm, timeout=TIMEOUT_3MIN):
+def verify_wsl2_guest_running(vm: VirtualMachineForTests, timeout: int = TIMEOUT_3MIN) -> bool:
     def _get_wsl2_running_status():
         guests_status = run_ssh_commands(
             host=vm.ssh_exec,
@@ -636,3 +637,168 @@ def verify_wsl2_guest_running(vm, timeout=TIMEOUT_3MIN):
     except TimeoutExpiredError:
         LOGGER.error("WSL2 guest is not running in the VM!")
         raise
+    return False
+
+
+def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
+    """
+    Verifies that WSL2 is functioning on windows vm.
+    Args:
+        vm: An instance of `VirtualMachineForTests`
+    Raises:
+        TimeoutExpiredError: If WSL2 fails to return the expected output within
+            the specified timeout period.
+    """
+    test_str = "TEST"
+    samples = TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=TIMEOUT_15SEC,
+        func=run_ssh_commands,
+        host=vm.ssh_exec,
+        commands=shlex.split(f"wsl echo {test_str}"),
+    )
+    try:
+        for sample in samples:
+            if sample and test_str in sample[0]:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"VM {vm.name} failed to start WSL2")
+        raise
+
+
+def verify_cpumanager_workers(schedulable_nodes: list[Node]) -> None:
+    """Verify cluster nodes have CPU Manager labels
+
+    Args:
+        schedulable_nodes (list[Node]): List of schedulable node objects.
+
+    Raises:
+        ResourceValueError: If no node has CPU Manager enabled.
+    """
+    LOGGER.info("Verifying cluster nodes have CPU Manager labels")
+    if not any(node.labels.cpumanager == "true" for node in schedulable_nodes):
+        raise ResourceValueError("Cluster does not have CPU Manager enabled on any node")
+
+
+def verify_hugepages_1gi(hugepages_gib_values: list[float | int]) -> None:
+    """Verify that cluster nodes have 1Gi hugepages enabled.
+
+    Args:
+        hugepages_gib_values (list[float | int]): List of hugepage sizes (in GiB) from worker nodes.
+
+    Raises:
+        ResourceValueError: If 1Gi hugepages are not configured or are insufficient.
+    """
+    LOGGER.info("Verifying cluster has 1Gi hugepages enabled")
+    if not hugepages_gib_values or max(hugepages_gib_values) < 1:
+        raise ResourceValueError("Cluster does not have sufficient 1Gi hugepages")
+
+
+def verify_rwx_default_storage(client: DynamicClient) -> None:
+    """Verify default storage class supports RWX mode.
+
+    Args:
+        client (DynamicClient): Kubernetes dynamic client used to query cluster resources.
+
+    Raises:
+       ResourceValueError: access mode is not RWX
+    """
+    storage_class = py_config["default_storage_class"]
+    LOGGER.info(f"Verifying default storage class {storage_class} supports RWX mode")
+
+    access_modes = StorageProfile(client=client, name=storage_class).first_claim_property_set_access_modes()
+    found_mode = access_modes[0] if access_modes else None
+    if found_mode != DataVolume.AccessMode.RWX:
+        raise ResourceValueError(
+            f"Default storage class '{storage_class}' doesn't support RWX mode "
+            f"(required: RWX, found: {found_mode or 'none'})"
+        )
+
+
+@contextmanager
+def create_windows2022_dv_from_registry(
+    dv_name: str,
+    namespace: str,
+    client: DynamicClient,
+    storage_class: str,
+) -> Generator[dict]:
+    """
+    Creates a Windows Server 2022 DataVolume from registry container disk.
+
+    Args:
+        dv_name: Name for the DataVolume
+        namespace: Kubernetes namespace
+        client: Kubernetes client
+        storage_class: Storage class name
+
+    Yields:
+        dict: DataVolume template dictionary with metadata and spec
+    """
+    from utilities.artifactory import cleanup_artifactory_secret_and_config_map, get_test_artifact_server_url
+
+    from utilities.os_utils import get_windows_container_disk_path
+
+    artifactory_secret = get_artifactory_secret(namespace=namespace)
+    artifactory_config_map = get_artifactory_config_map(namespace=namespace)
+
+    dv = DataVolume(
+        name=dv_name,
+        namespace=namespace,
+        storage_class=storage_class,
+        source="registry",
+        url=f"{get_test_artifact_server_url(schema='registry')}/{get_windows_container_disk_path(os_value=WIN_2K22)}",
+        size=Images.Windows.CONTAINER_DISK_DV_SIZE,
+        client=client,
+        api_name="storage",
+        secret=artifactory_secret,
+        cert_configmap=artifactory_config_map.name,
+    )
+    dv.to_dict()
+
+    try:
+        yield {"metadata": dv.res["metadata"], "spec": dv.res["spec"]}
+    finally:
+        cleanup_artifactory_secret_and_config_map(
+            artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
+        )
+
+
+@contextmanager
+def create_windows2022_vm_with_vtpm_from_registry(
+    dv_dict: dict,
+    namespace: str,
+    client: DynamicClient,
+    vm_name: str,
+    cpu_model: str | None,
+) -> Generator[VirtualMachineForTests]:
+    """
+    Creates a Windows Server 2022 VM with vTPM from registry container disk.
+
+    Args:
+        dv_dict: DataVolume template dictionary with metadata and spec
+        namespace: Kubernetes namespace
+        client: Kubernetes client
+        vm_name: Name for the VirtualMachine
+        cpu_model: CPU model specification (can be None)
+
+    Yields:
+        VirtualMachineForTests: Running Windows 2022 VM with vTPM
+    """
+    from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+    from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+
+    from utilities.virt import wait_for_windows_vm
+
+    with VirtualMachineForTests(
+        name=vm_name,
+        namespace=namespace,
+        client=client,
+        os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_LARGE, client=client),
+        vm_preference=VirtualMachineClusterPreference(name=WINDOWS_2K22_PREFERENCE, client=client),
+        data_volume_template=dv_dict,
+        cpu_model=cpu_model,
+    ) as vm:
+        running_vm(vm=vm)
+        wait_for_windows_vm(vm=vm, version="2022")
+        yield vm

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,20 +17,16 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
-from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
-from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from pyhelper_utils.shell import run_ssh_commands
-from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from utilities.constants import (
     DISK_SERIAL,
     HCO_DEFAULT_CPU_MODEL_KEY,
     OS_FLAVOR_WIN_CONTAINER_DISK,
-    OS_FLAVOR_WINDOWS,
     RHSM_SECRET_NAME,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
@@ -46,8 +42,6 @@ from utilities.constants import (
     WINDOWS_2K22_PREFERENCE,
     Images,
 )
-from utilities.data_collector import get_data_collector_dir, write_to_file
-from utilities.exceptions import ResourceValueError
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     ExecCommandOnPod,
@@ -258,50 +252,6 @@ def get_os_memory_value(vm):
         cmd = shlex.split("awk \"'{print$2/1024/1024;exit}'\" /proc/meminfo")
         meminfo = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip()
         return f"{round(float(meminfo))}Gi"
-
-
-def _collect_cpu_diagnostic_info(vm):
-    """Collect CPU diagnostic information when CPU count mismatch occurs."""
-    base_dir = get_data_collector_dir()
-    LOGGER.info(f"Collecting CPU diagnostic information for VM {vm.name}")
-
-    if vm.os_flavor == OS_FLAVOR_WINDOWS:
-        cmd = shlex.split('powershell.exe -command "Get-WinEvent -LogName System -MaxEvents 30 | Format-List"')
-    else:
-        cmd = shlex.split("bash -c 'dmesg | tail -n 30'")
-
-    output = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0]
-    write_to_file(base_directory=base_dir, file_name=f"{vm.name}_cpu_diagnostic.txt", content=output)
-
-
-def wait_for_guest_os_cpu_count(vm, spec_cpu_amount):
-    """Wait for the guest OS CPU count to match the VMI spec.
-
-    Args:
-        vm (VirtualMachineForTests): Target VM.
-        spec_cpu_amount (int): Expected CPU socket count from VMI spec.
-
-    Raises:
-        TimeoutExpiredError: If the guest OS CPU count does not match within the timeout.
-    """
-    sampler = TimeoutSampler(
-        wait_timeout=TIMEOUT_1MIN,
-        sleep=TIMEOUT_5SEC,
-        func=get_os_cpu_count,
-        vm=vm,
-    )
-    sample = None
-    try:
-        for sample in sampler:
-            if sample == spec_cpu_amount:
-                LOGGER.info(f"Guest OS CPU count matches VMI spec: {spec_cpu_amount}")
-                return
-    except TimeoutExpiredError:
-        _collect_cpu_diagnostic_info(vm=vm)
-        LOGGER.error(
-            f"Timed out waiting for guest OS CPU count to match VMI spec. Guest: {sample}; VMI: {spec_cpu_amount}"
-        )
-        raise
 
 
 def assert_guest_os_cpu_count(vm, spec_cpu_amount):
@@ -694,55 +644,6 @@ def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
     except TimeoutExpiredError:
         LOGGER.error(f"VM {vm.name} failed to start WSL2")
         raise
-
-
-def verify_cpumanager_workers(schedulable_nodes: list[Node]) -> None:
-    """Verify cluster nodes have CPU Manager labels
-
-    Args:
-        schedulable_nodes (list[Node]): List of schedulable node objects.
-
-    Raises:
-        ResourceValueError: If no node has CPU Manager enabled.
-    """
-    LOGGER.info("Verifying cluster nodes have CPU Manager labels")
-    if not any(node.labels.cpumanager == "true" for node in schedulable_nodes):
-        raise ResourceValueError("Cluster does not have CPU Manager enabled on any node")
-
-
-def verify_hugepages_1gi(hugepages_gib_values: list[float | int]) -> None:
-    """Verify that cluster nodes have 1Gi hugepages enabled.
-
-    Args:
-        hugepages_gib_values (list[float | int]): List of hugepage sizes (in GiB) from worker nodes.
-
-    Raises:
-        ResourceValueError: If 1Gi hugepages are not configured or are insufficient.
-    """
-    LOGGER.info("Verifying cluster has 1Gi hugepages enabled")
-    if not hugepages_gib_values or max(hugepages_gib_values) < 1:
-        raise ResourceValueError("Cluster does not have sufficient 1Gi hugepages")
-
-
-def verify_rwx_default_storage(client: DynamicClient) -> None:
-    """Verify default storage class supports RWX mode.
-
-    Args:
-        client (DynamicClient): Kubernetes dynamic client used to query cluster resources.
-
-    Raises:
-       ResourceValueError: access mode is not RWX
-    """
-    storage_class = py_config["default_storage_class"]
-    LOGGER.info(f"Verifying default storage class {storage_class} supports RWX mode")
-
-    access_modes = StorageProfile(client=client, name=storage_class).first_claim_property_set_access_modes()
-    found_mode = access_modes[0] if access_modes else None
-    if found_mode != DataVolume.AccessMode.RWX:
-        raise ResourceValueError(
-            f"Default storage class '{storage_class}' doesn't support RWX mode "
-            f"(required: RWX, found: {found_mode or 'none'})"
-        )
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,20 +17,16 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
-from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
-from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from pyhelper_utils.shell import run_ssh_commands
-from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from utilities.constants import (
     DISK_SERIAL,
     HCO_DEFAULT_CPU_MODEL_KEY,
     OS_FLAVOR_WIN_CONTAINER_DISK,
-    OS_FLAVOR_WINDOWS,
     RHSM_SECRET_NAME,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
@@ -47,8 +43,6 @@ from utilities.constants import (
     WINDOWS_2K22_PREFERENCE,
     Images,
 )
-from utilities.data_collector import get_data_collector_dir, write_to_file
-from utilities.exceptions import ResourceValueError
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     ExecCommandOnPod,
@@ -261,50 +255,6 @@ def get_os_memory_value(vm):
         cmd = shlex.split("awk \"'{print$2/1024/1024;exit}'\" /proc/meminfo")
         meminfo = run_ssh_commands(host=vm.ssh_exec, commands=cmd, wait_timeout=TIMEOUT_2MIN)[0].strip()
         return f"{round(float(meminfo))}Gi"
-
-
-def _collect_cpu_diagnostic_info(vm):
-    """Collect CPU diagnostic information when CPU count mismatch occurs."""
-    base_dir = get_data_collector_dir()
-    LOGGER.info(f"Collecting CPU diagnostic information for VM {vm.name}")
-
-    if vm.os_flavor == OS_FLAVOR_WINDOWS:
-        cmd = shlex.split('powershell.exe -command "Get-WinEvent -LogName System -MaxEvents 30 | Format-List"')
-    else:
-        cmd = shlex.split("bash -c 'dmesg | tail -n 30'")
-
-    output = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0]
-    write_to_file(base_directory=base_dir, file_name=f"{vm.name}_cpu_diagnostic.txt", content=output)
-
-
-def wait_for_guest_os_cpu_count(vm, spec_cpu_amount):
-    """Wait for the guest OS CPU count to match the VMI spec.
-
-    Args:
-        vm (VirtualMachineForTests): Target VM.
-        spec_cpu_amount (int): Expected CPU socket count from VMI spec.
-
-    Raises:
-        TimeoutExpiredError: If the guest OS CPU count does not match within the timeout.
-    """
-    sampler = TimeoutSampler(
-        wait_timeout=TIMEOUT_1MIN,
-        sleep=TIMEOUT_5SEC,
-        func=get_os_cpu_count,
-        vm=vm,
-    )
-    sample = None
-    try:
-        for sample in sampler:
-            if sample == spec_cpu_amount:
-                LOGGER.info(f"Guest OS CPU count matches VMI spec: {spec_cpu_amount}")
-                return
-    except TimeoutExpiredError:
-        _collect_cpu_diagnostic_info(vm=vm)
-        LOGGER.error(
-            f"Timed out waiting for guest OS CPU count to match VMI spec. Guest: {sample}; VMI: {spec_cpu_amount}"
-        )
-        raise
 
 
 def assert_guest_os_cpu_count(vm, spec_cpu_amount):
@@ -697,55 +647,6 @@ def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
     except TimeoutExpiredError:
         LOGGER.error(f"VM {vm.name} failed to start WSL2")
         raise
-
-
-def verify_cpumanager_workers(schedulable_nodes: list[Node]) -> None:
-    """Verify cluster nodes have CPU Manager labels
-
-    Args:
-        schedulable_nodes (list[Node]): List of schedulable node objects.
-
-    Raises:
-        ResourceValueError: If no node has CPU Manager enabled.
-    """
-    LOGGER.info("Verifying cluster nodes have CPU Manager labels")
-    if not any(node.labels.cpumanager == "true" for node in schedulable_nodes):
-        raise ResourceValueError("Cluster does not have CPU Manager enabled on any node")
-
-
-def verify_hugepages_1gi(hugepages_gib_values: list[float | int]) -> None:
-    """Verify that cluster nodes have 1Gi hugepages enabled.
-
-    Args:
-        hugepages_gib_values (list[float | int]): List of hugepage sizes (in GiB) from worker nodes.
-
-    Raises:
-        ResourceValueError: If 1Gi hugepages are not configured or are insufficient.
-    """
-    LOGGER.info("Verifying cluster has 1Gi hugepages enabled")
-    if not hugepages_gib_values or max(hugepages_gib_values) < 1:
-        raise ResourceValueError("Cluster does not have sufficient 1Gi hugepages")
-
-
-def verify_rwx_default_storage(client: DynamicClient) -> None:
-    """Verify default storage class supports RWX mode.
-
-    Args:
-        client (DynamicClient): Kubernetes dynamic client used to query cluster resources.
-
-    Raises:
-       ResourceValueError: access mode is not RWX
-    """
-    storage_class = py_config["default_storage_class"]
-    LOGGER.info(f"Verifying default storage class {storage_class} supports RWX mode")
-
-    access_modes = StorageProfile(client=client, name=storage_class).first_claim_property_set_access_modes()
-    found_mode = access_modes[0] if access_modes else None
-    if found_mode != DataVolume.AccessMode.RWX:
-        raise ResourceValueError(
-            f"Default storage class '{storage_class}' doesn't support RWX mode "
-            f"(required: RWX, found: {found_mode or 'none'})"
-        )
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -668,8 +668,7 @@ def create_windows2022_dv_from_registry(
     Yields:
         dict: DataVolume template dictionary with metadata and spec
     """
-    from utilities.artifactory import cleanup_artifactory_secret_and_config_map, get_test_artifact_server_url
-
+    from utilities.infra import cleanup_artifactory_secret_and_config_map, get_test_artifact_server_url
     from utilities.os_utils import get_windows_container_disk_path
 
     artifactory_secret = get_artifactory_secret(namespace=namespace)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http
 import logging
 import re
 import shlex
@@ -11,6 +12,7 @@ from typing import Generator, Optional
 import bitmath
 import requests
 import xmltodict
+from bs4 import BeautifulSoup
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.datavolume import DataVolume
@@ -145,6 +147,27 @@ def wait_for_cr_labels_change(expected_value, component, timeout=TIMEOUT_10MIN):
             f" current value:'{label}'"
         )
         raise
+
+
+def validate_runbook_url_exists(url, alert_name=None, production=False):
+    response = requests.get(url, allow_redirects=False)
+    LOGGER.info(response)
+    if response.status_code != http.HTTPStatus.OK:
+        return f"{url} validation failed: {response}"
+    if production:
+        assert alert_name
+        url_link = f"#virt-runbook-{alert_name}"
+        if NOT_PUBLISHED_MESSAGE in response.text:
+            LOGGER.error(f"{url} found with message {NOT_PUBLISHED_MESSAGE}: {response.content}")
+            return f"{url} not published yet."
+        soup = BeautifulSoup(response.content)
+        for link in soup.findAll("a"):
+            url_str = link.get("href")
+            if url_str and url_str.endswith(url_link):
+                LOGGER.info(f"Alert link is found : {link}")
+                return
+        LOGGER.warning(f"Alert url {url} not found for alert {alert_name}")
+        return f"Alert url {url} not found"
 
 
 def get_image_from_csv(image_string, csv_related_images):
@@ -282,6 +305,13 @@ def wait_for_guest_os_cpu_count(vm, spec_cpu_amount):
             f"Timed out waiting for guest OS CPU count to match VMI spec. Guest: {sample}; VMI: {spec_cpu_amount}"
         )
         raise
+
+
+def assert_guest_os_cpu_count(vm, spec_cpu_amount):
+    guest_os_cpu_amount = get_os_cpu_count(vm=vm)
+    assert guest_os_cpu_amount == spec_cpu_amount, (
+        f"Wrong amount of CPUs! Guest: {guest_os_cpu_amount}; VMI: {spec_cpu_amount}"
+    )
 
 
 def assert_guest_os_memory_amount(vm, spec_memory_amount):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,9 +5,10 @@ import logging
 import re
 import shlex
 import tarfile
+from collections.abc import Generator
 from contextlib import contextmanager
 from io import BytesIO
-from typing import Generator, Optional
+from typing import Optional
 
 import bitmath
 import requests
@@ -19,6 +20,8 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
@@ -46,11 +49,14 @@ from utilities.constants import (
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     ExecCommandOnPod,
+    cleanup_artifactory_secret_and_config_map,
     get_artifactory_config_map,
     get_artifactory_header,
     get_artifactory_secret,
     get_http_image_url,
+    get_test_artifact_server_url,
 )
+from utilities.os_utils import get_windows_container_disk_path
 from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
@@ -60,6 +66,7 @@ from utilities.virt import (
     wait_for_migration_finished,
     wait_for_ssh_connectivity,
     wait_for_updated_kv_value,
+    wait_for_windows_vm,
 )
 
 NUM_TEST_VMS = 3
@@ -664,8 +671,6 @@ def create_windows2022_dv_template_from_registry(
     Yields:
         dict: DataVolume template dictionary with metadata and spec
     """
-    from utilities.infra import cleanup_artifactory_secret_and_config_map, get_test_artifact_server_url
-    from utilities.os_utils import get_windows_container_disk_path
 
     artifactory_secret = get_artifactory_secret(namespace=namespace)
     artifactory_config_map = get_artifactory_config_map(namespace=namespace)
@@ -713,10 +718,6 @@ def create_windows2022_vm_with_vtpm(
     Yields:
         VirtualMachineForTests: Running Windows 2022 VM with vTPM
     """
-    from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
-    from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
-
-    from utilities.virt import wait_for_windows_vm
 
     with VirtualMachineForTests(
         name=vm_name,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -650,7 +650,7 @@ def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
 
 
 @contextmanager
-def create_windows2022_dv_from_registry(
+def create_windows2022_dv_template_from_registry(
     dv_name: str,
     namespace: str,
     client: DynamicClient,
@@ -697,8 +697,8 @@ def create_windows2022_dv_from_registry(
 
 
 @contextmanager
-def create_windows2022_vm_with_vtpm_from_registry(
-    dv_dict: dict,
+def create_windows2022_vm_with_vtpm(
+    dv_template: dict,
     namespace: str,
     client: DynamicClient,
     vm_name: str,
@@ -729,7 +729,7 @@ def create_windows2022_vm_with_vtpm_from_registry(
         os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
         vm_instance_type=VirtualMachineClusterInstancetype(name=U1_LARGE, client=client),
         vm_preference=VirtualMachineClusterPreference(name=WINDOWS_2K22_PREFERENCE, client=client),
-        data_volume_template=dv_dict,
+        data_volume_template=dv_template,
         cpu_model=cpu_model,
     ) as vm:
         running_vm(vm=vm)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import http
 import logging
 import re
 import shlex
@@ -12,20 +11,24 @@ from typing import Generator, Optional
 import bitmath
 import requests
 import xmltodict
-from bs4 import BeautifulSoup
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
+from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from pyhelper_utils.shell import run_ssh_commands
+from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from utilities.constants import (
     DISK_SERIAL,
     HCO_DEFAULT_CPU_MODEL_KEY,
+    OS_FLAVOR_WIN_CONTAINER_DISK,
+    OS_FLAVOR_WINDOWS,
     RHSM_SECRET_NAME,
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
@@ -37,8 +40,13 @@ from utilities.constants import (
     TIMEOUT_10SEC,
     TIMEOUT_15SEC,
     TIMEOUT_30MIN,
+    U1_LARGE,
+    WIN_2K22,
+    WINDOWS_2K22_PREFERENCE,
     Images,
 )
+from utilities.data_collector import get_data_collector_dir, write_to_file
+from utilities.exceptions import ResourceValueError
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     ExecCommandOnPod,
@@ -73,6 +81,7 @@ def create_vms(
     client=None,
     ssh=True,
     node_selector_labels=None,
+    cpu_model=None,
 ):
     """
     Create n number of fedora vms.
@@ -84,6 +93,7 @@ def create_vms(
         node_selector_labels (str): Labels for node selector.
         client (DynamicClient): DynamicClient object
         ssh (bool): enable SSH on the VM
+        cpu_model (str): CPU model to be used for the VMs
 
     Returns:
         list: List of VirtualMachineForTests
@@ -100,6 +110,7 @@ def create_vms(
             run_strategy=VirtualMachine.RunStrategy.ALWAYS,
             ssh=ssh,
             client=client,
+            cpu_model=cpu_model,
         ) as vm:
             vms_list.append(vm)
     return vms_list
@@ -134,27 +145,6 @@ def wait_for_cr_labels_change(expected_value, component, timeout=TIMEOUT_10MIN):
             f" current value:'{label}'"
         )
         raise
-
-
-def validate_runbook_url_exists(url, alert_name=None, production=False):
-    response = requests.get(url, allow_redirects=False)
-    LOGGER.info(response)
-    if response.status_code != http.HTTPStatus.OK:
-        return f"{url} validation failed: {response}"
-    if production:
-        assert alert_name
-        url_link = f"#virt-runbook-{alert_name}"
-        if NOT_PUBLISHED_MESSAGE in response.text:
-            LOGGER.error(f"{url} found with message {NOT_PUBLISHED_MESSAGE}: {response.content}")
-            return f"{url} not published yet."
-        soup = BeautifulSoup(response.content)
-        for link in soup.findAll("a"):
-            url_str = link.get("href")
-            if url_str and url_str.endswith(url_link):
-                LOGGER.info(f"Alert link is found : {link}")
-                return
-        LOGGER.warning(f"Alert url {url} not found for alert {alert_name}")
-        return f"Alert url {url} not found"
 
 
 def get_image_from_csv(image_string, csv_related_images):
@@ -225,7 +215,7 @@ def update_vm_instancetype_name(vm, instance_type_name):
 
 
 def clean_up_migration_jobs(client, vm):
-    for migration_job in VirtualMachineInstanceMigration.get(dyn_client=client, namespace=vm.namespace):
+    for migration_job in VirtualMachineInstanceMigration.get(client=client, namespace=vm.namespace):
         migration_job.clean_up()
 
 
@@ -250,11 +240,48 @@ def get_os_memory_value(vm):
         return f"{round(float(meminfo))}Gi"
 
 
-def assert_guest_os_cpu_count(vm, spec_cpu_amount):
-    guest_os_cpu_amount = get_os_cpu_count(vm=vm)
-    assert guest_os_cpu_amount == spec_cpu_amount, (
-        f"Wrong amount of CPUs! Guest: {guest_os_cpu_amount}; VMI: {spec_cpu_amount}"
+def _collect_cpu_diagnostic_info(vm):
+    """Collect CPU diagnostic information when CPU count mismatch occurs."""
+    base_dir = get_data_collector_dir()
+    LOGGER.info(f"Collecting CPU diagnostic information for VM {vm.name}")
+
+    if vm.os_flavor == OS_FLAVOR_WINDOWS:
+        cmd = shlex.split('powershell.exe -command "Get-WinEvent -LogName System -MaxEvents 30 | Format-List"')
+    else:
+        cmd = shlex.split("bash -c 'dmesg | tail -n 30'")
+
+    output = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0]
+    write_to_file(base_directory=base_dir, file_name=f"{vm.name}_cpu_diagnostic.txt", content=output)
+
+
+def wait_for_guest_os_cpu_count(vm, spec_cpu_amount):
+    """Wait for the guest OS CPU count to match the VMI spec.
+
+    Args:
+        vm (VirtualMachineForTests): Target VM.
+        spec_cpu_amount (int): Expected CPU socket count from VMI spec.
+
+    Raises:
+        TimeoutExpiredError: If the guest OS CPU count does not match within the timeout.
+    """
+    sampler = TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=TIMEOUT_5SEC,
+        func=get_os_cpu_count,
+        vm=vm,
     )
+    sample = None
+    try:
+        for sample in sampler:
+            if sample == spec_cpu_amount:
+                LOGGER.info(f"Guest OS CPU count matches VMI spec: {spec_cpu_amount}")
+                return
+    except TimeoutExpiredError:
+        _collect_cpu_diagnostic_info(vm=vm)
+        LOGGER.error(
+            f"Timed out waiting for guest OS CPU count to match VMI spec. Guest: {sample}; VMI: {spec_cpu_amount}"
+        )
+        raise
 
 
 def assert_guest_os_memory_amount(vm, spec_memory_amount):
@@ -481,8 +508,8 @@ def download_and_extract_tar(tarfile_url, dest_path):
     """Download and Extract the tar file."""
     artifactory_header = get_artifactory_header()
     request = requests.get(tarfile_url, verify=False, headers=artifactory_header, timeout=10)
-    thetarfile = tarfile.open(fileobj=BytesIO(request.content), mode="r|xz")
-    thetarfile.extractall(path=dest_path)
+    tar_file = tarfile.open(fileobj=BytesIO(request.content), mode="r|xz")
+    tar_file.extractall(path=dest_path)
 
     return True
 
@@ -578,15 +605,15 @@ def create_cirros_vm(
         yield vm
 
 
-def start_stress_on_vm(vm, stress_command):
+def start_stress_on_vm(vm: VirtualMachineForTests, stress_command: str) -> None:
     LOGGER.info(f"Running memory load in VM {vm.name}")
     if "windows" in vm.name:
         verify_wsl2_guest_running(vm=vm)
         verify_wsl2_guest_works(vm=vm)
         command = f"wsl nohup bash -c '{stress_command}'"
     else:
-        run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("sudo dnf install -y stress-ng"))
-        command = stress_command
+        command = f"sudo dnf install stress-ng -y; {stress_command}"
+
     run_ssh_commands(
         host=vm.ssh_exec,
         commands=shlex.split(command),
@@ -594,33 +621,7 @@ def start_stress_on_vm(vm, stress_command):
     )
 
 
-def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
-    """
-    Verifies that WSL2 is functioning on windows vm.
-    Args:
-        vm: An instance of `VirtualMachineForTests`
-    Raises:
-        TimeoutExpiredError: If WSL2 fails to return the expected output within
-            the specified timeout period.
-    """
-    echo_string = "TEST"
-    samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_1MIN,
-        sleep=TIMEOUT_15SEC,
-        func=run_ssh_commands,
-        host=vm.ssh_exec,
-        commands=shlex.split(f"wsl echo {echo_string}"),
-    )
-    try:
-        for sample in samples:
-            if sample and echo_string in sample[0]:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(f"VM {vm.name} failed to start WSL2")
-        raise
-
-
-def verify_wsl2_guest_running(vm, timeout=TIMEOUT_3MIN):
+def verify_wsl2_guest_running(vm: VirtualMachineForTests, timeout: int = TIMEOUT_3MIN) -> bool:
     def _get_wsl2_running_status():
         guests_status = run_ssh_commands(
             host=vm.ssh_exec,
@@ -639,3 +640,168 @@ def verify_wsl2_guest_running(vm, timeout=TIMEOUT_3MIN):
     except TimeoutExpiredError:
         LOGGER.error("WSL2 guest is not running in the VM!")
         raise
+    return False
+
+
+def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
+    """
+    Verifies that WSL2 is functioning on windows vm.
+    Args:
+        vm: An instance of `VirtualMachineForTests`
+    Raises:
+        TimeoutExpiredError: If WSL2 fails to return the expected output within
+            the specified timeout period.
+    """
+    test_str = "TEST"
+    samples = TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=TIMEOUT_15SEC,
+        func=run_ssh_commands,
+        host=vm.ssh_exec,
+        commands=shlex.split(f"wsl echo {test_str}"),
+    )
+    try:
+        for sample in samples:
+            if sample and test_str in sample[0]:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"VM {vm.name} failed to start WSL2")
+        raise
+
+
+def verify_cpumanager_workers(schedulable_nodes: list[Node]) -> None:
+    """Verify cluster nodes have CPU Manager labels
+
+    Args:
+        schedulable_nodes (list[Node]): List of schedulable node objects.
+
+    Raises:
+        ResourceValueError: If no node has CPU Manager enabled.
+    """
+    LOGGER.info("Verifying cluster nodes have CPU Manager labels")
+    if not any(node.labels.cpumanager == "true" for node in schedulable_nodes):
+        raise ResourceValueError("Cluster does not have CPU Manager enabled on any node")
+
+
+def verify_hugepages_1gi(hugepages_gib_values: list[float | int]) -> None:
+    """Verify that cluster nodes have 1Gi hugepages enabled.
+
+    Args:
+        hugepages_gib_values (list[float | int]): List of hugepage sizes (in GiB) from worker nodes.
+
+    Raises:
+        ResourceValueError: If 1Gi hugepages are not configured or are insufficient.
+    """
+    LOGGER.info("Verifying cluster has 1Gi hugepages enabled")
+    if not hugepages_gib_values or max(hugepages_gib_values) < 1:
+        raise ResourceValueError("Cluster does not have sufficient 1Gi hugepages")
+
+
+def verify_rwx_default_storage(client: DynamicClient) -> None:
+    """Verify default storage class supports RWX mode.
+
+    Args:
+        client (DynamicClient): Kubernetes dynamic client used to query cluster resources.
+
+    Raises:
+       ResourceValueError: access mode is not RWX
+    """
+    storage_class = py_config["default_storage_class"]
+    LOGGER.info(f"Verifying default storage class {storage_class} supports RWX mode")
+
+    access_modes = StorageProfile(client=client, name=storage_class).first_claim_property_set_access_modes()
+    found_mode = access_modes[0] if access_modes else None
+    if found_mode != DataVolume.AccessMode.RWX:
+        raise ResourceValueError(
+            f"Default storage class '{storage_class}' doesn't support RWX mode "
+            f"(required: RWX, found: {found_mode or 'none'})"
+        )
+
+
+@contextmanager
+def create_windows2022_dv_from_registry(
+    dv_name: str,
+    namespace: str,
+    client: DynamicClient,
+    storage_class: str,
+) -> Generator[dict]:
+    """
+    Creates a Windows Server 2022 DataVolume from registry container disk.
+
+    Args:
+        dv_name: Name for the DataVolume
+        namespace: Kubernetes namespace
+        client: Kubernetes client
+        storage_class: Storage class name
+
+    Yields:
+        dict: DataVolume template dictionary with metadata and spec
+    """
+    from utilities.artifactory import cleanup_artifactory_secret_and_config_map, get_test_artifact_server_url
+
+    from utilities.os_utils import get_windows_container_disk_path
+
+    artifactory_secret = get_artifactory_secret(namespace=namespace)
+    artifactory_config_map = get_artifactory_config_map(namespace=namespace)
+
+    dv = DataVolume(
+        name=dv_name,
+        namespace=namespace,
+        storage_class=storage_class,
+        source="registry",
+        url=f"{get_test_artifact_server_url(schema='registry')}/{get_windows_container_disk_path(os_value=WIN_2K22)}",
+        size=Images.Windows.CONTAINER_DISK_DV_SIZE,
+        client=client,
+        api_name="storage",
+        secret=artifactory_secret,
+        cert_configmap=artifactory_config_map.name,
+    )
+    dv.to_dict()
+
+    try:
+        yield {"metadata": dv.res["metadata"], "spec": dv.res["spec"]}
+    finally:
+        cleanup_artifactory_secret_and_config_map(
+            artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
+        )
+
+
+@contextmanager
+def create_windows2022_vm_with_vtpm_from_registry(
+    dv_dict: dict,
+    namespace: str,
+    client: DynamicClient,
+    vm_name: str,
+    cpu_model: str | None,
+) -> Generator[VirtualMachineForTests]:
+    """
+    Creates a Windows Server 2022 VM with vTPM from registry container disk.
+
+    Args:
+        dv_dict: DataVolume template dictionary with metadata and spec
+        namespace: Kubernetes namespace
+        client: Kubernetes client
+        vm_name: Name for the VirtualMachine
+        cpu_model: CPU model specification (can be None)
+
+    Yields:
+        VirtualMachineForTests: Running Windows 2022 VM with vTPM
+    """
+    from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+    from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+
+    from utilities.virt import wait_for_windows_vm
+
+    with VirtualMachineForTests(
+        name=vm_name,
+        namespace=namespace,
+        client=client,
+        os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_LARGE, client=client),
+        vm_preference=VirtualMachineClusterPreference(name=WINDOWS_2K22_PREFERENCE, client=client),
+        data_volume_template=dv_dict,
+        cpu_model=cpu_model,
+    ) as vm:
+        running_vm(vm=vm)
+        wait_for_windows_vm(vm=vm, version="2022")
+        yield vm

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,7 +77,6 @@ def create_vms(
     client=None,
     ssh=True,
     node_selector_labels=None,
-    cpu_model=None,
 ):
     """
     Create n number of fedora vms.
@@ -89,7 +88,6 @@ def create_vms(
         node_selector_labels (str): Labels for node selector.
         client (DynamicClient): DynamicClient object
         ssh (bool): enable SSH on the VM
-        cpu_model (str): CPU model to be used for the VMs
 
     Returns:
         list: List of VirtualMachineForTests
@@ -106,7 +104,6 @@ def create_vms(
             run_strategy=VirtualMachine.RunStrategy.ALWAYS,
             ssh=ssh,
             client=client,
-            cpu_model=cpu_model,
         ) as vm:
             vms_list.append(vm)
     return vms_list
@@ -232,7 +229,7 @@ def update_vm_instancetype_name(vm, instance_type_name):
 
 
 def clean_up_migration_jobs(client, vm):
-    for migration_job in VirtualMachineInstanceMigration.get(client=client, namespace=vm.namespace):
+    for migration_job in VirtualMachineInstanceMigration.get(dyn_client=client, namespace=vm.namespace):
         migration_job.clean_up()
 
 
@@ -488,8 +485,8 @@ def download_and_extract_tar(tarfile_url, dest_path):
     """Download and Extract the tar file."""
     artifactory_header = get_artifactory_header()
     request = requests.get(tarfile_url, verify=False, headers=artifactory_header, timeout=10)
-    tar_file = tarfile.open(fileobj=BytesIO(request.content), mode="r|xz")
-    tar_file.extractall(path=dest_path)
+    thetarfile = tarfile.open(fileobj=BytesIO(request.content), mode="r|xz")
+    thetarfile.extractall(path=dest_path)
 
     return True
 
@@ -585,15 +582,15 @@ def create_cirros_vm(
         yield vm
 
 
-def start_stress_on_vm(vm: VirtualMachineForTests, stress_command: str) -> None:
+def start_stress_on_vm(vm, stress_command):
     LOGGER.info(f"Running memory load in VM {vm.name}")
     if "windows" in vm.name:
         verify_wsl2_guest_running(vm=vm)
         verify_wsl2_guest_works(vm=vm)
         command = f"wsl nohup bash -c '{stress_command}'"
     else:
-        command = f"sudo dnf install stress-ng -y; {stress_command}"
-
+        run_ssh_commands(host=vm.ssh_exec, commands=shlex.split("sudo dnf install -y stress-ng"))
+        command = stress_command
     run_ssh_commands(
         host=vm.ssh_exec,
         commands=shlex.split(command),
@@ -601,7 +598,33 @@ def start_stress_on_vm(vm: VirtualMachineForTests, stress_command: str) -> None:
     )
 
 
-def verify_wsl2_guest_running(vm: VirtualMachineForTests, timeout: int = TIMEOUT_3MIN) -> bool:
+def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
+    """
+    Verifies that WSL2 is functioning on windows vm.
+    Args:
+        vm: An instance of `VirtualMachineForTests`
+    Raises:
+        TimeoutExpiredError: If WSL2 fails to return the expected output within
+            the specified timeout period.
+    """
+    echo_string = "TEST"
+    samples = TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=TIMEOUT_15SEC,
+        func=run_ssh_commands,
+        host=vm.ssh_exec,
+        commands=shlex.split(f"wsl echo {echo_string}"),
+    )
+    try:
+        for sample in samples:
+            if sample and echo_string in sample[0]:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"VM {vm.name} failed to start WSL2")
+        raise
+
+
+def verify_wsl2_guest_running(vm, timeout=TIMEOUT_3MIN):
     def _get_wsl2_running_status():
         guests_status = run_ssh_commands(
             host=vm.ssh_exec,
@@ -619,33 +642,6 @@ def verify_wsl2_guest_running(vm: VirtualMachineForTests, timeout: int = TIMEOUT
                 return True
     except TimeoutExpiredError:
         LOGGER.error("WSL2 guest is not running in the VM!")
-        raise
-    return False
-
-
-def verify_wsl2_guest_works(vm: VirtualMachineForTests) -> None:
-    """
-    Verifies that WSL2 is functioning on windows vm.
-    Args:
-        vm: An instance of `VirtualMachineForTests`
-    Raises:
-        TimeoutExpiredError: If WSL2 fails to return the expected output within
-            the specified timeout period.
-    """
-    test_str = "TEST"
-    samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_1MIN,
-        sleep=TIMEOUT_15SEC,
-        func=run_ssh_commands,
-        host=vm.ssh_exec,
-        commands=shlex.split(f"wsl echo {test_str}"),
-    )
-    try:
-        for sample in samples:
-            if sample and test_str in sample[0]:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(f"VM {vm.name} failed to start WSL2")
         raise
 
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -45,6 +45,7 @@ X86_64 = "x86_64"
 #  OS constants
 OS_FLAVOR_CIRROS = "cirros"
 OS_FLAVOR_WINDOWS = "win"
+OS_FLAVOR_WIN_CONTAINER_DISK = "win-container-disk"
 OS_FLAVOR_RHEL = "rhel"
 OS_FLAVOR_FEDORA = "fedora"
 
@@ -753,6 +754,7 @@ RHEL8_PREFERENCE = "rhel.8"
 RHEL9_PREFERENCE = "rhel.9"
 RHEL10_PREFERENCE = "rhel.10"
 U1_SMALL = "u1.small"
+U1_LARGE = "u1.large"
 PROMETHEUS_K8S = "prometheus-k8s"
 INSTANCE_TYPE_STR = "instance_type"
 U1_MEDIUM_STR = "u1.medium"
@@ -856,8 +858,16 @@ WIN_10 = "win10"
 WIN_11 = "win11"
 WIN_2K25 = "win2k25"
 WIN_2K22 = "win2k22"
+
+# Windows VirtualMachine preferences
+WINDOWS_11_PREFERENCE = "windows.11"
+WINDOWS_2K22_PREFERENCE = "windows.2k22"
 WIN_2K16 = "win2k16"
 WIN_2K19 = "win2k19"
+
+# Windows VirtualMachine preferences
+WINDOWS_11_PREFERENCE = "windows.11"
+WINDOWS_2K22_PREFERENCE = "windows.2k22"
 
 PUBLIC_DNS_SERVER_IP = "8.8.8.8"
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -344,6 +344,8 @@ LS_COMMAND = "ls -1 | sort | tr '\n' ' '"
 
 # hotplug
 HOTPLUG_DISK_SERIAL = "1234567890"
+HOTPLUG_DISK_VIRTIO_BUS = "virtio"
+HOTPLUG_DISK_SCSI_BUS = "scsi"
 
 ONE_CPU_CORE = 1
 ONE_CPU_THREAD = 1

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -867,10 +867,6 @@ WINDOWS_2K22_PREFERENCE = "windows.2k22"
 WIN_2K16 = "win2k16"
 WIN_2K19 = "win2k19"
 
-# Windows VirtualMachine preferences
-WINDOWS_11_PREFERENCE = "windows.11"
-WINDOWS_2K22_PREFERENCE = "windows.2k22"
-
 PUBLIC_DNS_SERVER_IP = "8.8.8.8"
 
 BIND_IMMEDIATE_ANNOTATION = {f"{Resource.ApiGroup.CDI_KUBEVIRT_IO}/storage.bind.immediate.requested": "true"}

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -346,6 +346,8 @@ LS_COMMAND = "ls -1 | sort | tr '\n' ' '"
 
 # hotplug
 HOTPLUG_DISK_SERIAL = "1234567890"
+HOTPLUG_DISK_VIRTIO_BUS = "virtio"
+HOTPLUG_DISK_SCSI_BUS = "scsi"
 
 ONE_CPU_CORE = 1
 ONE_CPU_THREAD = 1

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -346,8 +346,6 @@ LS_COMMAND = "ls -1 | sort | tr '\n' ' '"
 
 # hotplug
 HOTPLUG_DISK_SERIAL = "1234567890"
-HOTPLUG_DISK_VIRTIO_BUS = "virtio"
-HOTPLUG_DISK_SCSI_BUS = "scsi"
 
 ONE_CPU_CORE = 1
 ONE_CPU_THREAD = 1

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -45,6 +45,7 @@ X86_64 = "x86_64"
 #  OS constants
 OS_FLAVOR_CIRROS = "cirros"
 OS_FLAVOR_WINDOWS = "win"
+OS_FLAVOR_WIN_CONTAINER_DISK = "win-container-disk"
 OS_FLAVOR_RHEL = "rhel"
 OS_FLAVOR_FEDORA = "fedora"
 
@@ -768,6 +769,7 @@ RHEL8_PREFERENCE = "rhel.8"
 RHEL9_PREFERENCE = "rhel.9"
 RHEL10_PREFERENCE = "rhel.10"
 U1_SMALL = "u1.small"
+U1_LARGE = "u1.large"
 PROMETHEUS_K8S = "prometheus-k8s"
 INSTANCE_TYPE_STR = "instance_type"
 U1_MEDIUM_STR = "u1.medium"
@@ -871,8 +873,16 @@ WIN_10 = "win10"
 WIN_11 = "win11"
 WIN_2K25 = "win2k25"
 WIN_2K22 = "win2k22"
+
+# Windows VirtualMachine preferences
+WINDOWS_11_PREFERENCE = "windows.11"
+WINDOWS_2K22_PREFERENCE = "windows.2k22"
 WIN_2K16 = "win2k16"
 WIN_2K19 = "win2k19"
+
+# Windows VirtualMachine preferences
+WINDOWS_11_PREFERENCE = "windows.11"
+WINDOWS_2K22_PREFERENCE = "windows.2k22"
 
 PUBLIC_DNS_SERVER_IP = "8.8.8.8"
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -882,10 +882,6 @@ WINDOWS_2K22_PREFERENCE = "windows.2k22"
 WIN_2K16 = "win2k16"
 WIN_2K19 = "win2k19"
 
-# Windows VirtualMachine preferences
-WINDOWS_11_PREFERENCE = "windows.11"
-WINDOWS_2K22_PREFERENCE = "windows.2k22"
-
 PUBLIC_DNS_SERVER_IP = "8.8.8.8"
 
 BIND_IMMEDIATE_ANNOTATION = {f"{Resource.ApiGroup.CDI_KUBEVIRT_IO}/storage.bind.immediate.requested": "true"}

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -13,7 +13,42 @@ from utilities.os_utils import (
     WINDOWS_OS_MAPPING,
     generate_linux_instance_type_os_matrix,
     generate_os_matrix_dict,
+    get_windows_container_disk_path,
 )
+
+
+class TestGetWindowsContainerDiskPath:
+    """Test cases for get_windows_container_disk_path function"""
+
+    EXPECTED_DIR = "docker-local/kubevirt-common-instancetypes"
+
+    @pytest.mark.parametrize(
+        "os_value, expected_suffix",
+        [
+            pytest.param("win10", "windows10-container-disk:4.99", id="win10"),
+            pytest.param("win11", "windows11-container-disk:4.99", id="win11"),
+            pytest.param("win2k19", "windows2k19-container-disk:4.99", id="win2k19"),
+            pytest.param("win2k22", "windows2k22-container-disk:4.99", id="win2k22"),
+            pytest.param("win2k25", "windows2k25-container-disk:4.99", id="win2k25"),
+        ],
+    )
+    def test_get_windows_container_disk_path(self, os_value: str, expected_suffix: str):
+        """Test generating container disk path for valid Windows OS values"""
+        result = get_windows_container_disk_path(os_value=os_value)
+
+        assert result == f"{self.EXPECTED_DIR}/{expected_suffix}"
+
+    @pytest.mark.parametrize(
+        "os_value",
+        [
+            pytest.param("linux", id="linux"),
+            pytest.param("rhel9", id="rhel"),
+        ],
+    )
+    def test_get_windows_container_disk_path_invalid_os(self, os_value: str):
+        """Test error when os_value doesn't start with 'win'"""
+        with pytest.raises(ValueError, match="os_value must start with 'win'"):
+            get_windows_container_disk_path(os_value=os_value)
 
 
 class TestGenerateOsMatrixDict:


### PR DESCRIPTION
##### Short description:
Backport of #4761 to cnv-4.20: All Windows VMs in storage tests should be Windows 2022 using VTPM.

##### More details:
Added helper functions into `utils.py` that are context managers for DV and VM using Windows 2022 using instance types and preferences. These functions can be used in other modules such as CDI Clone, CDI Upload, Snasphots etc.

##### What this PR does / why we need it:
Backports Windows Server 2022 with vTPM support to cnv-4.20 branch.

##### Which issue(s) this PR fixes:
Backport of #4761

##### Special notes for reviewer:
- Cherry-pick had conflicts, manual replication was performed
- Branch-specific adaptation: Used `assert_hotplugvolume_nonexist_optional_restart` instead of `assert_hotplugvolume_nonexist`
- All changes from original PR applied successfully
- Original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/4761
- Co-authored: Claude Code

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-51351