### PR TITLE
[Observability] Set CPU topology to cores for Windows VM

### DIFF
--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -14,6 +14,7 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.resource import Resource
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+from ocp_resources.virtual_machine_preference import VirtualMachinePreference
 from ocp_utilities.monitoring import Prometheus
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -648,6 +649,7 @@ def create_windows11_wsl2_vm(
         vm_name (str): The name of the VM
         storage_class (str): The storage class to use for the DataVolume
     """
+    windows_preference_name = "windows.11"
     artifactory_secret = get_artifactory_secret(namespace=namespace)
     artifactory_config_map = get_artifactory_config_map(namespace=namespace)
     dv = DataVolume(
@@ -663,22 +665,36 @@ def create_windows11_wsl2_vm(
         cert_configmap=artifactory_config_map.name,
     )
     dv.to_dict()
-    with VirtualMachineForTests(
-        os_flavor=OS_FLAVOR_WINDOWS,
-        name=vm_name,
-        namespace=namespace,
+    base_preference = VirtualMachineClusterPreference(client=client, name=windows_preference_name)
+    base_spec = base_preference.instance.to_dict()["spec"]
+
+    with VirtualMachinePreference(
         client=client,
-        vm_instance_type=VirtualMachineClusterInstancetype(client=client, name="u1.large"),
-        vm_preference=VirtualMachineClusterPreference(client=client, name="windows.11"),
-        data_volume_template={"metadata": dv.res["metadata"], "spec": dv.res["spec"]},
-    ) as vm:
-        try:
-            running_vm(vm=vm, dv_wait_timeout=TIMEOUT_40MIN)
-            yield vm
-        finally:
-            cleanup_artifactory_secret_and_config_map(
-                artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
-            )
+        namespace=namespace,
+        name=f"{vm_name}-{windows_preference_name}-preference",
+        cpu={"preferredCPUTopology": "cores"},
+        clock=base_spec.get("clock"),
+        devices=base_spec.get("devices"),
+        features=base_spec.get("features"),
+        firmware=base_spec.get("firmware"),
+        requirements=base_spec.get("requirements"),
+    ) as preference:
+        with VirtualMachineForTests(
+            os_flavor=OS_FLAVOR_WINDOWS,
+            name=vm_name,
+            namespace=namespace,
+            client=client,
+            vm_instance_type=VirtualMachineClusterInstancetype(client=client, name="u1.large"),
+            vm_preference=preference,
+            data_volume_template={"metadata": dv.res["metadata"], "spec": dv.res["spec"]},
+        ) as vm:
+            try:
+                running_vm(vm=vm, dv_wait_timeout=TIMEOUT_40MIN)
+                yield vm
+            finally:
+                cleanup_artifactory_secret_and_config_map(
+                    artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
+                )
 
 
 def get_vm_comparison_info_dict(vm: VirtualMachineForTests) -> dict[str, str]:


### PR DESCRIPTION
##### Short description:
Windows VMs perform better with cores topology instead of sockets, reducing idle CPU usage from 60%+ to normal levels on AWS.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for Windows 11 virtual machine configuration by refactoring preference handling to use dedicated preference objects instead of cluster-level preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4847)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->