### PR TITLE
[Storage] Remove jira marker CNV-85325 from online-resize tests

### DIFF
--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -28,7 +28,6 @@ pytestmark = pytest.mark.usefixtures("xfail_if_gcp_storage_class")
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-6793")
-@pytest.mark.jira("CNV-85325", run=False)
 @pytest.mark.parametrize(
     "rhel_dv_for_online_resize, rhel_vm_for_online_resize",
     [
@@ -116,7 +115,6 @@ def test_disk_expand_then_clone_fail(
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-6578")
-@pytest.mark.jira("CNV-85325", run=False)
 @pytest.mark.parametrize(
     "rhel_dv_for_online_resize, rhel_vm_for_online_resize",
     [


### PR DESCRIPTION
##### What this PR does / why we need it:

WASP bug is expected to be fixed
https://redhat.atlassian.net/browse/CNV-85325

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled two previously skipped test cases for online storage resize operations. Tests now run during automated test execution to validate sequential disk expansion and disk expansion with cloning workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->