### PR TITLE
WIP: [VIRT] Fix descheduler tests on compact clusters

### DIFF
--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import shlex
 
 import pytest
 from kubernetes.utils.quantity import parse_quantity
@@ -7,6 +8,7 @@ from ocp_resources.pod_disruption_budget import PodDisruptionBudget
 from ocp_resources.resource import Resource, ResourceEditor
 from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 from ocp_utilities.infra import get_pods_by_name_prefix
+from pyhelper_utils.shell import run_command
 
 from tests.utils import start_stress_on_vm
 from tests.virt.node.descheduler.constants import (
@@ -28,7 +30,10 @@ from tests.virt.utils import (
 )
 from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC
 from utilities.infra import wait_for_pods_deletion
-from utilities.virt import wait_for_migration_finished
+from utilities.virt import (
+    uncordon_node,
+    wait_for_migration_finished,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -135,6 +140,20 @@ def node_with_min_memory_labeled_for_descheduler_test(node_with_least_available_
 def node_with_max_memory_labeled_for_descheduler_test(node_with_most_available_memory):
     with ResourceEditor(patches={node_with_most_available_memory: {"metadata": {"labels": DESCHEDULER_TEST_LABEL}}}):
         yield
+
+
+@pytest.fixture(scope="class")
+def unloaded_migration_target_node(admin_client, node_with_most_available_memory):
+    """Drain and uncordon node to reduce loadage."""
+    LOGGER.info(f"Draining node {node_with_most_available_memory.name} to reduce loadage")
+    run_command(
+        command=shlex.split(
+            f"oc adm drain {node_with_most_available_memory.name} --delete-emptydir-data --ignore-daemonsets=true --force --timeout=60s"
+        ),
+        check=False,
+    )
+    uncordon_node(admin_client=admin_client, node=node_with_most_available_memory)
+    yield node_with_most_available_memory
 
 
 @pytest.fixture(scope="class")

--- a/tests/virt/node/descheduler/test_descheduler.py
+++ b/tests/virt/node/descheduler/test_descheduler.py
@@ -41,6 +41,7 @@ class TestDeschedulerEvictsVMFromUtilizationImbalance:
         self,
         node_with_least_available_memory,
         node_with_min_memory_labeled_for_descheduler_test,
+        unloaded_migration_target_node,
         deployed_vms_for_utilization_imbalance,
         vms_boot_time_before_utilization_imbalance,
         utilization_imbalance,
@@ -100,12 +101,10 @@ class TestDeschedulerNodeLabel:
         self,
         node_with_least_available_memory,
         node_with_min_memory_labeled_for_descheduler_test,
-        node_with_most_available_memory,
+        unloaded_migration_target_node,
         deployed_vms_on_labeled_node,
     ):
-        with ResourceEditor(
-            patches={node_with_most_available_memory: {"metadata": {"labels": DESCHEDULER_TEST_LABEL}}}
-        ):
+        with ResourceEditor(patches={unloaded_migration_target_node: {"metadata": {"labels": DESCHEDULER_TEST_LABEL}}}):
             verify_at_least_one_vm_migrated(
                 vms=deployed_vms_on_labeled_node, node_before=node_with_least_available_memory
             )

--- a/tests/virt/node/descheduler/utils.py
+++ b/tests/virt/node/descheduler/utils.py
@@ -192,6 +192,7 @@ def deploy_vms(
 
 
 def verify_at_least_one_vm_migrated(vms, node_before):
+    LOGGER.info(f"Waiting for at least one VM to migrate from node {node_before.name}")
     samples = TimeoutSampler(
         wait_timeout=TIMEOUT_5MIN,
         sleep=TIMEOUT_20SEC,

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2110,9 +2110,22 @@ def vm_instance_from_template(
         yield vm
 
 
+def uncordon_node(admin_client, node):
+    """Uncordon node and wait for it to stabilize.
+
+    Args:
+        admin_client (DynamicClient): Admin client
+        node (Node): Node to uncordon
+    """
+    hco_namespace = get_hco_namespace(admin_client=admin_client)
+    LOGGER.info(f"Uncordon node {node.name}")
+    run(f"oc adm uncordon {node.name}", shell=True)
+    wait_for_node_schedulable_status(node=node, status=True)
+    wait_for_kv_stabilize(admin_client=admin_client, hco_namespace=hco_namespace)
+
+
 @contextmanager
 def node_mgmt_console(admin_client, node, node_mgmt):
-    hco_namespace = get_hco_namespace(admin_client=admin_client)
     try:
         LOGGER.info(f"{node_mgmt.capitalize()} the node {node.name}")
         extra_opts = "--delete-emptydir-data --ignore-daemonsets=true --force" if node_mgmt == "drain" else ""
@@ -2127,10 +2140,7 @@ def node_mgmt_console(admin_client, node, node_mgmt):
             run(
                 shlex.split('pkill -f "oc adm drain"'),
             )
-        LOGGER.info(f"Uncordon node {node.name}")
-        run(f"oc adm uncordon {node.name}", shell=True)
-        wait_for_node_schedulable_status(node=node, status=True)
-        wait_for_kv_stabilize(admin_client=admin_client, hco_namespace=hco_namespace)
+        uncordon_node(admin_client=admin_client, node=node)
 
 
 @contextmanager


### PR DESCRIPTION
##### Short description:
Fix descheduler tests on compact clusters

##### More details:
On compact clusters baseline pod utilization is typically 40-46%, which prevents nodes from qualifying as underutilized (<40% threshold). This causes descheduler to skip evictions.

The fix drains the migration target node before tests, reducing pod count, ensuring at least one node qualifies as underutilized.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


Co-Authored-By: Claude Sonnet 4.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced descheduler test infrastructure with improved node management fixtures for migration scenarios.
  * Strengthened test coverage for VM migration and node labeling validation in descheduler functionality.
  * Improved test diagnostics and logging for better test visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4871)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->