### PR TITLE
net, l2 bridge: NAD live update tests

### DIFF
--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -53,6 +53,8 @@ class TcpServer:
         vm (BaseVirtualMachine): The virtual machine where the server runs.
         port (int): The port on which the server listens for client connections.
         bind_ip (str): The IP address to bind the server to (optional).
+        bind_dev (str): Guest network device to bind the server socket to via SO_BINDTODEVICE
+            (e.g. "eth1"). Forces responses out this interface, bypassing ECMP routing.
     """
 
     def __init__(
@@ -60,11 +62,13 @@ class TcpServer:
         vm: BaseVirtualMachine,
         port: int,
         bind_ip: str | None = None,
+        bind_dev: str | None = None,
     ):
         self._vm = vm
         self._port = port
         self._cmd = f"{_IPERF_BIN} --server --port {self._port} --one-off"
         self._cmd += f" --bind {bind_ip}" if bind_ip else ""
+        self._cmd += f" --bind-dev {bind_dev}" if bind_dev else ""
 
     def __enter__(self) -> "TcpServer":
         self._vm.console(
@@ -100,6 +104,8 @@ class VMTcpClient(BaseTcpClient):
         server_port (int): The port on which the server listens for connections.
         maximum_segment_size (int): Define explicitly the TCP payload size (in bytes).
                                     Default value is 0 (do not change mss).
+        bind_dev (str): Guest network device to bind the client socket to via SO_BINDTODEVICE
+            (e.g. "eth1"). Forces traffic out this interface, bypassing ECMP routing.
     """
 
     def __init__(
@@ -108,9 +114,11 @@ class VMTcpClient(BaseTcpClient):
         server_ip: str,
         server_port: int,
         maximum_segment_size: int = 0,
+        bind_dev: str | None = None,
     ):
         super().__init__(server_ip=server_ip, server_port=server_port)
         self._vm = vm
+        self._cmd += f" --bind-dev {bind_dev}" if bind_dev else ""
         self._cmd += f" --set-mss {maximum_segment_size}" if maximum_segment_size else ""
 
     def __enter__(self) -> "VMTcpClient":

--- a/libs/vm/factory.py
+++ b/libs/vm/factory.py
@@ -41,9 +41,10 @@ def _fill_vm_spec_defaults(spec: VMSpec | None) -> VMSpec:
     vmi_spec.domain.devices.disks = vmi_spec.domain.devices.disks or []
     vmi_spec.volumes = vmi_spec.volumes or []
 
-    disk, volume = containerdisk_storage(image=fedora_image())
-    vmi_spec.domain.devices.disks.insert(0, disk)
-    vmi_spec.volumes.insert(0, volume)
+    if not any(vol.dataVolume for vol in vmi_spec.volumes):
+        disk, volume = containerdisk_storage(image=fedora_image())
+        vmi_spec.domain.devices.disks.insert(0, disk)
+        vmi_spec.volumes.insert(0, volume)
 
     vmi_spec.domain.cpu = vmi_spec.domain.cpu or CPU(cores=1)
     vmi_spec.domain.memory = vmi_spec.domain.memory or Memory(guest="1Gi")

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -149,10 +149,16 @@ class LabelSelectorRequirement:
 
 
 @dataclass
+class DataVolumeRef:
+    name: str
+
+
+@dataclass
 class Volume:
     name: str
     containerDisk: ContainerDisk | None = None  # noqa: N815
     cloudInitNoCloud: CloudInitNoCloud | None = None  # noqa: N815
+    dataVolume: DataVolumeRef | None = None  # noqa: N815
 
 
 @dataclass

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -42,6 +42,15 @@ LOGGER = logging.getLogger(__name__)
 
 RHCOS9_WORKER_LABEL: Final[str] = f"{NODE_ROLE_KUBERNETES_IO}/worker-rhcos9"
 
