### PR TITLE
net, libs: Refactor infra cloudinit + arp-ignore cmd

### DIFF
--- a/tests/network/kubemacpool/utils.py
+++ b/tests/network/kubemacpool/utils.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from ipaddress import ip_interface
 
 from libs.net.ip import random_ipv4_address
+from tests.network.libs.connectivity import ARP_ISOLATION_SYSCTL_CMD
 from utilities.network import cloud_init_network_data, get_vmi_mac_address_by_iface_name
 from utilities.virt import (
     VirtualMachineForTests,
@@ -55,14 +56,7 @@ def create_vm(name, namespace, iface_config, node_selector, client, mac_pool):
         iface: {"addresses": [f"{iface_config[iface].ip_address}/24"]}
         for iface in ("eth%d" % idx for idx in range(1, 5))
     }
-    runcmd = [
-        # 2 kernel flags are used to disable wrong arp behavior
-        "sysctl -w net.ipv4.conf.all.arp_ignore=1",
-        # Send arp reply only if ip belongs to the interface
-        "sysctl -w net.ipv4.conf.all.arp_announce=2",
-    ]
-
-    cloud_init_data = prepare_cloud_init_user_data(section="runcmd", data=runcmd)
+    cloud_init_data = prepare_cloud_init_user_data(section="runcmd", data=ARP_ISOLATION_SYSCTL_CMD)
 
     network_data_data["ethernets"] = _data
     cloud_init_data.update(cloud_init_network_data(data=network_data_data))

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -9,13 +9,13 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status, lookup_iface_status_ip, wait_for_missing_iface_status
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import Affinity, CloudInitNoCloud, Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
 from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import primary_iface_cloud_init
 from tests.network.utils import update_cloud_init_extra_user_data
 from utilities import console
 from utilities.constants import (
@@ -41,6 +41,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, prepare_cloud
 LOGGER = logging.getLogger(__name__)
 
 RHCOS9_WORKER_LABEL: Final[str] = f"{NODE_ROLE_KUBERNETES_IO}/worker-rhcos9"
+
 
 NETWORK_MANAGER_UNMANAGE_RUNCMD = [
     'sudo echo -e "[main]\nno-auto-default=*\nignore-carrier=*" > /etc/NetworkManager/conf.d/no-nm-ownership.conf',
@@ -403,7 +404,7 @@ def secondary_network_vm(
         spec.template.spec.affinity = affinity
 
     ethernets = {}
-    primary = _masquerade_iface_cloud_init()
+    primary = primary_iface_cloud_init()
     if primary:
         ethernets["eth0"] = primary
     ethernets["eth1"] = cloudinit.EthernetDevice(addresses=secondary_iface_addresses)
@@ -416,22 +417,6 @@ def secondary_network_vm(
     )
     spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
     return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
-
-
-def _masquerade_iface_cloud_init() -> cloudinit.EthernetDevice | None:
-    """Return cloud-init ethernet config for a masquerade (primary) interface.
-
-    Returns:
-        EthernetDevice with static IPv6 and optional DHCP4, or None if IPv6 is not supported.
-    """
-    if not ipv6_supported_cluster():
-        return None
-    return cloudinit.EthernetDevice(
-        addresses=["fd10:0:2::2/120"],
-        gateway6="fd10:0:2::1",
-        dhcp4=ipv4_supported_cluster(),
-        dhcp6=False,
-    )
 
 
 @contextlib.contextmanager

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -16,6 +16,7 @@ from libs.vm.spec import Affinity, CloudInitNoCloud, Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
 from tests.network.libs import cloudinit
 from tests.network.libs.cloudinit import primary_iface_cloud_init
+from tests.network.libs.connectivity import ARP_ISOLATION_SYSCTL_CMD
 from tests.network.utils import update_cloud_init_extra_user_data
 from utilities import console
 from utilities.constants import (
@@ -485,8 +486,7 @@ def _cloud_init_data(
         "modprobe mpls_router",  # In order to test mpls we need to load driver
         "sysctl -w net.mpls.platform_labels=1000",  # Activate mpls labeling feature
         "sysctl -w net.mpls.conf.eth4.input=1",  # Allow incoming mpls traffic
-        "sysctl -w net.ipv4.conf.all.arp_ignore=1",  # 2 kernel flags are used to disable wrong arp behavior
-        "sysctl -w net.ipv4.conf.all.arp_announce=2",  # Send arp reply only if ip belongs to the interface
+        *ARP_ISOLATION_SYSCTL_CMD,
         f"ip addr add {mpls_local_ip} dev lo",
         f"ip -f mpls route add {mpls_local_tag} dev lo",
         "nmcli connection up eth4",  # In order to add mpls route we need to make sure that connection is UP

--- a/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
@@ -14,6 +14,7 @@ from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import CloudInitNoCloud, Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
 from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import primary_iface_cloud_init
 from tests.network.localnet.liblocalnet import GUEST_1ST_IFACE_NAME, GUEST_3RD_IFACE_NAME
 
 LOGGER = logging.getLogger(__name__)
@@ -59,17 +60,6 @@ def secondary_network_vm(
     spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
 
     return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
-
-
-def primary_iface_cloud_init() -> cloudinit.EthernetDevice | None:
-    if not ipv6_supported_cluster():
-        return None
-    return cloudinit.EthernetDevice(
-        addresses=["fd10:0:2::2/120"],
-        gateway6="fd10:0:2::1",
-        dhcp4=ipv4_supported_cluster(),
-        dhcp6=False,
-    )
 
 
 def secondary_iface_cloud_init(host_address: int) -> cloudinit.EthernetDevice:

--- a/tests/network/libs/cloudinit.py
+++ b/tests/network/libs/cloudinit.py
@@ -3,6 +3,7 @@ from typing import Any, Final
 
 import yaml
 
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from tests.network.libs.apimachinery import dict_normalization_for_dataclass
 
 NETWORK_DATA: Final[str] = "networkData"
@@ -85,3 +86,22 @@ def format_cloud_config(userdata: UserData) -> str:
 
 def cloudinit(netdata: NetworkData) -> dict[str, Any]:
     return {NETWORK_DATA: todict(no_cloud=netdata)}
+
+
+def primary_iface_cloud_init() -> EthernetDevice | None:
+    """Return cloud-init ethernet config for the masquerade primary interface.
+
+    Configures a static IPv6 address on eth0 when the cluster supports IPv6,
+    enabling per-family connectivity verification. Returns None on IPv4-only clusters.
+
+    Returns:
+        EthernetDevice with static IPv6 and optional DHCP4, or None if IPv6 is not supported.
+    """
+    if not ipv6_supported_cluster():
+        return None
+    return EthernetDevice(
+        addresses=["fd10:0:2::2/120"],
+        gateway6="fd10:0:2::1",
+        dhcp4=ipv4_supported_cluster(),
+        dhcp6=False,
+    )

--- a/tests/network/libs/connectivity.py
+++ b/tests/network/libs/connectivity.py
@@ -1,4 +1,14 @@
 import ipaddress
+from typing import Final
+
+ARP_ISOLATION_SYSCTL_CMD: Final[list[str]] = [
+    # Only answer ARP for the IP assigned to the receiving interface —
+    # prevents eth1 from responding to ARP for eth2's IP when queried from the same VLAN.
+    "sysctl -w net.ipv4.conf.all.arp_ignore=1",
+    # Use the sender IP belonging to the outgoing interface in ARP requests,
+    # preventing the peer from caching a wrong MAC for the wrong IP.
+    "sysctl -w net.ipv4.conf.all.arp_announce=2",
+]
 
 
 def build_ping_command(dst_ip: str, count: int, timeout: int) -> str:


### PR DESCRIPTION
##### What this PR does / why we need it:
Move shared elements to eliminate duplication across packages:
- Commands constant for arp-ignore: used in l2_bridge and kmp packages and to be used in upcoming changes.
- `primary_iface_cloud_init` to cloudinit lib: shared helper that returns the standard masquerade eth0 cloud-init config with a static IPv6 address for dual-stack clusters, or None on IPv4-only clusters.

##### Which issue(s) this PR fixes: -

##### Special notes for reviewer: - 

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored test infrastructure to standardize VM network configuration management across test suites.
  * Enhanced network isolation testing by consolidating ARP configuration logic into shared test utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->