### PR TITLE
[Storage] Add CBT backup/restore test descriptions (STD)

### DIFF
--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -420,9 +420,7 @@ class TestForcedFullBackup:
             2. Wait for backup to complete
 
         Expected:
-            - Full backup completes successfully
-            - New backup is independent of previous backup chain
-            - Existing backup chain checkpoints are preserved and unchanged
+            - Forced full backup completes as a new independent backup while preserving existing checkpoint chain unchanged
         """
 
     @pytest.mark.polarion("CNV-16022")
@@ -438,9 +436,7 @@ class TestForcedFullBackup:
             2. Wait for backup to complete
 
         Expected:
-            - Full backup completes successfully
-            - New backup is independent of previous backup chain
-            - Existing backup chain checkpoints are preserved and unchanged
+            - Forced full backup completes as a new independent backup while preserving existing checkpoint chain unchanged
         """
 
 
@@ -471,9 +467,7 @@ class TestBackupErrorHandling:
             3. Wait for backup operation to complete
 
         Expected:
-            - Backup fails with storage full error
-            - No partial backup data remains on PVC
-            - VM remains accessible and unaffected
+            - Backup fails with storage full error, leaves no partial backup data on the target PVC, and the VM remains accessible and unaffected
         """
 
     @pytest.mark.polarion("CNV-16024")
@@ -491,9 +485,7 @@ class TestBackupErrorHandling:
             3. Wait for backup operation to complete
 
         Expected:
-            - Backup fails with storage full error
-            - No partial backup data remains on scratch PVC
-            - VM remains accessible and unaffected
+            - Backup fails with storage full error, leaves no partial backup data on the scratch PVC, and the VM remains accessible and unaffected
         """
 
 

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -335,50 +335,6 @@ class TestHotplugBackup:
         """
 
 
-class TestForcedFullBackup:
-    """
-    Forced full backup validation.
-
-    Preconditions:
-        - Running VM with CBT enabled
-        - Test data written to VM
-        - Full backup completed
-        - Incremental backup completed
-    """
-
-    @pytest.mark.polarion("CNV-16021")
-    def test_forced_full_backup_push_mode(self):
-        """
-        Test that a forced full backup can be triggered even with existing checkpoints.
-
-        Preconditions:
-            - Backup PVC available
-
-        Steps:
-            1. Trigger a forced full backup in push mode
-            2. Wait for backup to complete
-
-        Expected:
-            - Forced full backup completes as a new independent backup while preserving existing checkpoint chain unchanged
-        """
-
-    @pytest.mark.polarion("CNV-16022")
-    def test_forced_full_backup_pull_mode(self):
-        """
-        Test that a forced full backup can be triggered in pull mode even with existing checkpoints.
-
-        Preconditions:
-            - Scratch PVC available for pull mode
-
-        Steps:
-            1. Trigger a forced full backup in pull mode
-            2. Wait for backup to complete
-
-        Expected:
-            - Forced full backup completes as a new independent backup while preserving existing checkpoint chain unchanged
-        """
-
-
 class TestBackupErrorHandling:
     """
     Backup error handling and negative scenarios.

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -2,6 +2,11 @@
 CBT (Changed Block Tracking) backup and restore validation
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/cbt.md
+
+Preconditions:
+    - incrementalBackup feature gate enabled
+    - CBT label selectors configured
+    - Test namespace opted in to CBT
 """
 
 import pytest
@@ -14,9 +19,6 @@ class TestFullBackupRestore:
     Full backup and restore validation for push and pull modes.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
         - Test data written to VM
     """
@@ -67,9 +69,6 @@ class TestIncrementalBackupRestore:
     Incremental backup and restore validation for push and pull modes.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
         - Full backup completed
         - Test data written to VM
@@ -121,9 +120,6 @@ class TestMultipleIncrementalBackups:
     Multiple incremental backups and restore validation.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
         - Full backup completed
         - Test data written to VM
@@ -179,9 +175,6 @@ class TestMultipleDiskBackup:
     Backup and restore validation for VMs with multiple disks.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
         - VM has boot disk and data disk
         - Test data written to both disks
@@ -228,31 +221,28 @@ class TestMultipleDiskBackup:
         """
 
 
-class TestBackupAfterMigration:
+class TestBackupAfterLiveMigration:
     """
-    Backup and restore after VM migration on different storage backends.
+    Backup and restore after VM live migration (requires RWX shared storage).
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
+        - VM disks on RWX backend PVC
         - At least two worker nodes available
         - Test data written to VM
         - Full backup completed before migration
     """
 
     @pytest.mark.polarion("CNV-16005")
-    def test_migration_backup_rwx_push_mode_restore(self):
+    def test_incremental_backup_after_live_migration_push_mode(self):
         """