+MULTI_IFACE_ARP_RUNCMD = [
+    # Only answer ARP for the IP assigned to the receiving interface —
+    # prevents eth1 from responding to ARP for eth2's IP when queried from the same VLAN.
+    "sysctl -w net.ipv4.conf.all.arp_ignore=1",
+    # Use the sender IP belonging to the outgoing interface in ARP requests,
+    # preventing the peer from caching a wrong MAC for the wrong IP.
+    "sysctl -w net.ipv4.conf.all.arp_announce=2",
+]
+
 NETWORK_MANAGER_UNMANAGE_RUNCMD = [
     'sudo echo -e "[main]\nno-auto-default=*\nignore-carrier=*" > /etc/NetworkManager/conf.d/no-nm-ownership.conf',
     "sudo systemctl restart NetworkManager",
@@ -500,8 +509,7 @@ def _cloud_init_data(
         "modprobe mpls_router",  # In order to test mpls we need to load driver
         "sysctl -w net.mpls.platform_labels=1000",  # Activate mpls labeling feature
         "sysctl -w net.mpls.conf.eth4.input=1",  # Allow incoming mpls traffic
-        "sysctl -w net.ipv4.conf.all.arp_ignore=1",  # 2 kernel flags are used to disable wrong arp behavior
-        "sysctl -w net.ipv4.conf.all.arp_announce=2",  # Send arp reply only if ip belongs to the interface
+        *MULTI_IFACE_ARP_RUNCMD,
         f"ip addr add {mpls_local_ip} dev lo",
         f"ip -f mpls route add {mpls_local_tag} dev lo",
         "nmcli connection up eth4",  # In order to add mpls route we need to make sure that connection is UP

--- a/tests/network/l2_bridge/nad_ref_change/conftest.py
+++ b/tests/network/l2_bridge/nad_ref_change/conftest.py
@@ -1,0 +1,206 @@
+from collections.abc import Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+import tests.network.libs.nodenetworkconfigurationpolicy as libnncp
+from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
+from libs.net.netattachdef import CNIPluginBridgeConfig, NetConfig, NetworkAttachmentDefinition
+from libs.net.vmspec import lookup_iface_status, wait_for_ifaces_status
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.l2_bridge.libl2bridge import MULTI_IFACE_ARP_RUNCMD
+from tests.network.l2_bridge.nad_ref_change.lib_helpers import (
+    GUEST_IFACE_1,
+    GUEST_IFACE_2,
+    NET_SEED,
+    VM_IFACE_1,
+    VM_IFACE_2,
+    bridge_vm,
+)
+from tests.network.libs.connectivity import poll_tcp_connectivity
+from utilities.constants import Images
+from utilities.storage import get_default_storage_class
+
+
+@pytest.fixture(scope="module")
+def bridge_nad_a(
+    admin_client: DynamicClient,
+    namespace: Namespace,
+    bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
+    vlan_index_number: Generator[int],
+) -> Generator[NetworkAttachmentDefinition]:
+    bridge = bridge_nncp.desired_state_spec.interfaces[0].name  # type: ignore
+    with NetworkAttachmentDefinition(
+        name="nad-vlan-a",
+        namespace=namespace.name,
+        config=NetConfig(
+            name="nad-vlan-a", plugins=[CNIPluginBridgeConfig(bridge=bridge, vlan=next(vlan_index_number))]
+        ),
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="module")
+def bridge_nad_b(
+    admin_client: DynamicClient,
+    namespace: Namespace,
+    bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
+    vlan_index_number: Generator[int],
+) -> Generator[NetworkAttachmentDefinition]:
+    bridge = bridge_nncp.desired_state_spec.interfaces[0].name  # type: ignore[union-attr, index]
+    with NetworkAttachmentDefinition(
+        name="nad-vlan-b",
+        namespace=namespace.name,
+        config=NetConfig(
+            name="nad-vlan-b", plugins=[CNIPluginBridgeConfig(bridge=bridge, vlan=next(vlan_index_number))]
+        ),
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="module")
+def ref_vm(
+    namespace: Namespace,
+    unprivileged_client: DynamicClient,
+    bridge_nad_a: NetworkAttachmentDefinition,
+    bridge_nad_b: NetworkAttachmentDefinition,
+) -> Generator[BaseVirtualMachine]:
+    iface_a_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=1)
+    iface_b_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=2)
+    with bridge_vm(
+        namespace=namespace.name,
+        name="ref-vm",
+        client=unprivileged_client,
+        nad_names=[bridge_nad_a.name, bridge_nad_b.name],
+        ip_addresses=[iface_a_ips, iface_b_ips],
+        iface_names=[VM_IFACE_1, VM_IFACE_2],
+        runcmd=MULTI_IFACE_ARP_RUNCMD,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                VM_IFACE_1: [addr.split("/")[0] for addr in iface_a_ips],
+                VM_IFACE_2: [addr.split("/")[0] for addr in iface_b_ips],
+            },
+        )
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def under_test_vm_two_ifaces(
+    namespace: Namespace,
+    unprivileged_client: DynamicClient,
+    bridge_nad_a: NetworkAttachmentDefinition,
+    bridge_nad_b: NetworkAttachmentDefinition,
+    ref_vm: BaseVirtualMachine,
+) -> Generator[BaseVirtualMachine]:
+    iface_a_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=3)
+    iface_b_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=4)
+    with bridge_vm(
+        namespace=namespace.name,
+        name="under-test-vm-two-ifaces",
+        client=unprivileged_client,
+        nad_names=[bridge_nad_a.name, bridge_nad_a.name],
+        ip_addresses=[iface_a_ips, iface_b_ips],
+        iface_names=[VM_IFACE_1, VM_IFACE_2],
+        runcmd=MULTI_IFACE_ARP_RUNCMD,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                VM_IFACE_1: [addr.split("/")[0] for addr in iface_a_ips],
+                VM_IFACE_2: [addr.split("/")[0] for addr in iface_b_ips],
+            },
+        )
+        for ip in filter_link_local_addresses(
+            ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=VM_IFACE_1).ipAddresses
+        ):
+            poll_tcp_connectivity(
+                client_vm=vm,
+                server_vm=ref_vm,
+                server_ip=str(ip),
+                server_bind_dev=GUEST_IFACE_1,
+            )
+        for ip in filter_link_local_addresses(
+            ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=VM_IFACE_2).ipAddresses
+        ):
+            poll_tcp_connectivity(
+                client_vm=vm,
+                server_vm=ref_vm,
+                server_ip=str(ip),
+                server_bind_dev=GUEST_IFACE_2,
+                expect_connectivity=False,
+            )
+        yield vm
+
+
+@pytest.fixture()
+def non_migratable_under_test_vm(
+    admin_client: DynamicClient,
+    namespace: Namespace,
+    unprivileged_client: DynamicClient,
+    bridge_nad_a: NetworkAttachmentDefinition,
+    bridge_nad_b: NetworkAttachmentDefinition,
+    ref_vm: BaseVirtualMachine,
+) -> Generator[BaseVirtualMachine]:
+    dv_name = "non-migratable-dv"
+    sc = get_default_storage_class(client=admin_client)
+    dv_template = {
+        "metadata": {"name": dv_name},
+        "spec": {
+            "storage": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": sc.name,
+                "resources": {"requests": {"storage": "20Gi"}},
+            },
+            "source": {
+                "registry": {"url": f"docker://{Images.Fedora.FEDORA_CONTAINER_IMAGE}"},
+            },
+        },
+    }
+    iface_a_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=3)
+    with bridge_vm(
+        namespace=namespace.name,
+        name="non-migratable-under-test-vm",
+        client=unprivileged_client,
+        nad_names=[bridge_nad_a.name],
+        ip_addresses=[iface_a_ips],
+        iface_names=[VM_IFACE_1],
+        rwo_dv_name=dv_name,
+        data_volume_template=dv_template,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                VM_IFACE_1: [addr.split("/")[0] for addr in iface_a_ips],
+            },
+        )
+        for ip in filter_link_local_addresses(
+            ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=VM_IFACE_1).ipAddresses
+        ):
+            poll_tcp_connectivity(
+                client_vm=vm,
+                server_vm=ref_vm,
+                server_ip=str(ip),
+                server_bind_dev=GUEST_IFACE_1,
+            )
+        for ip in filter_link_local_addresses(
+            ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=VM_IFACE_2).ipAddresses
+        ):
+            poll_tcp_connectivity(
+                client_vm=vm,
+                server_vm=ref_vm,
+                server_ip=str(ip),
+                server_bind_dev=GUEST_IFACE_2,
+                expect_connectivity=False,
+            )
+        yield vm

