### PR TITLE
pytest: guard incremental classes against partial collection

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,6 +50,7 @@ from utilities.exceptions import MissingEnvironmentVariableError, StorageSanityE
 from utilities.junit_ai_utils import enrich_junit_xml, setup_ai_analysis
 from utilities.logger import setup_logging
 from utilities.pytest_utils import (
+    assert_incremental_classes_fully_collected,
     config_default_storage_class,
     deploy_run_in_progress_config_map,
     deploy_run_in_progress_namespace,
@@ -844,6 +845,7 @@ def pytest_sessionstart(session):
 
 
 def pytest_collection_finish(session):
+    assert_incremental_classes_fully_collected(items=session.items)
     validate_collected_tests_arch_params(session=session)
     if session.config.getoption("--collect-tests-markers"):
         get_tests_cluster_markers(items=session.items, filepath=session.config.getoption("--tests-markers-file"))

--- a/tests/network/macspoof/test_macspoof.py
+++ b/tests/network/macspoof/test_macspoof.py
@@ -7,7 +7,6 @@ from utilities.network import assert_ping_successful
 @pytest.mark.incremental
 class TestMacSpoof:
     @pytest.mark.ipv4
-    @pytest.mark.s390x
     @pytest.mark.polarion("CNV-7264")
     def test_macspoof_prevent_connectivity(
         self,

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import socket
 import sys
+from collections import defaultdict
 from typing import Any
 
 import pytest
@@ -609,3 +610,49 @@ def update_cpu_arch_related_config(cpu_arch_option: str) -> None:
                 generate_instance_type_matrix_dicts(os_dict=py_config, cpu_arch=arch)
             else:
                 generate_instance_type_matrix_dicts(os_dict=py_config)
+
+
+def assert_incremental_classes_fully_collected(items: list[pytest.Item]) -> None:
+    """Verify that all tests defined in incremental classes were collected.
+
+    Incremental classes require ordered execution — running a subset produces
+    misleading results.  Fail early (at collection time) if any test in an
+    incremental class was filtered out, so the problem is caught before any
+    test runs.
+
+    Args:
+        items: The full list of collected pytest items.
+
+    Raises:
+        pytest.UsageError: When one or more incremental classes are missing collected tests.
+    """
+    incremental_parents: dict[pytest.Class, list[str]] = defaultdict(list)
+    for item in items:
+        if (
+            isinstance(item, pytest.Function)
+            and isinstance(item.parent, pytest.Class)
+            and "incremental" in item.keywords
+        ):
+            incremental_parents[item.parent].append(item.function.__name__)
+
+    errors = []
+    for parent, collected_names in incremental_parents.items():
+        cls = parent.cls
+        all_tests = [
+            name
+            for name in cls.__dict__
+            if name.startswith("test")
+            and callable(getattr(cls, name))
+            and getattr(getattr(cls, name), "__test__", True)
+            and not _is_xfail_no_run(getattr(cls, name))
+        ]
+        missing = [name for name in all_tests if name not in set(collected_names)]
+        if missing:
+            errors.append(f"{cls.__qualname__}: not collected: {missing}")
+
+    if errors:
+        raise pytest.UsageError("Incremental classes partially collected:\n" + "\n".join(errors))
+
+
+def _is_xfail_no_run(method: object) -> bool:
+    return any(mark.name == "xfail" and mark.kwargs.get("run") is False for mark in getattr(method, "pytestmark", []))

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -11,6 +11,7 @@ from utilities.exceptions import MissingEnvironmentVariableError, UnsupportedCPU
 
 # Circular dependencies are already mocked in conftest.py
 from utilities.pytest_utils import (
+    assert_incremental_classes_fully_collected,
     config_default_storage_class,
     deploy_run_in_progress_config_map,
     deploy_run_in_progress_namespace,
@@ -2181,3 +2182,141 @@ class TestUpdateCpuArchRelatedConfig:
             mock_get_cluster_arch.assert_not_called()
             mock_generate_common.assert_not_called()
             mock_generate_instance.assert_not_called()
+
+
+class TestAssertIncrementalClassesFullyCollected:
+    """Test cases for assert_incremental_classes_fully_collected function."""
+
+    def test_all_tests_collected_no_error(self):
+        """No error when all tests in an incremental class are collected."""
+
+        class MyClass:
+            def test_one(self): ...
+
+            def test_two(self): ...
+
+        parent = self._make_class_parent(cls=MyClass)
+        items = [
+            self._make_function_item(test_name="test_one", parent=parent),
+            self._make_function_item(test_name="test_two", parent=parent),
+        ]
+
+        assert_incremental_classes_fully_collected(items=items)
+
+    def test_missing_test_raises_usage_error(self):
+        """UsageError raised when a test in an incremental class is not collected."""
+
+        class MyClass:
+            def test_one(self): ...
+
+            def test_two(self): ...
+
+            def test_three(self): ...
+
+        parent = self._make_class_parent(cls=MyClass)
+        items = [self._make_function_item(test_name="test_one", parent=parent)]
+
+        with pytest.raises(pytest.UsageError, match="test_two"):
+            assert_incremental_classes_fully_collected(items=items)
+
+    def test_no_incremental_items_no_error(self):
+        """No error when no items carry the incremental marker."""
+
+        class MyClass:
+            def test_one(self): ...
+
+        parent = self._make_class_parent(cls=MyClass)
+        items = [self._make_function_item(test_name="test_one", parent=parent, is_incremental=False)]
+
+        assert_incremental_classes_fully_collected(items=items)
+
+    def test_non_function_items_ignored(self):
+        """Non-Function items are ignored even with the incremental keyword."""
+        item = MagicMock()
+        item.keywords = {"incremental": True}
+
+        assert_incremental_classes_fully_collected(items=[item])
+
+    def test_non_class_parent_ignored(self):
+        """Function items whose parent is not pytest.Class are ignored."""
+        item = MagicMock()
+        item.__class__ = pytest.Function
+        item.keywords = {"incremental": True}
+        item.parent = MagicMock()
+
+        assert_incremental_classes_fully_collected(items=[item])
+
+    def test_multiple_classes_all_errors_reported(self):
+        """All partial-collection errors across multiple incremental classes are reported together."""
+
+        class ClassA:
+            def test_one(self): ...
+
+            def test_two(self): ...
+
+        class ClassB:
+            def test_alpha(self): ...
+
+            def test_beta(self): ...
+
+        parent_a = self._make_class_parent(cls=ClassA)
+        parent_b = self._make_class_parent(cls=ClassB)
+        items = [
+            self._make_function_item(test_name="test_one", parent=parent_a),
+            self._make_function_item(test_name="test_alpha", parent=parent_b),
+        ]
+
+        with pytest.raises(pytest.UsageError) as exc_info:
+            assert_incremental_classes_fully_collected(items=items)
+
+        error_message = str(exc_info.value)
+        assert "test_two" in error_message
+        assert "test_beta" in error_message
+
+    def test_std_placeholder_methods_excluded(self):
+        """Methods with __test__ = False are treated as STD placeholders and not flagged as missing."""
+
+        class MyClass:
+            def test_one(self): ...
+
+            def test_two(self): ...
+
+        MyClass.test_two.__test__ = False
+
+        parent = self._make_class_parent(cls=MyClass)
+        items = [self._make_function_item(test_name="test_one", parent=parent)]
+
+        assert_incremental_classes_fully_collected(items=items)
+
+    def test_xfail_no_run_methods_excluded(self):
+        """Methods marked xfail(run=False) are not flagged as missing."""
+
+        class MyClass:
+            def test_one(self): ...
+
+            def test_two(self): ...
+
+        MyClass.test_two.pytestmark = [pytest.mark.xfail(run=False)]
+
+        parent = self._make_class_parent(cls=MyClass)
+        items = [self._make_function_item(test_name="test_one", parent=parent)]
+
+        assert_incremental_classes_fully_collected(items=items)
+
+    def test_empty_items_no_error(self):
+        """No error when the items list is empty."""
+        assert_incremental_classes_fully_collected(items=[])
+
+    def _make_class_parent(self, cls):
+        parent = MagicMock()
+        parent.__class__ = pytest.Class
+        parent.cls = cls
+        return parent
+
+    def _make_function_item(self, test_name, parent, is_incremental=True):
+        item = MagicMock()
+        item.__class__ = pytest.Function
+        item.parent = parent
+        item.function.__name__ = test_name
+        item.keywords = {"incremental": True} if is_incremental else {}
+        return item


### PR DESCRIPTION
##### What this PR does / why we need it:
Running a subset of an \`incremental\`-marked test class silently executes later tests without their required predecessors, producing misleading results. The existing \`_previousfailed\` propagation only guards against runtime failures — it has no effect when prior tests were never collected.

\`assert_incremental_classes_fully_collected()\` is called from \`pytest_collection_finish\`, which fires after all \`pytest_collection_modifyitems\` hooks — including built-in and external plugins that apply marker and keyword filters. This ensures the guard always sees the final collected set, not an intermediate one. If any tests from an incremental class are missing, a \`pytest.UsageError\` is raised before any test runs, listing every missing test per class.

Tests intentionally excluded in-code (\`__test__ = False\` STD placeholders or \`xfail(run=False)\` quarantined tests) are exempt from the check.

A macspoof test carrying \`@pytest.mark.s390x\` on only one of its two incremental tests is fixed (marker removed) to make the class consistent. A follow-up will consider whether the marker belongs at class level.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pytest collection now validates that classes marked as incremental are fully collected; missing incremental tests cause collection to fail with a clear error.

* **Tests**
  * Added tests covering incremental collection, edge cases, exclusions, and consolidated error reporting.
  * Removed a platform-only marker from a test class so those tests run more broadly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->