### PR TITLE
chore: bump mypy v1.20.0 → v2.0.0 and check-jsonschema 0.37.1 → 0.37.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         stages: [commit-msg]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.37.1"
+    rev: "0.37.2"
     hooks:
       - id: check-jsonschema
         name: Validate .coderabbit.yaml against schema
@@ -79,7 +79,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.0
+    rev: v2.0.0
     hooks:
       - id: mypy
         exclude: "test_(.*).py$"


### PR DESCRIPTION
##### What this PR does / why we need it:
Bumps pre-commit hooks:
- `mirrors-mypy`: v1.20.0 → v2.0.0
- `check-jsonschema`: 0.37.1 → 0.37.2

Split from #4910 for easier review.

##### Which issue(s) this PR fixes:
Supersedes part of #4910

##### Special notes for reviewer:
All pre-commit hooks pass with these version bumps — no code changes needed.

##### jira-ticket:

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling dependencies to include the latest compatible versions for improved code quality and type checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->