### PR TITLE
net: NAD live update VM info test

### DIFF
--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Any, Final
 
 from kubernetes.dynamic.client import ResourceField
+from ocp_resources.utils.resource_constants import ResourceConstants
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import retry
 
@@ -28,6 +29,14 @@ class VMInterfaceStatusStillExistsError(Exception):
 
 
 class IpNotFound(Exception):
+    pass
+
+
+class VMIConditionNotReachedError(Exception):
+    pass
+
+
+class VMIConditionStillPresentError(Exception):
     pass
 
 
@@ -194,3 +203,99 @@ def wait_for_ifaces_status(
                     )
                 ),
             )
+
+
+def wait_for_vmi_condition_status(
+    vm: BaseVirtualMachine,
+    condition: str,
+    status: str = ResourceConstants.Condition.Status.TRUE,
+    timeout: int = 300,
+    resource_version: str | None = None,
+) -> None:
+    """Wait for a VMI status condition using the Kubernetes Watch API.
+
+    Args:
+        vm: The virtual machine to watch.
+        condition: Condition type to wait for (e.g. "MigrationRequired").
+        status: Expected condition status ("True" or "False"). Defaults to "True".
+        timeout: Maximum seconds to wait.
+        resource_version: VMI resource version captured before the triggering action.
+            Ensures no condition transitions are missed between the action and this call.
+
+    Raises:
+        VMIConditionNotReachedError: If the condition is not reached within timeout.
+    """
+    vmi = vm.vmi
+    vmi_instance = vmi.instance
+    existing_conditions = vmi_instance.status.conditions
+    if existing_conditions and _vmi_condition_set(
+        existing_conditions=existing_conditions, required_condition=condition, status=status
+    ):
+        return
+
+    watch_from_resource_version = resource_version or vmi_instance.metadata.resourceVersion
+    for event in vmi.watcher(timeout=timeout, resource_version=watch_from_resource_version):
+        if event["type"] != "MODIFIED":
+            continue
+        existing_conditions = event["object"].status.conditions
+        if existing_conditions and _vmi_condition_set(
+            existing_conditions=existing_conditions, required_condition=condition, status=status
+        ):
+            return
+
+    raise VMIConditionNotReachedError(
+        f"VMI {vm.name}: condition {condition}={status} was not reached within {timeout}s."
+    )
+
+
+def wait_for_no_vmi_condition(
+    vm: BaseVirtualMachine,
+    condition: str,
+    timeout: int = 300,
+    resource_version: str | None = None,
+) -> None:
+    """Wait until a VMI status condition is absent or False.
+
+    Succeeds when the condition is either removed from the array or set to False.
+
+    Args:
+        vm: The virtual machine to watch.
+        condition: Condition type to wait on (e.g. "MigrationRequired").
+        timeout: Maximum seconds to wait.
+        resource_version: VMI resource version captured before the triggering action.
+            Ensures no condition transitions are missed between the action and this call.
+
+    Raises:
+        VMIConditionStillPresentError: If the condition is still True or present after timeout.
+    """
+    vmi = vm.vmi
+    vmi_instance = vmi.instance
+    existing_conditions = vmi_instance.status.conditions
+    if existing_conditions and _vmi_condition_not_set(
+        existing_conditions=existing_conditions, required_condition=condition
+    ):
+        return
+
+    watch_from_resource_version = resource_version or vmi_instance.metadata.resourceVersion
+    for event in vmi.watcher(timeout=timeout, resource_version=watch_from_resource_version):
+        if event["type"] != "MODIFIED":
+            continue
+        existing_conditions = event["object"].status.conditions
+        if existing_conditions and _vmi_condition_not_set(
+            existing_conditions=existing_conditions, required_condition=condition
+        ):
+            return
+
+    raise VMIConditionStillPresentError(f"VMI {vm.name}: condition {condition} is still present after {timeout}s.")
+
+
+def _vmi_condition_set(existing_conditions: list[ResourceField], required_condition: str, status: str) -> bool:
+    return any(cond.type == required_condition and cond.status == status for cond in existing_conditions)
+
+
+def _vmi_condition_not_set(existing_conditions: list[ResourceField], required_condition: str) -> bool:
+    return all(
+        cond.status == ResourceConstants.Condition.Status.FALSE
+        for cond in existing_conditions
+        if cond.type == required_condition
+    )

