### PR TITLE
fix: skip cluster connection on pytest --help

### DIFF
--- a/utilities/architecture.py
+++ b/utilities/architecture.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from functools import cache
 
 from ocp_resources.node import Node
@@ -27,6 +28,11 @@ def get_cluster_architecture() -> set[str]:
     # Needed for CI
     if arch := os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"):
         return {arch}
+
+    # Skip cluster connection for pytest flags that exit immediately without collecting tests
+    _pytest_exit_flags = {"--help", "-h", "--version"}
+    if not _pytest_exit_flags.isdisjoint(sys.argv):
+        return {"amd64"}
 
     # cache_admin_client is used here as this function is used to get the architecture when initialing pytest config
     nodes: list[Node] = list(Node.get(client=cache_admin_client()))

--- a/utilities/architecture.py
+++ b/utilities/architecture.py
@@ -29,10 +29,9 @@ def get_cluster_architecture() -> set[str]:
     if arch := os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"):
         return {arch}
 
-    # Skip cluster connection for pytest flags that exit immediately without collecting tests.
-    # Guard: only applies when invoked via pytest to avoid masking real detection in other contexts.
+    # Skip cluster connection for pytest flags that exit immediately without collecting tests
     _pytest_exit_flags = {"--help", "-h", "--version"}
-    if os.path.basename(sys.argv[0]) in ("pytest", "py.test") and not _pytest_exit_flags.isdisjoint(sys.argv):
+    if not _pytest_exit_flags.isdisjoint(sys.argv):
         return {"amd64"}
 
     # cache_admin_client is used here as this function is used to get the architecture when initialing pytest config

--- a/utilities/architecture.py
+++ b/utilities/architecture.py
@@ -29,9 +29,10 @@ def get_cluster_architecture() -> set[str]:
     if arch := os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"):
         return {arch}
 
-    # Skip cluster connection for pytest flags that exit immediately without collecting tests
+    # Skip cluster connection for pytest flags that exit immediately without collecting tests.
+    # Guard: only applies when invoked via pytest to avoid masking real detection in other contexts.
     _pytest_exit_flags = {"--help", "-h", "--version"}
-    if not _pytest_exit_flags.isdisjoint(sys.argv):
+    if os.path.basename(sys.argv[0]) in ("pytest", "py.test") and not _pytest_exit_flags.isdisjoint(sys.argv):
         return {"amd64"}
 
     # cache_admin_client is used here as this function is used to get the architecture when initialing pytest config

--- a/utilities/unittests/test_architecture.py
+++ b/utilities/unittests/test_architecture.py
@@ -148,23 +148,14 @@ class TestGetClusterArchitecture:
             ):
                 get_cluster_architecture()
 
-    def test_get_cluster_architecture_skips_cluster_on_help_flag(self):
-        """Test that --help flag skips cluster connection and returns default architecture"""
+    @pytest.mark.parametrize("exit_flag", ["--help", "-h", "--version"])
+    @patch("utilities.architecture.cache_admin_client")
+    @patch("utilities.architecture.Node")
+    def test_get_cluster_architecture_skips_cluster_on_exit_flag(self, mock_node_class, mock_cache_client, exit_flag):
+        """Test that pytest exit flags skip cluster connection and return default architecture"""
         with patch.dict(in_dict=os.environ, values={}, clear=True), patch("utilities.architecture.sys") as mock_sys:
-            mock_sys.argv = ["pytest", "--help"]
+            mock_sys.argv = ["pytest", exit_flag]
             result = get_cluster_architecture()
             assert result == {"amd64"}
-
-    def test_get_cluster_architecture_skips_cluster_on_short_help_flag(self):
-        """Test that -h flag skips cluster connection and returns default architecture"""
-        with patch.dict(in_dict=os.environ, values={}, clear=True), patch("utilities.architecture.sys") as mock_sys:
-            mock_sys.argv = ["pytest", "-h"]
-            result = get_cluster_architecture()
-            assert result == {"amd64"}
-
-    def test_get_cluster_architecture_skips_cluster_on_version_flag(self):
-        """Test that --version flag skips cluster connection and returns default architecture"""
-        with patch.dict(in_dict=os.environ, values={}, clear=True), patch("utilities.architecture.sys") as mock_sys:
-            mock_sys.argv = ["pytest", "--version"]
-            result = get_cluster_architecture()
-            assert result == {"amd64"}
+            mock_cache_client.assert_not_called()
+            mock_node_class.get.assert_not_called()

--- a/utilities/unittests/test_architecture.py
+++ b/utilities/unittests/test_architecture.py
@@ -147,3 +147,24 @@ class TestGetClusterArchitecture:
                 match="Cluster architecture could not be determined",
             ):
                 get_cluster_architecture()
+
+    def test_get_cluster_architecture_skips_cluster_on_help_flag(self):
+        """Test that --help flag skips cluster connection and returns default architecture"""
+        with patch.dict(in_dict=os.environ, values={}, clear=True), patch("utilities.architecture.sys") as mock_sys:
+            mock_sys.argv = ["pytest", "--help"]
+            result = get_cluster_architecture()
+            assert result == {"amd64"}
+
+    def test_get_cluster_architecture_skips_cluster_on_short_help_flag(self):
+        """Test that -h flag skips cluster connection and returns default architecture"""
+        with patch.dict(in_dict=os.environ, values={}, clear=True), patch("utilities.architecture.sys") as mock_sys:
+            mock_sys.argv = ["pytest", "-h"]
+            result = get_cluster_architecture()
+            assert result == {"amd64"}
+
+    def test_get_cluster_architecture_skips_cluster_on_version_flag(self):
+        """Test that --version flag skips cluster connection and returns default architecture"""
+        with patch.dict(in_dict=os.environ, values={}, clear=True), patch("utilities.architecture.sys") as mock_sys:
+            mock_sys.argv = ["pytest", "--version"]
+            result = get_cluster_architecture()
+            assert result == {"amd64"}


### PR DESCRIPTION
##### What this PR does / why we need it:
Running `pytest --help` triggers an unnecessary cluster connection that fails when no cluster is available.

**Root cause:** `pytest_testconfig` plugin `exec()`s `tests/global_config.py` during `pytest_cmdline_main`, which runs even for `--help`. This file imports `Images` from `utilities/constants.py`, which evaluates `get_cluster_architecture()` at module level — connecting to the cluster.

**Fix:** Add `sys.argv` check in `get_cluster_architecture()` to return a default architecture (`amd64`) for flags that exit immediately without collecting tests (`--help`, `-h`, `--version`). The check is guarded to only apply when invoked via pytest.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Only `--help`/`-h`/`--version` are guarded — these exit immediately without test collection. The guard also checks `sys.argv[0]` to ensure this only applies under pytest invocations.

**Testing:**
```bash
# Without a cluster — should print help without errors
uv run pytest --help
```

##### jira-ticket:

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved application startup performance by preventing unnecessary cluster access and node queries when help (`--help`, `-h`) or version (`--version`) command-line options are provided.

* **Tests**
  * Added comprehensive parametrized test coverage to validate that cluster communication is correctly skipped when help or version options are supplied to the application during testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->