--- a/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
+++ b/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
@@ -1,0 +1,106 @@
+from typing import Final
+
+from kubernetes.dynamic import DynamicClient
+
+from libs.net.vmspec import lookup_iface_status
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import (
+    CloudInitNoCloud,
+    DataVolumeRef,
+    Devices,
+    Disk,
+    Interface,
+    Multus,
+    Network,
+    SpecDisk,
+    Volume,
+)
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import primary_iface_cloud_init
+
+NET_SEED: Final[int] = 0
+
+VM_IFACE_1: Final[str] = "iface-1"
+VM_IFACE_2: Final[str] = "iface-2"
+
+GUEST_IFACE_1: Final[str] = "eth1"
+GUEST_IFACE_2: Final[str] = "eth2"
+
+
+def iface_info(vm: BaseVirtualMachine, iface_name: str) -> dict:
+    iface = lookup_iface_status(vm=vm, iface_name=iface_name)
+    return {
+        "name": iface.name,
+        "macAddress": iface.macAddress,
+        "ipAddresses": sorted(iface.ipAddresses or []),
+    }
+
+
+def bridge_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    nad_names: list[str],
+    ip_addresses: list[list[str]],
+    iface_names: list[str],
+    runcmd: list[str] | None = None,
+    rwo_dv_name: str | None = None,
+    data_volume_template: dict | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with a masquerade primary interface and bridge-bound secondary interfaces.
+
+    Interface layout in guest OS:
+        eth0 = masquerade (pod network, primary — handles default route and IPv6)
+        eth1 = first secondary bridge interface
+        eth2 = second secondary bridge interface (if present)
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name.
+        client: Kubernetes dynamic client.
+        nad_names: NAD names (multus networkName) for the secondary interfaces, in spec order.
+        ip_addresses: Per-interface CIDR address lists, aligned with nad_names.
+            Each inner list contains one address per supported IP family.
+        iface_names: Logical interface names for the VM spec, aligned with nad_names.
+        rwo_dv_name: When set, boots from an existing RWO DataVolume instead of a container disk.
+            The DataVolume's RWO access mode causes KubeVirt to set LiveMigratable: False.
+        data_volume_template: When set, added to VM spec.dataVolumeTemplates so the VM
+            owns and manages the DataVolume lifecycle.
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.devices = Devices(
+        interfaces=[
+            Interface(name="default", masquerade={}),
+            *[Interface(name=iface_name, bridge={}) for iface_name in iface_names],
+        ]
+    )
+    spec.template.spec.networks = [
+        Network(name="default", pod={}),
+        *[
+            Network(name=iface_name, multus=Multus(networkName=nad_name))
+            for iface_name, nad_name in zip(iface_names, nad_names)
+        ],
+    ]
+    ethernets = {}
+    primary = primary_iface_cloud_init()
+    if primary:
+        ethernets["eth0"] = primary
+    for i, addresses in enumerate(ip_addresses):
+        ethernets[f"eth{i + 1}"] = cloudinit.EthernetDevice(addresses=addresses)
+    userdata = cloudinit.UserData(users=[], runcmd=runcmd)
+    disk, volume = cloudinitdisk_storage(
+        data=CloudInitNoCloud(
+            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)) if ethernets else "",
+            userData=cloudinit.format_cloud_config(userdata=userdata),
+        )
+    )
+    if rwo_dv_name:
+        dv_disk = SpecDisk(name=rwo_dv_name, disk=Disk(bus="virtio"))
+        dv_volume = Volume(name=rwo_dv_name, dataVolume=DataVolumeRef(name=rwo_dv_name))
+        spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=dv_volume, disk=dv_disk)
+    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    vm = fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
+    if data_volume_template:
+        vm.body["spec"].setdefault("dataVolumeTemplates", []).append(data_volume_template)
+    return vm