--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -18,6 +18,7 @@ from libs.vm.spec import (
     Devices,
     Disk,
     Metadata,
+    Network,
     SpecDisk,
     VMISpec,
     VMSpec,
@@ -114,6 +115,19 @@ class BaseVirtualMachine(VirtualMachine):
             self: {"spec": {"template": {"metadata": {"annotations": self._spec.template.metadata.annotations}}}}
         }
         ResourceEditor(patches=patches).update()
+
+    def set_networks(self, networks: list[Network]) -> None:
+        """Replace all secondary networks in the VM spec with a single atomic patch.
+
+        Updates the in-memory spec first so the object stays consistent with the cluster
+        without requiring a re-fetch after the patch.
+
+        Args:
+            networks: Full list of Network entries to apply (including the pod network).
+        """
+        self._spec.template.spec.networks = networks
+        serialized = [asdict(obj=net, dict_factory=self._filter_out_none_values) for net in networks]
+        ResourceEditor(patches={self: {"spec": {"template": {"spec": {"networks": serialized}}}}}).update()
 
     def set_template_affinity(self, affinity: Affinity | None) -> None:
         """Replace the VM template affinity.

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -43,6 +43,9 @@ LOGGER = logging.getLogger(__name__)
 
 RHCOS9_WORKER_LABEL: Final[str] = f"{NODE_ROLE_KUBERNETES_IO}/worker-rhcos9"
 
+LINUX_BRIDGE_IFACE_NAME_1: Final[str] = "linux-bridge-1"
+LINUX_BRIDGE_IFACE_NAME_2: Final[str] = "linux-bridge-2"
+
 
 NETWORK_MANAGER_UNMANAGE_RUNCMD = [
     'sudo echo -e "[main]\nno-auto-default=*\nignore-carrier=*" > /etc/NetworkManager/conf.d/no-nm-ownership.conf',

--- a/tests/network/l2_bridge/nad_ref_change/conftest.py
+++ b/tests/network/l2_bridge/nad_ref_change/conftest.py
@@ -1,0 +1,84 @@
+from collections.abc import Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+from libs.net.ip import random_cidr_addresses_by_family
+from libs.net.netattachdef import CNIPluginBridgeConfig, NetConfig, NetworkAttachmentDefinition
+from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.l2_bridge.libl2bridge import LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2
+from tests.network.l2_bridge.nad_ref_change.lib_helpers import (
+    NET_SEED,
+    two_secondary_bridge_vm,
+)
+from tests.network.libs import nodenetworkconfigurationpolicy as libnncp
+from tests.network.libs.connectivity import ARP_ISOLATION_SYSCTL_CMD
+
+
+@pytest.fixture(scope="module")
+def bridge_nad_a(
+    admin_client: DynamicClient,
+    namespace: Namespace,
+    bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
+    vlan_index_number: Generator[int],
+) -> Generator[NetworkAttachmentDefinition]:
+    bridge = bridge_nncp.desired_state_spec.interfaces[0].name  # type: ignore
+    with NetworkAttachmentDefinition(
+        name="nad-vlan-a",
+        namespace=namespace.name,
+        config=NetConfig(
+            name="nad-vlan-a", plugins=[CNIPluginBridgeConfig(bridge=bridge, vlan=next(vlan_index_number))]
+        ),
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="module")
+def bridge_nad_b(
+    admin_client: DynamicClient,
+    namespace: Namespace,
+    bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
+    vlan_index_number: Generator[int],
+) -> Generator[NetworkAttachmentDefinition]:
+    bridge = bridge_nncp.desired_state_spec.interfaces[0].name  # type: ignore[union-attr, index]
+    with NetworkAttachmentDefinition(
+        name="nad-vlan-b",
+        namespace=namespace.name,
+        config=NetConfig(
+            name="nad-vlan-b", plugins=[CNIPluginBridgeConfig(bridge=bridge, vlan=next(vlan_index_number))]
+        ),
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="class")
+def under_test_vm_two_ifaces(
+    namespace: Namespace,
+    unprivileged_client: DynamicClient,
+    bridge_nad_a: NetworkAttachmentDefinition,
+) -> Generator[BaseVirtualMachine]:
+    iface_a_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=3)
+    iface_b_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=4)
+    with two_secondary_bridge_vm(
+        namespace=namespace.name,
+        name="under-test-vm-two-ifaces",
+        client=unprivileged_client,
+        nad_names=[bridge_nad_a.name, bridge_nad_a.name],
+        ip_addresses=[iface_a_ips, iface_b_ips],
+        iface_names=[LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2],
+        runcmd=ARP_ISOLATION_SYSCTL_CMD,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],
+                LINUX_BRIDGE_IFACE_NAME_2: [addr.split("/")[0] for addr in iface_b_ips],
+            },
+        )
+        yield vm

--- a/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
+++ b/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
@@ -1,0 +1,99 @@
+from copy import deepcopy
+from typing import Final
+
+from kubernetes.dynamic import DynamicClient
+
+from libs.net.vmspec import wait_for_no_vmi_condition, wait_for_vmi_condition_status
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import (
+    CloudInitNoCloud,
+    Devices,
+    Interface,
+    Multus,
+    Network,
+)
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import primary_iface_cloud_init
+
+NET_SEED: Final[int] = 0
+
+
+GUEST_IFACE_1: Final[str] = "eth1"
+GUEST_IFACE_2: Final[str] = "eth2"
+
+
+def update_nad_references(vm: BaseVirtualMachine, nad_name_by_net: dict[str, str]) -> None:
+    """Update secondary network NAD references and wait for the change to be fully applied.
+
+    Patches the VM spec atomically, then waits for the MigrationRequired condition to
+    appear (change detected) and disappear (migration completed).
+
+    Args:
+        vm: The virtual machine to update.
+        nad_name_by_net: Mapping of interface name to new NAD name.
+    """
+    resource_version = vm.vmi.instance.metadata.resourceVersion
+    networks = deepcopy(vm.template_spec.networks) or []
+    for network in networks:
+        if network.name in nad_name_by_net and network.multus:
+            network.multus.networkName = nad_name_by_net[network.name]
+    vm.set_networks(networks=networks)
+    wait_for_vmi_condition_status(vm=vm, condition="MigrationRequired", resource_version=resource_version)
+    wait_for_no_vmi_condition(vm=vm, condition="MigrationRequired")
+
+
+def two_secondary_bridge_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    nad_names: list[str],
+    ip_addresses: list[list[str]],
+    iface_names: list[str],
+    runcmd: list[str] | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with a masquerade primary interface and bridge-bound secondary interfaces.
+
+    Interface layout in guest OS:
+        eth0 = masquerade (pod network, primary — handles default route and IPv6)
+        eth1 = first secondary bridge interface
+        eth2 = second secondary bridge interface (if present)
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name.
+        client: Kubernetes dynamic client.
+        nad_names: NAD names (multus networkName) for the secondary interfaces, in spec order.
+        ip_addresses: Per-interface CIDR address lists, aligned with nad_names.
+            Each inner list contains one address per supported IP family.
+        iface_names: Logical interface names for the VM spec, aligned with nad_names.
+        runcmd: Commands to run on first boot via cloud-init runcmd. None means no extra commands.
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.devices = Devices(
+        interfaces=[
+            Interface(name="default", masquerade={}),
+            *[Interface(name=iface_name, bridge={}) for iface_name in iface_names],
+        ]
+    )
+    spec.template.spec.networks = [
+        Network(name="default", pod={}),
+        *[
+            Network(name=iface_name, multus=Multus(networkName=nad_name))
+            for iface_name, nad_name in zip(iface_names, nad_names)
+        ],
+    ]
+    ethernets = {}
+    if primary := primary_iface_cloud_init():
+        ethernets["eth0"] = primary
+    for i, addresses in enumerate(ip_addresses):
+        ethernets[f"eth{i + 1}"] = cloudinit.EthernetDevice(addresses=addresses)
+    userdata = cloudinit.UserData(users=[], runcmd=runcmd)
+    disk, volume = cloudinitdisk_storage(
+        data=CloudInitNoCloud(
+            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)) if ethernets else "",
+            userData=cloudinit.format_cloud_config(userdata=userdata),
+        )
+    )
+    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)

--- a/tests/network/l2_bridge/nad_ref_change/test_nad_ref_change.py
+++ b/tests/network/l2_bridge/nad_ref_change/test_nad_ref_change.py
@@ -13,6 +13,12 @@ Preconditions:
 
 import pytest
 
+from libs.net.vmspec import lookup_iface_status
+from tests.network.l2_bridge.libl2bridge import LINUX_BRIDGE_IFACE_NAME_1
+from tests.network.l2_bridge.nad_ref_change.lib_helpers import (
+    update_nad_references,
+)
+
 
 @pytest.mark.incremental
 class TestRunningVMLinuxBridgeVlanChange:
@@ -25,23 +31,23 @@ class TestRunningVMLinuxBridgeVlanChange:
         Initial (both ifaces on VLAN-A):
             Under-test VM             Reference VM
             +-----------+             +-----------+
-            |  iface-1  |---VLAN-A -->|  iface-A  |
-            |  iface-2  |---VLAN-A -->|  iface-A  |
-            +-----------+             |  iface-B  |
-                                      +-----------+
+            |  iface-1  |\\           |           |
+            |           | >--VLAN-A --|  iface-1  |
+            |  iface-2  |/            |  iface-2  |
+            +-----------+             +-----------+
 
         After first test (iface-1: VLAN-A -> VLAN-B):
             Under-test VM             Reference VM
             +-----------+             +-----------+
-            |  iface-1  |---VLAN-B -->|  iface-B  |
-            |  iface-2  |---VLAN-A -->|  iface-A  |
+            |  iface-1  |---VLAN-B -->|  iface-2  |
+            |  iface-2  |---VLAN-A -->|  iface-1  |
             +-----------+             +-----------+
 
         After third test (iface-1: VLAN-B -> VLAN-A, iface-2: VLAN-A -> VLAN-B):
             Under-test VM             Reference VM
             +-----------+             +-----------+
-            |  iface-1  |---VLAN-A -->|  iface-A  |
-            |  iface-2  |---VLAN-B -->|  iface-B  |
+            |  iface-1  |---VLAN-A -->|  iface-1  |
+            |  iface-2  |---VLAN-B -->|  iface-2  |
             +-----------+             +-----------+
 
     Preconditions:
@@ -52,10 +58,12 @@ class TestRunningVMLinuxBridgeVlanChange:
         - No TCP connectivity between the under-test VM and the reference VM on NAD-VLAN-B
     """
 
