### PR TITLE
iuo: Fix teardown timeout by narrowing custom template fixture scope

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Generator
 from copy import deepcopy
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -14,6 +18,11 @@ from utilities.hco import (
     update_hco_templates_spec,
     wait_for_auto_boot_config_stabilization,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.hyperconverged import HyperConverged
+    from ocp_resources.namespace import Namespace
 
 pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]
 
@@ -41,24 +50,29 @@ def validate_template_dict(template_dict, resource_string):
     )
 
 
-@pytest.fixture(scope="class")
-def updated_hco_cr_custom_template_scope_class(
-    admin_client,
-    hco_namespace,
-    hyperconverged_resource_scope_class,
-    golden_images_namespace,
-):
+@pytest.fixture
+def updated_hco_cr_custom_template_scope_function(
+    admin_client: DynamicClient,
+    hco_namespace: Namespace,
+    hyperconverged_resource_scope_function: HyperConverged,
+    golden_images_namespace: Namespace,
+) -> Generator[dict[str, Any]]:
+    """Apply custom DataImportCron template to HCO CR.
+
+    Yields:
+        The custom template dict applied to HCO CR.
+    """
     yield from update_hco_templates_spec(
         admin_client=admin_client,
         hco_namespace=hco_namespace,
-        hyperconverged_resource=hyperconverged_resource_scope_class,
+        hyperconverged_resource=hyperconverged_resource_scope_function,
         updated_template=CUSTOM_CRON_TEMPLATE,
         custom_datasource_name=CUSTOM_DATASOURCE_NAME,
         golden_images_namespace=golden_images_namespace,
     )
 
 
-@pytest.mark.usefixtures("updated_hco_cr_custom_template_scope_class")
+@pytest.mark.usefixtures("updated_hco_cr_custom_template_scope_function")
 class TestCustomTemplates:
     @pytest.mark.order(before="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-8707")
@@ -93,7 +107,7 @@ class TestCustomTemplates:
         self,
         admin_client,
         hco_namespace,
-        disabled_common_boot_image_import_hco_spec_scope_function,
+        disabled_common_boot_image_import_hco_spec_scope_class,
         hyperconverged_status_templates_scope_function,
         ssp_spec_templates_scope_function,
         image_stream_names,


### PR DESCRIPTION
##### What this PR does / why we need it:

PR #4860 added `verify_boot_sources_reimported()` to the teardown of
`disabled_common_boot_image_import_hco_spec`. This function waits for
**all** DataSources with label `cdi.kubevirt.io/dataImportCron` to reach
`Ready=True`.

The test `test_add_custom_data_import_cron_template_disable_spec` creates
`custom-datasource` backed by a fake ImageStream (`custom-test-guest`).
This DataSource can never become Ready. When the
`disabled_common_boot_image_import` fixture tears down and calls
`verify_boot_sources_reimported`, `custom-datasource` is still present,
causing a 600s timeout and `AssertionError`.

**Root cause:** Both fixtures (`updated_hco_cr_custom_template` and
`disabled_common_boot_image_import`) shared the same scope, so pytest
did not guarantee that `custom-datasource` would be cleaned up before
`verify_boot_sources_reimported` ran.

**Fix:** Use pytest's scope-based teardown ordering:
- Keep `updated_hco_cr_custom_template` as **function-scoped**
- Use `disabled_common_boot_image_import_hco_spec_scope_class` (**class-scoped**)
  in `test_add_custom_data_import_cron_template_disable_spec`

Pytest guarantees function-scoped fixtures tear down before class-scoped
ones, so `custom-datasource` is always removed before
`verify_boot_sources_reimported` runs.

**Trade-off:** The custom template fixture setup/teardown (~95s) now runs
per-test instead of once per class. With 3 tests this adds ~190s (~3 min)
to the job runtime.

##### Which issue(s) this PR fixes:

CNV-88015

##### Special notes for reviewer:

- Alternative approach in PR #4968 adds a `data_source_names` filter to
  `verify_boot_sources_reimported()`. That works but is a workaround — the
  utility function shouldn't need to know which DataSources are test-created.
  This PR fixes the root cause (fixture scope ordering).
- The dependency-trick approach (adding `disabled_common_boot_image_import`
  as a dependency of the custom template fixture) was also tested but caused
  all 3 tests to disable/re-enable boot image import, leading to reimport
  failures after multiple cycles.

##### jira-ticket:

CNV-88015