--- a/tests/network/l2_bridge/nad_ref_change/test_nad_ref_change.py
+++ b/tests/network/l2_bridge/nad_ref_change/test_nad_ref_change.py
@@ -13,6 +13,20 @@ Preconditions:
 
 import pytest
 
+from libs.net.ip import filter_link_local_addresses
+from libs.net.vmspec import lookup_iface_status
+from tests.network.l2_bridge.nad_ref_change.lib_helpers import (
+    GUEST_IFACE_1,
+    GUEST_IFACE_2,
+    VM_IFACE_1,
+    VM_IFACE_2,
+    iface_info,
+)
+from tests.network.libs.connectivity import (
+    poll_tcp_connectivity,
+    update_nad_references,
+)
+
 
 @pytest.mark.incremental
 class TestRunningVMLinuxBridgeVlanChange:
@@ -25,23 +39,23 @@ class TestRunningVMLinuxBridgeVlanChange:
         Initial (both ifaces on VLAN-A):
             Under-test VM             Reference VM
             +-----------+             +-----------+
-            |  iface-1  |---VLAN-A -->|  iface-A  |
-            |  iface-2  |---VLAN-A -->|  iface-A  |
-            +-----------+             |  iface-B  |
-                                      +-----------+
+            |  iface-1  |\\           |           |
+            |           | >--VLAN-A --|  iface-1  |
+            |  iface-2  |/            |  iface-2  |
+            +-----------+             +-----------+
 
         After first test (iface-1: VLAN-A -> VLAN-B):
             Under-test VM             Reference VM
             +-----------+             +-----------+