-    __test__ = False
-
     @pytest.mark.polarion("CNV-15945")
-    def test_vm_state_iface_info_preserved(self):
+    def test_vm_state_iface_info_preserved(
+        self,
+        under_test_vm_two_ifaces,
+        bridge_nad_b,
+    ):
         """
         Test that the under-test VM remains running and its secondary network metadata is unchanged
         after the NAD reference change.
@@ -75,6 +83,16 @@ class TestRunningVMLinuxBridgeVlanChange:
             - Guest first secondary interface MAC address, name, and IP addresses are the same before and after the
               NAD reference change
         """
+        iface_before = lookup_iface_status(vm=under_test_vm_two_ifaces, iface_name=LINUX_BRIDGE_IFACE_NAME_1)
+
+        update_nad_references(
+            vm=under_test_vm_two_ifaces, nad_name_by_net={LINUX_BRIDGE_IFACE_NAME_1: bridge_nad_b.name}
+        )
+
+        iface_after = lookup_iface_status(vm=under_test_vm_two_ifaces, iface_name=LINUX_BRIDGE_IFACE_NAME_1)
+        assert iface_after == iface_before, (
+            f"Interface info changed after NAD reference update: before={iface_before}, after={iface_after}"
+        )
 
     @pytest.mark.polarion("CNV-15972")
     def test_connectivity(self):