-        Test that a VM can be backed up (push mode) after migration (RWX backend) and restored with post-migration data.
+        Test that a VM can be backed up (push mode) after live migration and restored with post-migration data.
 
         Preconditions:
             - Backup PVC available
-            - VM disks on RWX backend PVC
 
         Steps:
-            1. Migrate the VM to another node
+            1. Live migrate the VM to another node
             2. Wait for migration to complete
             3. Write new test data to VM
             4. Perform an incremental backup in push mode
@@ -266,62 +256,15 @@ class TestBackupAfterMigration:
         """
 
     @pytest.mark.polarion("CNV-16006")
-    def test_migration_backup_rwx_pull_mode_restore(self):
+    def test_incremental_backup_after_live_migration_pull_mode(self):
         """
-        Test that a VM can be backed up (pull mode) after migration (RWX backend) and restored with post-migration data.
+        Test that a VM can be backed up (pull mode) after live migration and restored with post-migration data.
 
         Preconditions:
             - Scratch PVC available for pull mode
-            - VM disks on RWX backend PVC
 
         Steps:
-            1. Migrate the VM to another node
-            2. Wait for migration to complete
-            3. Write new test data to VM
-            4. Perform an incremental backup in pull mode
-            5. Wait for backup to complete
-            6. Delete the original VM
-            7. Restore VM from the incremental backup
-            8. Start the restored VM
-
-        Expected:
-            - Restored VM boots successfully and pre-migration and post-migration test data are present
-        """
-
-    @pytest.mark.polarion("CNV-16007")
-    def test_migration_backup_rwo_push_mode_restore(self):
-        """
-        Test that a VM can be backed up (push mode) after migration (RWO backend) and restored with post-migration data.
-
-        Preconditions:
-            - Backup PVC available
-            - VM disks on RWO backend PVC
-
-        Steps:
-            1. Migrate the VM to another node
-            2. Wait for migration to complete
-            3. Write new test data to VM
-            4. Perform an incremental backup in push mode
-            5. Wait for backup to complete
-            6. Delete the original VM
-            7. Restore VM from the incremental backup
-            8. Start the restored VM
-
-        Expected:
-            - Restored VM boots successfully and pre-migration and post-migration test data are present
-        """
-
-    @pytest.mark.polarion("CNV-16008")
-    def test_migration_backup_rwo_pull_mode_restore(self):
-        """
-        Test that a VM can be backed up (pull mode) after migration (RWO backend) and restored with post-migration data.
-
-        Preconditions:
-            - Scratch PVC available for pull mode
-            - VM disks on RWO backend PVC
-
-        Steps:
-            1. Migrate the VM to another node
+            1. Live migrate the VM to another node
             2. Wait for migration to complete
             3. Write new test data to VM
             4. Perform an incremental backup in pull mode
@@ -340,9 +283,6 @@ class TestHotplugBackup:
     Backup and restore validation for VMs with hotplugged disks.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
         - Full backup completed
         - Test data written to VM
@@ -363,8 +303,9 @@ class TestHotplugBackup:
             4. Perform a full backup in push mode
             5. Wait for backup to complete
             6. Delete the original VM
-            7. Restore VM from the backup with both disks
-            8. Start the restored VM
+            7. Delete the hotplugged disk PVC
+            8. Restore VM from the backup with both disks
+            9. Start the restored VM
 
         Expected:
             - Restored VM boots successfully and test data from both original and hotplugged disks is present
@@ -385,8 +326,9 @@ class TestHotplugBackup:
             4. Perform a full backup in pull mode
             5. Wait for backup to complete
             6. Delete the original VM
-            7. Restore VM from the backup with both disks
-            8. Start the restored VM
+            7. Delete the hotplugged disk PVC
+            8. Restore VM from the backup with both disks
+            9. Start the restored VM
 
         Expected:
             - Restored VM boots successfully and test data from both original and hotplugged disks is present
@@ -398,9 +340,6 @@ class TestForcedFullBackup:
     Forced full backup validation.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
         - Test data written to VM
         - Full backup completed
@@ -445,9 +384,6 @@ class TestBackupErrorHandling:
     Backup error handling and negative scenarios.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running VM with CBT enabled
         - Test data written to VM
     """
@@ -494,9 +430,6 @@ class TestConcurrentBackups:
     Concurrent backup operations on multiple VMs.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - 5 running VMs with CBT enabled
         - Test data written to each VM
     """