-            |  iface-1  |---VLAN-B -->|  iface-B  |
-            |  iface-2  |---VLAN-A -->|  iface-A  |
+            |  iface-1  |---VLAN-B -->|  iface-2  |
+            |  iface-2  |---VLAN-A -->|  iface-1  |
             +-----------+             +-----------+
 
         After third test (iface-1: VLAN-B -> VLAN-A, iface-2: VLAN-A -> VLAN-B):
             Under-test VM             Reference VM
             +-----------+             +-----------+
-            |  iface-1  |---VLAN-A -->|  iface-A  |
-            |  iface-2  |---VLAN-B -->|  iface-B  |
+            |  iface-1  |---VLAN-A -->|  iface-1  |
+            |  iface-2  |---VLAN-B -->|  iface-2  |
             +-----------+             +-----------+
 
     Preconditions:
@@ -52,10 +66,13 @@ class TestRunningVMLinuxBridgeVlanChange:
         - No TCP connectivity between the under-test VM and the reference VM on NAD-VLAN-B
     """
 
-    __test__ = False
-
     @pytest.mark.polarion("CNV-15945")
-    def test_vm_state_iface_info_preserved(self):
+    def test_vm_state_iface_info_preserved(
+        self,
+        under_test_vm_two_ifaces,
+        bridge_nad_a,
+        bridge_nad_b,
+    ):
         """
         Test that the under-test VM remains running and its secondary network metadata is unchanged
         after the NAD reference change.