@@ -87,13 +105,15 @@ class TestRunningVMLinuxBridgeVlanChange:
             - Running reference VM with secondary Linux bridge networks connected to NAD-VLAN-A and NAD-VLAN-B
 
         Steps:
-            1. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-A
-            2. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-B
+            1. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-B
+            2. Poll TCP connection from the under-test VM to the reference VM on NAD-VLAN-A
 
         Expected:
             - Under-test VM eventually has TCP connectivity to the reference VM on NAD-VLAN-B
             - Under-test VM has no TCP connectivity to the reference VM on NAD-VLAN-A
         """
+
+    test_connectivity.__test__ = False
 
     @pytest.mark.polarion("CNV-15946")
     def test_two_networks(self):
@@ -120,6 +140,8 @@ class TestRunningVMLinuxBridgeVlanChange:
             - Under-test VM first secondary network eventually has TCP connectivity to the reference VM on NAD-VLAN-A
             - Under-test VM second secondary network eventually has TCP connectivity to the reference VM on NAD-VLAN-B
         """
+
+    test_two_networks.__test__ = False
 
 
 @pytest.mark.polarion("CNV-15947")

--- a/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/lib_helpers.py
@@ -1,7 +1,6 @@
 import ipaddress
 import logging
 from collections.abc import Iterator
