### PR TITLE
fix: use architecture-aware Fedora preference in storage fixtures

### DIFF
--- a/tests/storage/general/conftest.py
+++ b/tests/storage/general/conftest.py
@@ -7,10 +7,11 @@ import logging
 import pytest
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+from pytest_testconfig import config as py_config
 
 from tests.storage.cdi_import.utils import get_importer_pod_node, wait_dv_and_get_importer
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
-from utilities.constants import OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_5MIN, TIMEOUT_12MIN, U1_SMALL, Images
+from utilities.constants import AMD_64, OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_5MIN, TIMEOUT_12MIN, U1_SMALL, Images
 from utilities.storage import create_dv, data_volume_template_with_source_ref_dict, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm
 
@@ -53,13 +54,15 @@ def fedora_vm_with_instance_type(
     The VM is created with U1_SMALL instance type and Fedora preference,
     using a DataVolume template from the provided data source.
     """
+    cpu_arch = py_config["cpu_arch"]
+    preference_name = f"{OS_FLAVOR_FEDORA}.{cpu_arch}" if cpu_arch and cpu_arch != AMD_64 else OS_FLAVOR_FEDORA
     with VirtualMachineForTests(
         name="fedora-vm",
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_FEDORA,
         vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
-        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client),
+        vm_preference=VirtualMachineClusterPreference(name=preference_name, client=unprivileged_client),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=fedora_data_source_scope_module,
             storage_class=storage_class_name_scope_function,


### PR DESCRIPTION
##### Short description:

Fix Fedora VM boot failures on s390x by using architecture-aware preference selection

##### More details:

The `fedora_vm_with_instance_type` fixture hardcoded `OS_FLAVOR_FEDORA` preference, which enables SecureBoot. On s390x, SecureBoot is unsupported, causing VMI boot failures with error: "EFI OVMF roms missing for booting in EFI mode with SecureBoot=true"

This caused `test_disk_falloc` to fail with VMI stuck in "Scheduled" state.

Changes:
-  `tests/storage/general/conftest.py`:  Update `fedora_vm_with_instance_type` to dynamically construct the preference name based on cluster architecture. It uses the "fedora" preference for amd64 architecture and the "fedora.{arch}" preference for other architectures.

Fixes: tests/storage/general/test_storage_behavior.py::test_disk_falloc timeout on s390x clusters.

##### What this PR does / why we need it:

This PR fixes VMI boot failures on s390x clusters by replacing hardcoded Fedora preference with architecture-aware dynamic selection. The hardcoded preference enabled SecureBoot which is unsupported on s390x (missing EFI OVMF ROMs), causing tests to timeout with VMs stuck in "Scheduled" state.

##### Which issue(s) this PR fixes:

Fixes: `tests/storage/general/test_storage_behavior.py::test_disk_falloc` timeout on s390x clusters

##### Special notes for reviewer:

##### jira-ticket:

NONE

Signed-off-by: Alexander Mamani <alexander.mamani@ibm.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixture updated to select virtual machine cluster preference dynamically based on detected CPU architecture; Fedora OS flavor, instance type and data volume template remain unchanged.
  * Improves consistency of test runs across architectures and reduces hardcoded, architecture-specific assumptions in test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->