### PR TITLE
net, stability: Fix test_interfaces_stability_after_migration

### DIFF
--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -2,6 +2,7 @@ from typing import Final
 
 import pytest
 
+from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from tests.network.l2_bridge.vmi_interfaces_stability.lib_helpers import (
     assert_interfaces_stable,
     monitor_vmi_events,
@@ -22,5 +23,12 @@ class TestInterfacesStability:
     @pytest.mark.polarion("CNV-14340")
     def test_interfaces_stability_after_migration(self, running_linux_bridge_vm, stable_ips):
         migrate_vm_and_verify(vm=running_linux_bridge_vm)
+        primary_network = lookup_primary_network(vm=running_linux_bridge_vm)
+        primary_iface = lookup_iface_status(
+            vm=running_linux_bridge_vm,
+            iface_name=primary_network.name,
+            predicate=lambda iface: bool(iface["ipAddress"]),
+        )
+        stable_ips[primary_network.name] = primary_iface.ipAddress
         for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
             assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))


### PR DESCRIPTION
##### What this PR does / why we need it:
The test fails with error:
AssertionError: IP mismatch on default: event reports "ip-1", stable state has "ip-2"

The default interface uses masquerade networking - its IP is the virt-launcher pod IP. When the VM migrates to a different node, the new pod gets an IP from a different subnet, so the pre-migration stable_ips no longer matches.

##### Which issue(s) this PR fixes:
Wait for stable interfaces IPs and then capture the interface IPs from the post-migration VMI.
The test then monitors stability against that post-migration baseline.

##### Special notes for reviewer: -

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved VM migration interface stability test: during migration the test now refreshes the primary network’s interface-to-IP mapping by inspecting current interface status, uses the updated mapping to determine expected interfaces/IPs, and validates stability accordingly—removing reliance on a prior fixture-provided IP list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->