### PR TITLE
[VIRT] Skip test_cloud_init_disk_vm due to CNV-87521

### DIFF
--- a/tests/virt/node/general/test_cloud_init_disk_vm.py
+++ b/tests/virt/node/general/test_cloud_init_disk_vm.py
@@ -18,6 +18,7 @@ def vm_with_cloud_init_disk(namespace):
 
 
 @pytest.mark.polarion("CNV-10555")
+@pytest.mark.jira("CNV-87521", run=False)
 def test_vm_with_cloud_init_disk_logging_no_disk_capacity(vm_with_cloud_init_disk, admin_client):
     assert "No disk capacity" not in vm_with_cloud_init_disk.vmi.get_virt_launcher_pod(
         privileged_client=admin_client


### PR DESCRIPTION
##### What this PR does / why we need it:
Skip test_cloud_init_disk_vm due to the product bug:
https://redhat.atlassian.net/browse/CNV-87521

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update addresses internal test infrastructure and development tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->