@@ -75,9 +92,25 @@ class TestRunningVMLinuxBridgeVlanChange:
             - Guest first secondary interface MAC address, name, and IP addresses are the same before and after the
               NAD reference change
         """
+        iface_before = iface_info(vm=under_test_vm_two_ifaces, iface_name=VM_IFACE_1)
+
+        update_nad_references(vm=under_test_vm_two_ifaces, updates={VM_IFACE_1: bridge_nad_b.name})
+        under_test_vm_two_ifaces.wait_for_ready_status(status=True)
+
+        iface_after = iface_info(vm=under_test_vm_two_ifaces, iface_name=VM_IFACE_1)
+        assert iface_after == iface_before, (
+            f"Interface info changed after NAD reference update: before={iface_before}, after={iface_after}"
+        )
 
     @pytest.mark.polarion("CNV-15972")
-    def test_connectivity(self):
+    def test_connectivity(
+        self,
+        subtests,
+        under_test_vm_two_ifaces,
+        bridge_nad_a,
+        bridge_nad_b,
+        ref_vm,
+    ):
         """
         Test that the under-test VM has TCP connectivity to the reference VM on the new NAD-VLAN-B and no TCP
         connectivity on the old NAD-VLAN-A after the NAD reference change.
@@ -87,16 +120,39 @@ class TestRunningVMLinuxBridgeVlanChange:
             - Running reference VM with secondary Linux bridge networks connected to NAD-VLAN-A and NAD-VLAN-B
 
         Steps:
-            1. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-A
-            2. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-B
+            1. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-B
+            2. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-A
 
         Expected:
             - Under-test VM eventually has TCP connectivity to the reference VM on NAD-VLAN-B
             - Under-test VM has no TCP connectivity to the reference VM on NAD-VLAN-A
         """
+        for ref_iface_name, nad, expect_connectivity, server_bind_dev in [
+            (VM_IFACE_2, bridge_nad_b, True, GUEST_IFACE_2),
+            (VM_IFACE_1, bridge_nad_a, False, GUEST_IFACE_1),
+        ]:
+            for ip in filter_link_local_addresses(
+                ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=ref_iface_name).ipAddresses
+            ):
+                with subtests.test(msg=f"{ip} on {nad.name}"):
+                    poll_tcp_connectivity(
+                        client_vm=under_test_vm_two_ifaces,
+                        server_vm=ref_vm,
+                        server_ip=str(ip),
+                        expect_connectivity=expect_connectivity,
+                        client_bind_dev=GUEST_IFACE_1,
+                        server_bind_dev=server_bind_dev,
+                    )
 
     @pytest.mark.polarion("CNV-15946")
-    def test_two_networks(self):
+    def test_two_networks(
+        self,
+        subtests,
+        under_test_vm_two_ifaces,
+        bridge_nad_a,
+        bridge_nad_b,
+        ref_vm,
+    ):
         """
         Test that both secondary Linux bridge networks on a running VM can have their VLANs
         changed in a single patch, with each network switching to a different VLAN.
@@ -120,10 +176,38 @@ class TestRunningVMLinuxBridgeVlanChange:
             - Under-test VM first secondary network eventually has TCP connectivity to the reference VM on NAD-VLAN-A
             - Under-test VM second secondary network eventually has TCP connectivity to the reference VM on NAD-VLAN-B
         """
+        update_nad_references(
+            vm=under_test_vm_two_ifaces,
+            updates={VM_IFACE_1: bridge_nad_a.name, VM_IFACE_2: bridge_nad_b.name},
+        )
+        under_test_vm_two_ifaces.wait_for_ready_status(status=True)
+
+        for ref_iface_name, nad, client_bind_dev, server_bind_dev in [
+            (VM_IFACE_2, bridge_nad_b, GUEST_IFACE_2, GUEST_IFACE_2),
+            (VM_IFACE_1, bridge_nad_a, GUEST_IFACE_1, GUEST_IFACE_1),
+        ]:
+            for ip in filter_link_local_addresses(
+                ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=ref_iface_name).ipAddresses
+            ):
+                with subtests.test(msg=f"{ip} on {nad.name}"):
+                    poll_tcp_connectivity(
+                        client_vm=under_test_vm_two_ifaces,
+                        server_vm=ref_vm,
+                        server_ip=str(ip),
+                        client_bind_dev=client_bind_dev,
+                        server_bind_dev=server_bind_dev,
+                    )
 
 
+@pytest.mark.jira("CNV-87878", run=False)
 @pytest.mark.polarion("CNV-15947")
-def test_non_migratable_vm_nad_change_not_applied():
+def test_non_migratable_vm_nad_change_not_applied(
+    subtests,
+    non_migratable_under_test_vm,
+    bridge_nad_a,
+    bridge_nad_b,
+    ref_vm,
+):
     """
     [NEGATIVE] Test that changing the NAD reference on a non-migratable VM does not
     silently succeed — the VM remains connected to the original network.
