### PR TITLE
chore: update CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,8 +41,16 @@ reviews:
   auto_title_placeholder: "@coderabbitai"
   review_status: true
   commit_status: true
+  review_details: true
   poem: false
   collapse_walkthrough: true
+
+  # Auto-suggest labels
+  labeling_instructions:
+    - label: "new-tests"
+      instructions: "Apply when the PR adds new test files (test_*.py) or new test functions (def test_*)."
+    - label: "docs-only"
+      instructions: "Apply when the PR only changes .md files."
   sequence_diagrams: false
   changed_files_summary: true
 
@@ -53,18 +61,37 @@ reviews:
   # Abort review if PR is closed
   abort_on_close: true
 
+  # Pre-merge checks for PR quality
+  pre_merge_checks:
+    title:
+      mode: error
+      requirements: "Must be under 120 chars and clearly describe the change."
+    description:
+      mode: error
+    custom_checks:
+      - name: "STP link required"
+        mode: error
+        instructions: |
+          Every new test file (test_*.py) MUST include an STP link in the
+          module, class, or test docstring. If no STP exists, an RFE or
+          Jira link is required instead. Fail if a new test file has
+          neither.
+
   # Auto-review configuration
   auto_review:
     enabled: true
     auto_incremental_review: true
     drafts: false
+    auto_pause_after_reviewed_commits: 10
     ignore_title_keywords:
       - "WIP"
     base_branches:
       - main
+      - cnv-4.21
       - cnv-4.20
       - cnv-4.19
       - cnv-4.18
+
 
   # Enabled linting and security tools
   tools:
@@ -99,6 +126,23 @@ reviews:
     github-checks:
       enabled: true
       timeout_ms: 90000
+    # Disabled tools (no JS/TS, PHP, Ruby, Kotlin, Rust, or Terraform in this repo)
+    biome:
+      enabled: false
+    eslint:
+      enabled: false
+    phpstan:
+      enabled: false
+    rubocop:
+      enabled: false
+    detekt:
+      enabled: false
+    clippy:
+      enabled: false
+    checkov:
+      enabled: false
+    tflint:
+      enabled: false
 
 chat:
   auto_reply: true


### PR DESCRIPTION
##### What this PR does / why we need it:
Update CodeRabbit configuration with additional review features, pre-merge checks, and cleanup of irrelevant tools.

**Changes:**
- Add pre-merge checks: title validation (under 120 chars), description check, STP link enforcement for new test files
- Enable `review_details` for transparency on ignored files and suppressed comments
- Increase `auto_pause_after_reviewed_commits` from 5 to 10
- Add `cnv-4.21` to auto-review base branches
- Disable 8 irrelevant tools (biome, eslint, phpstan, rubocop, detekt, clippy, checkov, tflint) — no JS/TS, PHP, Ruby, Kotlin, Rust, or Terraform in this repo
- Add labeling instructions: `new-tests` (new test files/functions), `docs-only` (markdown-only PRs)

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
All changes are in `.coderabbit.yaml` only. Schema validation removed some initially planned options (`commit_status_on_failure`, `fortune`, `linked_issue_assessment`, `ignore_authors`) as they are not yet in the v2 schema.

The `new-tests` and `docs-only` labels need to be created in the repo for auto-labeling to work.

##### jira-ticket:
NONE

Assisted-by: Claude <noreply@anthropic.com>