@@ -548,9 +481,6 @@ class TestWindowsVMFullBackup:
     Full backup and restore validation for Windows VMs.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running Windows VM with CBT enabled
         - Test data written to Windows VM
     """
@@ -602,9 +532,6 @@ class TestWindowsVMIncrementalBackup:
     Incremental backup and restore validation for Windows VMs.
 
     Preconditions:
-        - incrementalBackup feature gate enabled
-        - CBT label selectors configured
-        - Test namespace and VMs opted in to CBT
         - Running Windows VM with CBT enabled
         - Full backup completed
         - Test data written to Windows VM

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -2,7 +2,6 @@
 CBT (Changed Block Tracking) backup and restore validation
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/cbt.md
-Jira: https://issues.redhat.com/browse/CNV-61530
 """
 
 import pytest

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -1,8 +1,8 @@
 """
 CBT (Changed Block Tracking) backup and restore validation
 
-STP Reference: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/cbt.md
-Jira Epic: CNV-61530
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/cbt.md
+Jira: https://issues.redhat.com/browse/CNV-61530
 """
 
 import pytest

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -1,0 +1,704 @@
+"""
+CBT (Changed Block Tracking) backup and restore validation
+
+STP Reference: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/cbt.md
+Jira Epic: CNV-61530
+"""
+
+import pytest
+
+__test__ = False
+
+
+class TestFullBackupRestore:
+    """
+    Full backup and restore validation for push and pull modes.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - Test data written to VM
+    """
+
+    @pytest.mark.polarion("CNV-15997")
+    def test_full_backup_push_mode_restore(self):
+        """
+        Test that a VM can be backed up (push mode) and restored from a full backup.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Create a backup tracker for the VM
+            2. Perform a full backup in push mode
+            3. Wait for backup to complete
+            4. Delete the original VM
+            5. Restore VM from the full backup
+            6. Start the restored VM
+
+        Expected:
+            - Full backup completes successfully
+            - Restored VM boots successfully and is accessible
+            - Test data is present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-15996")
+    def test_full_backup_pull_mode_restore(self):
+        """
+        Test that a full backup in pull mode can be performed and the VM can be restored.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Create a backup tracker for the VM
+            2. Perform a full backup in pull mode
+            3. Wait for backup to complete
+            4. Delete the original VM
+            5. Restore VM from the backup
+            6. Start the restored VM
+
+        Expected:
+            - Full backup completes successfully
+            - Restored VM boots successfully and is accessible
+            - Test data is present in restored VM
+        """
+
+
+class TestIncrementalBackupRestore:
+    """
+    Incremental backup and restore validation for push and pull modes.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - Full backup completed
+        - Test data written to VM
+    """
+
+    @pytest.mark.polarion("CNV-15998")
+    def test_incremental_backup_push_mode_restore(self):
+        """
+        Test that a VM can be backed up (push mode) and restored from an incremental backup.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Write new test data to VM
+            2. Perform an incremental backup in push mode
+            3. Wait for backup to complete
+            4. Delete the original VM
+            5. Restore VM from the incremental backup
+            6. Start the restored VM
+
+        Expected:
+            - Incremental backup completes successfully
+            - Restored VM boots successfully and is accessible
+            - Original test data and new test data are present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16000")
+    def test_incremental_backup_pull_mode_restore(self):
+        """
+        Test that an incremental backup in pull mode can be performed and the VM can be restored.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Write new test data to VM
+            2. Perform an incremental backup in pull mode
+            3. Wait for backup to complete
+            4. Delete the original VM
+            5. Restore VM from the incremental backup
+            6. Start the restored VM
+
+        Expected:
+            - Incremental backup completes successfully
+            - Restored VM boots successfully and is accessible
+            - Original test data and new test data are present in restored VM
+        """
+
+
+class TestMultipleIncrementalBackups:
+    """
+    Multiple incremental backups and restore validation.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - Full backup completed
+        - Test data written to VM
+    """
+
+    @pytest.mark.polarion("CNV-16002")
+    def test_multiple_incremental_backups_push_mode_restore(self):
+        """
+        Test that a VM can be restored from multiple incremental backups (push mode) with all data present.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Write additional test data to VM
+            2. Perform first incremental backup in push mode
+            3. Write more test data to VM
+            4. Perform second incremental backup in push mode
+            5. Wait for all backups to complete
+            6. Delete the original VM
+            7. Restore VM from the latest incremental backup
+            8. Start the restored VM
+
+        Expected:
+            - All incremental backups complete successfully
+            - Restored VM boots successfully and is accessible
+            - All test data is present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16001")
+    def test_multiple_incremental_backups_pull_mode_restore(self):
+        """
+        Test that a VM can be restored from multiple incremental backups (pull mode) with all data present.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Write additional test data to VM
+            2. Perform first incremental backup in pull mode
+            3. Write more test data to VM
+            4. Perform second incremental backup in pull mode
+            5. Wait for all backups to complete
+            6. Delete the original VM
+            7. Restore VM from the latest incremental backup
+            8. Start the restored VM
+
+        Expected:
+            - All incremental backups complete successfully
+            - Restored VM boots successfully and is accessible
+            - All test data is present in restored VM
+        """
+
+
+class TestMultipleDiskBackup:
+    """
+    Backup and restore validation for VMs with multiple disks.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - VM has boot disk and data disk
+        - Test data written to both disks
+    """
+
+    @pytest.mark.polarion("CNV-16003")
+    def test_backup_multiple_disks_push_mode_restore(self):
+        """
+        Test that a VM with multiple disks can be backed up (push mode) and restored with all disks accessible.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Create a backup tracker for the VM
+            2. Perform a full backup in push mode
+            3. Wait for backup to complete
+            4. Delete the original VM
+            5. Restore VM from the backup with both disks
+            6. Start the restored VM
+
+        Expected:
+            - Backup completes successfully for both disks
+            - Restored VM boots successfully and is accessible
+            - Test data from both disks is present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16004")
+    def test_backup_multiple_disks_pull_mode_restore(self):
+        """
+        Test that a VM with multiple disks can be backed up (pull mode) and restored with all disks accessible.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Create a backup tracker for the VM
+            2. Perform a full backup in pull mode
+            3. Wait for backup to complete
+            4. Delete the original VM
+            5. Restore VM from the backup with both disks
+            6. Start the restored VM
+
+        Expected:
+            - Backup completes successfully for both disks
+            - Restored VM boots successfully and is accessible
+            - Test data from both disks is present in restored VM
+        """
+
+
+class TestBackupAfterMigration:
+    """
+    Backup and restore after VM migration on different storage backends.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - At least two worker nodes available
+        - Test data written to VM
+        - Full backup completed before migration
+    """
+
+    @pytest.mark.polarion("CNV-16005")
+    def test_migration_backup_rwx_push_mode_restore(self):
+        """
+        Test that a VM can be backed up (push mode) after migration (RWX backend) and restored with post-migration data.
+
+        Preconditions:
+            - Backup PVC available
+            - VM disks on RWX backend PVC
+
+        Steps:
+            1. Migrate the VM to another node
+            2. Wait for migration to complete
+            3. Write new test data to VM
+            4. Perform an incremental backup in push mode
+            5. Wait for backup to complete
+            6. Delete the original VM
+            7. Restore VM from the incremental backup
+            8. Start the restored VM
+
+        Expected:
+            - Migration completes successfully
+            - Incremental backup after migration completes successfully
+            - Restored VM boots successfully and is accessible
+            - Pre-migration and post-migration test data are present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16006")
+    def test_migration_backup_rwx_pull_mode_restore(self):
+        """
+        Test that a VM can be backed up (pull mode) after migration (RWX backend) and restored with post-migration data.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+            - VM disks on RWX backend PVC
+
+        Steps:
+            1. Migrate the VM to another node
+            2. Wait for migration to complete
+            3. Write new test data to VM
+            4. Perform an incremental backup in pull mode
+            5. Wait for backup to complete
+            6. Delete the original VM
+            7. Restore VM from the incremental backup
+            8. Start the restored VM
+
+        Expected:
+            - Migration completes successfully
+            - Incremental backup after migration completes successfully
+            - Restored VM boots successfully and is accessible
+            - Pre-migration and post-migration test data are present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16007")
+    def test_migration_backup_rwo_push_mode_restore(self):
+        """
+        Test that a VM can be backed up (push mode) after migration (RWO backend) and restored with post-migration data.
+
+        Preconditions:
+            - Backup PVC available
+            - VM disks on RWO backend PVC
+
+        Steps:
+            1. Migrate the VM to another node
+            2. Wait for migration to complete
+            3. Write new test data to VM
+            4. Perform an incremental backup in push mode
+            5. Wait for backup to complete
+            6. Delete the original VM
+            7. Restore VM from the incremental backup
+            8. Start the restored VM
+
+        Expected:
+            - Migration completes successfully
+            - Incremental backup after migration completes successfully
+            - Restored VM boots successfully and is accessible
+            - Pre-migration and post-migration test data are present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16008")
+    def test_migration_backup_rwo_pull_mode_restore(self):
+        """
+        Test that a VM can be backed up (pull mode) after migration (RWO backend) and restored with post-migration data.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+            - VM disks on RWO backend PVC
+
+        Steps:
+            1. Migrate the VM to another node
+            2. Wait for migration to complete
+            3. Write new test data to VM
+            4. Perform an incremental backup in pull mode
+            5. Wait for backup to complete
+            6. Delete the original VM
+            7. Restore VM from the incremental backup
+            8. Start the restored VM
+
+        Expected:
+            - Migration completes successfully
+            - Incremental backup after migration completes successfully
+            - Restored VM boots successfully and is accessible
+            - Pre-migration and post-migration test data are present in restored VM
+        """
+
+
+class TestHotplugBackup:
+    """
+    Backup and restore validation for VMs with hotplugged disks.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - Full backup completed
+        - Test data written to VM
+    """
+
+    @pytest.mark.polarion("CNV-16009")
+    def test_backup_with_hotplugged_disk_push_mode_restore(self):
+        """
+        Test that a VM with hotplugged disk can be backed up (push mode) and restored with hotplugged disk data accessible.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Hotplug a new disk to the running VM
+            2. Mount the hotplugged disk in the VM
+            3. Write test data to hotplugged disk
+            4. Perform a full backup in push mode
+            5. Wait for backup to complete
+            6. Delete the original VM
+            7. Restore VM from the backup with both disks
+            8. Start the restored VM
+
+        Expected:
+            - Backup completes successfully for all disks
+            - Restored VM boots successfully and is accessible
+            - Test data from both original and hotplugged disks is present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16010")
+    def test_backup_with_hotplugged_disk_pull_mode_restore(self):
+        """
+        Test that a VM with hotplugged disk can be backed up (pull mode) and restored with hotplugged disk data accessible.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Hotplug a new disk to the running VM
+            2. Mount the hotplugged disk in the VM
+            3. Write test data to hotplugged disk
+            4. Perform a full backup in pull mode
+            5. Wait for backup to complete
+            6. Delete the original VM
+            7. Restore VM from the backup with both disks
+            8. Start the restored VM
+
+        Expected:
+            - Backup completes successfully for all disks
+            - Restored VM boots successfully and is accessible
+            - Test data from both original and hotplugged disks is present in restored VM
+        """
+
+
+class TestForcedFullBackup:
+    """
+    Forced full backup validation.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - Test data written to VM
+        - Full backup completed
+        - Incremental backup completed
+    """
+
+    @pytest.mark.polarion("CNV-16021")
+    def test_forced_full_backup_push_mode(self):
+        """
+        Test that a forced full backup can be triggered even with existing checkpoints.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Trigger a forced full backup in push mode
+            2. Wait for backup to complete
+
+        Expected:
+            - Full backup completes successfully
+            - New backup is independent of previous backup chain
+            - Existing backup chain checkpoints are preserved and unchanged
+        """
+
+    @pytest.mark.polarion("CNV-16022")
+    def test_forced_full_backup_pull_mode(self):
+        """
+        Test that a forced full backup can be triggered in pull mode even with existing checkpoints.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Trigger a forced full backup in pull mode
+            2. Wait for backup to complete
+
+        Expected:
+            - Full backup completes successfully
+            - New backup is independent of previous backup chain
+            - Existing backup chain checkpoints are preserved and unchanged
+        """
+
+
+class TestBackupErrorHandling:
+    """
+    Backup error handling and negative scenarios.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running VM with CBT enabled
+        - Test data written to VM
+    """
+
+    @pytest.mark.polarion("CNV-16023")
+    def test_backup_fails_when_storage_full_push_mode(self):
+        """
+        [NEGATIVE] Test that backup fails gracefully when backup PVC is full.
+
+        Preconditions:
+            - Backup PVC with insufficient capacity for the VM's data
+            - VM with data exceeding backup PVC capacity
+
+        Steps:
+            1. Create a backup tracker for the VM
+            2. Attempt full backup in push mode to the small PVC
+            3. Wait for backup operation to complete
+
+        Expected:
+            - Backup fails with storage full error
+            - No partial backup data remains on PVC
+            - VM remains accessible and unaffected
+        """
+
+    @pytest.mark.polarion("CNV-16024")
+    def test_backup_fails_when_storage_full_pull_mode(self):
+        """
+        [NEGATIVE] Test that backup fails gracefully when scratch PVC is full in pull mode.
+
+        Preconditions:
+            - Scratch PVC with insufficient capacity for the VM's data
+            - VM with data exceeding scratch PVC capacity
+
+        Steps:
+            1. Create a backup tracker for the VM
+            2. Attempt full backup in pull mode to the small scratch PVC
+            3. Wait for backup operation to complete
+
+        Expected:
+            - Backup fails with storage full error
+            - No partial backup data remains on scratch PVC
+            - VM remains accessible and unaffected
+        """
+
+
+class TestConcurrentBackups:
+    """
+    Concurrent backup operations on multiple VMs.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - 5 running VMs with CBT enabled
+        - Test data written to each VM
+    """
+
+    @pytest.mark.polarion("CNV-16011")
+    def test_concurrent_backups_push_mode_restore(self):
+        """
+        Test that concurrent backups (push mode) on multiple VMs complete successfully and all VMs can be restored.
+
+        Preconditions:
+            - Backup PVCs available for each VM
+
+        Steps:
+            1. Create backup trackers for all VMs
+            2. Start simultaneous backups in push mode on all VMs
+            3. Wait for all backups to complete
+            4. Delete all original VMs
+            5. Restore all VMs from their respective backups
+            6. Start all restored VMs
+
+        Expected:
+            - All backups complete successfully
+            - All restored VMs boot and are accessible
+            - All test data is present in each restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16012")
+    def test_concurrent_backups_pull_mode_restore(self):
+        """
+        Test that concurrent backups (pull mode) on multiple VMs complete successfully and all VMs can be restored.
+
+        Preconditions:
+            - Scratch PVCs available for each VM (pull mode)
+
+        Steps:
+            1. Create backup trackers for all VMs
+            2. Start simultaneous backups in pull mode on all VMs
+            3. Wait for all backups to complete
+            4. Delete all original VMs
+            5. Restore all VMs from their respective backups
+            6. Start all restored VMs
+
+        Expected:
+            - All backups complete successfully
+            - All restored VMs boot and are accessible
+            - All test data is present in each restored VM
+        """
+
+
+@pytest.mark.tier3
+class TestWindowsVMFullBackup:
+    """
+    Full backup and restore validation for Windows VMs.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running Windows VM with CBT enabled
+        - Test data written to Windows VM
+    """
+
+    @pytest.mark.polarion("CNV-16013")
+    def test_windows_vm_full_backup_push_mode_restore(self):
+        """
+        Test that a Windows VM can be backed up (push mode) and restored from a full backup.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Create a backup tracker for the Windows VM
+            2. Perform a full backup in push mode
+            3. Wait for backup to complete
+            4. Delete the original Windows VM
+            5. Restore Windows VM from the backup
+            6. Start the restored VM
+
+        Expected:
+            - Full backup completes successfully
+            - Restored Windows VM boots successfully and is accessible
+            - Test data is present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16014")
+    def test_windows_vm_full_backup_pull_mode_restore(self):
+        """
+        Test that a Windows VM can be backed up (pull mode) and restored from a full backup.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Create a backup tracker for the Windows VM
+            2. Perform a full backup in pull mode
+            3. Wait for backup to complete
+            4. Delete the original Windows VM
+            5. Restore Windows VM from the backup
+            6. Start the restored VM
+
+        Expected:
+            - Full backup completes successfully
+            - Restored Windows VM boots successfully and is accessible
+            - Test data is present in restored VM
+        """
+
+
+@pytest.mark.tier3
+class TestWindowsVMIncrementalBackup:
+    """
+    Incremental backup and restore validation for Windows VMs.
+
+    Preconditions:
+        - incrementalBackup feature gate enabled
+        - CBT label selectors configured
+        - Test namespace and VMs opted in to CBT
+        - Running Windows VM with CBT enabled
+        - Full backup completed
+        - Test data written to Windows VM
+    """
+
+    @pytest.mark.polarion("CNV-16015")
+    def test_windows_vm_incremental_backup_push_mode_restore(self):
+        """
+        Test that a Windows VM can be backed up (push mode) and restored from an incremental backup.
+
+        Preconditions:
+            - Backup PVC available
+
+        Steps:
+            1. Write new test data to Windows VM
+            2. Perform an incremental backup in push mode
+            3. Wait for backup to complete
+            4. Delete the original Windows VM
+            5. Restore Windows VM from the incremental backup
+            6. Start the restored VM
+
+        Expected:
+            - Incremental backup completes successfully
+            - Restored Windows VM boots successfully and is accessible
+            - Original test data and new test data are present in restored VM
+        """
+
+    @pytest.mark.polarion("CNV-16016")
+    def test_windows_vm_incremental_backup_pull_mode_restore(self):
+        """
+        Test that a Windows VM can be backed up (pull mode) and restored from an incremental backup.
+
+        Preconditions:
+            - Scratch PVC available for pull mode
+
+        Steps:
+            1. Write new test data to Windows VM
+            2. Perform an incremental backup in pull mode
+            3. Wait for backup to complete
+            4. Delete the original Windows VM
+            5. Restore Windows VM from the incremental backup
+            6. Start the restored VM
+
+        Expected:
+            - Incremental backup completes successfully
+            - Restored Windows VM boots successfully and is accessible
+            - Original test data and new test data are present in restored VM
+        """

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -297,13 +297,13 @@ class TestHotplugBackup:
             - Backup PVC available
 
         Steps:
