### PR TITLE
tox: add version 5.0.0 to bugs check and remove skip on CNV-85477

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -74,7 +74,6 @@ class TestConnectivityOVSBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.gating
     @pytest.mark.polarion("CNV-12556")
-    @pytest.mark.jira("CNV-85477", run=False)
     def test_ovs_bridge(
         self,
         subtests,

--- a/tox.ini
+++ b/tox.ini
@@ -80,18 +80,6 @@ commands =
 
 
 #Jira
-# TODO: remove once verify-bugs-are-open-gh is checked and works properly
-[testenv:verify-bugs-are-open]
-recreate=True
-setenv =
-    PYTHONPATH = {toxinidir}
-deps:
-    python-utility-scripts
-commands =
-    pip install pip --upgrade
-    pip install tox --upgrade
-    pyutils-jira --config-file-path jira.cfg --target-versions "vfuture,4.22.0,4.22.z" --verbose
-
 [testenv:verify-bugs-are-open-gh]
 recreate=True
 passenv =
@@ -102,7 +90,8 @@ setenv =
 deps =
     python-utility-scripts
 commands =
-    pyutils-jira --cloud --url https://redhat.atlassian.net --target-versions "vfuture,4.22.0,4.22.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
+#TODO remove 5.0.0 when the branch is created
+    pyutils-jira --cloud --url https://redhat.atlassian.net --target-versions "vfuture,4.22.0,4.22.z,5.0.0" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
 
 #Unused code
 [testenv:unused-code]


### PR DESCRIPTION
##### What this PR does / why we need it:
Fix failing verify-bugs-open check

 - Add version 5.0.0 to 
 - Remove skip for  CNV-85477
##### Which issue(s) this PR fixes:
Failing CI check, for example - https://github.com/RedHatQE/openshift-virtualization-tests/pull/4898/checks?check_run_id=76802565863

referenced bugs:
https://redhat.atlassian.net/browse/CNV-87184
https://redhat.atlassian.net/browse/CNV-85477


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test/verification configuration: removed one verification environment and extended target versions to include 5.0.0.
  * Adjusted test selection/marking for a network connectivity test, changing how it’s included in test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->