### PR TITLE
Remove CNV-87302 xfail from PQC test

### DIFF
--- a/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
@@ -9,7 +9,6 @@ import logging
 import pytest
 
 from utilities.constants import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
-from utilities.jira import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 pytestmark = pytest.mark.post_upgrade
@@ -42,8 +41,6 @@ def test_cnv_services_pqc_key_exchange(subtests, fips_enabled_cluster, pqc_statu
         with subtests.test(msg=service_name):
             if service_name == HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD:
                 pytest.xfail(f"CNV-82351: {service_name} — plaintext HTTP behind TLS route, TLS planned for 5.0")
-            if service_name == "kubevirt-migration-prometheus" and is_jira_open(jira_id="CNV-87302"):
-                pytest.xfail(f"{service_name} — known bug: CNV-87302")
             assert accepted is not None, f"Service {service_name} is unreachable"
             if fips_enabled_cluster:
                 runtime = services_tls_runtime.get(service_name, "go")


### PR DESCRIPTION
##### Short description:
CNV-87302 (kubevirt-migration-prometheus rejects PQC) is verified. Remove the is_jira_open xfail and unused import.
Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed conditional test skip for `kubevirt-migration-prometheus`, enabling full reachability and PQC acceptance testing of the service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4864)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->