### PR TITLE
Proposal: Quarantine dashboard on GitHub pages

### DIFF
--- a/.github/workflows/quarantine-dashboard.yml
+++ b/.github/workflows/quarantine-dashboard.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 8 * * 1'
   workflow_dispatch:
+  push:
+    branches:
+      - quarantine-dashboard  # temp
 
 permissions:
   contents: write

--- a/.github/workflows/quarantine-dashboard.yml
+++ b/.github/workflows/quarantine-dashboard.yml
@@ -38,7 +38,7 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Upload dashboard as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quarantine-dashboard-${{ steps.timestamp.outputs.date }}
           path: output/dashboard.html
@@ -55,5 +55,6 @@ jobs:
 
       - name: Comment on workflow run
         run: |
-          echo "✅ Dashboard generated successfully!"
-          echo "📊 View at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/reports/dashboard.html"
+          echo "## ✅ Dashboard Generated" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📊 **[View Dashboard](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/reports/dashboard.html)**" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/quarantine-dashboard.yml
+++ b/.github/workflows/quarantine-dashboard.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Generate quarantine dashboard
         run: |
@@ -45,7 +45,7 @@ jobs:
           retention-days: 30
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v.4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./output

--- a/.github/workflows/quarantine-dashboard.yml
+++ b/.github/workflows/quarantine-dashboard.yml
@@ -1,0 +1,56 @@
+name: Generate Quarantine Dashboard
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate-dashboard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Generate quarantine dashboard
+        run: |
+          mkdir -p output
+          uv run quarantine-dashboard --output-dir output --keep-clones
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate timestamp
+        id: timestamp
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Upload dashboard as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: quarantine-dashboard-${{ steps.timestamp.outputs.date }}
+          path: output/dashboard.html
+          retention-days: 30
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./output
+          destination_dir: reports
+          keep_files: true
+          commit_message: 'Update quarantine dashboard - ${{ steps.timestamp.outputs.date }}'
+
+      - name: Comment on workflow run
+        run: |
+          echo "✅ Dashboard generated successfully!"
+          echo "📊 View at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/reports/dashboard.html"

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ docs/source/rst
 
 # For local run (debug).
 ocp_resources
+
+# Quarantine dashboard report
+scripts/quarantine_stats/dashboard.html

--- a/docs/QUARANTINE_GUIDELINES.md
+++ b/docs/QUARANTINE_GUIDELINES.md
@@ -182,6 +182,40 @@ When submitting quarantine PR:
 
 **GitHub Label**: `quarantine` label will be added automatically
 
+## Quarantine Tracking and Reporting
+
+### Automated Quarantine Dashboard
+
+An automated quarantine dashboard is generated weekly to track quarantined tests across all versions and teams.
+
+**Viewing the Dashboard:**
+
+Live dashboard (updated weekly): **https://redhatqe.github.io/openshift-virtualization-tests/reports/dashboard.html**
+
+The dashboard includes:
+- **Version Summary**: Total, active, and quarantined test counts per version (main, cnv-4.21, cnv-4.20, etc.)
+- **Team Breakdown**: Quarantined tests organized by team across all versions
+- **Detailed Test List**: All quarantined tests with:
+  - Test name and file location
+  - Associated Jira ticket (if available)
+  - Quarantine reason
+  - Team/category
+
+**Automation:**
+
+The dashboard is automatically generated every **Monday at 8:00 UTC** via GitHub Actions workflow ([`.github/workflows/quarantine-dashboard.yml`](../.github/workflows/quarantine-dashboard.yml)) and published to GitHub Pages.
+
+**Manual Generation:**
+
+To generate the dashboard locally:
+
+```bash
+# Generate HTML dashboard
+uv run quarantine-dashboard
+# Generate JSON for analysis
+uv run quarantine-dashboard --json
+```
+
 
 ## De-Quarantine and Re-inclusion Process
 

--- a/scripts/quarantine_stats/generate_dashboard.py
+++ b/scripts/quarantine_stats/generate_dashboard.py
@@ -475,9 +475,9 @@ def clone_or_update_repo(repo: str, base_dir: Path, github_token: str | None = N
 
     # Clone new repo - use token if provided for private repos
     if github_token:
-        repo_url = f"https://{github_token}@github.com/{repo}.git"
+        repo_url = f"https://x-access-token:{github_token}@github.com/{repo}.git"
         # Log without exposing the token
-        LOGGER.info("Cloning: https://***@github.com/%s.git (with token)", repo)
+        LOGGER.info("Cloning: https://x-access-token:***@github.com/%s.git (with token)", repo)
     else:
         repo_url = f"https://github.com/{repo}.git"
         LOGGER.info("Cloning: %s", repo_url)

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -14,7 +14,6 @@ from tests.storage.utils import (
 from utilities.constants import (
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
-    TIMEOUT_1MIN,
     TIMEOUT_40MIN,
     Images,
 )
@@ -107,13 +106,11 @@ def test_successful_vm_restart_with_cloned_dv(
     cluster_csi_drivers_names,
 ):
     size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
-
-    with DataVolume(
-        name="dv-target",
+    with create_dv(
+        dv_name="dv-target",
         namespace=namespace.name,
         client=unprivileged_client,
         size=size,
-        api_name="storage",
         storage_class=storage_class_name_scope_module,
         source_ref={
             "kind": fedora_data_source_scope_module.kind,
@@ -121,9 +118,7 @@ def test_successful_vm_restart_with_cloned_dv(
             "namespace": fedora_data_source_scope_module.namespace,
         },
     ) as cdv:
-        cdv.wait(timeout=TIMEOUT_1MIN, wait_for_exists_only=True)
-        cdv.pvc.wait()
-
+        cdv.wait_for_dv_success()
         with create_vm_from_dv(
             client=unprivileged_client,
             dv=cdv,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -14,6 +14,7 @@ from tests.storage.utils import (
 from utilities.constants import (
     OS_FLAVOR_FEDORA,
     OS_FLAVOR_WINDOWS,
+    TIMEOUT_1MIN,
     TIMEOUT_40MIN,
     Images,
 )
@@ -106,11 +107,13 @@ def test_successful_vm_restart_with_cloned_dv(
     cluster_csi_drivers_names,
 ):
     size = get_dv_size_from_datasource(data_source=fedora_data_source_scope_module)
-    with create_dv(
-        dv_name="dv-target",
+
+    with DataVolume(
+        name="dv-target",
         namespace=namespace.name,
         client=unprivileged_client,
         size=size,
+        api_name="storage",
         storage_class=storage_class_name_scope_module,
         source_ref={
             "kind": fedora_data_source_scope_module.kind,
@@ -118,7 +121,9 @@ def test_successful_vm_restart_with_cloned_dv(
             "namespace": fedora_data_source_scope_module.namespace,
         },
     ) as cdv:
-        cdv.wait_for_dv_success()
+        cdv.wait(timeout=TIMEOUT_1MIN, wait_for_exists_only=True)
+        cdv.pvc.wait()
+
         with create_vm_from_dv(
             client=unprivileged_client,
             dv=cdv,


### PR DESCRIPTION
##### What this PR does / why we need it:
This PR is proposing a way to expose the quarantine dashboard script artifact in a scheduled way, so we can keep better track of the quarantined tests weekly. The workflow can also be triggered manually ad hoc. 
To enable this, we'd need to enable GH Pages for this repository. 

This is a preview of the result hosted in my forked repo Pages -> https://ema-aka-young.github.io/openshift-virtualization-tests/reports/dashboard.html

##### Which issue(s) this PR fixes:
It proposes a way to have a weekly view of quarantined tests shared on a publicly accessible place.

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
