### PR TITLE
Make verify_boot_sources_reimported flexible to select DataSources

### DIFF
--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -386,6 +386,7 @@ def enable_common_boot_image_import_spec_wait_for_data_import_cron(hco_resource,
         admin_client=admin_client,
         namespace=namespace.name,
         consecutive_checks_count=1,
+        data_source_names={next(iter(dict_entry)) for dict_entry in py_config["data_import_cron_matrix"]},
     )
 
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1118,9 +1118,12 @@ def get_data_sources_managed_by_data_import_cron(client: DynamicClient, namespac
 
 
 def verify_boot_sources_reimported(
-    admin_client: DynamicClient, namespace: str, consecutive_checks_count: int = 6
+    admin_client: DynamicClient,
+    namespace: str,
+    consecutive_checks_count: int = 6,
+    data_source_names: list[str] | None = None,
 ) -> bool:
-    """Verify all DataImportCron-managed DataSources reach Ready=True.
+    """Verify DataImportCron-managed DataSources reach Ready=True.
 
     Checks DataSources sequentially each with its own timeout. Stops on the first
     DataSource that does not become ready.
@@ -1129,12 +1132,18 @@ def verify_boot_sources_reimported(
         admin_client: Cluster admin client.
         namespace: Namespace containing the DataImportCron-managed DataSources.
         consecutive_checks_count: Consecutive Ready=True polls required for stability.
+        data_source_names: Verify DataSources whose name is in this
+            set. DataSources outside the set (e.g. from custom DIC templates) are
+            skipped. When None, all DIC-managed DataSources are verified.
 
     Returns:
         True if all DataSources reached Ready=True otherwise false
     """
     try:
         for data_source in get_data_sources_managed_by_data_import_cron(client=admin_client, namespace=namespace):
+            if data_source_names is not None and data_source.name not in data_source_names:
+                LOGGER.info(f"Skipping DataSource {data_source.name}: not in golden image data source list")
+                continue
             LOGGER.info(f"Waiting for DataSource {data_source.name} consistent ready status")
             utilities.infra.wait_for_consistent_resource_conditions(
                 dynamic_client=admin_client,

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -766,7 +766,11 @@ class TestDisableCommonBootImageImportHcoSpec:
         except StopIteration:
             pass
 
-        mock_enable_spec.assert_called_once()
+        mock_enable_spec.assert_called_once_with(
+            hco_resource=mock_hco,
+            admin_client=mock_admin_client,
+            namespace=mock_namespace,
+        )
 
     @patch("utilities.hco.enable_common_boot_image_import_spec_wait_for_data_import_cron")
     @patch("utilities.hco.wait_for_deleted_data_import_crons")
@@ -797,6 +801,10 @@ class TestDisableCommonBootImageImportHcoSpec:
 class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
     """Test cases for enable_common_boot_image_import_spec_wait_for_data_import_cron"""
 
+    @patch(
+        "utilities.hco.py_config",
+        {"data_import_cron_matrix": [{"rhel9": {}}, {"fedora": {}}]},
+    )
     @patch("utilities.hco.wait_for_hco_conditions")
     @patch("utilities.hco.wait_for_ssp_conditions")
     @patch("utilities.hco.wait_for_at_least_one_auto_update_data_import_cron")
@@ -828,6 +836,7 @@ class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
             admin_client=mock_admin_client,
             namespace=mock_namespace.name,
             consecutive_checks_count=1,
+            data_source_names={"rhel9", "fedora"},
         )
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Add optional data_source_names filter so callers can limit verification
to specific DataSources. 
##### Which issue(s) this PR fixes:
Filtering unwanted datasources like custom ones without any imagestream. This should be seen as a w/a only. 
##### Special notes for reviewer:

##### jira-ticket:
More context refer : https://redhat.atlassian.net/browse/CNV-88015
