### PR TITLE
Fix `IndexError` in config_default_storage_class when storage class not in matrix

### DIFF
--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -112,6 +112,46 @@ def get_matrix_params(pytest_config, matrix_name):
     return _matrix_params if isinstance(_matrix_params, list) else [_matrix_params]
 
 
+def _validate_storage_class_options(
+    cmd_default_storage_class: str | None = None,
+    cmdline_storage_class_matrix: list[str] | None = None,
+) -> None:
+    """Validates that storage class CLI options reference existing storage classes.
+
+    Args:
+        cmd_default_storage_class: Value from --default-storage-class CLI option.
+        cmdline_storage_class_matrix: Parsed values from --storage-class-matrix CLI option.
+
+    Raises:
+        ValueError: If any storage class name is not found in py_config["system_storage_class_matrix"].
+    """
+    available_sc_names = [sc_name for sc in py_config["system_storage_class_matrix"] for sc_name in sc]
+
+    if cmdline_storage_class_matrix:
+        # Verify storage classes passed via --storage-class-matrix are supported
+        if invalid_sc_names := set(cmdline_storage_class_matrix) - set(available_sc_names):
+            raise ValueError(
+                f"Storage class(es) {sorted(invalid_sc_names)} from --storage-class-matrix not found. "
+                f"Available storage classes: {available_sc_names}"
+            )
+
+        # Verify default storage class passed via --default-storage-class exists in --storage-class-matrix
+        if cmd_default_storage_class and cmd_default_storage_class not in cmdline_storage_class_matrix:
+            raise ValueError(
+                f"Default storage class '{cmd_default_storage_class}' not in --storage-class-matrix. "
+                f"Matrix storage classes: {cmdline_storage_class_matrix}"
+            )
+
+        return
+
+    # Verify default storage class passed via --default-storage-class is supported (when matrix is not passed from cli)
+    if cmd_default_storage_class and cmd_default_storage_class not in available_sc_names:
+        raise ValueError(
+            f"Default storage class '{cmd_default_storage_class}' not found in system storage class matrix. "
+            f"Available storage classes: {available_sc_names}"
+        )
+
+
 def config_default_storage_class(session):
     # Default storage class selection order:
     # 1. --default-storage-class from command line
@@ -123,26 +163,43 @@ def config_default_storage_class(session):
     global_config_default_sc = py_config["default_storage_class"]
     cmd_default_storage_class = session.config.getoption(name="default_storage_class")
     cmdline_storage_class_matrix = session.config.getoption(name="storage_class_matrix")
+    system_storage_class_matrix = py_config["system_storage_class_matrix"]
+
+    parsed_cmdline_matrix = cmdline_storage_class_matrix.split(",") if cmdline_storage_class_matrix else None
+    try:
+        _validate_storage_class_options(
+            cmd_default_storage_class=cmd_default_storage_class,
+            cmdline_storage_class_matrix=parsed_cmdline_matrix,
+        )
+    except ValueError as error:
+        error_message = str(error)
+        target_location = os.path.join(get_data_collector_base_directory(), "utilities", "pytest_exit_errors")
+        write_to_file(
+            file_name="storage_class_validation_error",
+            content=error_message,
+            base_directory=target_location,
+        )
+        pytest.exit(reason=error_message, returncode=4)
+
     updated_default_sc = None
     if cmd_default_storage_class:
         updated_default_sc = cmd_default_storage_class
-    elif cmdline_storage_class_matrix:
-        cmdline_storage_class_matrix = cmdline_storage_class_matrix.split(",")
+    elif parsed_cmdline_matrix:
         updated_default_sc = (
-            global_config_default_sc
-            if global_config_default_sc in cmdline_storage_class_matrix
-            else cmdline_storage_class_matrix[0]
+            global_config_default_sc if global_config_default_sc in parsed_cmdline_matrix else parsed_cmdline_matrix[0]
         )
 
     # Update only if the requested default sc is not the same as set in global_config
     if updated_default_sc and updated_default_sc != global_config_default_sc:
         py_config["default_storage_class"] = updated_default_sc
