### PR TITLE
network: remove VMI MAC lookup helper from utilities/network

### DIFF
--- a/tests/network/kubemacpool/test_kubemacpool.py
+++ b/tests/network/kubemacpool/test_kubemacpool.py
@@ -1,8 +1,9 @@
 import pytest
 from kubernetes.client.rest import ApiException
 
+from libs.net.vmspec import lookup_iface_status
 from tests.network.kubemacpool import utils as kmp_utils
-from utilities.network import assert_ping_successful, get_vmi_mac_address_by_iface_name
+from utilities.network import assert_ping_successful
 from utilities.virt import VirtualMachineForTests
 
 pytestmark = [pytest.mark.ipv4]
@@ -44,7 +45,9 @@ class TestKMPConnectivity:
         from kubemacpool belongs to range and connectivity is OK"""
         for vm in (running_vm_a, running_vm_b):
             assert mac_pool.mac_is_within_range(
-                mac=get_vmi_mac_address_by_iface_name(vmi=vm.vmi, iface_name=vm.default_masquerade_iface_config.name),
+                mac=lookup_iface_status(
+                    vm=vm, iface_name=vm.default_masquerade_iface_config.name, predicate=lambda _: True, timeout=1
+                ).mac,
             )
         assert_ping_successful(
             src_vm=running_vm_a,
@@ -59,7 +62,9 @@ class TestKMPConnectivity:
         from kubemacpool belongs to range and connectivity is OK"""
         for vm in (running_vm_a, running_vm_b):
             assert mac_pool.mac_is_within_range(
-                mac=get_vmi_mac_address_by_iface_name(vmi=vm.vmi, iface_name=vm.auto_mac_iface_config.name),
+                mac=lookup_iface_status(
+                    vm=vm, iface_name=vm.auto_mac_iface_config.name, predicate=lambda _: True, timeout=1
+                ).mac,
             )
         assert_ping_successful(src_vm=running_vm_a, dst_ip=running_vm_b.auto_mac_iface_config.ip_address)
 