-            1. Hotplug a new disk to the running VM
+            1. Hotplug a new DataVolume to the running VM
             2. Mount the hotplugged disk in the VM
             3. Write test data to hotplugged disk
             4. Perform a full backup in push mode
             5. Wait for backup to complete
             6. Delete the original VM
-            7. Delete the hotplugged disk PVC
+            7. Delete the hotplugged DataVolume
             8. Restore VM from the backup with both disks
             9. Start the restored VM
 
@@ -320,13 +320,13 @@ class TestHotplugBackup:
             - Scratch PVC available for pull mode
 
         Steps:
-            1. Hotplug a new disk to the running VM
+            1. Hotplug a new DataVolume to the running VM
             2. Mount the hotplugged disk in the VM
             3. Write test data to hotplugged disk
             4. Perform a full backup in pull mode
             5. Wait for backup to complete
             6. Delete the original VM
-            7. Delete the hotplugged disk PVC
+            7. Delete the hotplugged DataVolume
             8. Restore VM from the backup with both disks
             9. Start the restored VM
 

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -39,9 +39,7 @@ class TestFullBackupRestore:
             6. Start the restored VM
 
         Expected:
-            - Full backup completes successfully
-            - Restored VM boots successfully and is accessible
-            - Test data is present in restored VM
+            - Restored VM boots successfully and test data is present
         """
 
     @pytest.mark.polarion("CNV-15996")
@@ -61,9 +59,7 @@ class TestFullBackupRestore:
             6. Start the restored VM
 
         Expected:
-            - Full backup completes successfully
-            - Restored VM boots successfully and is accessible
-            - Test data is present in restored VM
+            - Restored VM boots successfully and test data is present
         """
 
 