-        default_storage_class_configuration = [
+        matching_configurations = [
             sc_dict
-            for sc in py_config["storage_class_matrix"]
+            for sc in system_storage_class_matrix
             for sc_name, sc_dict in sc.items()
             if sc_name == updated_default_sc
-        ][0]
+        ]
+
+        default_storage_class_configuration = matching_configurations[0]
 
         py_config["default_volume_mode"] = default_storage_class_configuration["volume_mode"]
         py_config["default_access_mode"] = default_storage_class_configuration["access_mode"]

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 import utilities.constants
+
+# Circular dependencies are already mocked in conftest.py
+from utilities import pytest_utils
 from utilities.constants.architecture import (
     AMD_64,
     ARM_64,
@@ -19,9 +22,8 @@ from utilities.constants.instance_types import (
     RHEL9_PREFERENCE,
 )
 from utilities.exceptions import MissingEnvironmentVariableError, UnsupportedCPUArchitectureError
-
-# Circular dependencies are already mocked in conftest.py
 from utilities.pytest_utils import (
+    _validate_storage_class_options,
     assert_incremental_classes_fully_collected,
     config_default_storage_class,
     deploy_run_in_progress_config_map,
@@ -269,6 +271,10 @@ class TestConfigDefaultStorageClass:
                 {"new-sc": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
                 {"original-sc": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
             ],
+            "system_storage_class_matrix": [
+                {"new-sc": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
+                {"original-sc": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
         },
     )
     def test_config_default_storage_class_cmd_override(self):
@@ -292,6 +298,10 @@ class TestConfigDefaultStorageClass:
         {
             "default_storage_class": "original-sc",
             "storage_class_matrix": [
+                {"first-sc": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
+                {"second-sc": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
+            "system_storage_class_matrix": [
                 {"first-sc": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
                 {"second-sc": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
             ],
@@ -321,6 +331,10 @@ class TestConfigDefaultStorageClass:
                 {"first-sc": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
                 {"original-sc": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
             ],
+            "system_storage_class_matrix": [
+                {"first-sc": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
+                {"original-sc": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
         },
     )
     def test_config_default_storage_class_matrix_contains_default(self):
@@ -338,7 +352,13 @@ class TestConfigDefaultStorageClass:
         # Should keep original-sc since it's in the matrix
         assert py_config["default_storage_class"] == "original-sc"
 
-    @patch("utilities.pytest_utils.py_config", {"default_storage_class": "original-sc"})
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {
+            "default_storage_class": "original-sc",
+            "system_storage_class_matrix": [],
+        },
+    )
     def test_config_default_storage_class_no_changes(self):
         """Test no changes when no overrides provided"""
         mock_session = MagicMock()
@@ -353,6 +373,263 @@ class TestConfigDefaultStorageClass:
 
         # Should remain unchanged
         assert py_config["default_storage_class"] == "original-sc"
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {
+            "default_storage_class": "original-sc",
+            "system_storage_class_matrix": [
+                {"existing-sc-1": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
+                {"existing-sc-2": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
+        },
+    )
+    @patch("utilities.pytest_utils.write_to_file")
+    @patch("utilities.pytest_utils.get_data_collector_base_directory", return_value="/tmp")
+    @patch("utilities.pytest_utils.pytest.exit", side_effect=SystemExit(4))
+    def test_config_default_storage_class_not_found_raises_error(
+        self, mock_pytest_exit, mock_get_base_dir, mock_write_to_file
+    ):
+        """Test clean exit when requested default storage class is not in system matrix"""
+        mock_session = MagicMock()
+        mock_session.config.getoption.side_effect = lambda name: {
+            "default_storage_class": "nonexistent-sc",
+            "storage_class_matrix": None,
+        }.get(name)
+
+        with pytest.raises(SystemExit):
+            config_default_storage_class(mock_session)
+
+        mock_pytest_exit.assert_called_once()
+        assert mock_pytest_exit.call_args[1]["returncode"] == 4
+        assert "nonexistent-sc" in mock_pytest_exit.call_args[1]["reason"]
+        mock_write_to_file.assert_called_once()
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {
+            "default_storage_class": "original-sc",
+            "system_storage_class_matrix": [
+                {"existing-sc-1": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
+                {"existing-sc-2": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
+        },
+    )
+    @patch("utilities.pytest_utils.write_to_file")
+    @patch("utilities.pytest_utils.get_data_collector_base_directory", return_value="/tmp")
+    @patch("utilities.pytest_utils.pytest.exit", side_effect=SystemExit(4))
+    def test_config_default_storage_class_invalid_matrix_values_raises_error(
+        self, mock_pytest_exit, mock_get_base_dir, mock_write_to_file
+    ):
+        """Test clean exit when --storage-class-matrix contains invalid storage class names"""
+        mock_session = MagicMock()
+        mock_session.config.getoption.side_effect = lambda name: {
+            "default_storage_class": None,
+            "storage_class_matrix": "nonexistent-sc,existing-sc-1",
+        }.get(name)
+
+        with pytest.raises(SystemExit):
+            config_default_storage_class(mock_session)
+
+        mock_pytest_exit.assert_called_once()
+        assert mock_pytest_exit.call_args[1]["returncode"] == 4
+        assert "nonexistent-sc" in mock_pytest_exit.call_args[1]["reason"]
+        mock_write_to_file.assert_called_once()
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {
+            "default_storage_class": "original-sc",
+            "system_storage_class_matrix": [
+                {"sc-1": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
+                {"sc-2": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
+        },
+    )
+    @patch("utilities.pytest_utils.write_to_file")
+    @patch("utilities.pytest_utils.get_data_collector_base_directory", return_value="/tmp")
+    @patch("utilities.pytest_utils.pytest.exit", side_effect=SystemExit(4))
+    def test_config_default_storage_class_not_in_matrix_raises_error(
+        self, mock_pytest_exit, mock_get_base_dir, mock_write_to_file
+    ):
+        """Test clean exit when --default-storage-class is not in --storage-class-matrix"""
+        mock_session = MagicMock()
+        mock_session.config.getoption.side_effect = lambda name: {
+            "default_storage_class": "sc-1",
+            "storage_class_matrix": "sc-2",
+        }.get(name)
+
+        with pytest.raises(SystemExit):
+            config_default_storage_class(mock_session)
+
+        mock_pytest_exit.assert_called_once()
+        assert mock_pytest_exit.call_args[1]["returncode"] == 4
+        assert "sc-1" in mock_pytest_exit.call_args[1]["reason"]
+        mock_write_to_file.assert_called_once()
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {
+            "default_storage_class": "original-sc",
+            "system_storage_class_matrix": [
+                {"sc-1": {"volume_mode": "Filesystem", "access_mode": "ReadWriteOnce"}},
+                {"sc-2": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
+        },
+    )
+    def test_config_default_storage_class_both_options_valid(self):
+        """Test correct update when both --default-storage-class and --storage-class-matrix are valid"""
+        mock_session = MagicMock()
+        mock_session.config.getoption.side_effect = lambda name: {
+            "default_storage_class": "sc-1",
+            "storage_class_matrix": "sc-1,sc-2",
+        }.get(name)
+
+        config_default_storage_class(mock_session)
+
+        assert pytest_utils.py_config["default_storage_class"] == "sc-1"
+        assert pytest_utils.py_config["default_volume_mode"] == "Filesystem"
+        assert pytest_utils.py_config["default_access_mode"] == "ReadWriteOnce"
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {
+            "default_storage_class": "original-sc",
+            "system_storage_class_matrix": [
+                {"original-sc": {"volume_mode": "Block", "access_mode": "ReadWriteMany"}},
+            ],
+        },
+    )
+    def test_config_default_storage_class_same_as_global(self):
+        """Test no update when --default-storage-class matches global default"""
+        mock_session = MagicMock()
+        mock_session.config.getoption.side_effect = lambda name: {
+            "default_storage_class": "original-sc",
+            "storage_class_matrix": None,
+        }.get(name)
+
+        config_default_storage_class(mock_session)
+
+        assert pytest_utils.py_config["default_storage_class"] == "original-sc"
+
+
+class TestValidateStorageClassOptions:
+    """Test cases for _validate_storage_class_options function"""
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}, {"sc-2": {}}, {"sc-3": {}}]},
+    )
+    def test_valid_matrix_and_default(self):
+        """Test no error when all values are valid"""
+        _validate_storage_class_options(
+            cmd_default_storage_class="sc-1",
+            cmdline_storage_class_matrix=["sc-1", "sc-2"],
+        )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}, {"sc-2": {}}]},
+    )
+    def test_valid_matrix_no_default(self):
+        """Test no error when matrix is valid and no default is specified"""
+        _validate_storage_class_options(
+            cmd_default_storage_class=None,
+            cmdline_storage_class_matrix=["sc-1", "sc-2"],
+        )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}]},
+    )
+    def test_no_options(self):
+        """Test no error when no options are specified"""
+        _validate_storage_class_options(
+            cmd_default_storage_class=None,
+            cmdline_storage_class_matrix=None,
+        )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}, {"sc-2": {}}]},
+    )
+    def test_invalid_matrix_value(self):
+        """Test ValueError for invalid storage class in matrix"""
+        with pytest.raises(ValueError, match=r"from --storage-class-matrix not found"):
+            _validate_storage_class_options(
+                cmd_default_storage_class=None,
+                cmdline_storage_class_matrix=["bad-sc"],
+            )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}, {"sc-2": {}}]},
+    )
+    def test_invalid_default_sc(self):
+        """Test ValueError for default SC not in system matrix"""
+        with pytest.raises(ValueError, match=r"Default storage class 'bad-sc' not found"):
+            _validate_storage_class_options(
+                cmd_default_storage_class="bad-sc",
+                cmdline_storage_class_matrix=None,
+            )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}, {"sc-2": {}}]},
+    )
+    def test_valid_default_no_matrix(self):
+        """Test no error when default SC is valid and no matrix is specified"""
+        _validate_storage_class_options(
+            cmd_default_storage_class="sc-1",
+            cmdline_storage_class_matrix=None,
+        )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}]},
+    )
+    def test_multiple_invalid_matrix_values(self):
+        """Test all invalid storage class names are reported"""
+        with pytest.raises(ValueError, match=r"\['bad-sc-1', 'bad-sc-2'\]"):
+            _validate_storage_class_options(
+                cmd_default_storage_class=None,
+                cmdline_storage_class_matrix=["bad-sc-1", "bad-sc-2"],
+            )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}]},
+    )
+    def test_invalid_matrix_checked_before_default_not_in_matrix(self):
+        """Test matrix validation runs before default-in-matrix check"""
+        with pytest.raises(ValueError, match=r"from --storage-class-matrix not found"):
+            _validate_storage_class_options(
+                cmd_default_storage_class="sc-1",
+                cmdline_storage_class_matrix=["bad-sc"],
+            )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}, {"sc-2": {}}, {"sc-3": {}}]},
+    )
+    def test_default_sc_not_in_matrix(self):
+        """Test ValueError when default SC exists on system but not in the provided matrix"""
+        with pytest.raises(ValueError, match=r"not in --storage-class-matrix"):
+            _validate_storage_class_options(
+                cmd_default_storage_class="sc-1",
+                cmdline_storage_class_matrix=["sc-2", "sc-3"],
+            )
+
+    @patch(
+        "utilities.pytest_utils.py_config",
+        {"system_storage_class_matrix": [{"sc-1": {}}, {"sc-2": {}}]},
+    )
+    def test_valid_matrix_skips_system_check_for_default(self):
+        """Test that when matrix is valid, default SC is only checked against matrix not system"""
+        _validate_storage_class_options(
+            cmd_default_storage_class="sc-1",
+            cmdline_storage_class_matrix=["sc-1"],
+        )
 
 
 class TestSeparator:


### PR DESCRIPTION
##### What this PR does / why we need it:
When a `--storage-class-matrix` CLI value does not match any key in the configured `storage_class_matrix` in `tests/global_config*.py` 
Adding validation before indexing into the list comprehension result. 
When the requested storage class is not found in the matrix, raise a clear error message listing the available storage class names instead of crashing with an opaque `IndexError`.

##### Which issue(s) this PR fixes:
When a user passes `--storage-class-matrix=hostpath-provisioner`, for example, but `hostpath-provisioner` does not match any key in the `storage_class_matrix` configuration in `tests/global_config.py`.

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of CLI storage-class options, including safer handling of default storage-class selection.
  * Added clearer error messages when unsupported storage classes are provided and ensured default volume/access modes are populated from the correct storage-class definitions.

* **Tests**
  * Expanded unit test coverage for valid/invalid storage-class matrices, override scenarios, and failure ordering to prevent ambiguous validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->