### PR TITLE
net, libs: Refactor random ip address helpers

### DIFF
--- a/libs/net/ip.py
+++ b/libs/net/ip.py
@@ -1,6 +1,7 @@
 import ipaddress
 import random
 from functools import cache
+from ipaddress import IPv4Interface, IPv6Interface
 from typing import Final
 
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster, supported_cluster_ip_versions
@@ -15,8 +16,8 @@ _IPV6_HEADER_SIZE: Final[int] = 40
 ICMP_HEADER_SIZE: Final[int] = 8
 
 
-def random_cidr_addresses_by_family(net_seed: int, host_address: int) -> list[str]:
-    """Return CIDR-formatted addresses for each IP family supported by the cluster.
+def random_cidr_addresses_by_family(net_seed: int, host_address: int) -> list[IPv4Interface | IPv6Interface]:
+    """Return IP interface objects for each IP family supported by the cluster.
 
     This library uses /24 for IPv4 and /64 for IPv6 VM subnets, matching the
     subnet definitions in this module. VMs with the same net_seed share the
@@ -28,50 +29,38 @@ def random_cidr_addresses_by_family(net_seed: int, host_address: int) -> list[st
         host_address: Host portion of the address — must be unique per VM in the test.
 
     Returns:
-        List of CIDR strings (e.g. ["192.168.1.1/24", "fd00::1/64"]).
+        List of IPv4Interface/IPv6Interface objects (e.g. [IPv4Interface("172.16.1.1/24")]).
     """
-    return [
-        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
-        for ip in random_ip_addresses_by_family(net_seed=net_seed, host_address=host_address)
-    ]
-
-
-def random_ip_addresses_by_family(
-    net_seed: int,
-    host_address: int,
-) -> list[str]:
-    """Generate IP addresses for each IP family supported by the cluster network stack.
-
-    Args:
-        net_seed: Seed index for selecting the random network portion of the address.
-        host_address: Host portion of the address, used to place VMs on the same subnet.
-
-    Returns:
-        List of IP address strings, one per IP family supported by the cluster.
-    """
-    ips = []
+    addresses: list[IPv4Interface | IPv6Interface] = []
     if ipv4_supported_cluster():
-        ips.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
+        addresses.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
     if ipv6_supported_cluster():
-        ips.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
-    return ips
+        addresses.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
+    return addresses
 
 
-def random_ipv4_address(net_seed: int, host_address: int) -> str:
+def random_ipv4_address(net_seed: int, host_address: int, subnet_length: int = 24) -> IPv4Interface:
     """Construct a random IPv4 address using a cached list of random third octets.
 
     Uses a pre-defined network address, a cached random third octet and the given
     host address to generate deterministic yet randomized IPv4 addresses.
+    /24 is used for the default subnet.
 
     Args:
         net_seed (int): The index used to select a random third octet from the cached list.
         host_address (int): The last (fourth) octet of the IPv4 address.
+        subnet_length (int): Prefix length to embed in the interface (24–32). Defaults to 24.
 
     Returns:
-        str: A string representing a randomized IPv4 address.
+        IPv4Interface with the randomized address and embedded prefix length.
+
+    Raises:
+        ValueError: If subnet_length is not in the range [24, 32].
     """
+    if not 24 <= subnet_length <= 32:
+        raise ValueError(f"subnet_length must be between 24 and 32, got {subnet_length}")
     third_octets = _random_octets(count=_MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION)
-    return f"{_IPV4_ADDRESS_SUBNET_PREFIX_VMI}.{third_octets[net_seed]}.{host_address}"
+    return IPv4Interface(f"{_IPV4_ADDRESS_SUBNET_PREFIX_VMI}.{third_octets[net_seed]}.{host_address}/{subnet_length}")
 
 
 @cache
@@ -90,21 +79,30 @@ def _random_octets(count: int) -> list[int]:
     return random.sample(range(1, 254), count)
 
 
-def random_ipv6_address(net_seed: int, host_address: int) -> str:
+def random_ipv6_address(net_seed: int, host_address: int, subnet_length: int = 64) -> IPv6Interface:
     """Construct a random IPv6 address using a cached list of random seventh hextets.
 
     Uses a pre-defined network prefix, a cached random seventh hextet and the given
     host address to generate deterministic yet randomized IPv6 addresses.
+    /64 is used for the default subnet.
 
     Args:
         net_seed (int): The index used to select a random seventh hextet from the cached list.
         host_address (int): The last (eighth) hextet of the IPv6 address.
+        subnet_length (int): Prefix length to embed in the interface (64–128). Defaults to 64.
 
     Returns:
-        str: A string representing a randomized IPv6 address.
+        IPv6Interface with the randomized address and embedded prefix length.
+
+    Raises:
+        ValueError: If subnet_length is not in the range [64, 128].
     """
+    if not 64 <= subnet_length <= 128:
+        raise ValueError(f"subnet_length must be between 64 and 128, got {subnet_length}")
     seventh_hextets = _random_hextets(count=_MAX_NUM_OF_RANDOM_HEXTETS_PER_SESSION)
-    return f"{_IPV6_ADDRESS_SUBNET_PREFIX_VMI}::{seventh_hextets[net_seed]:x}:{host_address:x}"
+    return IPv6Interface(
+        f"{_IPV6_ADDRESS_SUBNET_PREFIX_VMI}::{seventh_hextets[net_seed]:x}:{host_address:x}/{subnet_length}"
+    )
 
 
 @cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -780,7 +780,13 @@ def running_vm_upgrade_a(
 ):
     name = "vm-upgrade-a"
     cloud_init_data = cloud_init_network_data(
-        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=1)}}}
+        data={
+            "ethernets": {
+                "eth1": {
+                    "addresses": [str(addr) for addr in random_cidr_addresses_by_family(net_seed=0, host_address=1)]
+                }
+            }
+        }
     )
     with VirtualMachineForTests(
         name=name,
@@ -813,7 +819,13 @@ def running_vm_upgrade_b(
 ):
     name = "vm-upgrade-b"
     cloud_init_data = cloud_init_network_data(
-        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=2)}}}
+        data={
+            "ethernets": {
+                "eth1": {
+                    "addresses": [str(addr) for addr in random_cidr_addresses_by_family(net_seed=0, host_address=2)]
+                }
+            }
+        }
     )
     with VirtualMachineForTests(
         name=name,

--- a/tests/network/bgp/conftest.py
+++ b/tests/network/bgp/conftest.py
@@ -40,8 +40,8 @@ APP_CUDN_LABEL: Final[dict] = {"app": "cudn"}
 BGP_DATA_PATH: Final[Path] = Path(__file__).resolve().parent / "data" / "frr-config"
 CUDN_BGP_LABEL: Final[dict] = {"cudn-bgp": "blue"}
 CUDN_SUBNET_IPV4: Final[str] = "192.168.10.0/24"
-EXTERNAL_PROVIDER_SUBNET_IPV4: Final[str] = f"{random_ipv4_address(net_seed=1, host_address=0)}/24"
-EXTERNAL_PROVIDER_IP_V4: Final[str] = f"{random_ipv4_address(net_seed=1, host_address=150)}/24"
+EXTERNAL_PROVIDER_SUBNET_IPV4: Final[str] = str(random_ipv4_address(net_seed=1, host_address=0))
+EXTERNAL_PROVIDER_IP_V4: Final[str] = str(random_ipv4_address(net_seed=1, host_address=150))
 IPERF3_SERVER_PORT: Final[int] = 2354
 LOCALNET_NETWORK_NAME: Final[str] = "localnet-network-bgp"
 

--- a/tests/network/bgp/evpn/conftest.py
+++ b/tests/network/bgp/evpn/conftest.py
@@ -48,7 +48,7 @@ from tests.network.libs.vm_factory import udn_vm
 EVPN_ADVERTISE_LABEL: Final[dict] = {"advertise": "evpn"}
 APP_EVPN_CUDN_LABEL: Final[dict] = {**EVPN_ADVERTISE_LABEL, "app": "cudn-evpn"}
 CUDN_EVPN_BGP_LABEL: Final[dict] = {"cudn-bgp": "evpn"}
-EXTERNAL_L2_ENDPOINT_IPV4: Final[str] = f"{random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=250)}/24"
+EXTERNAL_L2_ENDPOINT_IPV4: Final[str] = str(random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=250))
 EXTERNAL_L2_ENDPOINT_IPV6: Final[str] = f"{ipaddress.ip_network(CUDN_EVPN_SUBNET_IPV6, strict=False)[250]}/64"
 EXTERNAL_L2_ENDPOINT_MAC: Final[str] = "02:00:05:00:fa:00"
 EXTERNAL_L3_ENDPOINT_IPV4: Final[str] = "192.168.100.100/24"

--- a/tests/network/bgp/evpn/libevpn.py
+++ b/tests/network/bgp/evpn/libevpn.py
@@ -26,8 +26,8 @@ from tests.network.libs.bgp import CLUSTER_FRR_ASN, EXTERNAL_FRR_ASN, NET_TOOLS_
 LOGGER = logging.getLogger(__name__)
 
 EVPN_CUDN_NET_SEED: int = 5
-CUDN_EVPN_SUBNET_IPV4: str = f"{random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=0)}/24"
-CUDN_EVPN_SUBNET_IPV6: str = f"{random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=0)}/64"
+CUDN_EVPN_SUBNET_IPV4: str = str(random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=0))
+CUDN_EVPN_SUBNET_IPV6: str = str(random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=0))
 
 _BRIDGE_NAME: str = "br0"
 _VXLAN_NAME: str = "vxlan0"

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
     from tests.network.bgp.evpn.libevpn import EndpointTcpClient
 
 
-_L2_ENDPOINT_IPV4: str = f"{random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/24"
-_L2_ENDPOINT_IPV6: str = f"{random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/64"
+_L2_ENDPOINT_IPV4: str = str(random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249))
+_L2_ENDPOINT_IPV6: str = str(random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249))
 
 
 pytestmark = [

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -138,7 +138,7 @@ def linux_bond_bridge_attached_vma(
     networks = OrderedDict()
     networks[linux_br1bond_nad.name] = linux_br1bond_nad.name
     netdata = netcloud.NetworkData(
-        ethernets={"eth1": netcloud.EthernetDevice(addresses=[f"{random_ipv4_address(net_seed=0, host_address=1)}/24"])}
+        ethernets={"eth1": netcloud.EthernetDevice(addresses=[str(random_ipv4_address(net_seed=0, host_address=1))])}
     )
 
     with VirtualMachineForTests(
@@ -166,9 +166,7 @@ def linux_bond_bridge_attached_vmb(
     name = "bond-vmb"
     networks = OrderedDict()
     networks[linux_br1bond_nad.name] = linux_br1bond_nad.name
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=2))]}}}
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(

--- a/tests/network/connectivity/utils.py
+++ b/tests/network/connectivity/utils.py
@@ -41,9 +41,9 @@ def secondary_interfaces_cloud_init_data(
         interface_name = f"eth{i + 1}"
         addresses = []
         if ipv4_supported_cluster():
-            addresses.append(f"{random_ipv4_address(net_seed=i, host_address=host_id)}/24")
+            addresses.append(str(random_ipv4_address(net_seed=i, host_address=host_id)))
         if ipv6_supported_cluster():
-            addresses.append(f"{random_ipv6_address(net_seed=i, host_address=host_id)}/64")
+            addresses.append(str(random_ipv6_address(net_seed=i, host_address=host_id)))
 
         ethernets[interface_name] = {"addresses": addresses}
 

--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -51,7 +51,7 @@ GENEVE_HEADER = 16
 UDP_HEADER = 8
 IPV4_HEADER = 20
 ETHERNET_HEADER = 14
-SPECIFIC_HOST_MASK = "32"
+SPECIFIC_HOST_MASK = 32
 
 
 @pytest.fixture(scope="module")
@@ -351,7 +351,7 @@ def vmb_ingress_multi_network_policy(
         network_name=flat_overlay_vma_vmb_nad.name,
         policy_types=["Ingress"],
         ingress=create_ip_block(
-            ip_address=f"{random_ipv4_address(net_seed=0, host_address=123)}/{SPECIFIC_HOST_MASK}",
+            ip_address=str(random_ipv4_address(net_seed=0, host_address=123, subnet_length=SPECIFIC_HOST_MASK)),
         ),
         client=admin_client,
     ) as mnp:

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -40,7 +40,7 @@ def create_flat_overlay_vm(
     networks = {nad_name: nad_name}
     network_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=host_ip_suffix)}/24"]},
+            "eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=host_ip_suffix))]},
         }
     }
     cloud_init_data = compose_cloud_init_data_dict(network_data=network_data)

--- a/tests/network/general/test_cnv_tuning_regression.py
+++ b/tests/network/general/test_cnv_tuning_regression.py
@@ -36,9 +36,7 @@ def linux_bridge_device(nmstate_dependent_placeholder, admin_client, worker_node
 def cnv_tuning_vm(unprivileged_client, worker_node1, linux_bridge_nad, linux_bridge_device):
     name = "tuning-vma"
     networks = {"net1": linux_bridge_nad.name}
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=1))]}}}
 
     with VirtualMachineForTests(
         namespace=linux_bridge_nad.namespace,

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -151,9 +151,7 @@ def bond_bridge_attached_vma(
     name = "bond-vma"
     networks = OrderedDict()
     networks[br1bond_nad.name] = br1bond_nad.name
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=1))]}}}
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(
@@ -181,9 +179,7 @@ def bond_bridge_attached_vmb(
     name = "bond-vmb"
     networks = OrderedDict()
     networks[br1bond_nad.name] = br1bond_nad.name
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=2))]}}}
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -97,9 +97,7 @@ def bridge_attached_vma(worker_node1, namespace, unprivileged_client, br1test_br
     name = "vma"
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=1))]}}}
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(
@@ -122,9 +120,7 @@ def bridge_attached_vmb(worker_node2, namespace, unprivileged_client, br1test_br
     name = "vmb"
     networks = OrderedDict()
     networks[br1test_bridge_nad.name] = br1test_bridge_nad.name
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=2))]}}}
     cloud_init_data = cloud_init_network_data(data=network_data_data)
 
     with VirtualMachineForTests(

--- a/tests/network/jumbo_frame/utils.py
+++ b/tests/network/jumbo_frame/utils.py
@@ -32,7 +32,7 @@ def create_vm_for_jumbo_test(
 def cloud_init_data_for_secondary_traffic(index):
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=index)}/24"]},
+            "eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=index))]},
         }
     }
 

--- a/tests/network/kubemacpool/utils.py
+++ b/tests/network/kubemacpool/utils.py
@@ -28,22 +28,22 @@ def vm_network_config(mac_pool, all_nads, end_ip_octet, mac_uid):
     """
     return {
         "eth1": IfaceTuple(
-            ip_address=random_ipv4_address(net_seed=0, host_address=end_ip_octet),
+            ip_address=random_ipv4_address(net_seed=0, host_address=end_ip_octet).ip,
             mac_address=mac_pool.get_mac_from_pool(),
             name=all_nads[0],
         ),
         "eth2": IfaceTuple(
-            ip_address=random_ipv4_address(net_seed=1, host_address=end_ip_octet),
+            ip_address=random_ipv4_address(net_seed=1, host_address=end_ip_octet).ip,
             mac_address="auto",
             name=all_nads[1],
         ),
         "eth3": IfaceTuple(
-            ip_address=random_ipv4_address(net_seed=2, host_address=end_ip_octet),
+            ip_address=random_ipv4_address(net_seed=2, host_address=end_ip_octet).ip,
             mac_address=f"02:0{mac_uid}:00:00:00:00",
             name=all_nads[2],
         ),
         "eth4": IfaceTuple(
-            ip_address=random_ipv4_address(net_seed=3, host_address=end_ip_octet),
+            ip_address=random_ipv4_address(net_seed=3, host_address=end_ip_octet).ip,
             mac_address="auto",
             name=all_nads[3],
         ),

--- a/tests/network/l2_bridge/bandwidth/conftest.py
+++ b/tests/network/l2_bridge/bandwidth/conftest.py
@@ -1,4 +1,3 @@
-import ipaddress
 from collections.abc import Generator
 from ipaddress import ip_interface
 from typing import Final
@@ -8,7 +7,7 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 
 from libs.net import nodenetworkconfigurationpolicy as libnncp
-from libs.net.ip import random_ip_addresses_by_family
+from libs.net.ip import random_cidr_addresses_by_family
 from libs.net.netattachdef import (
     CNIPluginBandwidthConfig,
     CNIPluginBridgeConfig,
@@ -62,10 +61,7 @@ def server_vm(
     namespace: Namespace,
     bandwidth_nad: NetworkAttachmentDefinition,
 ) -> Generator[BaseVirtualMachine]:
-    addresses = [
-        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
-        for ip in random_ip_addresses_by_family(net_seed=0, host_address=1)
-    ]
+    addresses = random_cidr_addresses_by_family(net_seed=0, host_address=1)
     with secondary_network_vm(
         namespace=namespace.name,
         name="bw-server-vm",
@@ -92,10 +88,7 @@ def client_vm(
     namespace: Namespace,
     bandwidth_nad: NetworkAttachmentDefinition,
 ) -> Generator[BaseVirtualMachine]:
-    addresses = [
-        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
-        for ip in random_ip_addresses_by_family(net_seed=0, host_address=2)
-    ]
+    addresses = random_cidr_addresses_by_family(net_seed=0, host_address=2)
     with secondary_network_vm(
         namespace=namespace.name,
         name="bw-client-vm",

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -35,9 +35,9 @@ from utilities.network import (
 #       |.......|---eth4:172.16.4.1    : mpls test :                               172.16.4.2:eth4---|........|
 
 
-VMA_MPLS_LOOPBACK_IP = f"{random_ipv4_address(net_seed=5, host_address=1)}/32"
+VMA_MPLS_LOOPBACK_IP = str(random_ipv4_address(net_seed=5, host_address=1, subnet_length=32))
 VMA_MPLS_ROUTE_TAG = 100
-VMB_MPLS_LOOPBACK_IP = f"{random_ipv4_address(net_seed=6, host_address=1)}/32"
+VMB_MPLS_LOOPBACK_IP = str(random_ipv4_address(net_seed=6, host_address=1, subnet_length=32))
 VMB_MPLS_ROUTE_TAG = 200
 
 
@@ -183,10 +183,10 @@ def l2_bridge_running_vm_a(
     }
 
     interface_ip_addresses = [
-        random_ipv4_address(net_seed=0, host_address=1),
-        random_ipv4_address(net_seed=2, host_address=1),
-        random_ipv4_address(net_seed=3, host_address=1),
-        random_ipv4_address(net_seed=4, host_address=1),
+        random_ipv4_address(net_seed=0, host_address=1).ip,
+        random_ipv4_address(net_seed=2, host_address=1).ip,
+        random_ipv4_address(net_seed=3, host_address=1).ip,
+        random_ipv4_address(net_seed=4, host_address=1).ip,
     ]
     with bridge_attached_vm(
         name="vm-fedora-1",
@@ -198,7 +198,7 @@ def l2_bridge_running_vm_a(
         mpls_local_ip=VMA_MPLS_LOOPBACK_IP,
         mpls_dest_ip=VMB_MPLS_LOOPBACK_IP,
         mpls_dest_tag=VMB_MPLS_ROUTE_TAG,
-        mpls_route_next_hop=random_ipv4_address(net_seed=4, host_address=2),
+        mpls_route_next_hop=random_ipv4_address(net_seed=4, host_address=2).ip,
         client=unprivileged_client,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         dhcp_interface_config={"addresses": [f"{interface_ip_addresses[2]}/24"]},
@@ -211,10 +211,10 @@ def l2_bridge_running_vm_a(
 @pytest.fixture(scope="class")
 def l2_bridge_running_vm_b(namespace, worker_node2, l2_bridge_all_nads, unprivileged_client):
     interface_ip_addresses = [
-        random_ipv4_address(net_seed=0, host_address=2),
-        random_ipv4_address(net_seed=2, host_address=2),
-        random_ipv4_address(net_seed=3, host_address=2),
-        random_ipv4_address(net_seed=4, host_address=2),
+        random_ipv4_address(net_seed=0, host_address=2).ip,
+        random_ipv4_address(net_seed=2, host_address=2).ip,
+        random_ipv4_address(net_seed=3, host_address=2).ip,
+        random_ipv4_address(net_seed=4, host_address=2).ip,
     ]
     with bridge_attached_vm(
         name="vm-fedora-2",
@@ -225,7 +225,7 @@ def l2_bridge_running_vm_b(namespace, worker_node2, l2_bridge_all_nads, unprivil
         mpls_local_ip=VMB_MPLS_LOOPBACK_IP,
         mpls_dest_ip=VMA_MPLS_LOOPBACK_IP,
         mpls_dest_tag=VMA_MPLS_ROUTE_TAG,
-        mpls_route_next_hop=random_ipv4_address(net_seed=4, host_address=1),
+        mpls_route_next_hop=random_ipv4_address(net_seed=4, host_address=1).ip,
         client=unprivileged_client,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
         dhcp_interface_config={"dhcp4": False},

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 import time
-from ipaddress import IPv4Address, ip_interface
+from ipaddress import IPv4Address, IPv4Interface, IPv6Interface, ip_interface
 from typing import Final, cast
 
 from kubernetes.dynamic import DynamicClient
@@ -104,13 +104,7 @@ def create_vm_with_secondary_interface_on_setup(
     cloud_init_data = compose_cloud_init_data_dict(
         network_data={
             "ethernets": {
-                "eth1": {
-                    "addresses": [
-                        f"{random_ipv4_address(net_seed=0, host_address=ipv4_address_suffix)}/{
-                            IPV4_ADDRESS_SUBNET_PREFIX_LENGTH
-                        }"
-                    ]
-                }
+                "eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=ipv4_address_suffix))]}
             }
         }
     )
@@ -435,7 +429,7 @@ def secondary_network_vm(
     client: DynamicClient,
     nad_name: str,
     secondary_iface_name: str,
-    secondary_iface_addresses: list[str],
+    secondary_iface_addresses: list[IPv4Interface | IPv6Interface],
     affinity: Affinity | None = None,
     labels: dict[str, str] | None = None,
 ) -> BaseVirtualMachine:
@@ -447,7 +441,7 @@ def secondary_network_vm(
         client: Kubernetes dynamic client.
         nad_name: NetworkAttachmentDefinition name for the secondary interface.
         secondary_iface_name: Name of the secondary network interface in the VM spec.
-        secondary_iface_addresses: CIDR addresses to assign to the secondary interface via cloud-init.
+        secondary_iface_addresses: IP interface objects for the secondary interface, one per supported IP family.
         affinity: Optional node or pod affinity rules for scheduling.
         labels: Optional labels to apply to the VM template metadata for pod scheduling.
     """
@@ -472,7 +466,7 @@ def secondary_network_vm(
     primary = primary_iface_cloud_init()
     if primary:
         ethernets["eth0"] = primary
-    ethernets["eth1"] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
+    ethernets["eth1"] = cloudinit.EthernetDevice(addresses=[str(addr) for addr in secondary_iface_addresses])
 
     disk, volume = cloudinitdisk_storage(
         data=CloudInitNoCloud(

--- a/tests/network/l2_bridge/migration_stuntime/conftest.py
+++ b/tests/network/l2_bridge/migration_stuntime/conftest.py
@@ -57,8 +57,8 @@ def stuntime_server_vm(
         nad_name=l2_bridge_stuntime_nad.name,
         secondary_iface_name=STUNTIME_BRIDGE_IFACE_NAME,
         secondary_iface_addresses=[
-            f"{random_ipv4_address(net_seed=0, host_address=1)}/24",
-            f"{random_ipv6_address(net_seed=0, host_address=1)}/64",
+            random_ipv4_address(net_seed=0, host_address=1),
+            random_ipv6_address(net_seed=0, host_address=1),
         ],
         labels=dict([SERVER_VM_LABEL]),
     ) as server_vm:
@@ -81,8 +81,8 @@ def stuntime_client_vm(
         nad_name=l2_bridge_stuntime_nad.name,
         secondary_iface_name=STUNTIME_BRIDGE_IFACE_NAME,
         secondary_iface_addresses=[
-            f"{random_ipv4_address(net_seed=0, host_address=2)}/24",
-            f"{random_ipv6_address(net_seed=0, host_address=2)}/64",
+            random_ipv4_address(net_seed=0, host_address=2),
+            random_ipv6_address(net_seed=0, host_address=2),
         ],
         affinity=new_pod_affinity(label=SERVER_VM_LABEL),
         labels=dict([CLIENT_VM_LABEL]),

--- a/tests/network/l2_bridge/nad_ref_change/conftest.py
+++ b/tests/network/l2_bridge/nad_ref_change/conftest.py
@@ -39,8 +39,8 @@ def ref_vm(
         run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
-                LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],
-                LINUX_BRIDGE_IFACE_NAME_2: [addr.split("/")[0] for addr in iface_b_ips],
+                LINUX_BRIDGE_IFACE_NAME_1: [str(addr.ip) for addr in iface_a_ips],
+                LINUX_BRIDGE_IFACE_NAME_2: [str(addr.ip) for addr in iface_b_ips],
             },
         )
         yield vm
@@ -66,8 +66,8 @@ def under_test_vm_two_ifaces(
         run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
-                LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],
-                LINUX_BRIDGE_IFACE_NAME_2: [addr.split("/")[0] for addr in iface_b_ips],
+                LINUX_BRIDGE_IFACE_NAME_1: [str(addr.ip) for addr in iface_a_ips],
+                LINUX_BRIDGE_IFACE_NAME_2: [str(addr.ip) for addr in iface_b_ips],
             },
         )
         yield vm
@@ -100,7 +100,7 @@ def non_migratable_under_test_vm(
         run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
-                LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],
+                LINUX_BRIDGE_IFACE_NAME_1: [str(addr.ip) for addr in iface_a_ips],
             },
         )
         yield vm

--- a/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
+++ b/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
@@ -1,3 +1,4 @@
+from ipaddress import IPv4Interface, IPv6Interface
 from typing import Final
 
 from kubernetes.dynamic import DynamicClient
@@ -119,7 +120,7 @@ def two_secondary_bridge_vm(
     name: str,
     client: DynamicClient,
     nad_names: list[str],
-    ip_addresses: list[list[str]],
+    ip_addresses: list[list[IPv4Interface | IPv6Interface]],
     iface_names: list[str],
     runcmd: list[str] | None = None,
 ) -> BaseVirtualMachine:
@@ -135,8 +136,8 @@ def two_secondary_bridge_vm(
         name: VM name.
         client: Kubernetes dynamic client.
         nad_names: NAD names (multus networkName) for the secondary interfaces, in spec order.
-        ip_addresses: Per-interface CIDR address lists, aligned with nad_names.
-            Each inner list contains one address per supported IP family.
+        ip_addresses: Per-interface IP interface objects, aligned with nad_names.
+            Each inner list contains one IPv4Interface/IPv6Interface per supported IP family.
         iface_names: Logical interface names for the VM spec, aligned with nad_names.
         runcmd: Commands to run on first boot via cloud-init runcmd. None means no extra commands.
     """
@@ -154,7 +155,7 @@ def non_migratable_bridge_vm(
     name: str,
     client: DynamicClient,
     nad_names: list[str],
-    ip_addresses: list[list[str]],
+    ip_addresses: list[list[IPv4Interface | IPv6Interface]],
     iface_names: list[str],
     runcmd: list[str] | None = None,
 ) -> BaseVirtualMachine:
@@ -168,7 +169,7 @@ def non_migratable_bridge_vm(
         name: VM name.
         client: Kubernetes dynamic client.
         nad_names: NAD names for the secondary interfaces, in spec order.
-        ip_addresses: Per-interface CIDR address lists, aligned with nad_names.
+        ip_addresses: Per-interface IP interface objects, aligned with nad_names.
         iface_names: Logical interface names for the VM spec, aligned with nad_names.
         runcmd: Commands to run on first boot via cloud-init runcmd. None means no extra commands.
     """
@@ -200,7 +201,7 @@ def non_migratable_bridge_vm(
 
 def _bridge_vm_spec(
     nad_names: list[str],
-    ip_addresses: list[list[str]],
+    ip_addresses: list[list[IPv4Interface | IPv6Interface]],
     iface_names: list[str],
     runcmd: list[str] | None = None,
 ) -> VMSpec:
@@ -222,7 +223,7 @@ def _bridge_vm_spec(
     if primary := primary_iface_cloud_init():
         ethernets["eth0"] = primary
     for i, addresses in enumerate(ip_addresses):
-        ethernets[f"eth{i + 1}"] = cloudinit.EthernetDevice(addresses=addresses)
+        ethernets[f"eth{i + 1}"] = cloudinit.EthernetDevice(addresses=[str(addr) for addr in addresses])
     userdata = cloudinit.UserData(users=[], runcmd=runcmd)
     disk, volume = cloudinitdisk_storage(
         data=CloudInitNoCloud(

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -109,7 +109,7 @@ def running_utility_vm_for_connectivity_check(
 def hot_plugged_interface_with_address(running_vm_for_nic_hot_plug, index_number, hot_plugged_interface):
     set_secondary_static_ip_address(
         vm=running_vm_for_nic_hot_plug,
-        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
+        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)).ip,
         vmi_interface=hot_plugged_interface,
     )
 
@@ -150,7 +150,7 @@ def hot_plugged_second_interface_with_address(
 ):
     set_secondary_static_ip_address(
         vm=running_vm_with_secondary_and_hot_plugged_interfaces,
-        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
+        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)).ip,
         vmi_interface=hot_plugged_interface_on_vm_created_with_secondary_interface,
     )
 
@@ -212,7 +212,7 @@ def hot_plugged_jumbo_interface_with_address(
         vm=running_vm_for_jumbo_nic_hot_plug,
         hot_plugged_interface_name=f"{HOT_PLUG_STR}-jumbo-iface",
         net_attach_def_name=network_attachment_definition_for_jumbo_hot_plug.name,
-        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
+        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)).ip,
     )
 
 
@@ -226,7 +226,7 @@ def hot_plugged_jumbo_interface_in_utility_vm(
         vm=running_utility_vm_for_connectivity_check,
         hot_plugged_interface_name=f"{HOT_PLUG_STR}-jumbo-utility-iface",
         net_attach_def_name=network_attachment_definition_for_jumbo_hot_plug.name,
-        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
+        ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)).ip,
     )
 
     yield iface
@@ -572,14 +572,14 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
             vm=sriov_hot_plug_vm1,
             hot_plugged_interface_name=sriov_network_for_hot_plug.name,
             net_attach_def_name=f"{namespace.name}/{sriov_network_for_hot_plug.name}",
-            ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
+            ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)).ip,
             sriov=True,
         )
         hot_plug_interface_and_set_address(
             vm=sriov_hot_plug_vm2,
             hot_plugged_interface_name=sriov_network_for_hot_plug.name,
             net_attach_def_name=f"{namespace.name}/{sriov_network_for_hot_plug.name}",
-            ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
+            ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)).ip,
             sriov=True,
         )
         assert_ping_successful(

--- a/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
@@ -1,6 +1,7 @@
 import ipaddress
 import logging
 from collections.abc import Iterator
+from ipaddress import IPv4Interface, IPv6Interface
 
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.resource import ResourceField
@@ -60,13 +61,11 @@ def secondary_network_vm(
 
 
 def secondary_iface_cloud_init(host_address: int) -> cloudinit.EthernetDevice:
-    ips = secondary_iface_ips(host_address=host_address)
-    addresses = [f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24" for ip in ips]
-    return cloudinit.EthernetDevice(addresses=addresses)
+    return cloudinit.EthernetDevice(addresses=[str(addr) for addr in secondary_iface_ips(host_address=host_address)])
 
 
-def secondary_iface_ips(host_address: int) -> list[str]:
-    ips = []
+def secondary_iface_ips(host_address: int) -> list[IPv4Interface | IPv6Interface]:
+    ips: list[IPv4Interface | IPv6Interface] = []
     if ipv4_supported_cluster():
         ips.append(random_ipv4_address(net_seed=0, host_address=host_address))
     if ipv6_supported_cluster():

--- a/tests/network/libs/dhcpd.py
+++ b/tests/network/libs/dhcpd.py
@@ -10,9 +10,9 @@ from utilities.constants.timeouts import TIMEOUT_5SEC, TIMEOUT_30SEC
 from utilities.network import LOGGER
 from utilities.virt import VirtualMachineForTests
 
-DHCP_IP_SUBNET: Final[str] = random_ipv4_address(net_seed=3, host_address=0).rpartition(".")[0]
-DHCP_IP_RANGE_START: Final[str] = random_ipv4_address(net_seed=3, host_address=3)
-DHCP_IP_RANGE_END: Final[str] = random_ipv4_address(net_seed=3, host_address=10)
+DHCP_IP_SUBNET: Final[str] = str(random_ipv4_address(net_seed=3, host_address=0).ip).rpartition(".")[0]
+DHCP_IP_RANGE_START: Final[str] = str(random_ipv4_address(net_seed=3, host_address=3).ip)
+DHCP_IP_RANGE_END: Final[str] = str(random_ipv4_address(net_seed=3, host_address=10).ip)
 UNIQUE_CLIENT_ID = f"dhcp-client-id-{uuid.uuid4().hex[:16]}"
 DHCP_SERVICE_RESTART = "sudo systemctl restart dhcpd"
 DHCP_SERVER_CONF_FILE = """

--- a/tests/network/libs/localnet.py
+++ b/tests/network/libs/localnet.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import uuid
 from collections.abc import Generator
+from ipaddress import IPv4Interface, IPv6Interface
 from typing import Final
 
 from kubernetes.dynamic import DynamicClient
@@ -43,19 +44,19 @@ LOGGER = logging.getLogger(__name__)
 
 
 def ip_addresses_from_pool(
-    ipv4_pool: Generator[str],
-    ipv6_pool: Generator[str],
-) -> list[str]:
-    """Draw IP addresses from pools according to the cluster network IP stack.
+    ipv4_pool: Generator[IPv4Interface],
+    ipv6_pool: Generator[IPv6Interface],
+) -> list[IPv4Interface | IPv6Interface]:
+    """Draw IP interface objects from pools according to the cluster network IP stack.
 
     Args:
-        ipv4_pool: Generator yielding IPv4 address.
-        ipv6_pool: Generator yielding IPv6 address.
+        ipv4_pool: Generator yielding IPv4Interface addresses.
+        ipv6_pool: Generator yielding IPv6Interface addresses.
 
     Returns:
-        List of IP addresses, one per IP family supported by the cluster.
+        List of IPv4Interface/IPv6Interface objects, one per supported IP family.
     """
-    addresses = []
+    addresses: list[IPv4Interface | IPv6Interface] = []
     if ipv4_supported_cluster():
         addresses.append(next(ipv4_pool))
     if ipv6_supported_cluster():

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator, Iterator
+from ipaddress import IPv4Interface, IPv6Interface
 
 import pytest
 from kubernetes.dynamic import DynamicClient
@@ -125,20 +126,20 @@ def cudn_localnet_no_vlan(
 
 
 @pytest.fixture(scope="module")
-def ipv4_localnet_address_pool() -> Generator[str]:
-    return (f"{random_ipv4_address(net_seed=0, host_address=host_value)}/24" for host_value in range(1, 254))
+def ipv4_localnet_address_pool() -> Generator[IPv4Interface]:
+    return (random_ipv4_address(net_seed=0, host_address=host_value) for host_value in range(1, 254))
 
 
 @pytest.fixture(scope="module")
-def ipv6_localnet_address_pool() -> Generator[str]:
-    return (f"{random_ipv6_address(net_seed=0, host_address=host_value)}/64" for host_value in range(1, 254))
+def ipv6_localnet_address_pool() -> Generator[IPv6Interface]:
+    return (random_ipv6_address(net_seed=0, host_address=host_value) for host_value in range(1, 254))
 
 
 @pytest.fixture(scope="module")
 def vm_localnet_1(
     unprivileged_client: DynamicClient,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     namespace_localnet_1: Namespace,
     cudn_localnet: libcudn.ClusterUserDefinedNetwork,
     cudn_localnet_no_vlan: libcudn.ClusterUserDefinedNetwork,
@@ -164,16 +165,22 @@ def vm_localnet_1(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        ),
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ],
                     ),
                     GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        ),
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ],
                     ),
                 }
             )
@@ -186,8 +193,8 @@ def vm_localnet_1(
 @pytest.fixture(scope="module")
 def vm_localnet_2(
     namespace_localnet_2: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     cudn_localnet: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
@@ -201,10 +208,13 @@ def vm_localnet_2(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        ),
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ],
                     )
                 }
             )
@@ -257,8 +267,8 @@ def cudn_localnet_ovs_bridge(
 @pytest.fixture(scope="function")
 def vm_ovs_bridge_localnet_link_down(
     namespace_localnet_1: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
@@ -274,10 +284,13 @@ def vm_ovs_bridge_localnet_link_down(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        )
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ]
                     )
                 }
             )
@@ -290,8 +303,8 @@ def vm_ovs_bridge_localnet_link_down(
 @pytest.fixture(scope="module")
 def vm_ovs_bridge_localnet_1(
     namespace_localnet_1: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
@@ -307,10 +320,13 @@ def vm_ovs_bridge_localnet_1(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        )
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ]
                     )
                 }
             )
@@ -323,8 +339,8 @@ def vm_ovs_bridge_localnet_1(
 @pytest.fixture(scope="module")
 def vm_ovs_bridge_localnet_2(
     namespace_localnet_1: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
@@ -340,10 +356,13 @@ def vm_ovs_bridge_localnet_2(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        )
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ]
                     )
                 }
             )
@@ -476,8 +495,8 @@ def cudn_localnet_ovs_bridge_jumbo_frame(
 @pytest.fixture(scope="module")
 def vm1_ovs_bridge_localnet_jumbo_frame(
     namespace_localnet_1: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     cudn_localnet_ovs_bridge_jumbo_frame: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
@@ -495,10 +514,13 @@ def vm1_ovs_bridge_localnet_jumbo_frame(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        )
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ]
                     )
                 }
             )
@@ -511,8 +533,8 @@ def vm1_ovs_bridge_localnet_jumbo_frame(
 @pytest.fixture(scope="module")
 def vm2_ovs_bridge_localnet_jumbo_frame(
     namespace_localnet_1: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     cudn_localnet_ovs_bridge_jumbo_frame: libcudn.ClusterUserDefinedNetwork,
     unprivileged_client: DynamicClient,
 ) -> Generator[BaseVirtualMachine]:
@@ -530,10 +552,13 @@ def vm2_ovs_bridge_localnet_jumbo_frame(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        )
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ]
                     )
                 }
             )

--- a/tests/network/localnet/ipam/conftest.py
+++ b/tests/network/localnet/ipam/conftest.py
@@ -33,7 +33,7 @@ def localnet_ipam_nad(
                 topology=libnad.CNIPluginOvnK8sConfig.Topology.LOCALNET.value,
                 netAttachDefName=f"{namespace_localnet_1.name}/{localnet_ipam_nad_name}",
                 vlanID=vlan_id,
-                subnets=f"{random_ipv4_address(net_seed=0, host_address=0)}/24",
+                subnets=str(random_ipv4_address(net_seed=0, host_address=0)),
             )
         ],
     )

--- a/tests/network/localnet/migration_stuntime/conftest.py
+++ b/tests/network/localnet/migration_stuntime/conftest.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Generator
+from ipaddress import IPv4Interface, IPv6Interface
 
 import pytest
 from kubernetes.dynamic import DynamicClient
@@ -37,8 +38,8 @@ def localnet_stuntime_server_vm(
     nncp_localnet_on_secondary_node_nic: libnncp.NodeNetworkConfigurationPolicy,
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     namespace_localnet_1: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_1.name,
@@ -52,10 +53,13 @@ def localnet_stuntime_server_vm(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        )
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ]
                     )
                 }
             )
@@ -72,8 +76,8 @@ def localnet_stuntime_client_vm(
     unprivileged_client: DynamicClient,
     cudn_localnet_ovs_bridge: libcudn.ClusterUserDefinedNetwork,
     namespace_localnet_1: Namespace,
-    ipv4_localnet_address_pool: Generator[str],
-    ipv6_localnet_address_pool: Generator[str],
+    ipv4_localnet_address_pool: Generator[IPv4Interface],
+    ipv6_localnet_address_pool: Generator[IPv6Interface],
     localnet_stuntime_server_vm: BaseVirtualMachine,
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
@@ -88,10 +92,13 @@ def localnet_stuntime_client_vm(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool,
-                            ipv6_pool=ipv6_localnet_address_pool,
-                        )
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool,
+                                ipv6_pool=ipv6_localnet_address_pool,
+                            )
+                        ]
                     )
                 }
             )

--- a/tests/network/localnet/nad_ref_change/conftest.py
+++ b/tests/network/localnet/nad_ref_change/conftest.py
@@ -70,8 +70,8 @@ def ref_vm_localnet(
         cloud_init=localnet_cloudinit(
             network_data=cloudinit.NetworkData(
                 ethernets={
-                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_a_ips),
-                    GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_b_ips),
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=[str(addr) for addr in iface_a_ips]),
+                    GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(addresses=[str(addr) for addr in iface_b_ips]),
                 }
             ),
             runcmd=ARP_ISOLATION_SYSCTL_CMD,
@@ -80,8 +80,8 @@ def ref_vm_localnet(
         run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
-                IFACE_A_NAME: [addr.split("/")[0] for addr in iface_a_ips],
-                IFACE_B_NAME: [addr.split("/")[0] for addr in iface_b_ips],
+                IFACE_A_NAME: [str(addr.ip) for addr in iface_a_ips],
+                IFACE_B_NAME: [str(addr.ip) for addr in iface_b_ips],
             },
         )
         yield vm
@@ -102,14 +102,16 @@ def under_test_vm_localnet(
         interfaces=[Interface(name=IFACE_A_NAME, bridge={})],
         cloud_init=localnet_cloudinit(
             network_data=cloudinit.NetworkData(
-                ethernets={GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_a_ips)}
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=[str(addr) for addr in iface_a_ips])
+                }
             ),
         ),
     ) as vm:
         run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
-                IFACE_A_NAME: [addr.split("/")[0] for addr in iface_a_ips],
+                IFACE_A_NAME: [str(addr.ip) for addr in iface_a_ips],
             },
         )
         yield vm

--- a/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
@@ -36,6 +36,7 @@ def localnet_server_vm(
     cudn_localnet: libcudn.ClusterUserDefinedNetwork,
     nncp_localnet: libnncp.NodeNetworkConfigurationPolicy,
 ) -> Generator[BaseVirtualMachine]:
+    addresses = random_cidr_addresses_by_family(net_seed=0, host_address=_SERVER_HOST_ADDRESS)
     with localnet_vm(
         namespace=namespace_localnet_1.name,
         name="server-vm",
@@ -50,11 +51,7 @@ def localnet_server_vm(
         ],
         cloud_init=localnet_cloudinit(
             network_data=cloudinit.NetworkData(
-                ethernets={
-                    GUEST_2ND_IFACE_NAME: EthernetDevice(
-                        addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_SERVER_HOST_ADDRESS)
-                    )
-                }
+                ethernets={GUEST_2ND_IFACE_NAME: EthernetDevice(addresses=[str(addr) for addr in addresses])}
             )
         ),
         affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
@@ -69,6 +66,7 @@ def localnet_client_vm(
     cudn_localnet: libcudn.ClusterUserDefinedNetwork,
     nncp_localnet: libnncp.NodeNetworkConfigurationPolicy,
 ) -> Generator[BaseVirtualMachine]:
+    addresses = random_cidr_addresses_by_family(net_seed=0, host_address=_CLIENT_HOST_ADDRESS)
     with localnet_vm(
         namespace=namespace_localnet_1.name,
         name="client-vm",
@@ -83,11 +81,7 @@ def localnet_client_vm(
         ],
         cloud_init=localnet_cloudinit(
             network_data=cloudinit.NetworkData(
-                ethernets={
-                    GUEST_2ND_IFACE_NAME: EthernetDevice(
-                        addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_CLIENT_HOST_ADDRESS)
-                    )
-                }
+                ethernets={GUEST_2ND_IFACE_NAME: EthernetDevice(addresses=[str(addr) for addr in addresses])}
             )
         ),
         affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),

--- a/tests/network/macspoof/conftest.py
+++ b/tests/network/macspoof/conftest.py
@@ -114,7 +114,7 @@ def linux_bridge_attached_vma(
 ):
     name = "vma"
     networks, network_data_data = _networks_data(
-        nad=linux_macspoof_nad, ip=f"{random_ipv4_address(net_seed=0, host_address=1)}/24"
+        nad=linux_macspoof_nad, ip=str(random_ipv4_address(net_seed=0, host_address=1))
     )
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,
@@ -142,7 +142,7 @@ def linux_bridge_attached_vmb(
 ):
     name = "vmb"
     networks, network_data_data = _networks_data(
-        nad=linux_macspoof_nad, ip=f"{random_ipv4_address(net_seed=0, host_address=2)}/24"
+        nad=linux_macspoof_nad, ip=str(random_ipv4_address(net_seed=0, host_address=2))
     )
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -119,9 +119,7 @@ def vma(
 ):
     name = "vma"
     networks = {br1test_nad.name: br1test_nad.name}
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=1))]}}}
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,
         ipv6_network_data=ipv6_primary_interface_cloud_init_data,
@@ -151,9 +149,7 @@ def vmb(
 ):
     name = "vmb"
     networks = {br1test_nad.name: br1test_nad.name}
-    network_data_data = {
-        "ethernets": {"eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]}}
-    }
+    network_data_data = {"ethernets": {"eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=2))]}}}
     cloud_init_data = compose_cloud_init_data_dict(
         network_data=network_data_data,
         ipv6_network_data=ipv6_primary_interface_cloud_init_data,

--- a/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
+++ b/tests/network/nmstate/test_connectivity_after_nmstate_changes.py
@@ -101,7 +101,7 @@ def nmstate_linux_bridge_attached_vma(
     networks[nmstate_linux_nad.name] = nmstate_linux_nad.name
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=1)}/24"]},
+            "eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=1))]},
         }
     }
 
@@ -135,7 +135,7 @@ def nmstate_linux_bridge_attached_vmb(
     networks[nmstate_linux_nad.name] = nmstate_linux_nad.name
     network_data_data = {
         "ethernets": {
-            "eth1": {"addresses": [f"{random_ipv4_address(net_seed=0, host_address=2)}/24"]},
+            "eth1": {"addresses": [str(random_ipv4_address(net_seed=0, host_address=2))]},
         }
     }
 

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -1,5 +1,7 @@
 """SR-IOV library constants and utilities."""
 
+from ipaddress import IPv4Interface, IPv6Interface
+
 from kubernetes.dynamic import DynamicClient
 
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
@@ -24,7 +26,7 @@ def base_sriov_vm(
     client: DynamicClient,
     sriov_network_name: str,
     sriov_mac: str,
-    addresses: list[str],
+    addresses: list[IPv4Interface | IPv6Interface],
     memory_guest: str = "1Gi",
     memory_max_guest: str | None = None,
 ) -> BaseVirtualMachine:
@@ -39,8 +41,7 @@ def base_sriov_vm(
         client: Kubernetes dynamic client.
         sriov_network_name: Name of the SR-IOV NetworkAttachmentDefinition.
         sriov_mac: MAC address to assign to the SR-IOV interface.
-        addresses: CIDR addresses to assign to the SR-IOV interface
-            (e.g. ["172.16.0.1/24", "fd00::1/64"]).
+        addresses: IP interface objects for the SR-IOV interface, one per supported IP family.
         memory_guest: Initial guest memory (e.g. "1Gi"). Defaults to "1Gi".
         memory_max_guest: Maximum guest memory for hot-plug. None disables hot-plug.
 
@@ -58,7 +59,7 @@ def base_sriov_vm(
 
     ethernets: dict[str, cloudinit.EthernetDevice] = {}
     ethernets["sriov"] = cloudinit.EthernetDevice(
-        addresses=addresses,
+        addresses=[str(addr) for addr in addresses],
         match=MatchSelector(macaddress=sriov_mac),
         set_name=VM_SRIOV_IFACE_NAME,
     )
@@ -115,9 +116,9 @@ def sriov_cloud_init_data(
 ):
     sriov_addresses = []
     if ipv4_supported_cluster():
-        sriov_addresses.append(f"{random_ipv4_address(net_seed=net_seed, host_address=host_address)}/24")
+        sriov_addresses.append(str(random_ipv4_address(net_seed=net_seed, host_address=host_address)))
     if ipv6_supported_cluster():
-        sriov_addresses.append(f"{random_ipv6_address(net_seed=net_seed, host_address=host_address)}/64")
+        sriov_addresses.append(str(random_ipv6_address(net_seed=net_seed, host_address=host_address)))
 
     sriov_interface_data = {
         "ethernets": {

--- a/tests/network/upgrade/conftest.py
+++ b/tests/network/upgrade/conftest.py
@@ -1,3 +1,4 @@
+from ipaddress import IPv4Interface, IPv6Interface
 from typing import TYPE_CHECKING
 
 import pytest
@@ -76,7 +77,7 @@ def vma_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macsp
         networks=vm_nad_networks_data,
         interfaces=sorted(vm_nad_networks_data.keys()),
         client=unprivileged_client,
-        cloud_init_data=cloud_init(ip_address=random_ipv4_address(net_seed=0, host_address=1)),
+        cloud_init_data=cloud_init(ip_address=random_ipv4_address(net_seed=0, host_address=1).ip),
         body=fedora_vm_body(name=name),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
@@ -94,7 +95,7 @@ def vmb_upgrade_mac_spoof(worker_node1, unprivileged_client, upgrade_linux_macsp
         networks=vm_nad_networks_data,
         interfaces=sorted(vm_nad_networks_data.keys()),
         client=unprivileged_client,
-        cloud_init_data=cloud_init(ip_address=random_ipv4_address(net_seed=0, host_address=2)),
+        cloud_init_data=cloud_init(ip_address=random_ipv4_address(net_seed=0, host_address=2).ip),
         body=fedora_vm_body(name=name),
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
         run_strategy=VirtualMachine.RunStrategy.ALWAYS,
@@ -202,13 +203,13 @@ def cudn_localnet_upgrade(
 
 
 @pytest.fixture(scope="session")
-def ipv4_localnet_address_pool_upgrade() -> Generator[str]:
-    return (f"{random_ipv4_address(net_seed=0, host_address=host)}/24" for host in range(1, 254))
+def ipv4_localnet_address_pool_upgrade() -> Generator[IPv4Interface]:
+    return (random_ipv4_address(net_seed=0, host_address=host) for host in range(1, 254))
 
 
 @pytest.fixture(scope="session")
-def ipv6_localnet_address_pool_upgrade() -> Generator[str]:
-    return (f"{random_ipv6_address(net_seed=0, host_address=host)}/64" for host in range(1, 254))
+def ipv6_localnet_address_pool_upgrade() -> Generator[IPv6Interface]:
+    return (random_ipv6_address(net_seed=0, host_address=host) for host in range(1, 254))
 
 
 @pytest.fixture(scope="session")
@@ -217,10 +218,10 @@ def vm_localnet_upgrade_a(
     namespace_localnet_upgrade: Namespace,
     cudn_localnet_upgrade: ClusterUserDefinedNetwork,
     cudn_dedicated_nic_bridge_localnet_upgrade: ClusterUserDefinedNetwork,
-    ipv4_localnet_address_pool_upgrade: Generator[str],
-    ipv6_localnet_address_pool_upgrade: Generator[str],
-    ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[str],
-    ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[str],
+    ipv4_localnet_address_pool_upgrade: Generator[IPv4Interface],
+    ipv6_localnet_address_pool_upgrade: Generator[IPv6Interface],
+    ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[IPv4Interface],
+    ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[IPv6Interface],
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_upgrade.name,
@@ -241,16 +242,22 @@ def vm_localnet_upgrade_a(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool_upgrade,
-                            ipv6_pool=ipv6_localnet_address_pool_upgrade,
-                        ),
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool_upgrade,
+                                ipv6_pool=ipv6_localnet_address_pool_upgrade,
+                            )
+                        ],
                     ),
                     GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade,
-                            ipv6_pool=ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade,
-                        ),
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade,
+                                ipv6_pool=ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade,
+                            )
+                        ],
                     ),
                 }
             )
@@ -266,10 +273,10 @@ def vm_localnet_upgrade_b(
     namespace_localnet_upgrade: Namespace,
     cudn_localnet_upgrade: ClusterUserDefinedNetwork,
     cudn_dedicated_nic_bridge_localnet_upgrade: ClusterUserDefinedNetwork,
-    ipv4_localnet_address_pool_upgrade: Generator[str],
-    ipv6_localnet_address_pool_upgrade: Generator[str],
-    ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[str],
-    ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[str],
+    ipv4_localnet_address_pool_upgrade: Generator[IPv4Interface],
+    ipv6_localnet_address_pool_upgrade: Generator[IPv6Interface],
+    ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[IPv4Interface],
+    ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade: Generator[IPv6Interface],
 ) -> Generator[BaseVirtualMachine]:
     with localnet_vm(
         namespace=namespace_localnet_upgrade.name,
@@ -290,16 +297,22 @@ def vm_localnet_upgrade_b(
             network_data=cloudinit.NetworkData(
                 ethernets={
                     GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_localnet_address_pool_upgrade,
-                            ipv6_pool=ipv6_localnet_address_pool_upgrade,
-                        ),
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_localnet_address_pool_upgrade,
+                                ipv6_pool=ipv6_localnet_address_pool_upgrade,
+                            )
+                        ],
                     ),
                     GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(
-                        addresses=ip_addresses_from_pool(
-                            ipv4_pool=ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade,
-                            ipv6_pool=ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade,
-                        ),
+                        addresses=[
+                            str(addr)
+                            for addr in ip_addresses_from_pool(
+                                ipv4_pool=ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade,
+                                ipv6_pool=ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade,
+                            )
+                        ],
                     ),
                 }
             )
@@ -361,10 +374,10 @@ def cudn_dedicated_nic_bridge_localnet_upgrade(
 
 
 @pytest.fixture(scope="session")
-def ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade() -> Generator[str]:
-    return (f"{random_ipv4_address(net_seed=1, host_address=host)}/24" for host in range(1, 254))
+def ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade() -> Generator[IPv4Interface]:
+    return (random_ipv4_address(net_seed=1, host_address=host) for host in range(1, 254))
 
 
 @pytest.fixture(scope="session")
-def ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade() -> Generator[str]:
-    return (f"{random_ipv6_address(net_seed=1, host_address=host)}/64" for host in range(1, 254))
+def ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade() -> Generator[IPv6Interface]:
+    return (random_ipv6_address(net_seed=1, host_address=host) for host in range(1, 254))

--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -37,7 +37,7 @@ def namespaced_layer2_user_defined_network(admin_client, udn_namespace):
         name="layer2-udn",
         namespace=udn_namespace.name,
         role="Primary",
-        subnets=[f"{random_ipv4_address(net_seed=0, host_address=0)}/24"],
+        subnets=[str(random_ipv4_address(net_seed=0, host_address=0))],
         ipam={"lifecycle": "Persistent"},
         client=admin_client,
     ) as udn:

--- a/tests/storage/cdi_upload/conftest.py
+++ b/tests/storage/cdi_upload/conftest.py
@@ -110,7 +110,7 @@ def primary_udn_for_upload(admin_client, udn_namespace_for_dv_upload):
         name="layer2-udn-upload",
         namespace=udn_namespace_for_dv_upload.name,
         role="Primary",
-        subnets=[f"{random_ipv4_address(net_seed=0, host_address=0)}/24"],
+        subnets=[str(random_ipv4_address(net_seed=0, host_address=0))],
         ipam={"lifecycle": "Persistent"},
         client=admin_client,
     ) as udn:


### PR DESCRIPTION
##### What this PR does / why we need it:
The `random_ipv4_address` and `random_ipv6_address` helpers previously returned plain strings, requiring callers to manually append prefix lengths and making the type opaque.
    
Returning IPv4Interface/IPv6Interface gives callers access to the structured IP data (.ip for the bare address, .network for the subnet) without string parsing, and lets subnet_length be explicit and validated.

Callers that need a non-standard mask, may call `subnet_length=`  with the requested cidr.

##### Which issue(s) this PR fixes: -

##### Special notes for reviewer:
Reuested follow-up PR by approvers

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - IP address generators now support configurable subnet lengths for IPv4 and IPv6.
  - Generated addresses include their network prefix and are returned as structured interface values.
  - CIDR address generation now supports both IPv4 and IPv6 interface values directly.

- **Bug Fixes**
  - Network configuration consistently distinguishes bare IP addresses from CIDR prefixes.
  - Updated networking scenarios to correctly consume generated addresses across cloud-init, localnet, bridge, SR-IOV, and DHCP configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->