@@ -97,9 +93,7 @@ class TestIncrementalBackupRestore:
             6. Start the restored VM
 
         Expected:
-            - Incremental backup completes successfully
-            - Restored VM boots successfully and is accessible
-            - Original test data and new test data are present in restored VM
+            - Restored VM boots successfully and all test data is present
         """
 
     @pytest.mark.polarion("CNV-16000")
@@ -119,9 +113,7 @@ class TestIncrementalBackupRestore:
             6. Start the restored VM
 
         Expected:
-            - Incremental backup completes successfully
-            - Restored VM boots successfully and is accessible
-            - Original test data and new test data are present in restored VM
+            - Restored VM boots successfully and all test data is present
         """
 
 
@@ -157,9 +149,7 @@ class TestMultipleIncrementalBackups:
             8. Start the restored VM
 
         Expected:
-            - All incremental backups complete successfully
-            - Restored VM boots successfully and is accessible
-            - All test data is present in restored VM
+            - Restored VM boots successfully and all test data is present
         """
 
     @pytest.mark.polarion("CNV-16001")
@@ -181,9 +171,7 @@ class TestMultipleIncrementalBackups:
             8. Start the restored VM
 
         Expected:
-            - All incremental backups complete successfully
-            - Restored VM boots successfully and is accessible
-            - All test data is present in restored VM
+            - Restored VM boots successfully and all test data is present
         """
 
 
