### PR TITLE
infra: change parse_string_unsafe to updated parse functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import subprocess
 import tempfile
 from bisect import bisect_left
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from signal import SIGINT, SIGTERM, getsignal, signal
 
 import bcrypt
@@ -263,7 +263,7 @@ def session_start_time() -> datetime:
     Returns:
         datetime: UTC timestamp when test session began (timezone-naive)
     """
-    return datetime.now(timezone.utc).replace(tzinfo=None)
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 @pytest.fixture(scope="session")
@@ -2730,7 +2730,7 @@ def is_s390x_cluster(nodes_cpu_architecture):
 def hugepages_gib_values(workers):
     """Return the list of hugepage sizes (in GiB) across all worker nodes."""
     return [
-        int(bitmath.parse_string_unsafe(value).GiB)
+        int(bitmath.parse_string(value, strict=False).GiB)
         for worker in workers
         if (value := worker.instance.status.allocatable.get(NODE_HUGE_PAGES_1GI_KEY))
     ]

--- a/tests/infrastructure/sap/test_sap_hana_vm.py
+++ b/tests/infrastructure/sap/test_sap_hana_vm.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import bitmath
 import pytest
 import xmltodict
+from kubernetes.utils.quantity import parse_quantity
 from ocp_resources.node import Node
 from ocp_resources.sriov_network_node_policy import SriovNetworkNodePolicy
 from ocp_resources.template import Template
@@ -183,7 +184,7 @@ def verify_libvirt_huge_pages_configuration(template, vmi_xml_dict):
     libvirt_hugepages_size = bitmath.parse_string(
         f"{libvirt_huge_pages['@size']}{libvirt_huge_pages['@unit']}"
     ).to_GiB()
-    assert libvirt_hugepages_size == bitmath.parse_string_unsafe(expected_huge_pages), (
+    assert int(libvirt_hugepages_size.to_Byte().value) == int(parse_quantity(expected_huge_pages)), (
         f"Wrong huge pages configuration. Expected: {expected_huge_pages}, actual: {libvirt_hugepages_size}"
     )
 
@@ -193,7 +194,7 @@ def verify_libvirt_memory_configuration(expected_memory, vmi_xml_dict):
     calculated_libvirt_memory = bitmath.parse_string(
         f"{libvirt_expected_memory['#text']}{libvirt_expected_memory['@unit']}"
     ).to_GiB()
-    assert calculated_libvirt_memory == bitmath.parse_string_unsafe(expected_memory), (
+    assert int(calculated_libvirt_memory.to_Byte().value) == int(parse_quantity(expected_memory)), (
         f"Wrong memory configuration. Expected: {expected_memory}, actual: {libvirt_expected_memory}"
     )
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -16,7 +16,6 @@ from json import JSONDecodeError
 from subprocess import run
 from typing import TYPE_CHECKING, Any
 
-import bitmath
 import jinja2
 import pexpect
 import yaml
@@ -24,6 +23,7 @@ from benedict import benedict
 from kubernetes.client import ApiException
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import NotFoundError
+from kubernetes.utils.quantity import parse_quantity
 from ocp_resources.daemonset import DaemonSet
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
@@ -728,7 +728,7 @@ class VirtualMachineForTests(VirtualMachine):
             LOGGER.warning(
                 "Setting both memory.guest and requests.memory values! (Users should set VM memory via memory.guest!)"
             )
-            if bitmath.parse_string_unsafe(self.memory_guest) > bitmath.parse_string_unsafe(self.memory_requests):
+            if parse_quantity(self.memory_guest) > parse_quantity(self.memory_requests):
                 LOGGER.warning(
                     "Setting memory.guest bigger then requests.memory! (This might cause unpredictable issues!)"
                 )


### PR DESCRIPTION
##### What this PR does / why we need it:
change parse_string_unsafe to updated parse functions in Infra folder

 - Change `parse_string_unsafe` to `parse_string` in `tests/conftest.py` and 
 - Change `parse_string_unsafe` to `parse_quantity` in `test_sap_hana_vm.py` and `utilities/virt.py`


##### Which issue(s) this PR fixes:
Fix DeprecationWarning in Infra folder `parse_string_unsafe is deprecated as of 2.0.0 and will be removed in a future release`

##### Special notes for reviewer:
Should later be removed on other folders as well


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved session-timing fixture to generate consistent UTC timestamps.
  * Switched resource-quantity parsing to a safer parser and strengthened memory/hugepage validations.

* **Refactor**
  * Standardized parsing and numeric comparison of memory and hugepage values across code paths.
  * Preserved existing warnings and behavior while aligning value interpretation and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->