@@ -143,6 +227,21 @@ def test_non_migratable_vm_nad_change_not_applied():
         - Non-migratable under-test VM retains connectivity to the reference VM on NAD-VLAN-A
         - Non-migratable under-test VM has no connectivity to the reference VM on NAD-VLAN-B
     """
+    update_nad_references(vm=non_migratable_under_test_vm, updates={VM_IFACE_1: bridge_nad_b.name})
+    non_migratable_under_test_vm.wait_for_condition(condition="RestartRequired", status="True")
 
-
-test_non_migratable_vm_nad_change_not_applied.__test__ = False
+    for ref_iface_name, nad, expect_connectivity, server_bind_dev in [
+        (VM_IFACE_2, bridge_nad_b, False, GUEST_IFACE_2),
+        (VM_IFACE_1, bridge_nad_a, True, GUEST_IFACE_1),
+    ]:
+        for ip in filter_link_local_addresses(
+            ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=ref_iface_name).ipAddresses
+        ):
+            with subtests.test(msg=f"{ip} on {nad.name}"):
+                poll_tcp_connectivity(
+                    client_vm=non_migratable_under_test_vm,
+                    server_vm=ref_vm,
+                    server_ip=str(ip),
+                    expect_connectivity=expect_connectivity,
+                    server_bind_dev=server_bind_dev,
+                )

--- a/tests/network/libs/cloudinit.py
+++ b/tests/network/libs/cloudinit.py
@@ -3,6 +3,7 @@ from typing import Any, Final
 
 import yaml
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from tests.network.libs.apimachinery import dict_normalization_for_dataclass
 
 NETWORK_DATA: Final[str] = "networkData"
@@ -64,6 +65,11 @@ class UserData:
     Part of cloud-init's 'users and groups' module:
     https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups
     """
+    runcmd: list[str] | None = None
+    """
+    Commands to run on first boot:
+    https://cloudinit.readthedocs.io/en/latest/reference/modules.html#runcmd
+    """
 
 
 def todict(no_cloud: NetworkData | UserData) -> dict[str, Any]:
@@ -85,3 +91,22 @@ def format_cloud_config(userdata: UserData) -> str:
 
 def cloudinit(netdata: NetworkData) -> dict[str, Any]:
     return {NETWORK_DATA: todict(no_cloud=netdata)}
+
+
+def primary_iface_cloud_init() -> EthernetDevice | None:
+    """Return cloud-init ethernet config for the masquerade primary interface.
+
+    Configures a static IPv6 address on eth0 when the cluster supports IPv6,
+    enabling per-family connectivity verification. Returns None on IPv4-only clusters.
+
+    Returns:
+        EthernetDevice with static IPv6 and optional DHCP4, or None if IPv6 is not supported.
+    """
+    if not ipv6_supported_cluster():
+        return None
+    return EthernetDevice(
+        addresses=["fd10:0:2::2/120"],
+        gateway6="fd10:0:2::1",
+        dhcp4=ipv4_supported_cluster(),
+        dhcp6=False,
+    )

--- a/tests/network/libs/connectivity.py
+++ b/tests/network/libs/connectivity.py
@@ -1,5 +1,11 @@
 import ipaddress
 