@@ -217,9 +205,7 @@ class TestMultipleDiskBackup:
             6. Start the restored VM
 
         Expected:
-            - Backup completes successfully for both disks
-            - Restored VM boots successfully and is accessible
-            - Test data from both disks is present in restored VM
+            - Restored VM boots successfully and test data from both disks is present
         """
 
     @pytest.mark.polarion("CNV-16004")
@@ -239,9 +225,7 @@ class TestMultipleDiskBackup:
             6. Start the restored VM
 
         Expected:
-            - Backup completes successfully for both disks
-            - Restored VM boots successfully and is accessible
-            - Test data from both disks is present in restored VM
+            - Restored VM boots successfully and test data from both disks is present
         """
 
 
@@ -279,10 +263,7 @@ class TestBackupAfterMigration:
             8. Start the restored VM
 
         Expected:
-            - Migration completes successfully
-            - Incremental backup after migration completes successfully
-            - Restored VM boots successfully and is accessible
-            - Pre-migration and post-migration test data are present in restored VM
+            - Restored VM boots successfully and pre-migration and post-migration test data are present
         """
 
     @pytest.mark.polarion("CNV-16006")
@@ -305,10 +286,7 @@ class TestBackupAfterMigration:
             8. Start the restored VM
 
         Expected:
-            - Migration completes successfully
-            - Incremental backup after migration completes successfully
-            - Restored VM boots successfully and is accessible
-            - Pre-migration and post-migration test data are present in restored VM
+            - Restored VM boots successfully and pre-migration and post-migration test data are present
         """
 
     @pytest.mark.polarion("CNV-16007")
