### PR TITLE
Consider the node architecture when selecting schedulable nodes in multi-arch clusters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,7 @@ from utilities.constants import (
     KUBECONFIG,
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
     KUBEMACPOOL_MAC_RANGE_CONFIG,
+    KUBERNETES_ARCH_LABEL,
     LINUX_BRIDGE,
     MIGRATION_POLICY_VM_LABEL,
     NODE_HUGE_PAGES_1GI_KEY,
@@ -440,9 +441,13 @@ def nodes(admin_client):
 
 @pytest.fixture(scope="session")
 def schedulable_nodes(nodes):
-    """Get nodes marked as schedulable by kubevirt"""
+    """Get nodes marked as schedulable by kubevirt.
+
+    For multi-arch testing - filter nodes by the architecture being tested.
+    """
     schedulable_label = "kubevirt.io/schedulable"
-    yield [
+    cpu_arch = py_config.get("cpu_arch")
+    schedulable = [
         node
         for node in nodes
         if schedulable_label in node.labels.keys()
@@ -450,7 +455,11 @@ def schedulable_nodes(nodes):
         and not node.instance.spec.unschedulable
         and not kubernetes_taint_exists(node)
         and node.kubelet_ready
+        and (not cpu_arch or node.labels.get(KUBERNETES_ARCH_LABEL) == cpu_arch)
     ]
+
+    LOGGER.info(f"Schedulable nodes: {[node.name for node in schedulable]}, node architecture: {cpu_arch or 'all'}")
+    yield schedulable
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Short description:
For multi-arch testing - consider only nodes, that have the arch which is currently under-test, for scheduling VMs.

More details:
Consider only nodes with the arch, which is currently under-test, for scheduling.

What this PR does / why we need it:
This is required for testing regression of network tests on multi-arch clusters.

jira-ticket:
https://redhat.atlassian.net/browse/CNV-80548


