### PR TITLE
Wait for DataSource availability  after re-enabling common boot image 

### DIFF
--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -35,6 +35,7 @@ from utilities.ssp import (
     wait_for_deleted_data_import_crons,
     wait_for_ssp_conditions,
 )
+from utilities.storage import verify_boot_sources_reimported
 
 LOGGER = logging.getLogger(__name__)
 
@@ -381,6 +382,11 @@ def enable_common_boot_image_import_spec_wait_for_data_import_cron(hco_resource,
     wait_for_at_least_one_auto_update_data_import_cron(admin_client=admin_client, namespace=namespace)
     wait_for_ssp_conditions(admin_client=admin_client, hco_namespace=hco_namespace)
     wait_for_hco_conditions(admin_client=admin_client, hco_namespace=hco_namespace)
+    assert verify_boot_sources_reimported(
+        admin_client=admin_client,
+        namespace=namespace.name,
+        consecutive_checks_count=1,
+    )
 
 
 def update_common_boot_image_import_spec(hco_resource, enable):

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1120,8 +1120,18 @@ def get_data_sources_managed_by_data_import_cron(client: DynamicClient, namespac
 def verify_boot_sources_reimported(
     admin_client: DynamicClient, namespace: str, consecutive_checks_count: int = 6
 ) -> bool:
-    """
-    Verify that the boot sources are re-imported while changing a storage class.
+    """Verify all DataImportCron-managed DataSources reach Ready=True.
+
+    Checks DataSources sequentially each with its own timeout. Stops on the first
+    DataSource that does not become ready.
+
+    Args:
+        admin_client: Cluster admin client.
+        namespace: Namespace containing the DataImportCron-managed DataSources.
+        consecutive_checks_count: Consecutive Ready=True polls required for stability.
+
+    Returns:
+        True if all DataSources reached Ready=True otherwise false
     """
     try:
         for data_source in get_data_sources_managed_by_data_import_cron(client=admin_client, namespace=namespace):
@@ -1136,13 +1146,11 @@ def verify_boot_sources_reimported(
                 resource_name=data_source.name,
             )
         return True
-    except (TimeoutExpiredError, Exception) as exception:
-        fail_message = (
-            "Failed to re-import boot sources, exiting the pytest execution"
-            if isinstance(exception, TimeoutExpiredError)
-            else str(exception)
+    except TimeoutExpiredError as exception:
+        LOGGER.error(
+            f"Boot source DataSource did not reach Ready=True within {TIMEOUT_10MIN}s. "
+            f"namespace={namespace!r}, data_source={data_source.name!r}, timeout_error={exception!r}"
         )
-        LOGGER.error(fail_message)
         return False
 
 

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -802,8 +802,10 @@ class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
     @patch("utilities.hco.wait_for_at_least_one_auto_update_data_import_cron")
     @patch("utilities.hco.update_common_boot_image_import_spec")
     @patch("utilities.hco.Namespace")
+    @patch("utilities.hco.verify_boot_sources_reimported", return_value=True)
     def test_enable_spec(
         self,
+        mock_verify_boot,
         mock_namespace_class,
         mock_update_spec,
         mock_wait_dic,
@@ -822,6 +824,11 @@ class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
         mock_wait_dic.assert_called_once()
         mock_wait_ssp.assert_called_once()
         mock_wait_hco.assert_called_once()
+        mock_verify_boot.assert_called_once_with(
+            admin_client=mock_admin_client,
+            namespace=mock_namespace.name,
+            consecutive_checks_count=1,
+        )
 
 
 class TestUpdateCommonBootImageImportSpec:


### PR DESCRIPTION
##### Short description:
enable_common_boot_image_import_spec_wait_for_data_import_cron waits for DataImportCrons, SSP conditions and HCO conditions but none of these reflect DataSource state. CDI populates DataSource.Spec.Source asynchronously after the import completes so in slow environments tests can hit flaky behavior.
##### More details:

##### What this PR does / why we need it:
Wait for DataSource after re-enabling enableCommonBootImageImport. Without this, downstream tests can hit StopIteration on an empty DataSource.Spec.Source during the recovery window.(This behavior is observed few times in CI)

##### Which issue(s) this PR fixes:
cnv-tests-runner-containerized/6117/testReport/ --this failure is seen often
##### Special notes for reviewer:
makes tests stable. Current we failing lanes and jira tickets has more details 
##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-87599


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures boot sources are re-imported and verified after automatic data-import cycles to avoid missed updates.

* **Improvements**
  * More precise timeout handling for readiness checks and clearer, structured logging on failures.
  * Docstrings and status semantics clarified for reliability and maintainability.

* **Tests**
  * Unit tests updated to assert the new verification step runs during enablement flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->