@@ -331,10 +309,7 @@ class TestBackupAfterMigration:
             8. Start the restored VM
 
         Expected:
-            - Migration completes successfully
-            - Incremental backup after migration completes successfully
-            - Restored VM boots successfully and is accessible
-            - Pre-migration and post-migration test data are present in restored VM
+            - Restored VM boots successfully and pre-migration and post-migration test data are present
         """
 
     @pytest.mark.polarion("CNV-16008")
@@ -357,10 +332,7 @@ class TestBackupAfterMigration:
             8. Start the restored VM
 
         Expected:
-            - Migration completes successfully
-            - Incremental backup after migration completes successfully
-            - Restored VM boots successfully and is accessible
-            - Pre-migration and post-migration test data are present in restored VM
+            - Restored VM boots successfully and pre-migration and post-migration test data are present
         """
 
 
@@ -396,9 +368,7 @@ class TestHotplugBackup:
             8. Start the restored VM
 
         Expected:
-            - Backup completes successfully for all disks
-            - Restored VM boots successfully and is accessible
-            - Test data from both original and hotplugged disks is present in restored VM
+            - Restored VM boots successfully and test data from both original and hotplugged disks is present
         """
 
     @pytest.mark.polarion("CNV-16010")
@@ -420,9 +390,7 @@ class TestHotplugBackup:
             8. Start the restored VM
 
         Expected:
-            - Backup completes successfully for all disks
-            - Restored VM boots successfully and is accessible
-            - Test data from both original and hotplugged disks is present in restored VM
+            - Restored VM boots successfully and test data from both original and hotplugged disks is present
         """
 
 
