### PR TITLE
Support multi-arch cpu_arch in py_config and schedulable_nodes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,7 @@ from libs.storage.config import StorageClassConfig
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.constants import (
     AMD_64,
+    MULTIARCH,
     QUARANTINED,
     SETUP_ERROR,
     TIMEOUT_5MIN,
@@ -558,6 +559,15 @@ def filter_sno_only_tests(items: list[Item], config: Config) -> list[Item]:
     return items
 
 
+def filter_multiarch_tests(items: list[Item], config: Config) -> list[Item]:
+    if py_config.get("cluster_type") == MULTIARCH:
+        return items
+    discard_tests, items_to_return = remove_tests_from_list(items=items, filter_str="multiarch")
+    if discard_tests:
+        config.hook.pytest_deselected(items=discard_tests)
+    return items_to_return
+
+
 def remove_tests_from_list(items: list[Item], filter_str: str) -> tuple[list[Item], list[Item]]:
     discard_tests: list[Item] = []
     items_to_return: list[Item] = []
@@ -635,6 +645,7 @@ def pytest_collection_modifyitems(session, config, items):
         config.hook.pytest_deselected(items=discard)
     items[:] = filter_deprecated_api_tests(items=items, config=config)
     items[:] = filter_sno_only_tests(items=items, config=config)
+    items[:] = filter_multiarch_tests(items=items, config=config)
     items[:] = mark_nmstate_dependent_tests(items=items)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,7 @@ from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
 from libs.net.vmspec import lookup_iface_status
 from tests.utils import download_and_extract_tar
+from utilities.architecture import get_cluster_architecture
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.cluster import cache_admin_client, get_oc_whoami_username
@@ -446,6 +447,7 @@ def schedulable_nodes(nodes):
     """
     schedulable_label = "kubevirt.io/schedulable"
     cpu_arch = py_config.get("cpu_arch")
+    cpu_archs = [cpu_arch] if isinstance(cpu_arch, str) else cpu_arch
     schedulable = [
         node
         for node in nodes
@@ -454,7 +456,7 @@ def schedulable_nodes(nodes):
         and not node.instance.spec.unschedulable
         and not kubernetes_taint_exists(node)
         and node.kubelet_ready
-        and (not cpu_arch or node.labels.get(KUBERNETES_ARCH_LABEL) == cpu_arch)
+        and (not cpu_archs or node.labels.get(KUBERNETES_ARCH_LABEL) in cpu_archs)
     ]
 
     LOGGER.info(f"Schedulable nodes: {[node.name for node in schedulable]}, node architecture: {cpu_arch or 'all'}")
@@ -1026,7 +1028,7 @@ def mac_pool(admin_client, hco_namespace):
 
 @pytest.fixture(scope="session")
 def nodes_cpu_architecture():
-    return py_config["cpu_arch"]
+    return py_config.get("cpu_arch")
 
 
 @pytest.fixture(scope="session")
@@ -1478,7 +1480,7 @@ def cluster_info(
         f"\tOCS version: {ocs_current_version}\n"
         f"\tCNI type: {get_cluster_cni_type(admin_client=admin_client)}\n"
         f"\tWorkers type: {workers_type}\n"
-        f"\tCluster CPU Architecture: {nodes_cpu_architecture}\n"
+        f"\tCluster CPU Architecture: {nodes_cpu_architecture or ', '.join(sorted(get_cluster_architecture()))}\n"
         f"\tIPv4 cluster: {ipv4_supported_cluster()}\n"
         f"\tIPv6 cluster: {ipv6_supported_cluster()}\n"
         f"\tVirtctl version: \n\t{virtctl_client_version}\n\t{virtctl_server_version}\n"


### PR DESCRIPTION
##### What this PR does / why we need it:
Enable py_config and collection infrastructure to handle multi-arch
cluster runs with `--cpu-arch=amd64,arm64'.

##### Which issue(s) this PR fixes:
- Store `cpu_arch` as list in `py_config` for multi-arch runs so fixtures can read declared architectures
- Fix `schedulable_nodes` to normalize cpu_arch to list and use `in`
  membership check (handles both str and list[str])
- Add `filter_multiarch_tests` to deselect multiarch-marked tests on
  homogeneous clusters (fixes pytest-check-x86 tox collection failure)
- Update cluster info log to display comma-separated architectures
##### Special notes for reviewer:
Multiarch doc says:

> On clusters where nodes have different CPU architectures, you must pass `--cpu-arch` to select the architecture for the run. Use a single value (e.g. `--cpu-arch=amd64`) or, for tests marked with `multiarch`, a comma-separated list (e.g. `--cpu-arch=amd64,arm64`). Use the config file `tests/global_config_multiarch.py` and the `multiarch` marker for tests that run across multiple architectures. Do not pass `--cpu-arch` on homogeneous clusters.


##### jira-ticket:
NONE