+from ocp_resources.resource import ResourceEditor
+from timeout_sampler import TimeoutExpiredError, retry
+
+from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer, VMTcpClient
+from libs.vm.vm import BaseVirtualMachine
+
 
 def build_ping_command(dst_ip: str, count: int, timeout: int) -> str:
     """
@@ -16,3 +22,52 @@ def build_ping_command(dst_ip: str, count: int, timeout: int) -> str:
     ip = ipaddress.ip_address(address=dst_ip)
     ping_ipv6_flag = " -6" if ip.version == 6 else ""
     return f"ping{ping_ipv6_flag} {dst_ip} -c {count} -w {timeout}"
+
+
+def update_nad_references(vm: BaseVirtualMachine, updates: dict[str, str]) -> None:
+    """Patch the VM spec to update multiple secondary network NAD references in a single atomic call.
+
+    Args:
+        vm: The virtual machine to update.
+        updates: Mapping of interface name to new NAD name.
+    """
+    networks = vm.instance.spec.template.spec.networks
+    for network in networks:
+        if network["name"] in updates:
+            network["multus"].update({"networkName": updates[network["name"]]})
+    ResourceEditor(patches={vm: {"spec": {"template": {"spec": {"networks": networks}}}}}).update()
+
+
+@retry(wait_timeout=60, sleep=5, exceptions_dict={})
+def poll_tcp_connectivity(
+    client_vm: BaseVirtualMachine,
+    server_vm: BaseVirtualMachine,
+    server_ip: str,
+    client_bind_dev: str | None = None,
+    server_bind_dev: str | None = None,
+    expect_connectivity: bool = True,
+) -> bool:
+    """Poll TCP connectivity (or its absence) between two VMs, retrying until the expected state is reached.
+
+    Args:
+        client_vm: VM initiating the TCP connection.
+        server_vm: VM running the iperf3 server.
+        server_ip: IP address the server binds to.
+        client_bind_dev: Guest network device name to force the client out (e.g. "eth1").
+            Bypasses ECMP routing when both secondary interfaces share the same subnet.
+        server_bind_dev: Guest network device name to force the server responses out (e.g. "eth1").
+            Bypasses ECMP routing on the server VM when it has multiple secondary interfaces.
+        expect_connectivity: When True polls until connectivity exists; when False polls until it does not.
+
+    Returns:
+        True when the observed reachability matches expect_connectivity.
+    """
+    try:
+        with TcpServer(vm=server_vm, port=IPERF_SERVER_PORT, bind_ip=server_ip, bind_dev=server_bind_dev):
+            with VMTcpClient(
+                vm=client_vm, server_ip=server_ip, server_port=IPERF_SERVER_PORT, bind_dev=client_bind_dev
+            ):
+                reachable = True
+    except TimeoutExpiredError:
+        reachable = False
+    return reachable if expect_connectivity else not reachable


### PR DESCRIPTION
##### What this PR does / why we need it:
Implements the Linux bridge NAD live-update tests.
Automation for supporting live-updating a running VM's secondary network attachment without rebooting. Reassigning the VM's bridge port to a different VLAN. These tests verify the change is applied correctly: guest interface metadata is preserved, TCP connectivity follows the new VLAN, and the old VLAN is dropped, all without a VM restart.


##### Which issue(s) this PR fixes: -

##### Special notes for reviewer:
- The reference VM has two secondary interfaces on the same subnet (eth1=VLAN-A, eth2=VLAN-B). arp_ignore=1 and arp_announce=2 are set via cloud-init runcmd to prevent ARP cache poisoning between
  them. 
 - `iperf3` uses `--bind-dev` on both client and server to force traffic through the correct interface, bypassing Linux ECMP routing which otherwise picks the wrong VLAN path when both interfaces share
  the same /24.
- Follow-up PR for implementing localnet scenarios is WIP
##### jira-ticket: https://redhat.atlassian.net/browse/CNV-80573
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM specs now support data-volume-backed boot disks and data volume references.
  * Cloud-init generation improved to handle IPv6 and optional first-boot commands.

* **Tests**
  * Comprehensive multi-interface L2 bridge NAD tests added and re-enabled.
  * New test helpers and connectivity utilities with per-interface bind-device support for TCP checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->