@@ -559,9 +527,7 @@ class TestConcurrentBackups:
             6. Start all restored VMs
 
         Expected:
-            - All backups complete successfully
-            - All restored VMs boot and are accessible
-            - All test data is present in each restored VM
+            - All restored VMs boot successfully and test data is present in each VM
         """
 
     @pytest.mark.polarion("CNV-16012")
@@ -581,9 +547,7 @@ class TestConcurrentBackups:
             6. Start all restored VMs
 
         Expected:
-            - All backups complete successfully
-            - All restored VMs boot and are accessible
-            - All test data is present in each restored VM
+            - All restored VMs boot successfully and test data is present in each VM
         """
 
 
@@ -617,9 +581,7 @@ class TestWindowsVMFullBackup:
             6. Start the restored VM
 
         Expected:
-            - Full backup completes successfully
-            - Restored Windows VM boots successfully and is accessible
-            - Test data is present in restored VM
+            - Restored Windows VM boots successfully and test data is present
         """
 
     @pytest.mark.polarion("CNV-16014")
@@ -639,9 +601,7 @@ class TestWindowsVMFullBackup:
             6. Start the restored VM
 
         Expected:
-            - Full backup completes successfully
-            - Restored Windows VM boots successfully and is accessible
-            - Test data is present in restored VM
+            - Restored Windows VM boots successfully and test data is present
         """
 
 
@@ -676,9 +636,7 @@ class TestWindowsVMIncrementalBackup:
             6. Start the restored VM
 
         Expected:
-            - Incremental backup completes successfully
-            - Restored Windows VM boots successfully and is accessible
-            - Original test data and new test data are present in restored VM
+            - Restored Windows VM boots successfully and all test data is present
         """
 
     @pytest.mark.polarion("CNV-16016")
@@ -698,7 +656,5 @@ class TestWindowsVMIncrementalBackup:
             6. Start the restored VM
 
         Expected:
-            - Incremental backup completes successfully
-            - Restored Windows VM boots successfully and is accessible
-            - Original test data and new test data are present in restored VM
+            - Restored Windows VM boots successfully and all test data is present
         """


### PR DESCRIPTION

  ##### What this PR does / why we need it:

  Adds Software Test Descriptions (STD) for CBT (Changed Block Tracking) backup and restore workflows.

  **Coverage:**
  - Full and incremental backups (push/pull modes)
  - Multiple disks and hotplug scenarios
  - Post-migration backups (RWX/RWO storage backends)
  - Concurrent backup operations (5 VMs)
  - Windows VM backups (tier3)
  - Forced full backup (P1 scenario)
  - Error handling and negative tests (storage full)

  **Tests:** 24 tests across 11 test classes
  **Polarion IDs:** CNV-15996 through CNV-16024
  **STP:** https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/cbt.md
  **Epic:** CNV-61530

  ##### Which issue(s) this PR fixes:

  ##### Special notes for reviewer:

  ##### jira-ticket:

  https://redhat.atlassian.net/browse/CNV-61552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive CBT backup/restore test suite documenting full and incremental backups, multiple incremental sequences, multi-disk VMs, backups after live migration, hotplugged-disk scenarios, forced full backup behavior, storage-full error handling, concurrent backups across VMs, and Windows VM variants (tier3). Each scenario includes push and pull modes as docstring-only, informational (non-executable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->