### PR TITLE
Increase TLS propagation timeout to 60min and mark test as tier3

### DIFF
--- a/tests/install_upgrade_operators/crypto_policy/conftest.py
+++ b/tests/install_upgrade_operators/crypto_policy/conftest.py
@@ -44,7 +44,7 @@ from utilities.constants import (
     CLUSTER,
     KUBEVIRT_HCO_NAME,
     SSP_KUBEVIRT_HYPERCONVERGED,
-    TIMEOUT_40MIN,
+    TIMEOUT_60MIN,
     TLS_SECURITY_PROFILE,
 )
 from utilities.exceptions import MissingResourceException
@@ -210,7 +210,7 @@ def modern_tls_profile_applied(admin_client, hco_namespace, api_server, enabled_
         apiserver=api_server,
         tls_spec=TLS_MODERN_PROFILE,
     ):
-        wait_for_cluster_operator_stabilize(admin_client=admin_client, wait_timeout=TIMEOUT_40MIN)
+        wait_for_cluster_operator_stabilize(admin_client=admin_client, wait_timeout=TIMEOUT_60MIN)
         wait_for_hco_conditions(
             admin_client=admin_client,
             hco_namespace=hco_namespace,

--- a/tests/install_upgrade_operators/crypto_policy/test_tls_profile_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_tls_profile_propagation.py
@@ -16,7 +16,7 @@ from tests.install_upgrade_operators.crypto_policy.utils import check_service_ac
 from utilities.constants import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
 
 LOGGER = logging.getLogger(__name__)
-pytestmark = pytest.mark.post_upgrade
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.tier3]
 
 
 @pytest.mark.polarion("CNV-15973")

--- a/tests/install_upgrade_operators/crypto_policy/utils.py
+++ b/tests/install_upgrade_operators/crypto_policy/utils.py
@@ -33,7 +33,7 @@ from tests.install_upgrade_operators.utils import (
 from utilities.constants import (
     CLUSTER,
     TIMEOUT_2MIN,
-    TIMEOUT_40MIN,
+    TIMEOUT_60MIN,
     TLS_SECURITY_PROFILE,
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile, wait_for_hco_conditions
@@ -281,7 +281,7 @@ def update_apiserver_crypto_policy(
         patches={apiserver: {"spec": {TLS_SECURITY_PROFILE: tls_spec}}},
     ):
         yield
-    wait_for_cluster_operator_stabilize(admin_client=admin_client, wait_timeout=TIMEOUT_40MIN)
+    wait_for_cluster_operator_stabilize(admin_client=admin_client, wait_timeout=TIMEOUT_60MIN)
     wait_for_hco_conditions(
         admin_client=admin_client,
         hco_namespace=hco_namespace,


### PR DESCRIPTION
##### Short description:
Bare metal clusters with 3 control plane nodes can take up to 49 minutes for cluster operators to stabilize after applying the Modern TLS profile. Increase timeout from 40 to 60 minutes and mark the propagation test as tier3 since it is time-consuming.


Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-87542
