### PR TITLE
Add exclude filter to verify_boot_sources_reimported

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -124,6 +124,7 @@ def disabled_boot_image_import_excluding_custom_datasource(
     golden_images_namespace,
     golden_images_data_import_crons_scope_function,
 ):
+    """Disable common boot image import, skipping verification of the custom DataSource."""
     yield from disable_common_boot_image_import_hco_spec(
         admin_client=admin_client,
         hco_resource=hyperconverged_resource_scope_function,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -3,6 +3,7 @@ from ocp_resources.image_stream import ImageStream
 from ocp_resources.pod import Pod
 from ocp_utilities.infra import get_pods_by_name_prefix
 
+from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
     CUSTOM_TEMPLATE,
     HCO_CR_DATA_IMPORT_SCHEDULE_KEY,
@@ -15,6 +16,7 @@ from utilities.constants.hco import (
     COMMON_TEMPLATES_KEY_NAME,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
 )
+from utilities.hco import disable_common_boot_image_import_hco_spec
 from utilities.ssp import get_ssp_resource
 
 
@@ -113,3 +115,19 @@ def ssp_spec_templates_scope_function(ssp_resource_scope_function):
 @pytest.fixture(scope="session")
 def common_templates_scope_session(hyperconverged_status_scope_session):
     return hyperconverged_status_scope_session[SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME]
+
+
+@pytest.fixture()
+def disabled_boot_image_import_excluding_custom_datasource(
+    admin_client,
+    hyperconverged_resource_scope_function,
+    golden_images_namespace,
+    golden_images_data_import_crons_scope_function,
+):
+    yield from disable_common_boot_image_import_hco_spec(
+        admin_client=admin_client,
+        hco_resource=hyperconverged_resource_scope_function,
+        golden_images_namespace=golden_images_namespace,
+        golden_images_data_import_crons=golden_images_data_import_crons_scope_function,
+        exclude_data_source_names={CUSTOM_DATASOURCE_NAME},
+    )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -10,7 +10,6 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     get_template_dict_by_name,
     get_templates_by_type_from_hco_status,
 )
-from utilities.constants.pytest import QUARANTINED
 from utilities.hco import (
     update_hco_templates_spec,
     wait_for_auto_boot_config_stabilization,
@@ -88,11 +87,6 @@ class TestCustomTemplates:
             ssp_spec_templates_scope_function=ssp_spec_templates_scope_function,
         )
 
