### PR TITLE
[VIRT] Increase descheduler timeout and fix None taints handling

### DIFF
--- a/tests/virt/node/descheduler/utils.py
+++ b/tests/virt/node/descheduler/utils.py
@@ -193,7 +193,7 @@ def deploy_vms(
 
 def verify_at_least_one_vm_migrated(vms, node_before):
     samples = TimeoutSampler(
-        wait_timeout=TIMEOUT_5MIN,
+        wait_timeout=TIMEOUT_10MIN,
         sleep=TIMEOUT_20SEC,
         func=lambda: [vm.vmi.node.name for vm in vms],
     )
@@ -228,7 +228,7 @@ def wait_for_overutilized_soft_taint(node, taint_expected, wait_timeout=TIMEOUT_
     sampler = TimeoutSampler(
         wait_timeout=wait_timeout,
         sleep=TIMEOUT_5SEC,
-        func=lambda: any(taint_key in taint.values() for taint in node.instance.spec.taints),
+        func=lambda: any(taint_key in taint.values() for taint in (node.instance.spec.taints or [])),
     )
     try:
         for sample in sampler:


### PR DESCRIPTION
##### What this PR does / why we need it:
Current 5-minute timeout only allows 2 descheduler cycles, in some cases it can be not enough if descheduler selects other pods before VMs. Increasing timeout to 10 minutes.

Also fix TypeError when node has no taints (node.instance.spec.taints is None).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended timeout duration for VM migration verification test to allow additional time for test completion.
  * Improved robustness of node taint lookup in test utilities to better handle edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/4966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->