### PR TITLE
WIP: [Storage] Remove RWO skip in hotplug upgrade test, use RWX matrix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -601,7 +601,7 @@ def pytest_collection_modifyitems(session, config, items):
         config (pytest.Config): The pytest configuration object.
         items (list): A list of pytest.Item objects representing the tests.
     """
-    scope_match = re.compile(r"__(module|class|function)__$")
+    scope_match = re.compile(r"__(session|module|class|function)__$")
     for item in items:
         for fixture_name in [fixture_name for fixture_name in item.fixturenames if "_matrix" in fixture_name]:
             _matrix_name = scope_match.sub("", fixture_name)
@@ -747,7 +747,7 @@ def pytest_runtest_teardown(item):
 
 
 def pytest_generate_tests(metafunc):
-    scope_match = re.compile(r"__(module|class|function)__$")
+    scope_match = re.compile(r"__(session|module|class|function)__$")
     for fixture_name in [fname for fname in metafunc.fixturenames if "_matrix" in fname]:
         scope = scope_match.findall(fixture_name)
         if not scope:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2428,6 +2428,13 @@ def snapshot_storage_class_name_scope_module(
     return [*storage_class_matrix_snapshot_matrix__module__][0]
 
 
+@pytest.fixture(scope="session")
+def rwx_storage_class_name_scope_session(
+    storage_class_matrix_rwx_matrix__session__,
+):
+    return next(iter(storage_class_matrix_rwx_matrix__session__))
+
+
 @pytest.fixture(scope="class")
 def rhel_vm_with_cluster_instance_type_and_preference(namespace, unprivileged_client):
     with VirtualMachineForTests(

--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -1,10 +1,7 @@
 import logging
 
 import pytest
-from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
-from ocp_resources.storage_profile import StorageProfile
-from pytest_testconfig import py_config
 
 from tests.storage.upgrade.utils import (
     create_snapshot_for_upgrade,
@@ -122,13 +119,13 @@ def snapshots_for_upgrade_b(
 
 
 @pytest.fixture(scope="session")
-def blank_disk_dv_with_default_sc(upgrade_namespace_scope_session):
+def blank_disk_dv_with_rwx_sc(upgrade_namespace_scope_session, rwx_storage_class_name_scope_session):
     with create_dv(
         source="blank",
         dv_name="blank-dv",
         namespace=upgrade_namespace_scope_session.name,
         size="1Gi",
-        storage_class=py_config["default_storage_class"],
+        storage_class=rwx_storage_class_name_scope_session,
         consume_wffc=False,
         client=upgrade_namespace_scope_session.client,
     ) as dv:
@@ -182,14 +179,3 @@ def hotplug_volume_upg(fedora_vm_for_hotplug_upg):
 @pytest.fixture()
 def fedora_vm_for_hotplug_upg_ssh_connectivity(fedora_vm_for_hotplug_upg):
     wait_for_ssh_connectivity(vm=fedora_vm_for_hotplug_upg)
-
-
-@pytest.fixture(scope="session")
-def skip_if_config_default_storage_class_access_mode_rwo(admin_client):
-    storage_class = py_config["default_storage_class"]
-    access_modes = StorageProfile(name=storage_class, client=admin_client).first_claim_property_set_access_modes()
-    assert access_modes, f"Could not get the access mode from the {storage_class} storage profile"
-    access_mode = access_modes[0]
-    LOGGER.info(f"Storage class '{storage_class}' has access mode: '{access_mode}'")
-    if access_mode == DataVolume.AccessMode.RWO:
-        pytest.skip(reason="Skip when access_mode is RWO")

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -97,18 +97,17 @@ class TestUpgradeStorage:
     @pytest.mark.dependency(name=f"{STORAGE_NODE_ID_PREFIX}::test_vm_with_hotplug_before_upgrade")
     def test_vm_with_hotplug_before_upgrade(
         self,
-        skip_if_config_default_storage_class_access_mode_rwo,
         enabled_feature_gate_for_declarative_hotplug_volumes_upg,
         upgrade_namespace_scope_session,
-        blank_disk_dv_with_default_sc,
+        blank_disk_dv_with_rwx_sc,
         fedora_vm_for_hotplug_upg,
         hotplug_volume_upg,
     ):
-        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_upg, volume_name=blank_disk_dv_with_default_sc.name)
+        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_upg, volume_name=blank_disk_dv_with_rwx_sc.name)
         assert_disk_serial(vm=fedora_vm_for_hotplug_upg)
         assert_disk_bus(
             vm=fedora_vm_for_hotplug_upg,
-            volume=blank_disk_dv_with_default_sc,
+            volume=blank_disk_dv_with_rwx_sc,
             expected_bus=HOTPLUG_DISK_VIRTIO_BUS,
         )
         assert_hotplugvolume_nonexist(vm=fedora_vm_for_hotplug_upg)
@@ -204,16 +203,16 @@ class TestUpgradeStorage:
     def test_vm_with_hotplug_after_upgrade(
         self,
         upgrade_namespace_scope_session,
-        blank_disk_dv_with_default_sc,
+        blank_disk_dv_with_rwx_sc,
         fedora_vm_for_hotplug_upg,
         hotplug_volume_upg,
         fedora_vm_for_hotplug_upg_ssh_connectivity,
     ):
-        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_upg, volume_name=blank_disk_dv_with_default_sc.name)
+        wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_upg, volume_name=blank_disk_dv_with_rwx_sc.name)
         assert_disk_serial(vm=fedora_vm_for_hotplug_upg)
         assert_disk_bus(
             vm=fedora_vm_for_hotplug_upg,
-            volume=blank_disk_dv_with_default_sc,
+            volume=blank_disk_dv_with_rwx_sc,
             expected_bus=HOTPLUG_DISK_VIRTIO_BUS,
         )
         assert_hotplugvolume_nonexist(vm=fedora_vm_for_hotplug_upg)


### PR DESCRIPTION
##### Short description:
- The change replaces the `py_config["default_storage_class"]`
with a proper RWX storage class from the storage class matrix
in blank_disk_dv_with_rwx_sc,
and removes the `skip_if_config_default_storage_class_access_mode_rwo`
in favor of requesting the right storage class upfront.

- Add session scope to matrix fixture regex
The `scope_match` regex in `pytest_generate_tests` and
`pytest_collection_modifyitems` only accepted module, class, and function
scopes, causing collection to fail for session-scoped matrix fixtures
like `storage_class_matrix_rwx_matrix__session__`.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced pytest fixture scoping mechanism to recognize and support session-level scope patterns in fixture parametrization.
  * Refactored storage upgrade test fixtures to utilize read-write-many (RWX) storage classes, improving test isolation and coverage for storage upgrade validation scenarios.
  * Removed dependencies on default storage class configurations in upgrade tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->