-    @pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Teardown AssertionError in verify_boot_sources_reimported after re-enabling"
-        " enableCommonBootImageImport spec, CNV-88015",
-        run=False,
-    )
     @pytest.mark.dependency(name="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7914")
     def test_add_custom_data_import_cron_template_disable_spec(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -99,7 +99,7 @@ class TestCustomTemplates:
         self,
         admin_client,
         hco_namespace,
-        disabled_common_boot_image_import_hco_spec_scope_function,
+        disabled_boot_image_import_excluding_custom_datasource,
         hyperconverged_status_templates_scope_function,
         ssp_spec_templates_scope_function,
         image_stream_names,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -89,11 +89,11 @@ class TestCustomTemplates:
 
     @pytest.mark.dependency(name="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7914")
+    @pytest.mark.usefixtures("disabled_boot_image_import_excluding_custom_datasource")
     def test_add_custom_data_import_cron_template_disable_spec(
         self,
         admin_client,
         hco_namespace,
-        disabled_boot_image_import_excluding_custom_datasource,
         hyperconverged_status_templates_scope_function,
         ssp_spec_templates_scope_function,
         image_stream_names,

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -354,6 +354,7 @@ def disable_common_boot_image_import_hco_spec(
     hco_resource,
     golden_images_namespace,
     golden_images_data_import_crons,
+    exclude_data_source_names=None,
 ):
     if hco_resource.instance.spec[ENABLE_COMMON_BOOT_IMAGE_IMPORT]:
         update_common_boot_image_import_spec(
@@ -367,12 +368,15 @@ def disable_common_boot_image_import_hco_spec(
             hco_resource=hco_resource,
             admin_client=admin_client,
             namespace=golden_images_namespace,
+            exclude_data_source_names=exclude_data_source_names,
         )
     else:
         yield
 
 
-def enable_common_boot_image_import_spec_wait_for_data_import_cron(hco_resource, admin_client, namespace):
+def enable_common_boot_image_import_spec_wait_for_data_import_cron(
+    hco_resource, admin_client, namespace, exclude_data_source_names=None
+):
     hco_namespace = Namespace(name=hco_resource.namespace)
     update_common_boot_image_import_spec(
         hco_resource=hco_resource,
@@ -385,7 +389,7 @@ def enable_common_boot_image_import_spec_wait_for_data_import_cron(hco_resource,
         admin_client=admin_client,
         namespace=namespace.name,
         consecutive_checks_count=1,
-        data_source_names={next(iter(dict_entry)) for dict_entry in py_config["data_import_cron_matrix"]},
+        exclude_data_source_names=exclude_data_source_names,
     )
 
 

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -385,6 +385,7 @@ def enable_common_boot_image_import_spec_wait_for_data_import_cron(hco_resource,
         admin_client=admin_client,
         namespace=namespace.name,
         consecutive_checks_count=1,
+        data_source_names={next(iter(dict_entry)) for dict_entry in py_config["data_import_cron_matrix"]},
     )
 
 

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -1,6 +1,8 @@
 import json
 import logging
+from collections.abc import Collection, Generator
 from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from ocp_resources.cdi import CDI
@@ -38,6 +40,10 @@ from utilities.ssp import (
     wait_for_ssp_conditions,
 )
 from utilities.storage import verify_boot_sources_reimported
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.data_import_cron import DataImportCron
 
 LOGGER = logging.getLogger(__name__)
 
@@ -350,12 +356,12 @@ def wait_for_hco_version(client, hco_ns_name, cnv_version):
 
 
 def disable_common_boot_image_import_hco_spec(
-    admin_client,
-    hco_resource,
-    golden_images_namespace,
-    golden_images_data_import_crons,
-    exclude_data_source_names=None,
-):
+    admin_client: DynamicClient,
+    hco_resource: HyperConverged,
+    golden_images_namespace: Namespace,
+    golden_images_data_import_crons: list[DataImportCron],
+    exclude_data_source_names: Collection[str] | None = None,
+) -> Generator[None]:
     if hco_resource.instance.spec[ENABLE_COMMON_BOOT_IMAGE_IMPORT]:
         update_common_boot_image_import_spec(
             hco_resource=hco_resource,
@@ -375,8 +381,11 @@ def disable_common_boot_image_import_hco_spec(
 
 
 def enable_common_boot_image_import_spec_wait_for_data_import_cron(
-    hco_resource, admin_client, namespace, exclude_data_source_names=None
-):
+    hco_resource: HyperConverged,
+    admin_client: DynamicClient,
+    namespace: Namespace,
+    exclude_data_source_names: Collection[str] | None = None,
+) -> None:
     hco_namespace = Namespace(name=hco_resource.namespace)
     update_common_boot_image_import_spec(
         hco_resource=hco_resource,

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from collections.abc import Collection, Generator
+from collections.abc import Collection, Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -361,7 +361,7 @@ def disable_common_boot_image_import_hco_spec(
     golden_images_namespace: Namespace,
     golden_images_data_import_crons: list[DataImportCron],
     exclude_data_source_names: Collection[str] | None = None,
-) -> Generator[None]:
+) -> Iterator[None]:
     if hco_resource.instance.spec[ENABLE_COMMON_BOOT_IMAGE_IMPORT]:
         update_common_boot_image_import_spec(
             hco_resource=hco_resource,

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1139,7 +1139,7 @@ def verify_boot_sources_reimported(
             When None, all DIC-managed DataSources are verified.
 
     Returns:
-        True if all DataSources reached Ready=True otherwise false
+        True if all non-excluded DIC-managed DataSources reached Ready=True, otherwise False
     """
     try:
         for data_source in get_data_sources_managed_by_data_import_cron(client=admin_client, namespace=namespace):

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1124,7 +1124,7 @@ def verify_boot_sources_reimported(
     admin_client: DynamicClient,
     namespace: str,
     consecutive_checks_count: int = 6,
-    data_source_names: Collection[str] | None = None,
+    exclude_data_source_names: Collection[str] | None = None,
 ) -> bool:
     """Verify DataImportCron-managed DataSources reach Ready=True.
 
@@ -1135,17 +1135,17 @@ def verify_boot_sources_reimported(
         admin_client: Cluster admin client.
         namespace: Namespace containing the DataImportCron-managed DataSources.
         consecutive_checks_count: Consecutive Ready=True polls required for stability.
-        data_source_names: Verify DataSources whose name is in this
-            collection. DataSources outside the collection (e.g. from custom DIC templates) are
-            skipped. When None, all DIC-managed DataSources are verified.
+        exclude_data_source_names: DataSources whose name is in this collection
+            are skipped (e.g. custom DIC templates without valid sources).
+            When None, all DIC-managed DataSources are verified.
 
     Returns:
         True if all DataSources reached Ready=True otherwise false
     """
     try:
         for data_source in get_data_sources_managed_by_data_import_cron(client=admin_client, namespace=namespace):
-            if data_source_names is not None and data_source.name not in data_source_names:
-                LOGGER.info(f"Skipping DataSource {data_source.name}: not in golden image data source list")
+            if exclude_data_source_names is not None and data_source.name in exclude_data_source_names:
+                LOGGER.info(f"Skipping DataSource {data_source.name}: excluded from verification")
                 continue
             LOGGER.info(f"Waiting for DataSource {data_source.name} consistent ready status")
             utilities.infra.wait_for_consistent_resource_conditions(

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import shlex
+from collections.abc import Collection
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
@@ -1123,7 +1124,7 @@ def verify_boot_sources_reimported(
     admin_client: DynamicClient,
     namespace: str,
     consecutive_checks_count: int = 6,
-    data_source_names: list[str] | None = None,
+    data_source_names: Collection[str] | None = None,
 ) -> bool:
     """Verify DataImportCron-managed DataSources reach Ready=True.
 
@@ -1135,7 +1136,7 @@ def verify_boot_sources_reimported(
         namespace: Namespace containing the DataImportCron-managed DataSources.
         consecutive_checks_count: Consecutive Ready=True polls required for stability.
         data_source_names: Verify DataSources whose name is in this
-            set. DataSources outside the set (e.g. from custom DIC templates) are
+            collection. DataSources outside the collection (e.g. from custom DIC templates) are
             skipped. When None, all DIC-managed DataSources are verified.
 
     Returns:

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1120,9 +1120,12 @@ def get_data_sources_managed_by_data_import_cron(client: DynamicClient, namespac
 
 
 def verify_boot_sources_reimported(
-    admin_client: DynamicClient, namespace: str, consecutive_checks_count: int = 6
+    admin_client: DynamicClient,
+    namespace: str,
+    consecutive_checks_count: int = 6,
+    data_source_names: list[str] | None = None,
 ) -> bool:
-    """Verify all DataImportCron-managed DataSources reach Ready=True.
+    """Verify DataImportCron-managed DataSources reach Ready=True.
 
     Checks DataSources sequentially each with its own timeout. Stops on the first
     DataSource that does not become ready.
@@ -1131,12 +1134,18 @@ def verify_boot_sources_reimported(
         admin_client: Cluster admin client.
         namespace: Namespace containing the DataImportCron-managed DataSources.
         consecutive_checks_count: Consecutive Ready=True polls required for stability.
+        data_source_names: Verify DataSources whose name is in this
+            set. DataSources outside the set (e.g. from custom DIC templates) are
+            skipped. When None, all DIC-managed DataSources are verified.
 
     Returns:
         True if all DataSources reached Ready=True otherwise false
     """
     try:
         for data_source in get_data_sources_managed_by_data_import_cron(client=admin_client, namespace=namespace):
+            if data_source_names is not None and data_source.name not in data_source_names:
+                LOGGER.info(f"Skipping DataSource {data_source.name}: not in golden image data source list")
+                continue
             LOGGER.info(f"Waiting for DataSource {data_source.name} consistent ready status")
             utilities.infra.wait_for_consistent_resource_conditions(
                 dynamic_client=admin_client,

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -2,8 +2,7 @@ import logging
 import math
 import os
 import shlex
-from collections.abc import Collection
-from collections.abc import Generator
+from collections.abc import Collection, Generator
 from contextlib import contextmanager
 from typing import Any
 

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -766,7 +766,11 @@ class TestDisableCommonBootImageImportHcoSpec:
         except StopIteration:
             pass
 
-        mock_enable_spec.assert_called_once()
+        mock_enable_spec.assert_called_once_with(
+            hco_resource=mock_hco,
+            admin_client=mock_admin_client,
+            namespace=mock_namespace,
+        )
 
     @patch("utilities.hco.enable_common_boot_image_import_spec_wait_for_data_import_cron")
     @patch("utilities.hco.wait_for_deleted_data_import_crons")
@@ -797,6 +801,10 @@ class TestDisableCommonBootImageImportHcoSpec:
 class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
     """Test cases for enable_common_boot_image_import_spec_wait_for_data_import_cron"""
 
+    @patch(
+        "utilities.hco.py_config",
+        {"data_import_cron_matrix": [{"rhel9": {}}, {"fedora": {}}]},
+    )
     @patch("utilities.hco.wait_for_hco_conditions")
     @patch("utilities.hco.wait_for_ssp_conditions")
     @patch("utilities.hco.wait_for_at_least_one_auto_update_data_import_cron")
@@ -828,6 +836,7 @@ class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
             admin_client=mock_admin_client,
             namespace=mock_namespace.name,
             consecutive_checks_count=1,
+            data_source_names={"rhel9", "fedora"},
         )
 
 

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -770,6 +770,7 @@ class TestDisableCommonBootImageImportHcoSpec:
             hco_resource=mock_hco,
             admin_client=mock_admin_client,
             namespace=mock_namespace,
+            exclude_data_source_names=None,
         )
 
     @patch("utilities.hco.enable_common_boot_image_import_spec_wait_for_data_import_cron")
@@ -801,10 +802,6 @@ class TestDisableCommonBootImageImportHcoSpec:
 class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
     """Test cases for enable_common_boot_image_import_spec_wait_for_data_import_cron"""
 
-    @patch(
-        "utilities.hco.py_config",
-        {"data_import_cron_matrix": [{"rhel9": {}}, {"fedora": {}}]},
-    )
     @patch("utilities.hco.wait_for_hco_conditions")
     @patch("utilities.hco.wait_for_ssp_conditions")
     @patch("utilities.hco.wait_for_at_least_one_auto_update_data_import_cron")
@@ -836,7 +833,7 @@ class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
             admin_client=mock_admin_client,
             namespace=mock_namespace.name,
             consecutive_checks_count=1,
-            data_source_names={"rhel9", "fedora"},
+            exclude_data_source_names=None,
         )
 
 

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -776,6 +776,35 @@ class TestDisableCommonBootImageImportHcoSpec:
     @patch("utilities.hco.enable_common_boot_image_import_spec_wait_for_data_import_cron")
     @patch("utilities.hco.wait_for_deleted_data_import_crons")
     @patch("utilities.hco.update_common_boot_image_import_spec")
+    def test_disable_propagates_exclude_data_source_names(self, mock_update_spec, mock_wait_deleted, mock_enable_spec):
+        """Test that exclude_data_source_names is forwarded to the teardown call"""
+        mock_admin_client = MagicMock()
+        mock_hco = MagicMock()
+        mock_hco.instance.spec = {"enableCommonBootImageImport": True}
+        mock_namespace = MagicMock()
+        mock_dics = [MagicMock()]
+        exclude_names = {"custom-datasource"}
+
+        gen = disable_common_boot_image_import_hco_spec(
+            mock_admin_client, mock_hco, mock_namespace, mock_dics, exclude_data_source_names=exclude_names
+        )
+        next(gen)
+
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+
+        mock_enable_spec.assert_called_once_with(
+            hco_resource=mock_hco,
+            admin_client=mock_admin_client,
+            namespace=mock_namespace,
+            exclude_data_source_names=exclude_names,
+        )
+
+    @patch("utilities.hco.enable_common_boot_image_import_spec_wait_for_data_import_cron")
+    @patch("utilities.hco.wait_for_deleted_data_import_crons")
+    @patch("utilities.hco.update_common_boot_image_import_spec")
     def test_disable_when_already_disabled(self, mock_update_spec, mock_wait_deleted, mock_enable_spec):
         """Test context manager when common boot image import is already disabled"""
         mock_admin_client = MagicMock()
@@ -834,6 +863,39 @@ class TestEnableCommonBootImageImportSpecWaitForDataImportCron:
             namespace=mock_namespace.name,
             consecutive_checks_count=1,
             exclude_data_source_names=None,
+        )
+
+    @patch("utilities.hco.wait_for_hco_conditions")
+    @patch("utilities.hco.wait_for_ssp_conditions")
+    @patch("utilities.hco.wait_for_at_least_one_auto_update_data_import_cron")
+    @patch("utilities.hco.update_common_boot_image_import_spec")
+    @patch("utilities.hco.Namespace")
+    @patch("utilities.hco.verify_boot_sources_reimported", return_value=True)
+    def test_enable_spec_propagates_exclude_data_source_names(
+        self,
+        mock_verify_boot,
+        mock_namespace_class,
+        mock_update_spec,
+        mock_wait_dic,
+        mock_wait_ssp,
+        mock_wait_hco,
+    ):
+        """Test that exclude_data_source_names is forwarded to verify_boot_sources_reimported"""
+        mock_hco = MagicMock()
+        mock_hco.namespace = "openshift-cnv"
+        mock_admin_client = MagicMock()
+        mock_namespace = MagicMock()
+        exclude_names = {"custom-datasource"}
+
+        enable_common_boot_image_import_spec_wait_for_data_import_cron(
+            mock_hco, mock_admin_client, mock_namespace, exclude_data_source_names=exclude_names
+        )
+
+        mock_verify_boot.assert_called_once_with(
+            admin_client=mock_admin_client,
+            namespace=mock_namespace.name,
+            consecutive_checks_count=1,
+            exclude_data_source_names=exclude_names,
         )
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

After enabling common boot image imports, `verify_boot_sources_reimported` checks all DIC-managed DataSources. If the cluster has custom DataImportCron templates whose DataSources lack valid sources, the verification fails waiting for DataSources that will never become Ready.

This PR adds an optional `exclude_data_source_names` denylist parameter so callers can skip specific DataSources. The default remains "verify all", which is backward compatible and automatically covers multiarch DataSource names (e.g. `fedora-aarch64`) and valid custom templates without requiring an explicit allowlist.

The parameter is propagated through `disable_common_boot_image_import_hco_spec` so that `test_add_custom_data_import_cron_template_disable_spec` can exclude the custom DataSource during teardown verification.

This PR also de-quarantines `test_add_custom_data_import_cron_template_disable_spec`, which was quarantined due to the teardown `AssertionError` in `verify_boot_sources_reimported` (CNV-88015). The fix resolves the root cause, so the quarantine marker is removed.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
[CNV-88015](https://redhat.atlassian.net/browse/CNV-88015)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for excluding specific data sources during boot image import checks and re-enable flows.
  * Added a new test fixture that disables boot image import while excluding a custom data source.

* **Tests**
  * Updated unit tests to verify the exclusion list is passed through correctly.
  * Removed an expected-failure marker from an updated boot image import test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->