### PR TITLE
[IUO] Fix golden images custom namespace API path for HCO v1

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -105,7 +105,7 @@ def updated_common_template_custom_ns(
     with ResourceEditorValidateHCOReconcile(
         patches={
             hyperconverged_resource_scope_class: {
-                "spec": {COMMON_BOOT_IMAGE_NAMESPACE_STR: custom_golden_images_namespace.name}
+                "spec": {"workloadSources": {COMMON_BOOT_IMAGE_NAMESPACE_STR: custom_golden_images_namespace.name}}
             }
         },
         list_resource_reconcile=[SSP, CDI],
@@ -129,7 +129,7 @@ def updated_common_templates_non_existent_ns(
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
-        patches={hyperconverged_resource_scope_function: {"spec": {COMMON_BOOT_IMAGE_NAMESPACE_STR: "non-existent-ns"}}}
+        patches={hyperconverged_resource_scope_function: {"spec": {"workloadSources": {COMMON_BOOT_IMAGE_NAMESPACE_STR: "non-existent-ns"}}}}
     ):
         yield
     wait_for_hco_conditions(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -129,7 +129,11 @@ def updated_common_templates_non_existent_ns(
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
-        patches={hyperconverged_resource_scope_function: {"spec": {"workloadSources": {COMMON_BOOT_IMAGE_NAMESPACE_STR: "non-existent-ns"}}}}
+        patches={
+            hyperconverged_resource_scope_function: {
+                "spec": {"workloadSources": {COMMON_BOOT_IMAGE_NAMESPACE_STR: "non-existent-ns"}}
+            }
+        }
     ):
         yield
     wait_for_hco_conditions(


### PR DESCRIPTION
##### What this PR does / why we need it:
HCO v1 API moved commonBootImageNamespace from spec.commonBootImageNamespace to spec.workloadSources.commonBootImageNamespace. The old path is silently ignored, causing all 7 custom golden images namespace tests to fail.

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-87815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for custom golden image boot image namespace configuration to align with changes in resource specification structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->