### PR TITLE
net: Add interface stability test after guest-agent restart

### DIFF
--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -42,5 +42,9 @@ class TestInterfacesStability:
         Expected:
             - Interface IPs reported in VMI status remain unchanged throughout the monitoring period
         """
-
-    test_interfaces_stability_after_guest_agent_restart.__test__ = False
+        running_linux_bridge_vm.console(
+            commands=["sudo systemctl restart qemu-guest-agent.service"],
+            timeout=30,
+        )
+        for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
+            assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))

--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -24,3 +24,23 @@ class TestInterfacesStability:
         migrate_vm_and_verify(vm=running_linux_bridge_vm)
         for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
             assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))
+
+    @pytest.mark.polarion("CNV-16025")
+    def test_interfaces_stability_after_guest_agent_restart(self, running_linux_bridge_vm, stable_ips):
+        """
+        Test that interface IPs remain stable after restarting the guest agent inside the VM.
+
+        Jira: https://redhat.atlassian.net/browse/CNV-85415
+
+        Preconditions:
+            - Running Fedora VM with two secondary Linux bridge network interfaces
+            - Secondary interface IPs are stable and reported by the guest agent
+
+        Steps:
+            1. Restart the qemu-guest-agent service using systemctl inside the VM
+
+        Expected:
+            - Interface IPs reported in VMI status remain unchanged throughout the monitoring period
+        """
+
+    test_interfaces_stability_after_guest_agent_restart.__test__ = False


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds a test to `TestInterfacesStability` that restarts the qemu-guest-agent inside the VM via the guest console and verifies that VMI interface IPs remain unchanged throughout the monitoring period. Covers a regression scenario tracked in CNV-85415.

The PR follows the two-phase STD workflow: the first commit adds the STD placeholder (docstring + `__test__ = False`), the second commit adds the implementation.

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-85415

##### Special notes for reviewer:

##### jira-ticket:
CNV-85415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added a new test case to verify interface stability after guest agent service restart within running virtual machines, ensuring interface IPs remain stable and interface count consistency is maintained during monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->