### PR TITLE
fix: use architecture-aware RHEL preference in snapshot fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,7 @@ from utilities.constants.components import (
     VIRTCTL_CLI_DOWNLOADS,
 )
 from utilities.constants.hco import (
+    DATA_SOURCE_NAME,
     FEATURE_GATES,
     HCO_SUBSCRIPTION,
     HOTFIX_STR,
@@ -914,6 +915,17 @@ def rhel10_data_source_scope_session(golden_images_namespace):
         namespace=golden_images_namespace.name,
         name="rhel10",
         client=golden_images_namespace.client,
+        ensure_exists=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def latest_rhel_data_source(golden_images_namespace):
+    """Provide the DataSource for the latest RHEL version supported on this architecture."""
+    return DataSource(
+        client=golden_images_namespace.client,
+        name=py_config["latest_instance_type_rhel_os_dict"][DATA_SOURCE_NAME],
+        namespace=golden_images_namespace.name,
         ensure_exists=True,
     )
 

--- a/tests/infrastructure/conftest.py
+++ b/tests/infrastructure/conftest.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 import pytest
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
-from ocp_resources.data_source import DataSource
-from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError
 
 from tests.infrastructure.utils import (
@@ -12,7 +10,6 @@ from tests.infrastructure.utils import (
     verify_tekton_operator_installed,
 )
 from tests.utils import verify_cpumanager_workers, verify_hugepages_1gi, verify_rwx_default_storage
-from utilities.constants.hco import DATA_SOURCE_NAME
 from utilities.exceptions import ResourceMissingFieldError, ResourceValueError
 from utilities.pytest_utils import exit_pytest_execution
 
@@ -99,13 +96,3 @@ def infrastructure_special_infra_sanity(
             junitxml_property=junitxml_plugin,
             admin_client=admin_client,
         )
-
-
-@pytest.fixture(scope="module")
-def latest_rhel_data_source(golden_images_namespace):
-    return DataSource(
-        client=golden_images_namespace.client,
-        name=py_config["latest_instance_type_rhel_os_dict"][DATA_SOURCE_NAME],
-        namespace=golden_images_namespace.name,
-        ensure_exists=True,
-    )

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -47,7 +47,7 @@ from utilities.constants import Images
 from utilities.constants.cluster import CNV_TEST_SERVICE_ACCOUNT
 from utilities.constants.components import CDI_OPERATOR, CDI_UPLOADPROXY
 from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_RHEL
-from utilities.constants.instance_types import RHEL10_PREFERENCE, U1_SMALL
+from utilities.constants.instance_types import PREFERENCE_STR, U1_SMALL
 from utilities.constants.networking import SECURITY_CONTEXT
 from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5SEC, TIMEOUT_30MIN
 from utilities.hco import (
@@ -382,7 +382,7 @@ def rhel_vm_for_snapshot(
     admin_client,
     namespace,
     rhel_vm_name,
-    rhel10_data_source_scope_session,
+    latest_rhel_data_source,
     snapshot_storage_class_name_scope_module,
 ):
     """Create a RHEL VM with using DataSource that supports snapshots"""
@@ -392,9 +392,12 @@ def rhel_vm_for_snapshot(
         client=admin_client,
         os_flavor=OS_FLAVOR_RHEL,
         vm_instance_type=VirtualMachineClusterInstancetype(client=admin_client, name=U1_SMALL),
-        vm_preference=VirtualMachineClusterPreference(client=admin_client, name=RHEL10_PREFERENCE),
+        vm_preference=VirtualMachineClusterPreference(
+            client=admin_client,
+            name=py_config["latest_instance_type_rhel_os_dict"][PREFERENCE_STR],
+        ),
         data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=rhel10_data_source_scope_session,
+            data_source=latest_rhel_data_source,
             storage_class=snapshot_storage_class_name_scope_module,
         ),
     ) as vm:

--- a/tests/storage/vm_export/conftest.py
+++ b/tests/storage/vm_export/conftest.py
@@ -17,11 +17,12 @@ from ocp_resources.virtual_machine_cluster_preference import (
 )
 from ocp_resources.virtual_machine_export import VirtualMachineExport
 from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
+from pytest_testconfig import config as py_config
 
 from tests.storage.constants import TEST_FILE_CONTENT, TEST_FILE_NAME
 from tests.storage.vm_export.utils import create_blank_dv_by_specific_user, get_manifest_from_vmexport, get_manifest_url
 from utilities.constants.images import OS_FLAVOR_RHEL
-from utilities.constants.instance_types import U1_SMALL
+from utilities.constants.instance_types import PREFERENCE_STR, U1_SMALL
 from utilities.constants.pytest import UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
 from utilities.infra import create_ns, login_with_user_password
 from utilities.storage import data_volume_template_with_source_ref_dict, write_file_via_ssh
@@ -202,7 +203,7 @@ def vmexport_download_path(tmp_path):
 def rhel_vm_for_snapshot_with_content(
     unprivileged_client,
     namespace,
-    rhel10_data_source_scope_session,
+    latest_rhel_data_source,
     snapshot_storage_class_name_scope_module,
 ):
     with VirtualMachineForTests(
@@ -211,9 +212,11 @@ def rhel_vm_for_snapshot_with_content(
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_RHEL,
         vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
-        vm_preference=VirtualMachineClusterPreference(name="rhel.10"),
+        vm_preference=VirtualMachineClusterPreference(
+            name=py_config["latest_instance_type_rhel_os_dict"][PREFERENCE_STR],
+        ),
         data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=rhel10_data_source_scope_session,
+            data_source=latest_rhel_data_source,
             storage_class=snapshot_storage_class_name_scope_module,
         ),
     ) as vm:


### PR DESCRIPTION
**Short description:** Use architecture-aware RHEL preference in snapshot and vmexport fixtures

**More details:**
The `rhel_vm_for_snapshot` and `rhel_vm_for_snapshot_with_content` fixtures hardcode `RHEL10_PREFERENCE`, which enables SecureBoot. On s390x, SecureBoot is unsupported (no EFI OVMF ROMs), causing VM boot failures. The codebase already handles this via per-architecture global configs -- these fixtures were bypassing that.

**What this PR does / why we need it:**
- Replaces hardcoded RHEL10 preference and data source in both fixtures with dynamic lookup via `py_config["latest_instance_type_rhel_os_dict"]`
- Adds a `latest_rhel_data_source_scope_session` fixture to `tests/conftest.py` alongside the existing rhel9/rhel10 data source fixtures
- Resolves to RHEL9 on s390x (no SecureBoot) and RHEL10 on amd64/arm64

**Which issue(s) this PR fixes:**

**Special notes for reviewer:**

**jira-ticket:** NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a session-scoped fixture that provides the “latest RHEL” data source for the active test run.
  * Updated snapshot and VM export test fixtures to use the latest RHEL data source and to determine RHEL instance-type preferences from test configuration (no longer hardcoded).
  * Removed a duplicate module-scoped “latest RHEL” fixture to consolidate shared setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->