@@ -69,7 +74,9 @@ class TestKMPConnectivity:
         from kubemacpool is belongs to range and connectivity is OK"""
         for vm in (running_vm_a, running_vm_b):
             assert mac_pool.mac_is_within_range(
-                mac=get_vmi_mac_address_by_iface_name(vmi=vm.vmi, iface_name=vm.auto_mac_tuning_iface_config.name),
+                mac=lookup_iface_status(
+                    vm=vm, iface_name=vm.auto_mac_tuning_iface_config.name, predicate=lambda _: True, timeout=1
+                ).mac,
             )
         assert_ping_successful(
             src_vm=running_vm_a,
@@ -93,7 +100,9 @@ class TestKMPConnectivity:
         enabled_ns_vm,
     ):
         assert mac_pool.mac_is_within_range(
-            mac=get_vmi_mac_address_by_iface_name(vmi=enabled_ns_vm.vmi, iface_name=enabled_ns_nad.name)
+            mac=lookup_iface_status(
+                vm=enabled_ns_vm, iface_name=enabled_ns_nad.name, predicate=lambda _: True, timeout=1
+            ).mac
         )
 
     @pytest.mark.polarion("CNV-4217")
@@ -105,7 +114,9 @@ class TestKMPConnectivity:
         no_label_ns_vm,
     ):
         assert mac_pool.mac_is_within_range(
-            mac=get_vmi_mac_address_by_iface_name(vmi=no_label_ns_vm.vmi, iface_name=no_label_ns_nad.name)
+            mac=lookup_iface_status(
+                vm=no_label_ns_vm, iface_name=no_label_ns_nad.name, predicate=lambda _: True, timeout=1
+            ).mac
         )
 
 
@@ -121,7 +132,9 @@ class TestNegatives:
     ):
         # KMP should not allocate.
         assert not mac_pool.mac_is_within_range(
-            mac=get_vmi_mac_address_by_iface_name(vmi=disabled_ns_vm.vmi, iface_name=disabled_ns_nad.name)
+            mac=lookup_iface_status(
+                vm=disabled_ns_vm, iface_name=disabled_ns_nad.name, predicate=lambda _: True, timeout=1
+            ).mac
         )
 
 

--- a/tests/network/kubemacpool/utils.py
+++ b/tests/network/kubemacpool/utils.py
@@ -3,7 +3,8 @@ from collections import namedtuple
 from ipaddress import ip_interface
 
 from libs.net.ip import random_ipv4_address
-from utilities.network import cloud_init_network_data, get_vmi_mac_address_by_iface_name
+from libs.net.vmspec import lookup_iface_status
+from utilities.network import cloud_init_network_data
 from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
@@ -144,8 +145,14 @@ class VirtualMachineWithMultipleAttachments(VirtualMachineForTests):
 
 def assert_macs_preseved(vm):
     for iface in vm.get_interfaces():
-        assert iface.macAddress == get_vmi_mac_address_by_iface_name(vmi=vm.vmi, iface_name=iface.name)
+        assert (
+            iface.macAddress
+            == lookup_iface_status(vm=vm, iface_name=iface.name, predicate=lambda _: True, timeout=1).mac
+        )
 
 
 def assert_manual_mac_configured(vm, iface_config):
-    assert iface_config.mac_address == get_vmi_mac_address_by_iface_name(vmi=vm.vmi, iface_name=iface_config.name)
+    assert (
+        iface_config.mac_address
+        == lookup_iface_status(vm=vm, iface_name=iface_config.name, predicate=lambda _: True, timeout=1).mac
+    )

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -7,6 +7,7 @@ from pyhelper_utils.shell import run_ssh_commands
 
 import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
 from libs.net.ip import random_ipv4_address
+from libs.net.vmspec import lookup_iface_status
 from tests.network.l2_bridge.libl2bridge import DHCP_INTERFACE_NAME, bridge_attached_vm
 from tests.network.libs.dhcpd import (
     DHCP_IP_RANGE_END,
@@ -21,7 +22,6 @@ from utilities.constants import LINUX_BRIDGE, WORKER_NODE_LABEL_KEY
 from utilities.data_utils import name_prefix
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
-    get_vmi_mac_address_by_iface_name,
     network_device,
     network_nad,
 )
@@ -182,7 +182,9 @@ def l2_bridge_running_vm_a(
         DHCP_IP_SUBNET=DHCP_IP_SUBNET,
         DHCP_IP_RANGE_START=DHCP_IP_RANGE_START,
         DHCP_IP_RANGE_END=DHCP_IP_RANGE_END,
-        CLIENT_MAC_ADDRESS=get_vmi_mac_address_by_iface_name(vmi=l2_bridge_running_vm_b.vmi, iface_name=dhcp_nad.name),
+        CLIENT_MAC_ADDRESS=lookup_iface_status(
+            vm=l2_bridge_running_vm_b, iface_name=dhcp_nad.name, predicate=lambda _: True, timeout=1
+        ).mac,
         UNIQUE_CLIENT_ID=UNIQUE_CLIENT_ID,
     )
     cloud_init_extra_user_data = {

--- a/tests/network/upgrade/test_upgrade_network.py
+++ b/tests/network/upgrade/test_upgrade_network.py
@@ -15,10 +15,7 @@ from utilities.constants import (
     DEPENDENCY_SCOPE_SESSION,
     KMP_VM_ASSIGNMENT_LABEL,
 )
-from utilities.network import (
-    assert_ping_successful,
-    get_vmi_mac_address_by_iface_name,
-)
+from utilities.network import assert_ping_successful
 
 LOGGER = logging.getLogger(__name__)
 DEPENDENCIES_NODE_ID_PREFIX = f"{os.path.abspath(__file__)}::TestUpgradeNetwork"
@@ -87,7 +84,9 @@ class TestUpgradeNetwork:
     ):
         for vm in (running_vm_upgrade_a, running_vm_upgrade_b):
             assert mac_pool.mac_is_within_range(
-                mac=get_vmi_mac_address_by_iface_name(vmi=vm.vmi, iface_name=upgrade_bridge_marker_nad.name)
+                mac=lookup_iface_status(
+                    vm=vm, iface_name=upgrade_bridge_marker_nad.name, predicate=lambda _: True, timeout=1
+                ).mac
             )
 
     @pytest.mark.sno
@@ -194,7 +193,9 @@ class TestUpgradeNetwork:
     ):
         for vm in (running_vm_upgrade_a, running_vm_upgrade_b):
             assert mac_pool.mac_is_within_range(
-                mac=get_vmi_mac_address_by_iface_name(vmi=vm.vmi, iface_name=upgrade_bridge_marker_nad.name)
+                mac=lookup_iface_status(
+                    vm=vm, iface_name=upgrade_bridge_marker_nad.name, predicate=lambda _: True, timeout=1
+                ).mac
             )
 
     @pytest.mark.sno

--- a/utilities/network.py
+++ b/utilities/network.py
@@ -660,13 +660,6 @@ class IfaceNotFound(Exception):
         return f"Interface not found for NAD {self.name}"
 
 
-def get_vmi_mac_address_by_iface_name(vmi, iface_name):
-    for iface in vmi.interfaces:
-        if iface.name == iface_name:
-            return iface.mac
-    raise IfaceNotFound(name=iface_name)
-
-
 def cloud_init_network_data(data):
     """
     Generate cloud init network data.


### PR DESCRIPTION
##### What this PR does / why we need it:
Callers of `utilities/network` should not depend on it for MAC address lookups when `libs/net/vmspec` already provides the right abstraction. This removes `get_vmi_mac_address_by_iface_name` and replaces all call sites with `lookup_iface_status` using a no-op predicate and a short timeout (1s).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated network connectivity test suite including kubemacpool, L2 bridge, and network upgrade scenarios to use improved interface status lookup mechanism for MAC address verification and validation.

* **Refactor**
  * Removed legacy MAC address lookup utility function from core network utilities, streamlining the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->