### PR TITLE
[Storage] fix: reuse hotplug volume per test class

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -174,6 +174,7 @@ def blank_disk_dv_multi_storage_scope_class(
         pytest.param({"persist": True, "bus": HOTPLUG_DISK_SCSI_BUS}, HOTPLUG_DISK_SCSI_BUS, id="scsi-bus"),
     ],
     indirect=["hotplug_volume_scope_class"],
+    scope="class",
 )
 @pytest.mark.conformance
 @pytest.mark.gating


### PR DESCRIPTION
##### Short description:

It was found that prior to the execution of `test_hotplug_volume_with_serial_and_persist_migrate` the hotplug volume gets  removed as a part of the previous test teardown. The hotplug volume is then re-added by `hotplug_volume_scope_class` however, this specific migrate test does not wait for the new volume to be `Ready` before starting the migration. This can cause a potential race condition where the migration resource is unaware that it needs to account for a VMI's hotplug volume, which can lead to the VMIM to be stuck in `Scheduling`, example seen here: 

https://jenkins-csb-cnvqe-main.dno.corp.redhat.com/view/Tests%20by%20Labels/view/rhcos10/view/4.22/job/test-pytest-cnv-4.22-storage-ocs-rhcos10/2/consoleText

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-85690


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted parametrization to use class-scoped values for hot-plug persistence tests, improving reliability of hot-plugged disk volume verification before migration operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4851)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4851)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->