-from typing import Final
 
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.resource import ResourceField
@@ -13,14 +12,12 @@ from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import CloudInitNoCloud, Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.l2_bridge.libl2bridge import LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2
 from tests.network.libs import cloudinit
 from tests.network.libs.cloudinit import primary_iface_cloud_init
 from tests.network.localnet.liblocalnet import GUEST_1ST_IFACE_NAME, GUEST_3RD_IFACE_NAME
 
 LOGGER = logging.getLogger(__name__)
-
-LINUX_BRIDGE_IFACE_NAME_1: Final[str] = "linux-bridge-1"
-LINUX_BRIDGE_IFACE_NAME_2: Final[str] = "linux-bridge-2"
 
 
 def secondary_network_vm(

--- a/tests/network/libs/cloudinit.py
+++ b/tests/network/libs/cloudinit.py
@@ -60,11 +60,16 @@ class NetworkData:
 class UserData:
     """Represents user configuration for cloud-init."""
 
-    users: list[Any]
     """
     Part of cloud-init's 'users and groups' module:
     https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups
     """
+    users: list[Any]
+    """
+    Commands to run on first boot:
+    https://cloudinit.readthedocs.io/en/latest/reference/modules.html#runcmd
+    """
+    runcmd: list[str] | None = None
 
 
 def todict(no_cloud: NetworkData | UserData) -> dict[str, Any]:


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds `test_vm_state_iface_info_preserved`: verifies that live-updating a secondary Linux bridge network's NAD reference on a running VM does not alter the guest interface identity (MAC address, name,
  IP addresses). This is the first test in the NAD live-update series for Linux bridge: it establishes the shared infrastructure that subsequent PRs in
  the series build on.

##### Which issue(s) this PR fixes: -

##### Special notes for reviewer:
 The two connectivity tests and the non-migratable negative test are present as STD placeholders (__test__ = False) they document the full planned test class but are not collected by pytest. They
  will be implemented in follow-up PRs.

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-80573
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fixtures, helpers and a VM factory for VLAN-backed bridge scenarios; new tests verify interface metadata and connectivity remain stable when network-attachment references are changed live.

* **New Features**
  * Added an atomic method to update a VM’s network attachments.
  * Cloud-init user data now supports runcmd to run commands on first boot.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->