### PR TITLE
make client in migration tests mandatory

### DIFF
--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -134,7 +134,9 @@ class TestVMMigrationAndState:
         depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"],
     )
     def test_migrate_vm(self, admin_client, golden_image_rhel_vm_with_instance_type):
-        migrate_vm_and_verify(vm=golden_image_rhel_vm_with_instance_type, check_ssh_connectivity=True)
+        migrate_vm_and_verify(
+            vm=golden_image_rhel_vm_with_instance_type, client=admin_client, check_ssh_connectivity=True
+        )
         validate_libvirt_persistent_domain(vm=golden_image_rhel_vm_with_instance_type, admin_client=admin_client)
 
     @pytest.mark.polarion("CNV-11836")

--- a/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_rhel_os.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.infrastructure.instance_types.supported_os.constants import (
@@ -23,6 +25,11 @@ from utilities.virt import (
     validate_virtctl_guest_agent_data_over_time,
     wait_for_console,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = [pytest.mark.post_upgrade]
 
@@ -133,7 +140,11 @@ class TestVMMigrationAndState:
         name=f"{TESTS_MODULE_IDENTIFIER}::{TESTS_MIGRATE_VM}",
         depends=[f"{TESTS_MODULE_IDENTIFIER}::{TEST_START_VM_TEST_NAME}"],
     )
-    def test_migrate_vm(self, admin_client, golden_image_rhel_vm_with_instance_type):
+    def test_migrate_vm(
+        self,
+        admin_client: DynamicClient,
+        golden_image_rhel_vm_with_instance_type: VirtualMachineForTests,
+    ):
         migrate_vm_and_verify(
             vm=golden_image_rhel_vm_with_instance_type, client=admin_client, check_ssh_connectivity=True
         )

--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -132,8 +132,10 @@ class TestCPUHotPlugInstanceType:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu_instance_type"])
     @pytest.mark.polarion("CNV-11402")
-    def test_migrate_snapshot_hotplugged_vm(self, hotplug_vm_snapshot_instance_type, instance_type_hotplug_vm):
-        migrate_vm_and_verify(vm=instance_type_hotplug_vm, check_ssh_connectivity=True)
+    def test_migrate_snapshot_hotplugged_vm(
+        self, admin_client, hotplug_vm_snapshot_instance_type, instance_type_hotplug_vm
+    ):
+        migrate_vm_and_verify(vm=instance_type_hotplug_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::decrease_cpu_value", depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu_instance_type"]

--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
 from ocp_resources.datavolume import DataVolume
@@ -26,6 +28,9 @@ from utilities.virt import (
     restart_vm_wait_for_running_vm,
     running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 pytestmark = [pytest.mark.usefixtures("skip_if_no_common_modern_cpu")]
 
@@ -133,7 +138,9 @@ class TestCPUHotPlugInstanceType:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu_instance_type"])
     @pytest.mark.polarion("CNV-11402")
     @pytest.mark.usefixtures("hotplug_vm_snapshot_instance_type")
-    def test_migrate_snapshot_hotplugged_vm(self, admin_client, instance_type_hotplug_vm):
+    def test_migrate_snapshot_hotplugged_vm(
+        self, admin_client: DynamicClient, instance_type_hotplug_vm: VirtualMachineForTests
+    ):
         migrate_vm_and_verify(vm=instance_type_hotplug_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.dependency(

--- a/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
+++ b/tests/infrastructure/instance_types/test_cpu_memory_hotplug_instancetype.py
@@ -132,9 +132,8 @@ class TestCPUHotPlugInstanceType:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu_instance_type"])
     @pytest.mark.polarion("CNV-11402")
-    def test_migrate_snapshot_hotplugged_vm(
-        self, admin_client, hotplug_vm_snapshot_instance_type, instance_type_hotplug_vm
-    ):
+    @pytest.mark.usefixtures("hotplug_vm_snapshot_instance_type")
+    def test_migrate_snapshot_hotplugged_vm(self, admin_client, instance_type_hotplug_vm):
         migrate_vm_and_verify(vm=instance_type_hotplug_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.dependency(

--- a/tests/infrastructure/numa/conftest.py
+++ b/tests/infrastructure/numa/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/infrastructure/numa/conftest.py
+++ b/tests/infrastructure/numa/conftest.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from ocp_resources.data_source import DataSource
 from ocp_resources.resource import Resource
@@ -8,6 +10,9 @@ from ocp_resources.virtual_machine_cluster_instancetype import (
 from utilities.constants import DATA_SOURCE_NAME
 from utilities.storage import data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 CX1_CLUSTER_INSTANCETYPE_MEMORY_SIZES = [2, 4, 8, 16, 32, 64]  # provided cluster cx1 instancetype sizes (Gi)
 
@@ -67,8 +72,7 @@ def created_vm_cx1_instancetype(
 
 @pytest.fixture()
 def migrated_numa_cx1_vm(
-    admin_client,
-    created_vm_cx1_instancetype,
-):
+    admin_client: DynamicClient, created_vm_cx1_instancetype: VirtualMachineForTests
+) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=created_vm_cx1_instancetype, client=admin_client, check_ssh_connectivity=True)
     return created_vm_cx1_instancetype

--- a/tests/infrastructure/numa/conftest.py
+++ b/tests/infrastructure/numa/conftest.py
@@ -67,6 +67,7 @@ def created_vm_cx1_instancetype(
 
 @pytest.fixture()
 def migrated_numa_cx1_vm(
+    admin_client,
     created_vm_cx1_instancetype,
 ):
-    migrate_vm_and_verify(vm=created_vm_cx1_instancetype, check_ssh_connectivity=True)
+    migrate_vm_and_verify(vm=created_vm_cx1_instancetype, client=admin_client, check_ssh_connectivity=True)

--- a/tests/infrastructure/numa/conftest.py
+++ b/tests/infrastructure/numa/conftest.py
@@ -71,3 +71,4 @@ def migrated_numa_cx1_vm(
     created_vm_cx1_instancetype,
 ):
     migrate_vm_and_verify(vm=created_vm_cx1_instancetype, client=admin_client, check_ssh_connectivity=True)
+    return created_vm_cx1_instancetype

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -17,6 +17,7 @@ Preconditions:
 """
 
 import ipaddress
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -32,14 +33,23 @@ from tests.network.bgp.evpn.libevpn import (
 )
 from utilities.virt import migrate_vm_and_verify
 
-_L2_ENDPOINT_IPV4: str = f"{random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/24"
-_L2_ENDPOINT_IPV6: str = f"{random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/64"
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.net.traffic_generator import TcpServer
+    from libs.vm.vm import BaseVirtualMachine
+    from tests.network.bgp.evpn.libevpn import EndpointTcpClient
+
 
 pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
     pytest.mark.usefixtures("evpn_setup_ready"),
 ]
+
+
+_L2_ENDPOINT_IPV4: str = f"{random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/24"
+_L2_ENDPOINT_IPV6: str = f"{random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/64"
 
 
 @pytest.mark.polarion("CNV-15227")
@@ -86,10 +96,10 @@ def test_stretched_l2_connectivity_udn_vm_and_external_provider(external_l2_endp
 
 @pytest.mark.polarion("CNV-15229")
 def test_stretched_l2_connectivity_is_preserved_over_live_migration(
-    admin_client,
-    evpn_stretched_l2_active_connections,
-    vm_evpn_target,
-    subtests,
+    admin_client: DynamicClient,
+    evpn_stretched_l2_active_connections: list[tuple[EndpointTcpClient, TcpServer]],
+    vm_evpn_target: BaseVirtualMachine,
+    subtests: pytest.Subtests,
 ):
     """
     Preconditions:
@@ -130,10 +140,10 @@ def test_routed_l3_connectivity_udn_vm_and_external_provider(external_l3_endpoin
 
 @pytest.mark.polarion("CNV-15231")
 def test_routed_l3_connectivity_is_preserved_over_live_migration(
-    admin_client,
-    evpn_routed_l3_active_connections,
-    vm_evpn_target,
-    subtests,
+    admin_client: DynamicClient,
+    evpn_routed_l3_active_connections: list[tuple[EndpointTcpClient, TcpServer]],
+    vm_evpn_target: BaseVirtualMachine,
+    subtests: pytest.Subtests,
 ):
     """
     Preconditions:

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -43,15 +43,15 @@ if TYPE_CHECKING:
     from tests.network.bgp.evpn.libevpn import EndpointTcpClient
 
 
+_L2_ENDPOINT_IPV4: str = f"{random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/24"
+_L2_ENDPOINT_IPV6: str = f"{random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/64"
+
+
 pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
     pytest.mark.usefixtures("evpn_setup_ready"),
 ]
-
-
-_L2_ENDPOINT_IPV4: str = f"{random_ipv4_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/24"
-_L2_ENDPOINT_IPV6: str = f"{random_ipv6_address(net_seed=EVPN_CUDN_NET_SEED, host_address=249)}/64"
 
 
 @pytest.mark.polarion("CNV-15227")

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -16,6 +16,8 @@ Preconditions:
     - Running connectivity reference VM with a primary EVPN-enabled CUDN.
 """
 
+from __future__ import annotations
+
 import ipaddress
 from typing import TYPE_CHECKING
 

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -86,6 +86,7 @@ def test_stretched_l2_connectivity_udn_vm_and_external_provider(external_l2_endp
 
 @pytest.mark.polarion("CNV-15229")
 def test_stretched_l2_connectivity_is_preserved_over_live_migration(
+    admin_client,
     evpn_stretched_l2_active_connections,
     vm_evpn_target,
     subtests,
@@ -102,7 +103,7 @@ def test_stretched_l2_connectivity_is_preserved_over_live_migration(
     Expected:
     - The initial TCP connection is preserved (no disconnection).
     """
-    migrate_vm_and_verify(vm=vm_evpn_target)
+    migrate_vm_and_verify(vm=vm_evpn_target, client=admin_client)
     for client, server in evpn_stretched_l2_active_connections:
         with subtests.test(f"IPv{ipaddress.ip_address(client.server_ip).version}"):
             assert is_tcp_connection(server=server, client=client)
@@ -129,6 +130,7 @@ def test_routed_l3_connectivity_udn_vm_and_external_provider(external_l3_endpoin
 
 @pytest.mark.polarion("CNV-15231")
 def test_routed_l3_connectivity_is_preserved_over_live_migration(
+    admin_client,
     evpn_routed_l3_active_connections,
     vm_evpn_target,
     subtests,
@@ -145,7 +147,7 @@ def test_routed_l3_connectivity_is_preserved_over_live_migration(
     Expected:
     - The initial TCP connection is preserved (no disconnection).
     """
-    migrate_vm_and_verify(vm=vm_evpn_target)
+    migrate_vm_and_verify(vm=vm_evpn_target, client=admin_client)
     for client, server in evpn_routed_l3_active_connections:
         with subtests.test(f"IPv{ipaddress.ip_address(client.server_ip).version}"):
             assert is_tcp_connection(server=server, client=client)

--- a/tests/network/bgp/test_bgp_connectivity.py
+++ b/tests/network/bgp/test_bgp_connectivity.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/network/bgp/test_bgp_connectivity.py
+++ b/tests/network/bgp/test_bgp_connectivity.py
@@ -17,8 +17,9 @@ def test_connectivity_cudn_vm_and_external_network(tcp_server_cudn_vm, tcp_clien
 
 @pytest.mark.polarion("CNV-12281")
 def test_connectivity_is_preserved_during_cudn_vm_migration(
+    admin_client,
     tcp_server_cudn_vm,
     tcp_client_external_network,
 ):
-    migrate_vm_and_verify(vm=tcp_server_cudn_vm.vm)
+    migrate_vm_and_verify(vm=tcp_server_cudn_vm.vm, client=admin_client)
     assert is_tcp_connection(server=tcp_server_cudn_vm, client=tcp_client_external_network)

--- a/tests/network/bgp/test_bgp_connectivity.py
+++ b/tests/network/bgp/test_bgp_connectivity.py
@@ -1,7 +1,14 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.net.traffic_generator import PodTcpClient, TcpServer
 
 pytestmark = [
     pytest.mark.bgp,
@@ -17,9 +24,9 @@ def test_connectivity_cudn_vm_and_external_network(tcp_server_cudn_vm, tcp_clien
 
 @pytest.mark.polarion("CNV-12281")
 def test_connectivity_is_preserved_during_cudn_vm_migration(
-    admin_client,
-    tcp_server_cudn_vm,
-    tcp_client_external_network,
+    admin_client: DynamicClient,
+    tcp_server_cudn_vm: TcpServer,
+    tcp_client_external_network: PodTcpClient,
 ):
     migrate_vm_and_verify(vm=tcp_server_cudn_vm.vm, client=admin_client)
     assert is_tcp_connection(server=tcp_server_cudn_vm, client=tcp_client_external_network)

--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import random
 from typing import TYPE_CHECKING

--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -288,6 +288,7 @@ def ping_before_migration(vmd_flat_overlay, vmc_flat_overlay_ip_address):
 @pytest.fixture()
 def migrated_vmc_flat_overlay(admin_client, vmc_flat_overlay):
     migrate_vm_and_verify(vm=vmc_flat_overlay, client=admin_client, check_ssh_connectivity=True)
+    return vmc_flat_overlay
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.cluster_operator import ClusterOperator
@@ -26,6 +27,11 @@ from utilities.constants import DEFAULT_RESOURCE_CONDITIONS, FLAT_OVERLAY_STR
 from utilities.infra import create_ns, wait_for_consistent_resource_conditions
 from utilities.network import assert_ping_successful, network_nad
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -286,7 +292,9 @@ def ping_before_migration(vmd_flat_overlay, vmc_flat_overlay_ip_address):
 
 
 @pytest.fixture()
-def migrated_vmc_flat_overlay(admin_client, vmc_flat_overlay):
+def migrated_vmc_flat_overlay(
+    admin_client: DynamicClient, vmc_flat_overlay: VirtualMachineForTests
+) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=vmc_flat_overlay, client=admin_client, check_ssh_connectivity=True)
     return vmc_flat_overlay
 

--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -286,8 +286,8 @@ def ping_before_migration(vmd_flat_overlay, vmc_flat_overlay_ip_address):
 
 
 @pytest.fixture()
-def migrated_vmc_flat_overlay(vmc_flat_overlay):
-    migrate_vm_and_verify(vm=vmc_flat_overlay, check_ssh_connectivity=True)
+def migrated_vmc_flat_overlay(admin_client, vmc_flat_overlay):
+    migrate_vm_and_verify(vm=vmc_flat_overlay, client=admin_client, check_ssh_connectivity=True)
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
@@ -8,6 +8,8 @@ Markers:
     - mixed_os_nodes
 """
 
+from __future__ import annotations
+
 import ipaddress
 from typing import TYPE_CHECKING
 

--- a/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
@@ -9,6 +9,7 @@ Markers:
 """
 
 import ipaddress
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -16,6 +17,12 @@ from libs.net.traffic_generator import is_tcp_connection
 from libs.vm.affinity import new_node_affinity
 from tests.network.l2_bridge.libl2bridge import RHCOS9_WORKER_LABEL
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.net.traffic_generator import TcpServer, VMTcpClient
+    from libs.vm.vm import BaseVirtualMachine
 
 
 @pytest.mark.mixed_os_nodes
@@ -31,10 +38,10 @@ class TestConnectivity:
     @pytest.mark.polarion("CNV-15949")
     def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos10(
         self,
-        admin_client,
-        subtests,
-        bridge_running_vms,
-        bridge_active_tcp_connections,
+        admin_client: DynamicClient,
+        subtests: pytest.Subtests,
+        bridge_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
+        bridge_active_tcp_connections: list[tuple[VMTcpClient, TcpServer]],
     ):
         """
         Test that an active TCP connection over a secondary Linux bridge network
@@ -63,10 +70,10 @@ class TestConnectivity:
     @pytest.mark.polarion("CNV-15964")
     def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos9(
         self,
-        admin_client,
-        subtests,
-        bridge_running_vms,
-        bridge_active_tcp_connections,
+        admin_client: DynamicClient,
+        subtests: pytest.Subtests,
+        bridge_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine],
+        bridge_active_tcp_connections: list[tuple[VMTcpClient, TcpServer]],
     ):
         """
         Test that an active TCP connection over a secondary Linux bridge network

--- a/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
@@ -31,6 +31,7 @@ class TestConnectivity:
     @pytest.mark.polarion("CNV-15949")
     def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos10(
         self,
+        admin_client,
         subtests,
         bridge_running_vms,
         bridge_active_tcp_connections,
@@ -52,7 +53,7 @@ class TestConnectivity:
         """
         server_vm, _ = bridge_running_vms
         server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=False))
-        migrate_vm_and_verify(vm=server_vm)
+        migrate_vm_and_verify(vm=server_vm, client=admin_client)
         for client, server in bridge_active_tcp_connections:
             with subtests.test(msg=f"IPv{ipaddress.ip_address(client.server_ip).version} after migration to RHCOS 10"):
                 assert is_tcp_connection(server=server, client=client), (
@@ -62,6 +63,7 @@ class TestConnectivity:
     @pytest.mark.polarion("CNV-15964")
     def test_linux_bridge_connectivity_preserved_during_server_migration_to_rhcos9(
         self,
+        admin_client,
         subtests,
         bridge_running_vms,
         bridge_active_tcp_connections,
@@ -83,7 +85,7 @@ class TestConnectivity:
         """
         server_vm, _ = bridge_running_vms
         server_vm.set_template_affinity(affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True))
-        migrate_vm_and_verify(vm=server_vm)
+        migrate_vm_and_verify(vm=server_vm, client=admin_client)
         for client, server in bridge_active_tcp_connections:
             with subtests.test(
                 msg=f"IPv{ipaddress.ip_address(client.server_ip).version} after migration back to RHCOS 9"

--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -21,8 +21,8 @@ class TestInterfacesStability:
             assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))
 
     @pytest.mark.polarion("CNV-14340")
-    def test_interfaces_stability_after_migration(self, running_linux_bridge_vm, stable_ips):
-        migrate_vm_and_verify(vm=running_linux_bridge_vm)
+    def test_interfaces_stability_after_migration(self, admin_client, running_linux_bridge_vm, stable_ips):
+        migrate_vm_and_verify(vm=running_linux_bridge_vm, client=admin_client)
         primary_network = lookup_primary_network(vm=running_linux_bridge_vm)
         primary_iface = lookup_iface_status(
             vm=running_linux_bridge_vm,

--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Final
 
 import pytest

--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -1,4 +1,4 @@
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
 
@@ -8,6 +8,11 @@ from tests.network.l2_bridge.vmi_interfaces_stability.lib_helpers import (
     monitor_vmi_events,
 )
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.vm.vm import BaseVirtualMachine
 
 STABILITY_PERIOD_IN_SECONDS: Final[int] = 300
 
@@ -21,7 +26,12 @@ class TestInterfacesStability:
             assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))
 
     @pytest.mark.polarion("CNV-14340")
-    def test_interfaces_stability_after_migration(self, admin_client, running_linux_bridge_vm, stable_ips):
+    def test_interfaces_stability_after_migration(
+        self,
+        admin_client: DynamicClient,
+        running_linux_bridge_vm: BaseVirtualMachine,
+        stable_ips: dict[str, str],
+    ):
         migrate_vm_and_verify(vm=running_linux_bridge_vm, client=admin_client)
         primary_network = lookup_primary_network(vm=running_linux_bridge_vm)
         primary_iface = lookup_iface_status(

--- a/tests/network/libs/stuntime.py
+++ b/tests/network/libs/stuntime.py
@@ -28,7 +28,7 @@ class ContinuousPing:
 
     Example:
         >>> with ContinuousPing(source_vm=client_vm, destination_ip=server_ip) as ping:
-        ...     migrate_vm_and_verify(vm=client_vm)
+        ...     migrate_vm_and_verify(vm=client_vm, client=admin_client)
         ...     ping.stop()
         ...     transmitted, received, lost = ping.report()
     """

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -398,9 +398,11 @@ def localnet_active_connections(
 
 
 @pytest.fixture()
-def migrated_localnet_vm(localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]) -> BaseVirtualMachine:
+def migrated_localnet_vm(
+    admin_client: DynamicClient, localnet_running_vms: tuple[BaseVirtualMachine, BaseVirtualMachine]
+) -> BaseVirtualMachine:
     vm, _ = localnet_running_vms
-    migrate_vm_and_verify(vm=vm)
+    migrate_vm_and_verify(vm=vm, client=admin_client)
     return vm
 
 

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ipaddress
 from ipaddress import ip_interface
 from typing import TYPE_CHECKING

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -1,5 +1,6 @@
 import ipaddress
 from ipaddress import ip_interface
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,6 +14,11 @@ from tests.network.localnet.liblocalnet import (
 )
 from utilities.virt import migrate_vm_and_verify
 
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.net.traffic_generator import TcpServer, VMTcpClient
+
 
 @pytest.mark.gating
 @pytest.mark.single_nic
@@ -20,9 +26,9 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.usefixtures("nncp_localnet")
 @pytest.mark.polarion("CNV-11775")
 def test_connectivity_over_migration_between_localnet_vms(
-    admin_client,
-    subtests,
-    localnet_active_connections,
+    admin_client: DynamicClient,
+    subtests: pytest.Subtests,
+    localnet_active_connections: list[tuple[VMTcpClient, TcpServer]],
 ):
     client, _ = localnet_active_connections[0]
     migrate_vm_and_verify(vm=client.vm, client=admin_client)

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -20,11 +20,12 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.usefixtures("nncp_localnet")
 @pytest.mark.polarion("CNV-11775")
 def test_connectivity_over_migration_between_localnet_vms(
+    admin_client,
     subtests,
     localnet_active_connections,
 ):
     client, _ = localnet_active_connections[0]
-    migrate_vm_and_verify(vm=client.vm)
+    migrate_vm_and_verify(vm=client.vm, client=admin_client)
     for client, server in localnet_active_connections:
         with subtests.test(f"IPv{ipaddress.ip_address(client.server_ip).version}"):
             assert is_tcp_connection(server=server, client=client)

--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ipaddress
 from ipaddress import ip_interface
 from typing import TYPE_CHECKING

--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -1,5 +1,6 @@
 import ipaddress
 from ipaddress import ip_interface
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,14 +14,19 @@ from tests.network.localnet.liblocalnet import (
 )
 from utilities.virt import migrate_vm_and_verify
 
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.net.traffic_generator import TcpServer, VMTcpClient
+
 
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")
 @pytest.mark.polarion("CNV-11905")
 def test_connectivity_over_migration_between_ovs_bridge_localnet_vms(
-    admin_client,
-    subtests,
-    ovs_bridge_localnet_active_connections,
+    admin_client: DynamicClient,
+    subtests: pytest.Subtests,
+    ovs_bridge_localnet_active_connections: list[tuple[VMTcpClient, TcpServer]],
 ):
     client, _ = ovs_bridge_localnet_active_connections[0]
     migrate_vm_and_verify(vm=client.vm, client=admin_client)

--- a/tests/network/localnet/test_ovs_bridge.py
+++ b/tests/network/localnet/test_ovs_bridge.py
@@ -18,11 +18,12 @@ from utilities.virt import migrate_vm_and_verify
 @pytest.mark.usefixtures("nncp_localnet_on_secondary_node_nic")
 @pytest.mark.polarion("CNV-11905")
 def test_connectivity_over_migration_between_ovs_bridge_localnet_vms(
+    admin_client,
     subtests,
     ovs_bridge_localnet_active_connections,
 ):
     client, _ = ovs_bridge_localnet_active_connections[0]
-    migrate_vm_and_verify(vm=client.vm)
+    migrate_vm_and_verify(vm=client.vm, client=admin_client)
     for client, server in ovs_bridge_localnet_active_connections:
         with subtests.test(msg=f"IPv{ipaddress.ip_address(client.server_ip).version}"):
             assert is_tcp_connection(server=server, client=client)

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -53,12 +53,14 @@ def running_vm_for_migration(
 
 
 @pytest.fixture()
-def migrated_vmi(running_vm_for_migration):
+def migrated_vmi(admin_client, running_vm_for_migration):
     LOGGER.info(f"Migrating {running_vm_for_migration.name}. Current node: {running_vm_for_migration.vmi.node.name}")
 
     iface_name = running_vm_for_migration.vmi.interfaces[0].name
     ip_addresses_before = lookup_iface_status(vm=running_vm_for_migration, iface_name=iface_name)["ipAddresses"]
-    migrated_vmi = migrate_vm_and_verify(vm=running_vm_for_migration, wait_for_migration_success=False)
+    migrated_vmi = migrate_vm_and_verify(
+        vm=running_vm_for_migration, client=admin_client, wait_for_migration_success=False
+    )
 
     for sample in TimeoutSampler(
         wait_timeout=60,

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
 from timeout_sampler import TimeoutSampler
@@ -12,6 +14,9 @@ from utilities.virt import (
     vm_console_run_commands,
     wait_for_console,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +58,7 @@ def running_vm_for_migration(
 
 
 @pytest.fixture()
-def migrated_vmi(admin_client, running_vm_for_migration):
+def migrated_vmi(admin_client: DynamicClient, running_vm_for_migration: VirtualMachineForTests) -> Generator[None]:
     LOGGER.info(f"Migrating {running_vm_for_migration.name}. Current node: {running_vm_for_migration.vmi.node.name}")
 
     iface_name = running_vm_for_migration.vmi.interfaces[0].name

--- a/tests/network/migration/test_masquerade_connectivity_after_migration.py
+++ b/tests/network/migration/test_masquerade_connectivity_after_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Generator
 from typing import TYPE_CHECKING

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -258,10 +258,8 @@ def ssh_in_background(br1test_nad, running_vma, running_vmb):
 
 
 @pytest.fixture(scope="module")
-def migrated_vmb_and_wait_for_success(running_vmb, http_service):
-    migrate_vm_and_verify(
-        vm=running_vmb,
-    )
+def migrated_vmb_and_wait_for_success(admin_client, running_vmb, http_service):
+    migrate_vm_and_verify(vm=running_vmb, client=admin_client)
 
 
 @pytest.fixture(scope="module")
@@ -270,7 +268,7 @@ def vma_ip_address(br1test_nad, running_vma):
 
 
 @pytest.fixture(scope="module")
-def migrated_vmb_without_waiting_for_success(vma_ip_address, running_vmb, br1test_nad):
+def migrated_vmb_without_waiting_for_success(admin_client, vma_ip_address, running_vmb, br1test_nad):
     """
     1. Assert ping is successful before migrating vmb.
     2. Migrate vmb without waiting for success. As soon as the VMI acquire a new IP address, return.
@@ -279,7 +277,7 @@ def migrated_vmb_without_waiting_for_success(vma_ip_address, running_vmb, br1tes
     """
     assert_ping_successful(src_vm=running_vmb, dst_ip=vma_ip_address, count=10)
     vmb_ip_before_migration = running_vmb.vmi.interfaces[0]["ipAddress"]
-    migrated_vmi = migrate_vm_and_verify(vm=running_vmb, wait_for_migration_success=False)
+    migrated_vmi = migrate_vm_and_verify(vm=running_vmb, client=admin_client, wait_for_migration_success=False)
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=1,

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -5,6 +5,8 @@ Network Migration test
 import logging
 import re
 import shlex
+from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.service import Service
@@ -37,6 +39,9 @@ from utilities.virt import (
     fedora_vm_body,
     migrate_vm_and_verify,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 PING_LOG = "ping.log"
 LOGGER = logging.getLogger(__name__)
@@ -258,7 +263,9 @@ def ssh_in_background(br1test_nad, running_vma, running_vmb):
 
 
 @pytest.fixture(scope="module")
-def migrated_vmb_and_wait_for_success(admin_client, running_vmb, http_service):
+def migrated_vmb_and_wait_for_success(
+    admin_client: DynamicClient, running_vmb: VirtualMachineForTests, http_service
+) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=running_vmb, client=admin_client)
     return running_vmb
 
@@ -269,7 +276,11 @@ def vma_ip_address(br1test_nad, running_vma):
 
 
 @pytest.fixture(scope="module")
-def migrated_vmb_without_waiting_for_success(admin_client, vma_ip_address, running_vmb, br1test_nad):
+def migrated_vmb_without_waiting_for_success(
+    admin_client: DynamicClient,
+    vma_ip_address: str,
+    running_vmb: VirtualMachineForTests,
+) -> Generator[None]:
     """
     1. Assert ping is successful before migrating vmb.
     2. Migrate vmb without waiting for success. As soon as the VMI acquire a new IP address, return.

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -2,6 +2,8 @@
 Network Migration test
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import shlex

--- a/tests/network/migration/test_migration.py
+++ b/tests/network/migration/test_migration.py
@@ -260,6 +260,7 @@ def ssh_in_background(br1test_nad, running_vma, running_vmb):
 @pytest.fixture(scope="module")
 def migrated_vmb_and_wait_for_success(admin_client, running_vmb, http_service):
     migrate_vm_and_verify(vm=running_vmb, client=admin_client)
+    return running_vmb
 
 
 @pytest.fixture(scope="module")

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -74,10 +74,11 @@ class TestSMPeerAuthentication:
     )
     def test_authentication_policy_from_mesh_over_migration(
         self,
+        admin_client,
         vm_fedora_with_service_mesh_annotation,
         httpbin_service_service_mesh,
     ):
-        migrate_vm_and_verify(vm=vm_fedora_with_service_mesh_annotation)
+        migrate_vm_and_verify(vm=vm_fedora_with_service_mesh_annotation, client=admin_client)
         result = run_console_command(
             vm=vm_fedora_with_service_mesh_annotation,
             command=AUTH_COMMAND.format(service=httpbin_service_service_mesh.app_name),

--- a/tests/network/service_mesh/test_service_mesh.py
+++ b/tests/network/service_mesh/test_service_mesh.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.network.service_mesh.constants import AUTH_COMMAND, EXPECTED_MESH_SUCCESS_OUTPUT
@@ -7,6 +9,11 @@ from tests.network.service_mesh.utils import (
     run_console_command,
 )
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from tests.network.utils import FedoraVirtualMachineForServiceMesh, ServiceMeshDeploymentService
 
 pytestmark = pytest.mark.service_mesh
 
@@ -74,9 +81,9 @@ class TestSMPeerAuthentication:
     )
     def test_authentication_policy_from_mesh_over_migration(
         self,
-        admin_client,
-        vm_fedora_with_service_mesh_annotation,
-        httpbin_service_service_mesh,
+        admin_client: DynamicClient,
+        vm_fedora_with_service_mesh_annotation: FedoraVirtualMachineForServiceMesh,
+        httpbin_service_service_mesh: ServiceMeshDeploymentService,
     ):
         migrate_vm_and_verify(vm=vm_fedora_with_service_mesh_annotation, client=admin_client)
         result = run_console_command(

--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from libs.net.ip import filter_link_local_addresses
@@ -7,6 +9,12 @@ from tests.network.utils import assert_no_ping
 from utilities.constants import QUARANTINED
 from utilities.network import assert_ping_successful
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.network_attachment_definition import NetworkAttachmentDefinition
+
+    from libs.vm.vm import BaseVirtualMachine
 
 pytestmark = [pytest.mark.special_infra, pytest.mark.sriov]
 
@@ -99,11 +107,11 @@ class TestSriovLiveMigration:
     @pytest.mark.polarion("CNV-6455")
     def test_sriov_migration(
         self,
-        admin_client,
-        subtests,
-        sriov_network,
-        sriov_vm_migrate,
-        sriov_vm2,
+        admin_client: DynamicClient,
+        subtests: pytest.Subtests,
+        sriov_network: NetworkAttachmentDefinition,
+        sriov_vm_migrate: BaseVirtualMachine,
+        sriov_vm2: BaseVirtualMachine,
     ):
         migrate_vm_and_verify(vm=sriov_vm_migrate, client=admin_client, check_ssh_connectivity=True)
         dst_ips = filter_link_local_addresses(

--- a/tests/network/sriov/test_sriov.py
+++ b/tests/network/sriov/test_sriov.py
@@ -99,12 +99,13 @@ class TestSriovLiveMigration:
     @pytest.mark.polarion("CNV-6455")
     def test_sriov_migration(
         self,
+        admin_client,
         subtests,
         sriov_network,
         sriov_vm_migrate,
         sriov_vm2,
     ):
-        migrate_vm_and_verify(vm=sriov_vm_migrate, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=sriov_vm_migrate, client=admin_client, check_ssh_connectivity=True)
         dst_ips = filter_link_local_addresses(
             ip_addresses=lookup_iface_status(vm=sriov_vm_migrate, iface_name=sriov_network.name)["ipAddresses"]
         )

--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -109,6 +109,7 @@ class TestVMWithExplicitIPAddressSpecification:
     @pytest.mark.polarion("CNV-12586")
     def test_seamless_cluster_connectivity_is_preserved_over_live_migration(
         self,
+        admin_client,
         client_server_tcp_connectivity_between_vms: tuple[TcpClient, TcpServer],
     ) -> None:
         """
@@ -128,7 +129,7 @@ class TestVMWithExplicitIPAddressSpecification:
         """
         client, server = client_server_tcp_connectivity_between_vms
 
-        migrate_vm_and_verify(vm=server.vm)
+        migrate_vm_and_verify(vm=server.vm, client=admin_client)
 
         assert is_tcp_connection(server=server, client=client)
 

--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -8,6 +8,7 @@ https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
 """
 
 import ipaddress
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -21,6 +22,9 @@ from tests.network.user_defined_network.ip_specification.libipspec import (
 )
 from utilities.constants import PUBLIC_DNS_SERVER_IP
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 
 @pytest.mark.ipv4
@@ -109,9 +113,9 @@ class TestVMWithExplicitIPAddressSpecification:
     @pytest.mark.polarion("CNV-12586")
     def test_seamless_cluster_connectivity_is_preserved_over_live_migration(
         self,
-        admin_client,
+        admin_client: DynamicClient,
         client_server_tcp_connectivity_between_vms: tuple[TcpClient, TcpServer],
-    ) -> None:
+    ):
         """
         Test that a VM with an explicit IP address specified can preserve connectivity during live migration.
 

--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -7,6 +7,8 @@ STP Reference:
 https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/ip-request.md
 """
 
+from __future__ import annotations
+
 import ipaddress
 from typing import TYPE_CHECKING
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ipaddress
 from typing import TYPE_CHECKING
 

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -77,12 +77,12 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-11674")
     @pytest.mark.single_nic
-    def test_ip_address_is_preserved_after_live_migration(self, vma_udn):
+    def test_ip_address_is_preserved_after_live_migration(self, admin_client, vma_udn):
         ip_before_migration = str(
             lookup_iface_status_ip(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name, ip_family=4)
         )
         assert ip_before_migration
-        migrate_vm_and_verify(vm=vma_udn)
+        migrate_vm_and_verify(vm=vma_udn, client=admin_client)
         ip_after_migration = str(
             lookup_iface_status_ip(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name, ip_family=4)
         )
@@ -108,8 +108,8 @@ class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11427")
     @pytest.mark.single_nic
     @pytest.mark.gating
-    def test_connectivity_is_preserved_during_client_live_migration(self, server, client):
-        migrate_vm_and_verify(vm=client.vm)
+    def test_connectivity_is_preserved_during_client_live_migration(self, admin_client, server, client):
+        migrate_vm_and_verify(vm=client.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)
 
     @pytest.mark.polarion("CNV-12177")
@@ -118,6 +118,6 @@ class TestPrimaryUdn:
         reason=f"{QUARANTINED}: Failed migration of vm in UDN: CNV-72782",
         run=False,
     )
-    def test_connectivity_is_preserved_during_server_live_migration(self, server, client):
-        migrate_vm_and_verify(vm=server.vm)
+    def test_connectivity_is_preserved_during_server_live_migration(self, admin_client, server, client):
+        migrate_vm_and_verify(vm=server.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -1,4 +1,5 @@
 import ipaddress
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
@@ -10,6 +11,11 @@ from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
 from tests.network.libs.vm_factory import udn_vm
 from utilities.constants import PUBLIC_DNS_SERVER_IP, QUARANTINED, TIMEOUT_1MIN
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.vm.vm import BaseVirtualMachine
 
 IP_ADDRESS = "ipAddress"
 SERVER_PORT = 5201
@@ -77,7 +83,9 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-11674")
     @pytest.mark.single_nic
-    def test_ip_address_is_preserved_after_live_migration(self, admin_client, vma_udn):
+    def test_ip_address_is_preserved_after_live_migration(
+        self, admin_client: DynamicClient, vma_udn: BaseVirtualMachine
+    ):
         ip_before_migration = str(
             lookup_iface_status_ip(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name, ip_family=4)
         )
@@ -108,7 +116,9 @@ class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11427")
     @pytest.mark.single_nic
     @pytest.mark.gating
-    def test_connectivity_is_preserved_during_client_live_migration(self, admin_client, server, client):
+    def test_connectivity_is_preserved_during_client_live_migration(
+        self, admin_client: DynamicClient, server: TcpServer, client: TcpClient
+    ):
         migrate_vm_and_verify(vm=client.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)
 
@@ -118,6 +128,8 @@ class TestPrimaryUdn:
         reason=f"{QUARANTINED}: Failed migration of vm in UDN: CNV-72782",
         run=False,
     )
-    def test_connectivity_is_preserved_during_server_live_migration(self, admin_client, server, client):
+    def test_connectivity_is_preserved_during_server_live_migration(
+        self, admin_client: DynamicClient, server: TcpServer, client: TcpClient
+    ):
         migrate_vm_and_verify(vm=server.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -1,7 +1,7 @@
 from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
-from kubernetes.dynamic import DynamicClient
 from ocp_resources.hyperconverged import HyperConverged
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.namespace import Namespace
@@ -11,10 +11,14 @@ from timeout_sampler import TimeoutExpiredError, retry
 from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
 from libs.net.udn import UDN_PASST_CORE_BINDING_NAME
 from libs.net.vmspec import lookup_primary_network
-from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs.vm_factory import udn_vm
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.virt import LOGGER, migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from libs.vm.vm import BaseVirtualMachine
 
 
 @retry(wait_timeout=400, sleep=10, exceptions_dict={})
@@ -83,7 +87,7 @@ def passt_running_vm_pair(
 @pytest.mark.single_nic
 @pytest.mark.polarion("CNV-12427")
 def test_passt_connectivity_is_preserved_during_client_live_migration(
-    admin_client, passt_enabled_in_hco, passt_running_vm_pair
+    admin_client: DynamicClient, passt_running_vm_pair: tuple[BaseVirtualMachine, BaseVirtualMachine]
 ):
     with client_server_active_connection(
         client_vm=passt_running_vm_pair[0],
@@ -98,7 +102,7 @@ def test_passt_connectivity_is_preserved_during_client_live_migration(
 @pytest.mark.single_nic
 @pytest.mark.polarion("CNV-12428")
 def test_passt_connectivity_is_preserved_during_server_live_migration(
-    admin_client, passt_enabled_in_hco, passt_running_vm_pair
+    admin_client: DynamicClient, passt_running_vm_pair: tuple[BaseVirtualMachine, BaseVirtualMachine]
 ):
     with client_server_active_connection(
         client_vm=passt_running_vm_pair[0],

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -82,24 +82,28 @@ def passt_running_vm_pair(
 @pytest.mark.ipv4
 @pytest.mark.single_nic
 @pytest.mark.polarion("CNV-12427")
-def test_passt_connectivity_is_preserved_during_client_live_migration(passt_enabled_in_hco, passt_running_vm_pair):
+def test_passt_connectivity_is_preserved_during_client_live_migration(
+    admin_client, passt_enabled_in_hco, passt_running_vm_pair
+):
     with client_server_active_connection(
         client_vm=passt_running_vm_pair[0],
         server_vm=passt_running_vm_pair[1],
         spec_logical_network=lookup_primary_network(vm=passt_running_vm_pair[1]).name,
     ) as (client, server):
-        migrate_vm_and_verify(vm=client.vm)
+        migrate_vm_and_verify(vm=client.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)
 
 
 @pytest.mark.ipv4
 @pytest.mark.single_nic
 @pytest.mark.polarion("CNV-12428")
-def test_passt_connectivity_is_preserved_during_server_live_migration(passt_enabled_in_hco, passt_running_vm_pair):
+def test_passt_connectivity_is_preserved_during_server_live_migration(
+    admin_client, passt_enabled_in_hco, passt_running_vm_pair
+):
     with client_server_active_connection(
         client_vm=passt_running_vm_pair[0],
         server_vm=passt_running_vm_pair[1],
         spec_logical_network=lookup_primary_network(vm=passt_running_vm_pair[1]).name,
     ) as (client, server):
-        migrate_vm_and_verify(vm=server.vm)
+        migrate_vm_and_verify(vm=server.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 from typing import TYPE_CHECKING
 

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -91,8 +91,8 @@ class TestCCLMSeveralVMs:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-12038")
-    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
-        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+    def test_compute_live_migrate_vms_after_cclm(self, admin_client, local_vms_after_cclm_migration):
+        verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14334")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
@@ -142,8 +142,8 @@ class TestCCLMWindowsWithVTPM:
         depends=[f"{TESTS_CLASS_NAME_WINDOWS_VM}::test_migrate_windows_vm_from_remote_to_local_cluster"]
     )
     @pytest.mark.polarion("CNV-12474")
-    def test_compute_live_migrate_windows_vms_after_cclm(self, local_vms_after_cclm_migration):
-        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+    def test_compute_live_migrate_windows_vms_after_cclm(self, admin_client, local_vms_after_cclm_migration):
+        verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14336")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -233,7 +233,9 @@ class TestCCLMFromStorageAtoB:
         depends=[f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster"]
     )
     @pytest.mark.polarion("CNV-15954")
-    def test_compute_live_migrate_vms_after_cclm(self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]):
+    def test_compute_live_migrate_vms_after_cclm(
+        self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
+    ):
         verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-15959")

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -4,6 +4,8 @@ Cross-cluster live migration tests.
 Jira epic: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -4,6 +4,8 @@ Cross-cluster live migration tests.
 Jira epic: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
 """
 
+from typing import TYPE_CHECKING
+
 import pytest
 from pytest_testconfig import config as py_config
 
@@ -17,6 +19,11 @@ from tests.storage.cross_cluster_live_migration.utils import (
 )
 from tests.storage.utils import check_file_in_vm
 from utilities.constants import TIMEOUT_10MIN, TIMEOUT_50MIN
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 TESTS_CLASS_NAME_SEVERAL_VMS = "TestCCLMSeveralVMs"
 TESTS_CLASS_NAME_WINDOWS_VM = "TestCCLMWindowsWithVTPM"
@@ -91,7 +98,9 @@ class TestCCLMSeveralVMs:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-12038")
-    def test_compute_live_migrate_vms_after_cclm(self, admin_client, local_vms_after_cclm_migration):
+    def test_compute_live_migrate_vms_after_cclm(
+        self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
+    ):
         verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14334")
@@ -142,7 +151,9 @@ class TestCCLMWindowsWithVTPM:
         depends=[f"{TESTS_CLASS_NAME_WINDOWS_VM}::test_migrate_windows_vm_from_remote_to_local_cluster"]
     )
     @pytest.mark.polarion("CNV-12474")
-    def test_compute_live_migrate_windows_vms_after_cclm(self, admin_client, local_vms_after_cclm_migration):
+    def test_compute_live_migrate_windows_vms_after_cclm(
+        self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
+    ):
         verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14336")
@@ -220,8 +231,8 @@ class TestCCLMFromStorageAtoB:
         depends=[f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster"]
     )
     @pytest.mark.polarion("CNV-15954")
-    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
-        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+    def test_compute_live_migrate_vms_after_cclm(self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]):
+        verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-15959")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):

--- a/tests/storage/cross_cluster_live_migration/utils.py
+++ b/tests/storage/cross_cluster_live_migration/utils.py
@@ -74,12 +74,12 @@ def configure_hco_live_migration_network(
     )
 
 
-def verify_compute_live_migration_after_cclm(client, local_vms):
+def verify_compute_live_migration_after_cclm(client: DynamicClient, local_vms: list[VirtualMachineForTests]) -> None:
     """
     Verify compute live migration for VMs after Cross-Cluster Live Migration (CCLM).
 
     Args:
-        client: Client to use for migration.
+        client: DynamicClient used to create migration resources.
         local_vms: List of VirtualMachineForTests objects in the local cluster
 
     Raises:

--- a/tests/storage/cross_cluster_live_migration/utils.py
+++ b/tests/storage/cross_cluster_live_migration/utils.py
@@ -74,11 +74,12 @@ def configure_hco_live_migration_network(
     )
 
 
-def verify_compute_live_migration_after_cclm(local_vms: list[VirtualMachineForTests]) -> None:
+def verify_compute_live_migration_after_cclm(client, local_vms):
     """
     Verify compute live migration for VMs after Cross-Cluster Live Migration (CCLM).
 
     Args:
+        client: Client to use for migration.
         local_vms: List of VirtualMachineForTests objects in the local cluster
 
     Raises:
@@ -87,7 +88,7 @@ def verify_compute_live_migration_after_cclm(local_vms: list[VirtualMachineForTe
     vms_failed_migration = {}
     for vm in local_vms:
         try:
-            migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)
+            migrate_vm_and_verify(vm=vm, client=client, check_ssh_connectivity=True)
         except Exception as migration_exception:
             vms_failed_migration[vm.name] = migration_exception
     assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -163,11 +163,8 @@ def test_disk_expand_then_clone_success(
     indirect=True,
 )
 @pytest.mark.s390x
-def test_disk_expand_then_migrate(rhel_vm_after_expand, orig_cksum):
-    migrate_vm_and_verify(
-        vm=rhel_vm_after_expand,
-        check_ssh_connectivity=True,
-    )
+def test_disk_expand_then_migrate(admin_client, rhel_vm_after_expand, orig_cksum):
+    migrate_vm_and_verify(vm=rhel_vm_after_expand, client=admin_client, check_ssh_connectivity=True)
     check_file_unchanged(orig_cksum=orig_cksum, vm=rhel_vm_after_expand)
 
 

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -2,6 +2,8 @@
 Online resize (PVC expanded while VM running)
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -3,6 +3,7 @@ Online resize (PVC expanded while VM running)
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.datavolume import DataVolume
@@ -19,6 +20,11 @@ from tests.storage.online_resize.utils import (
 from utilities.constants import TIMEOUT_1MIN, TIMEOUT_4MIN, TIMEOUT_5SEC
 from utilities.storage import add_dv_to_vm, create_dv, vm_snapshot
 from utilities.virt import migrate_vm_and_verify, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -163,7 +169,9 @@ def test_disk_expand_then_clone_success(
     indirect=True,
 )
 @pytest.mark.s390x
-def test_disk_expand_then_migrate(admin_client, rhel_vm_after_expand, orig_cksum):
+def test_disk_expand_then_migrate(
+    admin_client: DynamicClient, rhel_vm_after_expand: VirtualMachineForTests, orig_cksum: str
+):
     migrate_vm_and_verify(vm=rhel_vm_after_expand, client=admin_client, check_ssh_connectivity=True)
     check_file_unchanged(orig_cksum=orig_cksum, vm=rhel_vm_after_expand)
 

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -202,9 +202,10 @@ class TestStorageClassMigrationWithVolumeHotplug:
     @pytest.mark.dependency(
         depends=[f"{TESTS_CLASS_NAME_VOLUME_HOTPLUG}::test_vm_storage_class_migration_with_hotplugged_volume"]
     )
+    @pytest.mark.usefixtures("source_storage_class")
     @pytest.mark.polarion("CNV-11966")
     def test_migrate_vm_with_hotplugged_volume_after_storage_migration(
-        self, admin_client, source_storage_class, booted_vms_for_storage_class_migration
+        self, admin_client, booted_vms_for_storage_class_migration
     ):
         vms_failed_migration = {}
         for vm in booted_vms_for_storage_class_migration:
@@ -310,15 +311,17 @@ class TestStorageClassMigrationWindowsWithVTPM:
     @pytest.mark.dependency(
         depends=[f"{TESTS_CLASS_NAME_WINDOWS}::test_vm_storage_class_migration_windows_vm_with_vtpm"]
     )
+    @pytest.mark.usefixtures(
+        "source_storage_class",
+        "target_storage_class",
+        "online_vms_for_storage_class_migration",
+        "dv_wait_timeout",
+    )
     @pytest.mark.polarion("CNV-11515")
     def test_migrate_windows_vm_with_vtpm_after_storage_migration(
         self,
         admin_client,
-        source_storage_class,
-        target_storage_class,
         vms_for_storage_class_migration,
-        online_vms_for_storage_class_migration,
-        dv_wait_timeout,
     ):
         vms_failed_migration = {}
         for vm in vms_for_storage_class_migration:

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -75,11 +75,11 @@ class TestStorageClassMigrationAtoB:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_A_TO_B}::test_vm_storage_class_migration_a_to_b_running_vms"])
     @pytest.mark.polarion("CNV-11504")
-    def test_migrate_vms_after_storage_migration(self, booted_vms_for_storage_class_migration):
+    def test_migrate_vms_after_storage_migration(self, admin_client, booted_vms_for_storage_class_migration):
         vms_failed_migration = {}
         for vm in booted_vms_for_storage_class_migration:
             try:
-                migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)
+                migrate_vm_and_verify(vm=vm, client=admin_client, check_ssh_connectivity=True)
             except Exception as migration_exception:
                 vms_failed_migration[vm.name] = migration_exception
         assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"
@@ -204,12 +204,12 @@ class TestStorageClassMigrationWithVolumeHotplug:
     )
     @pytest.mark.polarion("CNV-11966")
     def test_migrate_vm_with_hotplugged_volume_after_storage_migration(
-        self, source_storage_class, booted_vms_for_storage_class_migration
+        self, admin_client, source_storage_class, booted_vms_for_storage_class_migration
     ):
         vms_failed_migration = {}
         for vm in booted_vms_for_storage_class_migration:
             try:
-                migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)
+                migrate_vm_and_verify(vm=vm, client=admin_client, check_ssh_connectivity=True)
             except Exception as migration_exception:
                 vms_failed_migration[vm.name] = migration_exception
         assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"
@@ -313,6 +313,7 @@ class TestStorageClassMigrationWindowsWithVTPM:
     @pytest.mark.polarion("CNV-11515")
     def test_migrate_windows_vm_with_vtpm_after_storage_migration(
         self,
+        admin_client,
         source_storage_class,
         target_storage_class,
         vms_for_storage_class_migration,
@@ -322,7 +323,7 @@ class TestStorageClassMigrationWindowsWithVTPM:
         vms_failed_migration = {}
         for vm in vms_for_storage_class_migration:
             try:
-                migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)
+                migrate_vm_and_verify(vm=vm, client=admin_client, check_ssh_connectivity=True)
             except Exception as migration_exception:
                 vms_failed_migration[vm.name] = migration_exception
         assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from pytest_testconfig import config as py_config
 
@@ -17,6 +19,11 @@ from tests.storage.storage_migration.utils import (
 from utilities.constants import TIMEOUT_60MIN
 from utilities.storage import verify_file_in_windows_vm
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 TESTS_CLASS_NAME_A_TO_B = "TestStorageClassMigrationAtoB"
 TESTS_CLASS_NAME_B_TO_A = "TestStorageClassMigrationBtoA"
@@ -75,7 +82,9 @@ class TestStorageClassMigrationAtoB:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_A_TO_B}::test_vm_storage_class_migration_a_to_b_running_vms"])
     @pytest.mark.polarion("CNV-11504")
-    def test_migrate_vms_after_storage_migration(self, admin_client, booted_vms_for_storage_class_migration):
+    def test_migrate_vms_after_storage_migration(
+        self, admin_client: DynamicClient, booted_vms_for_storage_class_migration: list[VirtualMachineForTests]
+    ):
         vms_failed_migration = {}
         for vm in booted_vms_for_storage_class_migration:
             try:
@@ -205,7 +214,9 @@ class TestStorageClassMigrationWithVolumeHotplug:
     @pytest.mark.usefixtures("source_storage_class")
     @pytest.mark.polarion("CNV-11966")
     def test_migrate_vm_with_hotplugged_volume_after_storage_migration(
-        self, admin_client, booted_vms_for_storage_class_migration
+        self,
+        admin_client: DynamicClient,
+        booted_vms_for_storage_class_migration: list[VirtualMachineForTests],
     ):
         vms_failed_migration = {}
         for vm in booted_vms_for_storage_class_migration:
@@ -312,16 +323,13 @@ class TestStorageClassMigrationWindowsWithVTPM:
         depends=[f"{TESTS_CLASS_NAME_WINDOWS}::test_vm_storage_class_migration_windows_vm_with_vtpm"]
     )
     @pytest.mark.usefixtures(
-        "source_storage_class",
-        "target_storage_class",
-        "online_vms_for_storage_class_migration",
-        "dv_wait_timeout",
+        "source_storage_class", "target_storage_class", "online_vms_for_storage_class_migration", "dv_wait_timeout"
     )
     @pytest.mark.polarion("CNV-11515")
     def test_migrate_windows_vm_with_vtpm_after_storage_migration(
         self,
-        admin_client,
-        vms_for_storage_class_migration,
+        admin_client: DynamicClient,
+        vms_for_storage_class_migration: list[VirtualMachineForTests],
     ):
         vms_failed_migration = {}
         for vm in vms_for_storage_class_migration:

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -2,6 +2,8 @@
 Automation for Hot Plug
 """
 
+from __future__ import annotations
+
 import logging
 import shlex
 from typing import TYPE_CHECKING

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -202,13 +202,13 @@ class TestHotPlugWithPersist:
 
     @pytest.mark.polarion("CNV-11390")
     @pytest.mark.dependency(depends=["test_hotplug_volume_with_bus_and_persist"])
+    @pytest.mark.usefixtures("expected_bus")
     @pytest.mark.s390x
     def test_hotplug_volume_with_bus_and_persist_migrate(
         self,
         admin_client,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
-        expected_bus,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -205,12 +205,15 @@ class TestHotPlugWithPersist:
     @pytest.mark.s390x
     def test_hotplug_volume_with_bus_and_persist_migrate(
         self,
+        admin_client,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
         expected_bus,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
-            migrate_vm_and_verify(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
+            migrate_vm_and_verify(
+                vm=fedora_vm_for_hotplug_scope_class, client=admin_client, check_ssh_connectivity=True
+            )
 
 
 @pytest.mark.parametrize(
@@ -244,11 +247,14 @@ class TestHotPlugWithSerialPersist:
     @pytest.mark.s390x
     def test_hotplug_volume_with_serial_and_persist_migrate(
         self,
+        admin_client,
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
-            migrate_vm_and_verify(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
+            migrate_vm_and_verify(
+                vm=fedora_vm_for_hotplug_scope_class, client=admin_client, check_ssh_connectivity=True
+            )
 
 
 @pytest.mark.parametrize(
@@ -284,12 +290,13 @@ class TestHotPlugWindows:
     @pytest.mark.dependency(depends=["test_windows_hotplug"])
     def test_windows_hotplug_migrate(
         self,
-        unprivileged_client,
+        admin_client,
         blank_disk_dv_multi_storage_scope_class,
         vm_instance_from_template_multi_storage_scope_class,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(
                 vm=vm_instance_from_template_multi_storage_scope_class,
+                client=admin_client,
                 check_ssh_connectivity=True,
             )

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -4,6 +4,7 @@ Automation for Hot Plug
 
 import logging
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.datavolume import DataVolume
@@ -28,6 +29,9 @@ from utilities.virt import (
     migrate_vm_and_verify,
     running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -206,9 +210,9 @@ class TestHotPlugWithPersist:
     @pytest.mark.s390x
     def test_hotplug_volume_with_bus_and_persist_migrate(
         self,
-        admin_client,
-        blank_disk_dv_multi_storage_scope_class,
-        fedora_vm_for_hotplug_scope_class,
+        admin_client: DynamicClient,
+        blank_disk_dv_multi_storage_scope_class: DataVolume,
+        fedora_vm_for_hotplug_scope_class: VirtualMachineForTests,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(
@@ -247,9 +251,9 @@ class TestHotPlugWithSerialPersist:
     @pytest.mark.s390x
     def test_hotplug_volume_with_serial_and_persist_migrate(
         self,
-        admin_client,
-        blank_disk_dv_multi_storage_scope_class,
-        fedora_vm_for_hotplug_scope_class,
+        admin_client: DynamicClient,
+        blank_disk_dv_multi_storage_scope_class: DataVolume,
+        fedora_vm_for_hotplug_scope_class: VirtualMachineForTests,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(
@@ -290,9 +294,9 @@ class TestHotPlugWindows:
     @pytest.mark.dependency(depends=["test_windows_hotplug"])
     def test_windows_hotplug_migrate(
         self,
-        admin_client,
-        blank_disk_dv_multi_storage_scope_class,
-        vm_instance_from_template_multi_storage_scope_class,
+        admin_client: DynamicClient,
+        blank_disk_dv_multi_storage_scope_class: DataVolume,
+        vm_instance_from_template_multi_storage_scope_class: VirtualMachineForTests,
     ):
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -155,14 +155,13 @@ class TestUpgradeStorage:
         ],
         scope=DEPENDENCY_SCOPE_SESSION,
     )
+    @pytest.mark.usefixtures("hotplug_volume_upg", "fedora_vm_for_hotplug_upg_ssh_connectivity")
     def test_vm_with_hotplug_after_upgrade(
         self,
         admin_client,
         upgrade_namespace_scope_session,
         blank_disk_dv_with_default_sc,
         fedora_vm_for_hotplug_upg,
-        hotplug_volume_upg,
-        fedora_vm_for_hotplug_upg_ssh_connectivity,
     ):
         wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_upg, volume_name=blank_disk_dv_with_default_sc.name)
         assert_disk_serial(vm=fedora_vm_for_hotplug_upg)

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -157,6 +157,7 @@ class TestUpgradeStorage:
     )
     def test_vm_with_hotplug_after_upgrade(
         self,
+        admin_client,
         upgrade_namespace_scope_session,
         blank_disk_dv_with_default_sc,
         fedora_vm_for_hotplug_upg,
@@ -171,4 +172,4 @@ class TestUpgradeStorage:
             expected_bus=HOTPLUG_DISK_VIRTIO_BUS,
         )
         assert_hotplugvolume_nonexist(vm=fedora_vm_for_hotplug_upg)
-        migrate_vm_and_verify(vm=fedora_vm_for_hotplug_upg, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=fedora_vm_for_hotplug_upg, client=admin_client, check_ssh_connectivity=True)

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.virtual_machine_restore import VirtualMachineRestore
@@ -20,6 +21,12 @@ from utilities.storage import (
     wait_for_vm_volume_ready,
 )
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.datavolume import DataVolume
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -158,10 +165,9 @@ class TestUpgradeStorage:
     @pytest.mark.usefixtures("hotplug_volume_upg", "fedora_vm_for_hotplug_upg_ssh_connectivity")
     def test_vm_with_hotplug_after_upgrade(
         self,
-        admin_client,
-        upgrade_namespace_scope_session,
-        blank_disk_dv_with_default_sc,
-        fedora_vm_for_hotplug_upg,
+        admin_client: DynamicClient,
+        blank_disk_dv_with_default_sc: DataVolume,
+        fedora_vm_for_hotplug_upg: VirtualMachineForTests,
     ):
         wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_upg, volume_name=blank_disk_dv_with_default_sc.name)
         assert_disk_serial(vm=fedora_vm_for_hotplug_upg)

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -153,8 +153,8 @@ def updated_arq_quota(request, namespace, application_aware_resource_quota):
 
 
 @pytest.fixture()
-def migrated_arq_vm(vm_for_aaq_test):
-    migrate_vm_and_verify(vm=vm_for_aaq_test)
+def migrated_arq_vm(admin_client, vm_for_aaq_test):
+    migrate_vm_and_verify(vm=vm_for_aaq_test, client=admin_client)
 
 
 # ACRQ - ApplicationAwareClusterResourceQuota, cluster level object containing quotas for multiple resources

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.application_aware_cluster_resource_quota import ApplicationAwareClusterResourceQuota
@@ -40,6 +41,9 @@ from utilities.virt import (
     restart_vm_wait_for_running_vm,
     running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -153,7 +157,7 @@ def updated_arq_quota(request, namespace, application_aware_resource_quota):
 
 
 @pytest.fixture()
-def migrated_arq_vm(admin_client, vm_for_aaq_test):
+def migrated_arq_vm(admin_client: DynamicClient, vm_for_aaq_test: VirtualMachineForTests) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=vm_for_aaq_test, client=admin_client)
     return vm_for_aaq_test
 

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -155,6 +155,7 @@ def updated_arq_quota(request, namespace, application_aware_resource_quota):
 @pytest.fixture()
 def migrated_arq_vm(admin_client, vm_for_aaq_test):
     migrate_vm_and_verify(vm=vm_for_aaq_test, client=admin_client)
+    return vm_for_aaq_test
 
 
 # ACRQ - ApplicationAwareClusterResourceQuota, cluster level object containing quotas for multiple resources

--- a/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
+++ b/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
+++ b/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
@@ -40,8 +40,8 @@ class TestAAQDifferentAllocationMethods:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::test_aaq_allocation_methods"])
     @pytest.mark.polarion("CNV-11387")
-    def test_aaq_vm_migration_with_different_allocation(self, vm_for_aaq_allocation_methods_test):
-        migrate_vm_and_verify(vm=vm_for_aaq_allocation_methods_test)
+    def test_aaq_vm_migration_with_different_allocation(self, admin_client, vm_for_aaq_allocation_methods_test):
+        migrate_vm_and_verify(vm=vm_for_aaq_allocation_methods_test, client=admin_client)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::test_aaq_allocation_methods"])
     @pytest.mark.polarion("CNV-11248")

--- a/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
+++ b/tests/virt/cluster/aaq/test_aaq_allocation_methods.py
@@ -1,9 +1,15 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 
 from tests.virt.cluster.aaq.utils import check_arq_status_values_different_allocations
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestAAQDifferentAllocationMethods"
@@ -40,7 +46,9 @@ class TestAAQDifferentAllocationMethods:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::test_aaq_allocation_methods"])
     @pytest.mark.polarion("CNV-11387")
-    def test_aaq_vm_migration_with_different_allocation(self, admin_client, vm_for_aaq_allocation_methods_test):
+    def test_aaq_vm_migration_with_different_allocation(
+        self, admin_client: DynamicClient, vm_for_aaq_allocation_methods_test: VirtualMachineForTests
+    ):
         migrate_vm_and_verify(vm=vm_for_aaq_allocation_methods_test, client=admin_client)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::test_aaq_allocation_methods"])

--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.pod import Pod
@@ -26,6 +27,11 @@ from utilities.constants import (
     REQUESTS_MEMORY_VMI_STR,
 )
 from utilities.virt import migrate_vm_and_verify, wait_for_running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -113,7 +119,9 @@ class TestARQCanManageVMs:
 
     @pytest.mark.dependency(depends=[f"{TESTS_VM_CLASS_NAME}::vm_gated"])
     @pytest.mark.polarion("CNV-11282")
-    def test_arq_vm_migration_allowed_when_quota_reached(self, admin_client, vm_for_aaq_test):
+    def test_arq_vm_migration_allowed_when_quota_reached(
+        self, admin_client: DynamicClient, vm_for_aaq_test: VirtualMachineForTests
+    ):
         migrate_vm_and_verify(vm=vm_for_aaq_test, client=admin_client)
 
     @pytest.mark.parametrize(

--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -113,8 +113,8 @@ class TestARQCanManageVMs:
 
     @pytest.mark.dependency(depends=[f"{TESTS_VM_CLASS_NAME}::vm_gated"])
     @pytest.mark.polarion("CNV-11282")
-    def test_arq_vm_migration_allowed_when_quota_reached(self, vm_for_aaq_test):
-        migrate_vm_and_verify(vm=vm_for_aaq_test)
+    def test_arq_vm_migration_allowed_when_quota_reached(self, admin_client, vm_for_aaq_test):
+        migrate_vm_and_verify(vm=vm_for_aaq_test, client=admin_client)
 
     @pytest.mark.parametrize(
         "updated_arq_quota",

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -130,7 +130,7 @@ class TestCommonTemplatesCentos:
     )
     def test_migrate_vm(self, admin_client, matrix_centos_os_vm_from_template):
         """Test SSH connectivity after migration"""
-        migrate_vm_and_verify(vm=matrix_centos_os_vm_from_template, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=matrix_centos_os_vm_from_template, client=admin_client, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=matrix_centos_os_vm_from_template, admin_client=admin_client)
 
     @pytest.mark.polarion("CNV-5904")

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -3,6 +3,7 @@ Common templates test CentOS support
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -26,6 +27,11 @@ from utilities.virt import (
     validate_virtctl_guest_agent_data_over_time,
     wait_for_console,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = pytest.mark.data_collector_scope(scope="module")
 
@@ -128,7 +134,7 @@ class TestCommonTemplatesCentos:
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify", depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"]
     )
-    def test_migrate_vm(self, admin_client, matrix_centos_os_vm_from_template):
+    def test_migrate_vm(self, admin_client: DynamicClient, matrix_centos_os_vm_from_template: VirtualMachineForTests):
         """Test SSH connectivity after migration"""
         migrate_vm_and_verify(vm=matrix_centos_os_vm_from_template, client=admin_client, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=matrix_centos_os_vm_from_template, admin_client=admin_client)

--- a/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
+++ b/tests/virt/cluster/common_templates/centos/test_centos_os_support.py
@@ -2,6 +2,8 @@
 Common templates test CentOS support
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -3,6 +3,7 @@ Common templates test Fedora OS support
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -28,6 +29,11 @@ from utilities.virt import (
     validate_virtctl_guest_agent_data_over_time,
     wait_for_console,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = pytest.mark.data_collector_scope(scope="module")
 
@@ -204,7 +210,7 @@ class TestCommonTemplatesFedora:
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify", depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"]
     )
-    def test_migrate_vm(self, admin_client, matrix_fedora_os_vm_from_template):
+    def test_migrate_vm(self, admin_client: DynamicClient, matrix_fedora_os_vm_from_template: VirtualMachineForTests):
         """Test SSH connectivity after migration"""
         migrate_vm_and_verify(vm=matrix_fedora_os_vm_from_template, client=admin_client, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=matrix_fedora_os_vm_from_template, admin_client=admin_client)

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -2,6 +2,8 @@
 Common templates test Fedora OS support
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
+++ b/tests/virt/cluster/common_templates/fedora/test_fedora_os_support.py
@@ -206,7 +206,7 @@ class TestCommonTemplatesFedora:
     )
     def test_migrate_vm(self, admin_client, matrix_fedora_os_vm_from_template):
         """Test SSH connectivity after migration"""
-        migrate_vm_and_verify(vm=matrix_fedora_os_vm_from_template, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=matrix_fedora_os_vm_from_template, client=admin_client, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=matrix_fedora_os_vm_from_template, admin_client=admin_client)
 
     @pytest.mark.polarion("CNV-5901")

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -3,6 +3,7 @@ Common templates test RHEL OS support
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -29,6 +30,11 @@ from utilities.virt import (
     validate_virtctl_guest_agent_data_over_time,
     wait_for_console,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = [
     pytest.mark.post_upgrade,
@@ -186,7 +192,7 @@ class TestCommonTemplatesRhel:
     @pytest.mark.dependency(
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify", depends=[f"{TESTS_CLASS_NAME}::vm_expose_ssh"]
     )
-    def test_migrate_vm(self, admin_client, matrix_rhel_os_vm_from_template):
+    def test_migrate_vm(self, admin_client: DynamicClient, matrix_rhel_os_vm_from_template: VirtualMachineForTests):
         """Test SSH connectivity after migration"""
         vm = matrix_rhel_os_vm_from_template
         migrate_vm_and_verify(vm=vm, client=admin_client, check_ssh_connectivity=True)

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -2,6 +2,8 @@
 Common templates test RHEL OS support
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_os_support.py
@@ -189,7 +189,7 @@ class TestCommonTemplatesRhel:
     def test_migrate_vm(self, admin_client, matrix_rhel_os_vm_from_template):
         """Test SSH connectivity after migration"""
         vm = matrix_rhel_os_vm_from_template
-        migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=vm, client=admin_client, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=vm, admin_client=admin_client)
 
     @pytest.mark.arm64

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -7,6 +7,7 @@ https://libvirt.org/formatdomain.html#elementsInput
 import logging
 import re
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
@@ -17,6 +18,9 @@ from tests.os_params import FEDORA_LATEST, RHEL_LATEST, RHEL_LATEST_LABELS
 from tests.virt.cluster.common_templates.utils import check_vm_xml_tablet_device, set_vm_tablet_device_dict
 from utilities.constants import VIRTIO
 from utilities.virt import VirtualMachineForTestsFromTemplate, migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -114,7 +118,9 @@ class TestRHELTabletDevice:
         ],
         indirect=True,
     )
-    def test_tablet_device_migrate_vm(self, admin_client, tablet_device_vm):
+    def test_tablet_device_migrate_vm(
+        self, admin_client: DynamicClient, tablet_device_vm: VirtualMachineForTestsFromTemplate
+    ):
         migrate_vm_and_verify(vm=tablet_device_vm, client=admin_client, check_ssh_connectivity=True)
 
 

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -114,8 +114,8 @@ class TestRHELTabletDevice:
         ],
         indirect=True,
     )
-    def test_tablet_device_migrate_vm(self, tablet_device_vm):
-        migrate_vm_and_verify(vm=tablet_device_vm, check_ssh_connectivity=True)
+    def test_tablet_device_migrate_vm(self, admin_client, tablet_device_vm):
+        migrate_vm_and_verify(vm=tablet_device_vm, client=admin_client, check_ssh_connectivity=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
+++ b/tests/virt/cluster/common_templates/rhel/test_rhel_tablet_device.py
@@ -4,6 +4,8 @@ https://github.com/kubevirt/kubevirt/pull/1987
 https://libvirt.org/formatdomain.html#elementsInput
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import shlex

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -2,6 +2,8 @@
 Common templates test Windows OS support
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -3,6 +3,7 @@ Common templates test Windows OS support
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -24,6 +25,11 @@ from utilities.virt import (
     validate_virtctl_guest_agent_after_guest_reboot,
     validate_virtctl_guest_agent_data_over_time,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = [
     pytest.mark.post_upgrade,
@@ -130,7 +136,7 @@ class TestCommonTemplatesWindows:
         name=f"{TESTS_CLASS_NAME}::migrate_vm_and_verify", depends=[f"{TESTS_CLASS_NAME}::start_vm"]
     )
     @pytest.mark.polarion("CNV-3335")
-    def test_migrate_vm(self, admin_client, matrix_windows_os_vm_from_template):
+    def test_migrate_vm(self, admin_client: DynamicClient, matrix_windows_os_vm_from_template: VirtualMachineForTests):
         """Test SSH connectivity after migration"""
         migrate_vm_and_verify(vm=matrix_windows_os_vm_from_template, client=admin_client, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=matrix_windows_os_vm_from_template, admin_client=admin_client)

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -132,7 +132,7 @@ class TestCommonTemplatesWindows:
     @pytest.mark.polarion("CNV-3335")
     def test_migrate_vm(self, admin_client, matrix_windows_os_vm_from_template):
         """Test SSH connectivity after migration"""
-        migrate_vm_and_verify(vm=matrix_windows_os_vm_from_template, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=matrix_windows_os_vm_from_template, client=admin_client, check_ssh_connectivity=True)
         validate_libvirt_persistent_domain(vm=matrix_windows_os_vm_from_template, admin_client=admin_client)
 
     @pytest.mark.polarion("CNV-5903")

--- a/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
+++ b/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
+++ b/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
@@ -28,8 +28,9 @@ pytestmark = [pytest.mark.longevity, pytest.mark.special_infra]
     ],
     indirect=True,
 )
-def test_migration_storm_linux_vms(linux_vms_with_pids):
+def test_migration_storm_linux_vms(admin_client, linux_vms_with_pids):
     run_migration_loop(
+        client=admin_client,
         iterations=int(py_config["linux_iterations"]),
         vms_with_pids=linux_vms_with_pids,
         os_type=LINUX_OS_PREFIX,
@@ -47,8 +48,9 @@ def test_migration_storm_linux_vms(linux_vms_with_pids):
     ],
     indirect=True,
 )
-def test_migration_storm_windows_vms(windows_vms_with_pids):
+def test_migration_storm_windows_vms(admin_client, windows_vms_with_pids):
     run_migration_loop(
+        client=admin_client,
         iterations=int(py_config["windows_iterations"]),
         vms_with_pids=windows_vms_with_pids,
         os_type=WINDOWS_OS_PREFIX,
@@ -66,8 +68,9 @@ def test_migration_storm_windows_vms(windows_vms_with_pids):
     ],
     indirect=True,
 )
-def test_migration_storm_wsl2_vms(wsl2_vms_with_pids):
+def test_migration_storm_wsl2_vms(admin_client, wsl2_vms_with_pids):
     run_migration_loop(
+        client=admin_client,
         iterations=int(py_config["windows_iterations"]),
         vms_with_pids=wsl2_vms_with_pids,
         os_type=WINDOWS_OS_PREFIX,

--- a/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
+++ b/tests/virt/cluster/longevity_tests/test_multi_vm_multi_migration.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from pytest_testconfig import config as py_config
 
@@ -12,6 +14,11 @@ from tests.virt.cluster.longevity_tests.constants import (
     WSL2_VM_PARAMS,
 )
 from tests.virt.cluster.longevity_tests.utils import run_migration_loop
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = [pytest.mark.longevity, pytest.mark.special_infra]
 
@@ -28,7 +35,9 @@ pytestmark = [pytest.mark.longevity, pytest.mark.special_infra]
     ],
     indirect=True,
 )
-def test_migration_storm_linux_vms(admin_client, linux_vms_with_pids):
+def test_migration_storm_linux_vms(
+    admin_client: DynamicClient, linux_vms_with_pids: dict[str, dict[str, VirtualMachineForTests]]
+):
     run_migration_loop(
         client=admin_client,
         iterations=int(py_config["linux_iterations"]),
@@ -48,7 +57,9 @@ def test_migration_storm_linux_vms(admin_client, linux_vms_with_pids):
     ],
     indirect=True,
 )
-def test_migration_storm_windows_vms(admin_client, windows_vms_with_pids):
+def test_migration_storm_windows_vms(
+    admin_client: DynamicClient, windows_vms_with_pids: dict[str, dict[str, VirtualMachineForTests]]
+):
     run_migration_loop(
         client=admin_client,
         iterations=int(py_config["windows_iterations"]),
@@ -68,7 +79,9 @@ def test_migration_storm_windows_vms(admin_client, windows_vms_with_pids):
     ],
     indirect=True,
 )
-def test_migration_storm_wsl2_vms(admin_client, wsl2_vms_with_pids):
+def test_migration_storm_wsl2_vms(
+    admin_client: DynamicClient, wsl2_vms_with_pids: dict[str, dict[str, VirtualMachineForTests]]
+):
     run_migration_loop(
         client=admin_client,
         iterations=int(py_config["windows_iterations"]),

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import shlex
 import shutil

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -2,6 +2,7 @@ import logging
 import shlex
 import shutil
 from threading import Thread
+from typing import TYPE_CHECKING
 
 from ocp_resources import pod
 from ocp_resources.data_source import DataSource
@@ -31,6 +32,9 @@ from utilities.virt import (
     wait_for_ssh_connectivity,
 )
 
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
 LOGGER = logging.getLogger(__name__)
 ADMIN_DOWNLOADS_FOLDER_PATH = r"C:\Users\Administrator\Downloads"
 
@@ -41,7 +45,13 @@ def decorate_log(msg):
     return f"{msg_decor}{msg}{msg_decor}"
 
 
-def run_migration_loop(client, iterations, vms_with_pids, os_type, wsl2_guest=False):
+def run_migration_loop(
+    client: DynamicClient,
+    iterations: int,
+    vms_with_pids: dict[str, dict[str, VirtualMachineForTests]],
+    os_type: str,
+    wsl2_guest: bool = False,
+) -> None:
     for iteration in range(iterations):
         LOGGER.info(decorate_log(f"Iteration {iteration + 1}"))
 

--- a/tests/virt/cluster/longevity_tests/utils.py
+++ b/tests/virt/cluster/longevity_tests/utils.py
@@ -41,13 +41,13 @@ def decorate_log(msg):
     return f"{msg_decor}{msg}{msg_decor}"
 
 
-def run_migration_loop(iterations, vms_with_pids, os_type, wsl2_guest=False):
+def run_migration_loop(client, iterations, vms_with_pids, os_type, wsl2_guest=False):
     for iteration in range(iterations):
         LOGGER.info(decorate_log(f"Iteration {iteration + 1}"))
 
         LOGGER.info(decorate_log("VM Migration"))
         vm_list = [vms_with_pids[vm_name]["vm"] for vm_name in vms_with_pids]
-        migrate_and_verify_multi_vms(vm_list=vm_list)
+        migrate_and_verify_multi_vms(client=client, vm_list=vm_list)
 
         LOGGER.info(decorate_log("PID check"))
         verify_pid_after_migrate_multi_vms(vms_with_pids=vms_with_pids, os_type=os_type)

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -100,6 +100,7 @@ def vm_for_migration_policy_test(
 @pytest.fixture()
 def vm_migrated_with_policy(admin_client, vm_for_migration_policy_test):
     migrate_vm_and_verify(vm=vm_for_migration_policy_test, client=admin_client)
+    return vm_for_migration_policy_test
 
 
 @pytest.fixture()
@@ -110,6 +111,7 @@ def vm_re_migrated_after_updating_migration_policy(admin_client, vm_for_migratio
     )
     remove_spec_param_from_migration_policy(migration_policy=migration_policy_a, param="allowAutoConverge")
     migrate_vm_and_verify(vm=vm_for_migration_policy_test, client=admin_client)
+    return vm_for_migration_policy_test
 
 
 @pytest.mark.rwx_default_storage

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from ocp_resources.migration_policy import MigrationPolicy
 from ocp_resources.resource import ResourceEditor
@@ -10,6 +12,9 @@ from utilities.virt import (
     migrate_vm_and_verify,
     running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 pytestmark = pytest.mark.data_collector_scope(scope="module")
 
@@ -98,13 +103,19 @@ def vm_for_migration_policy_test(
 
 
 @pytest.fixture()
-def vm_migrated_with_policy(admin_client, vm_for_migration_policy_test):
+def vm_migrated_with_policy(
+    admin_client: DynamicClient, vm_for_migration_policy_test: VirtualMachineForTests
+) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=vm_for_migration_policy_test, client=admin_client)
     return vm_for_migration_policy_test
 
 
 @pytest.fixture()
-def vm_re_migrated_after_updating_migration_policy(admin_client, vm_for_migration_policy_test, migration_policy_a):
+def vm_re_migrated_after_updating_migration_policy(
+    admin_client: DynamicClient,
+    vm_for_migration_policy_test: VirtualMachineForTests,
+    migration_policy_a: MigrationPolicy,
+) -> VirtualMachineForTests:
     assert_applied_migration_configuration(
         vmi=vm_for_migration_policy_test.vmi,
         migration_policy=migration_policy_a,

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -98,18 +98,18 @@ def vm_for_migration_policy_test(
 
 
 @pytest.fixture()
-def vm_migrated_with_policy(vm_for_migration_policy_test):
-    migrate_vm_and_verify(vm=vm_for_migration_policy_test)
+def vm_migrated_with_policy(admin_client, vm_for_migration_policy_test):
+    migrate_vm_and_verify(vm=vm_for_migration_policy_test, client=admin_client)
 
 
 @pytest.fixture()
-def vm_re_migrated_after_updating_migration_policy(vm_for_migration_policy_test, migration_policy_a):
+def vm_re_migrated_after_updating_migration_policy(admin_client, vm_for_migration_policy_test, migration_policy_a):
     assert_applied_migration_configuration(
         vmi=vm_for_migration_policy_test.vmi,
         migration_policy=migration_policy_a,
     )
     remove_spec_param_from_migration_policy(migration_policy=migration_policy_a, param="allowAutoConverge")
-    migrate_vm_and_verify(vm=vm_for_migration_policy_test)
+    migrate_vm_and_verify(vm=vm_for_migration_policy_test, client=admin_client)
 
 
 @pytest.mark.rwx_default_storage

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import logging
 import os

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -200,8 +200,8 @@ def attached_sysprep_volume_to_vm(sysprep_vm_credentials_from_bitwarden, sysprep
 
 
 @pytest.fixture()
-def migrated_sysprep_vm(sysprep_vm):
-    migrate_vm_and_verify(vm=sysprep_vm, check_ssh_connectivity=True)
+def migrated_sysprep_vm(admin_client, sysprep_vm):
+    migrate_vm_and_verify(vm=sysprep_vm, client=admin_client, check_ssh_connectivity=True)
 
 
 @pytest.fixture()

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import os
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.config_map import ConfigMap
@@ -19,6 +20,9 @@ from utilities.constants import BASE_IMAGES_DIR, OS_FLAVOR_WINDOWS, TCP_TIMEOUT_
 from utilities.ssp import get_windows_timezone
 from utilities.storage import get_downloaded_artifact
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -200,7 +204,7 @@ def attached_sysprep_volume_to_vm(sysprep_vm_credentials_from_bitwarden, sysprep
 
 
 @pytest.fixture()
-def migrated_sysprep_vm(admin_client, sysprep_vm):
+def migrated_sysprep_vm(admin_client: DynamicClient, sysprep_vm: VirtualMachineForTests) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=sysprep_vm, client=admin_client, check_ssh_connectivity=True)
     return sysprep_vm
 

--- a/tests/virt/cluster/sysprep/test_sysprep.py
+++ b/tests/virt/cluster/sysprep/test_sysprep.py
@@ -202,6 +202,7 @@ def attached_sysprep_volume_to_vm(sysprep_vm_credentials_from_bitwarden, sysprep
 @pytest.fixture()
 def migrated_sysprep_vm(admin_client, sysprep_vm):
     migrate_vm_and_verify(vm=sysprep_vm, client=admin_client, check_ssh_connectivity=True)
+    return sysprep_vm
 
 
 @pytest.fixture()

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -1,4 +1,5 @@
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.datavolume import DataVolume
@@ -27,6 +28,9 @@ from utilities.virt import (
     running_vm,
     target_vm_from_cloning_job,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 LABEL_TO_COPY_STR = "label-to-copy"
 LABEL_TO_EXCLUDE_STR = "label-to-exclude"
@@ -295,7 +299,7 @@ class TestVMCloneAndMigrate:
         )
 
     @pytest.mark.polarion("CNV-10320")
-    def test_migrate_the_vm_clone(self, admin_client, fedora_target_vm):
+    def test_migrate_the_vm_clone(self, admin_client: DynamicClient, fedora_target_vm: VirtualMachineForCloning):
         migrate_vm_and_verify(vm=fedora_target_vm, client=admin_client)
 
     @pytest.mark.parametrize(

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -295,8 +295,8 @@ class TestVMCloneAndMigrate:
         )
 
     @pytest.mark.polarion("CNV-10320")
-    def test_migrate_the_vm_clone(self, fedora_target_vm):
-        migrate_vm_and_verify(vm=fedora_target_vm)
+    def test_migrate_the_vm_clone(self, admin_client, fedora_target_vm):
+        migrate_vm_and_verify(vm=fedora_target_vm, client=admin_client)
 
     @pytest.mark.parametrize(
         "cloning_job_scope_function",

--- a/tests/virt/cluster/vm_cloning/test_vm_cloning.py
+++ b/tests/virt/cluster/vm_cloning/test_vm_cloning.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 from typing import TYPE_CHECKING
 

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -182,10 +182,10 @@ def pause_unpause_vmi_and_verify_status(vm):
     verify_vm_ready_status(vm=vm)
 
 
-def migrate_validate_run_strategy_vm(vm, run_strategy):
+def migrate_validate_run_strategy_vm(vm, client, run_strategy):
     LOGGER.info(f"The VM migration with runStrategy {run_strategy}")
     verify_vm_ready_status(vm=vm)
-    migrate_vm_and_verify(vm=vm)
+    migrate_vm_and_verify(vm=vm, client=client)
     verify_vm_ready_status(vm=vm)
     verify_vm_run_strategy(vm=vm, run_strategy=run_strategy)
 
@@ -304,5 +304,7 @@ class TestRunStrategyAdvancedActions:
     )
     @pytest.mark.rwx_default_storage
     @pytest.mark.usefixtures("start_vm_if_not_running")
-    def test_run_strategy_migrate_vm(self, lifecycle_vm, request_updated_vm_run_strategy):
-        migrate_validate_run_strategy_vm(vm=lifecycle_vm, run_strategy=request_updated_vm_run_strategy)
+    def test_run_strategy_migrate_vm(self, admin_client, lifecycle_vm, request_updated_vm_run_strategy):
+        migrate_validate_run_strategy_vm(
+            vm=lifecycle_vm, client=admin_client, run_strategy=request_updated_vm_run_strategy
+        )

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -3,6 +3,7 @@
 
 import logging
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 from kubernetes.client.rest import ApiException
@@ -16,6 +17,11 @@ from timeout_sampler import TimeoutSampler
 from tests.os_params import RHEL_LATEST
 from utilities.constants import TIMEOUT_10MIN
 from utilities.virt import migrate_vm_and_verify, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = pytest.mark.post_upgrade
 
@@ -182,7 +188,7 @@ def pause_unpause_vmi_and_verify_status(vm):
     verify_vm_ready_status(vm=vm)
 
 
-def migrate_validate_run_strategy_vm(vm, client, run_strategy):
+def migrate_validate_run_strategy_vm(vm: VirtualMachineForTests, client: DynamicClient, run_strategy: str) -> None:
     LOGGER.info(f"The VM migration with runStrategy {run_strategy}")
     verify_vm_ready_status(vm=vm)
     migrate_vm_and_verify(vm=vm, client=client)
@@ -304,7 +310,12 @@ class TestRunStrategyAdvancedActions:
     )
     @pytest.mark.rwx_default_storage
     @pytest.mark.usefixtures("start_vm_if_not_running")
-    def test_run_strategy_migrate_vm(self, admin_client, lifecycle_vm, request_updated_vm_run_strategy):
+    def test_run_strategy_migrate_vm(
+        self,
+        admin_client: DynamicClient,
+        lifecycle_vm: VirtualMachineForTests,
+        request_updated_vm_run_strategy: str,
+    ):
         migrate_validate_run_strategy_vm(
             vm=lifecycle_vm, client=admin_client, run_strategy=request_updated_vm_run_strategy
         )

--- a/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
+++ b/tests/virt/cluster/vm_lifecycle/test_vm_run_strategy.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 # Run strategies logic can be found under
 # https://kubevirt.io/user-guide/#/creation/run-strategies?id=run-strategies
-
 import logging
 import re
 from typing import TYPE_CHECKING

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -124,7 +124,7 @@ def migrated_vm(admin_client, vm_for_machine_type_test, machine_type_from_kubevi
     validate_machine_type(
         vm=vm_for_machine_type_test, expected_machine_type=machine_type_from_kubevirt_config, admin_client=admin_client
     )
-    migrate_vm_and_verify(vm=vm_for_machine_type_test)
+    migrate_vm_and_verify(vm=vm_for_machine_type_test, client=admin_client)
 
 
 @pytest.mark.polarion("CNV-3311")

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -125,6 +125,7 @@ def migrated_vm(admin_client, vm_for_machine_type_test, machine_type_from_kubevi
         vm=vm_for_machine_type_test, expected_machine_type=machine_type_from_kubevirt_config, admin_client=admin_client
     )
     migrate_vm_and_verify(vm=vm_for_machine_type_test, client=admin_client)
+    return vm_for_machine_type_test
 
 
 @pytest.mark.polarion("CNV-3311")

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
@@ -22,6 +23,9 @@ from utilities.virt import (
     running_vm,
     wait_for_updated_kv_value,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.data_collector_scope(scope="module")]
 LOGGER = logging.getLogger(__name__)
@@ -120,7 +124,11 @@ def restarted_vm(admin_client, vm_for_machine_type_test, machine_type_from_kubev
 
 
 @pytest.fixture()
-def migrated_vm(admin_client, vm_for_machine_type_test, machine_type_from_kubevirt_config):
+def migrated_vm(
+    admin_client: DynamicClient,
+    vm_for_machine_type_test: VirtualMachineForTests,
+    machine_type_from_kubevirt_config: str,
+) -> VirtualMachineForTests:
     validate_machine_type(
         vm=vm_for_machine_type_test, expected_machine_type=machine_type_from_kubevirt_config, admin_client=admin_client
     )

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -121,8 +121,8 @@ def bitlocker_encrypted_vm(windows_vtpm_vm):
 
 
 @pytest.fixture(scope="class")
-def migrated_encrypted_vm(bitlocker_encrypted_vm):
-    migrate_vm_and_verify(vm=bitlocker_encrypted_vm, check_ssh_connectivity=True)
+def migrated_encrypted_vm(admin_client, bitlocker_encrypted_vm):
+    migrate_vm_and_verify(vm=bitlocker_encrypted_vm, client=admin_client, check_ssh_connectivity=True)
     return bitlocker_encrypted_vm
 
 

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import shlex
 from typing import TYPE_CHECKING

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -1,5 +1,6 @@
 import logging
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.template import Template
@@ -17,6 +18,9 @@ from utilities.virt import (
     restart_vm_wait_for_running_vm,
     running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 pytestmark = [pytest.mark.tier3, pytest.mark.ibm_bare_metal, pytest.mark.special_infra, pytest.mark.high_resource_vm]
 
@@ -121,7 +125,9 @@ def bitlocker_encrypted_vm(windows_vtpm_vm):
 
 
 @pytest.fixture(scope="class")
-def migrated_encrypted_vm(admin_client, bitlocker_encrypted_vm):
+def migrated_encrypted_vm(
+    admin_client: DynamicClient, bitlocker_encrypted_vm: VirtualMachineForTestsFromTemplate
+) -> VirtualMachineForTestsFromTemplate:
     migrate_vm_and_verify(vm=bitlocker_encrypted_vm, client=admin_client, check_ssh_connectivity=True)
     return bitlocker_encrypted_vm
 

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -113,8 +113,8 @@ def windows_wsl2_vm(
 
 
 @pytest.fixture()
-def migrated_wsl2_vm(windows_wsl2_vm):
-    migrate_vm_and_verify(vm=windows_wsl2_vm, check_ssh_connectivity=True)
+def migrated_wsl2_vm(admin_client, windows_wsl2_vm):
+    migrate_vm_and_verify(vm=windows_wsl2_vm, client=admin_client, check_ssh_connectivity=True)
     return windows_wsl2_vm
 
 

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -3,6 +3,8 @@ WSL2 test
 Note: The windows image runs the WSL guest (Fedora-33) at boot.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import shlex

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -6,6 +6,7 @@ Note: The windows image runs the WSL guest (Fedora-33) at boot.
 import logging
 import re
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
@@ -21,6 +22,9 @@ from utilities.virt import (
     migrate_vm_and_verify,
     running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 pytestmark = [pytest.mark.special_infra, pytest.mark.high_resource_vm]
 
@@ -113,7 +117,7 @@ def windows_wsl2_vm(
 
 
 @pytest.fixture()
-def migrated_wsl2_vm(admin_client, windows_wsl2_vm):
+def migrated_wsl2_vm(admin_client: DynamicClient, windows_wsl2_vm: VirtualMachineForTests) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=windows_wsl2_vm, client=admin_client, check_ssh_connectivity=True)
     return windows_wsl2_vm
 

--- a/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
+++ b/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
@@ -81,5 +81,5 @@ class TestIsolateEmulatorThread:
     @pytest.mark.rwx_default_storage
     @pytest.mark.dependency(depends=[ISOLATE_EMULATOR_THREAD])
     @pytest.mark.polarion("CNV-10554")
-    def test_vm_with_isolate_emulator_thread_live_migrates(self, isolated_emulatorthread_vm):
-        migrate_vm_and_verify(vm=isolated_emulatorthread_vm)
+    def test_vm_with_isolate_emulator_thread_live_migrates(self, admin_client, isolated_emulatorthread_vm):
+        migrate_vm_and_verify(vm=isolated_emulatorthread_vm, client=admin_client)

--- a/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
+++ b/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
@@ -3,6 +3,7 @@ Test isolateEmulatorThread feature.
 """
 
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.template import Template
@@ -12,6 +13,11 @@ from tests.utils import (
     validate_dedicated_emulatorthread,
 )
 from utilities.virt import migrate_vm_and_verify, vm_instance_from_template
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -81,5 +87,7 @@ class TestIsolateEmulatorThread:
     @pytest.mark.rwx_default_storage
     @pytest.mark.dependency(depends=[ISOLATE_EMULATOR_THREAD])
     @pytest.mark.polarion("CNV-10554")
-    def test_vm_with_isolate_emulator_thread_live_migrates(self, admin_client, isolated_emulatorthread_vm):
+    def test_vm_with_isolate_emulator_thread_live_migrates(
+        self, admin_client: DynamicClient, isolated_emulatorthread_vm: VirtualMachineForTests
+    ):
         migrate_vm_and_verify(vm=isolated_emulatorthread_vm, client=admin_client)

--- a/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
+++ b/tests/virt/node/high_performance_vm/test_isolate_emulator_thread.py
@@ -2,6 +2,8 @@
 Test isolateEmulatorThread feature.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from kubernetes.dynamic.exceptions import UnprocessibleEntityError
@@ -24,6 +25,11 @@ from utilities.virt import (
     migrate_vm_and_verify,
     restart_vm_wait_for_running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = [pytest.mark.rwx_default_storage, pytest.mark.data_collector_scope(scope="module")]
 
@@ -79,7 +85,7 @@ class TestCPUHotPlug:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu"])
     @pytest.mark.polarion("CNV-10696")
     @pytest.mark.usefixtures("hotplug_vm_snapshot")
-    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplugged_vm):
+    def test_migrate_snapshot_hotplugged_vm(self, admin_client: DynamicClient, hotplugged_vm: VirtualMachineForTests):
         migrate_vm_and_verify(vm=hotplugged_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu"])
@@ -136,7 +142,7 @@ class TestMemoryHotPlug:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_memory"])
     @pytest.mark.polarion("CNV-10677")
     @pytest.mark.usefixtures("hotplug_vm_snapshot")
-    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplugged_vm):
+    def test_migrate_snapshot_hotplugged_vm(self, admin_client: DynamicClient, hotplugged_vm: VirtualMachineForTests):
         migrate_vm_and_verify(vm=hotplugged_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.parametrize(

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -78,7 +78,8 @@ class TestCPUHotPlug:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu"])
     @pytest.mark.polarion("CNV-10696")
-    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplug_vm_snapshot, hotplugged_vm):
+    @pytest.mark.usefixtures("hotplug_vm_snapshot")
+    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplugged_vm):
         migrate_vm_and_verify(vm=hotplugged_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu"])
@@ -134,7 +135,8 @@ class TestMemoryHotPlug:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_memory"])
     @pytest.mark.polarion("CNV-10677")
-    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplug_vm_snapshot, hotplugged_vm):
+    @pytest.mark.usefixtures("hotplug_vm_snapshot")
+    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplugged_vm):
         migrate_vm_and_verify(vm=hotplugged_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.parametrize(

--- a/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
+++ b/tests/virt/node/hotplug/test_cpu_memory_hotplug.py
@@ -78,8 +78,8 @@ class TestCPUHotPlug:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu"])
     @pytest.mark.polarion("CNV-10696")
-    def test_migrate_snapshot_hotplugged_vm(self, hotplug_vm_snapshot, hotplugged_vm):
-        migrate_vm_and_verify(vm=hotplugged_vm, check_ssh_connectivity=True)
+    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplug_vm_snapshot, hotplugged_vm):
+        migrate_vm_and_verify(vm=hotplugged_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_cpu"])
     @pytest.mark.polarion("CNV-10697")
@@ -134,8 +134,8 @@ class TestMemoryHotPlug:
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::hotplug_memory"])
     @pytest.mark.polarion("CNV-10677")
-    def test_migrate_snapshot_hotplugged_vm(self, hotplug_vm_snapshot, hotplugged_vm):
-        migrate_vm_and_verify(vm=hotplugged_vm, check_ssh_connectivity=True)
+    def test_migrate_snapshot_hotplugged_vm(self, admin_client, hotplug_vm_snapshot, hotplugged_vm):
+        migrate_vm_and_verify(vm=hotplugged_vm, client=admin_client, check_ssh_connectivity=True)
 
     @pytest.mark.parametrize(
         "hotplugged_sockets_memory_guest", [pytest.param({"memory_guest": FIVE_GI_MEMORY})], indirect=True

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -112,11 +112,10 @@ class TestProgressOfMigrationInVirtLauncher:
 
     @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-9058")
-    def test_progress_of_vm_migration_in_virt_launcher_pod(
-        self,
-        updated_log_verbosity_config,
-        vm_for_migration_progress_test,
-        source_pod_log_verbosity_test,
-        migrated_vm_with_policy,
-    ):
+    @pytest.mark.usefixtures(
+        "migrated_vm_with_policy",
+        "updated_log_verbosity_config",
+        "vm_for_migration_progress_test",
+    )
+    def test_progress_of_vm_migration_in_virt_launcher_pod(self, source_pod_log_verbosity_test):
         wait_for_all_progress_keys_in_pod_log(pod=source_pod_log_verbosity_test)

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -87,8 +87,8 @@ def source_pod_log_verbosity_test(admin_client, vm_for_migration_progress_test):
 
 
 @pytest.fixture()
-def migrated_vm_with_policy(migration_policy_with_bandwidth, vm_for_migration_progress_test):
-    migrate_vm_and_verify(vm=vm_for_migration_progress_test, wait_for_migration_success=False)
+def migrated_vm_with_policy(admin_client, migration_policy_with_bandwidth, vm_for_migration_progress_test):
+    migrate_vm_and_verify(vm=vm_for_migration_progress_test, client=admin_client, wait_for_migration_success=False)
 
 
 @pytest.mark.parametrize(

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -13,6 +15,11 @@ from utilities.virt import (
     migrate_vm_and_verify,
     running_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.pod import Pod
+    from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 
 LOGGER = logging.getLogger(__name__)
 
@@ -87,7 +94,11 @@ def source_pod_log_verbosity_test(admin_client, vm_for_migration_progress_test):
 
 
 @pytest.fixture()
-def migrated_vm_with_policy(admin_client, migration_policy_with_bandwidth, vm_for_migration_progress_test):
+def migrated_vm_with_policy(
+    admin_client: DynamicClient,
+    migration_policy_with_bandwidth,
+    vm_for_migration_progress_test: VirtualMachineForTests,
+) -> Generator[VirtualMachineInstanceMigration]:
     migration = migrate_vm_and_verify(
         vm=vm_for_migration_progress_test,
         client=admin_client,
@@ -125,5 +136,5 @@ class TestProgressOfMigrationInVirtLauncher:
         "updated_log_verbosity_config",
         "vm_for_migration_progress_test",
     )
-    def test_progress_of_vm_migration_in_virt_launcher_pod(self, source_pod_log_verbosity_test):
+    def test_progress_of_vm_migration_in_virt_launcher_pod(self, source_pod_log_verbosity_test: Pod):
         wait_for_all_progress_keys_in_pod_log(pod=source_pod_log_verbosity_test)

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -20,6 +20,7 @@ from utilities.virt import (
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
+    from ocp_resources.migration_policy import MigrationPolicy
     from ocp_resources.pod import Pod
     from ocp_resources.virtual_machine_instance_migration import VirtualMachineInstanceMigration
 
@@ -98,7 +99,8 @@ def source_pod_log_verbosity_test(admin_client, vm_for_migration_progress_test):
 @pytest.fixture()
 def migrated_vm_with_policy(
     admin_client: DynamicClient,
-    migration_policy_with_bandwidth,
+    migration_policy_with_bandwidth: MigrationPolicy,
+    source_pod_log_verbosity_test: Pod,
     vm_for_migration_progress_test: VirtualMachineForTests,
 ) -> Generator[VirtualMachineInstanceMigration]:
     migration = migrate_vm_and_verify(

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Generator
 from typing import TYPE_CHECKING

--- a/tests/virt/node/log_verbosity/test_log_virt_launcher.py
+++ b/tests/virt/node/log_verbosity/test_log_virt_launcher.py
@@ -88,7 +88,15 @@ def source_pod_log_verbosity_test(admin_client, vm_for_migration_progress_test):
 
 @pytest.fixture()
 def migrated_vm_with_policy(admin_client, migration_policy_with_bandwidth, vm_for_migration_progress_test):
-    migrate_vm_and_verify(vm=vm_for_migration_progress_test, client=admin_client, wait_for_migration_success=False)
+    migration = migrate_vm_and_verify(
+        vm=vm_for_migration_progress_test,
+        client=admin_client,
+        wait_for_migration_success=False,
+    )
+    try:
+        yield migration
+    finally:
+        migration.clean_up()
 
 
 @pytest.mark.parametrize(

--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -51,5 +51,5 @@ def xfail_if_no_odf_cephfs_sc(cluster_storage_classes_names):
     indirect=True,
 )
 @pytest.mark.usefixtures("xfail_if_no_odf_cephfs_sc")
-def test_vm_with_odf_cephfs_storage_class_migrates(vm_with_cephfs_storage):
-    migrate_vm_and_verify(vm=vm_with_cephfs_storage)
+def test_vm_with_odf_cephfs_storage_class_migrates(admin_client, vm_with_cephfs_storage):
+    migrate_vm_and_verify(vm=vm_with_cephfs_storage, client=admin_client)

--- a/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_odf_vm_migration.py
@@ -1,9 +1,16 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS
 from utilities.constants import StorageClassNames
 from utilities.storage import data_volume_template_with_source_ref_dict
 from utilities.virt import migrate_vm_and_verify, vm_instance_from_template
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 
 @pytest.fixture
@@ -51,5 +58,7 @@ def xfail_if_no_odf_cephfs_sc(cluster_storage_classes_names):
     indirect=True,
 )
 @pytest.mark.usefixtures("xfail_if_no_odf_cephfs_sc")
-def test_vm_with_odf_cephfs_storage_class_migrates(admin_client, vm_with_cephfs_storage):
+def test_vm_with_odf_cephfs_storage_class_migrates(
+    admin_client: DynamicClient, vm_with_cephfs_storage: VirtualMachineForTests
+):
     migrate_vm_and_verify(vm=vm_with_cephfs_storage, client=admin_client)

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.migration_policy import MigrationPolicy
@@ -27,6 +28,11 @@ from utilities.virt import (
     start_and_fetch_processid_on_linux_vm,
     start_and_fetch_processid_on_windows_vm,
 )
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 pytestmark = [
     pytest.mark.rwx_default_storage,
@@ -69,7 +75,9 @@ def vm_background_process_id(hotplugged_vm):
 
 
 @pytest.fixture()
-def migrated_hotplugged_vm(admin_client, hotplugged_vm):
+def migrated_hotplugged_vm(
+    admin_client: DynamicClient, hotplugged_vm: VirtualMachineForTests
+) -> VirtualMachineForTests:
     migrate_vm_and_verify(
         vm=hotplugged_vm,
         client=admin_client,

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -76,6 +76,7 @@ def migrated_hotplugged_vm(admin_client, hotplugged_vm):
         timeout=TIMEOUT_30MIN if "windows" in hotplugged_vm.name else TIMEOUT_15MIN,
         check_ssh_connectivity=True,
     )
+    return hotplugged_vm
 
 
 @pytest.fixture()

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -69,9 +69,10 @@ def vm_background_process_id(hotplugged_vm):
 
 
 @pytest.fixture()
-def migrated_hotplugged_vm(hotplugged_vm):
+def migrated_hotplugged_vm(admin_client, hotplugged_vm):
     migrate_vm_and_verify(
         vm=hotplugged_vm,
+        client=admin_client,
         timeout=TIMEOUT_30MIN if "windows" in hotplugged_vm.name else TIMEOUT_15MIN,
         check_ssh_connectivity=True,
     )

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 import shlex

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from pyhelper_utils.shell import run_ssh_commands
@@ -9,6 +10,11 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS
 from utilities.constants import TIMEOUT_1MIN
 from utilities.virt import migrate_vm_and_verify, running_vm, vm_instance_from_template
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -93,7 +99,7 @@ def get_disk_usage(ssh_exec):
 @pytest.mark.s390x
 @pytest.mark.rwx_default_storage
 @pytest.mark.usefixtures("running_fio_in_vm")
-def test_fedora_vm_load_migration(admin_client, vm_with_fio):
+def test_fedora_vm_load_migration(admin_client: DynamicClient, vm_with_fio: VirtualMachineForTests):
     LOGGER.info("Test migrate VM with disk load")
     migrate_vm_and_verify(vm=vm_with_fio, client=admin_client, check_ssh_connectivity=True)
     get_disk_usage(ssh_exec=vm_with_fio.ssh_exec)

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -92,7 +92,8 @@ def get_disk_usage(ssh_exec):
 )
 @pytest.mark.s390x
 @pytest.mark.rwx_default_storage
-def test_fedora_vm_load_migration(admin_client, vm_with_fio, running_fio_in_vm):
+@pytest.mark.usefixtures("running_fio_in_vm")
+def test_fedora_vm_load_migration(admin_client, vm_with_fio):
     LOGGER.info("Test migrate VM with disk load")
     migrate_vm_and_verify(vm=vm_with_fio, client=admin_client, check_ssh_connectivity=True)
     get_disk_usage(ssh_exec=vm_with_fio.ssh_exec)

--- a/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_disk_load_with_migration.py
@@ -92,7 +92,7 @@ def get_disk_usage(ssh_exec):
 )
 @pytest.mark.s390x
 @pytest.mark.rwx_default_storage
-def test_fedora_vm_load_migration(vm_with_fio, running_fio_in_vm):
+def test_fedora_vm_load_migration(admin_client, vm_with_fio, running_fio_in_vm):
     LOGGER.info("Test migrate VM with disk load")
-    migrate_vm_and_verify(vm=vm_with_fio, check_ssh_connectivity=True)
+    migrate_vm_and_verify(vm=vm_with_fio, client=admin_client, check_ssh_connectivity=True)
     get_disk_usage(ssh_exec=vm_with_fio.ssh_exec)

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -37,8 +37,10 @@ def stress_pid_before_migration(vm_with_memory_load, cpu_mem_io_stress_started):
 
 
 @pytest.fixture()
-def migrate_vm_with_memory_load(vm_with_memory_load):
-    migrate_vm_and_verify(vm=vm_with_memory_load, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN)
+def migrate_vm_with_memory_load(admin_client, vm_with_memory_load):
+    migrate_vm_and_verify(
+        vm=vm_with_memory_load, client=admin_client, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN
+    )
 
 
 @pytest.mark.usefixtures("migration_policy_with_allow_auto_converge")

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -41,6 +41,7 @@ def migrate_vm_with_memory_load(admin_client, vm_with_memory_load):
     migrate_vm_and_verify(
         vm=vm_with_memory_load, client=admin_client, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN
     )
+    return vm_with_memory_load
 
 
 @pytest.mark.usefixtures("migration_policy_with_allow_auto_converge")

--- a/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_vm_memory_load_with_migration.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -12,6 +13,11 @@ from tests.virt.constants import WINDOWS_10_WSL
 from tests.virt.utils import get_stress_ng_pid, verify_stress_ng_pid_not_changed
 from utilities.constants import STRESS_CPU_MEM_IO_COMMAND, TIMEOUT_20MIN, Images
 from utilities.virt import migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +43,9 @@ def stress_pid_before_migration(vm_with_memory_load, cpu_mem_io_stress_started):
 
 
 @pytest.fixture()
-def migrate_vm_with_memory_load(admin_client, vm_with_memory_load):
+def migrate_vm_with_memory_load(
+    admin_client: DynamicClient, vm_with_memory_load: VirtualMachineForTests
+) -> VirtualMachineForTests:
     migrate_vm_and_verify(
         vm=vm_with_memory_load, client=admin_client, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN
     )

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -105,6 +105,7 @@ def migrated_vm_with_guest_tools(
     vm_with_guest_tools,
 ):
     migrate_vm_and_verify(vm=vm_with_guest_tools, client=admin_client)
+    return vm_with_guest_tools
 
 
 @pytest.mark.polarion("CNV-9794")

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.config_map import ConfigMap
@@ -12,6 +13,9 @@ from ocp_resources.virtual_machine_cluster_preference import (
 from tests.os_params import WINDOWS_10
 from utilities.constants import OS_FLAVOR_WINDOWS, TIMEOUT_3MIN, VIRTIO_WIN
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 pytestmark = [pytest.mark.special_infra, pytest.mark.high_resource_vm]
 
@@ -101,9 +105,9 @@ def vm_with_guest_tools(
 
 @pytest.fixture(scope="class")
 def migrated_vm_with_guest_tools(
-    admin_client,
-    vm_with_guest_tools,
-):
+    admin_client: DynamicClient,
+    vm_with_guest_tools: VirtualMachineForTests,
+) -> VirtualMachineForTests:
     migrate_vm_and_verify(vm=vm_with_guest_tools, client=admin_client)
     return vm_with_guest_tools
 

--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -101,9 +101,10 @@ def vm_with_guest_tools(
 
 @pytest.fixture(scope="class")
 def migrated_vm_with_guest_tools(
+    admin_client,
     vm_with_guest_tools,
 ):
-    migrate_vm_and_verify(vm=vm_with_guest_tools)
+    migrate_vm_and_verify(vm=vm_with_guest_tools, client=admin_client)
 
 
 @pytest.mark.polarion("CNV-9794")

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -194,7 +194,8 @@ class TestKernelSamepageMerging:
     @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-10523")
     @pytest.mark.dependency(depends=["test_ksm_activated_when_node_under_pressure"])
-    def test_migrate_vm_when_ksm_active(self, admin_client, ksm_label_added_to_worker2, vms_for_ksm_test):
+    @pytest.mark.usefixtures("ksm_label_added_to_worker2")
+    def test_migrate_vm_when_ksm_active(self, admin_client, vms_for_ksm_test):
         migrate_vm_and_verify(vm=vms_for_ksm_test[0], client=admin_client)
 
     @pytest.mark.polarion("CNV-10524")

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -194,8 +194,8 @@ class TestKernelSamepageMerging:
     @pytest.mark.rwx_default_storage
     @pytest.mark.polarion("CNV-10523")
     @pytest.mark.dependency(depends=["test_ksm_activated_when_node_under_pressure"])
-    def test_migrate_vm_when_ksm_active(self, ksm_label_added_to_worker2, vms_for_ksm_test):
-        migrate_vm_and_verify(vm=vms_for_ksm_test[0])
+    def test_migrate_vm_when_ksm_active(self, admin_client, ksm_label_added_to_worker2, vms_for_ksm_test):
+        migrate_vm_and_verify(vm=vms_for_ksm_test[0], client=admin_client)
 
     @pytest.mark.polarion("CNV-10524")
     @pytest.mark.dependency(depends=["test_ksm_activated_when_node_under_pressure"])

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.kubevirt import KubeVirt
@@ -10,6 +11,11 @@ from utilities.constants import TIMEOUT_5MIN, TIMEOUT_30SEC
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import ExecCommandOnPod, label_nodes
 from utilities.virt import migrate_vm_and_verify, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -195,7 +201,9 @@ class TestKernelSamepageMerging:
     @pytest.mark.polarion("CNV-10523")
     @pytest.mark.dependency(depends=["test_ksm_activated_when_node_under_pressure"])
     @pytest.mark.usefixtures("ksm_label_added_to_worker2")
-    def test_migrate_vm_when_ksm_active(self, admin_client, vms_for_ksm_test):
+    def test_migrate_vm_when_ksm_active(
+        self, admin_client: DynamicClient, vms_for_ksm_test: list[VirtualMachineForTests]
+    ):
         migrate_vm_and_verify(vm=vms_for_ksm_test[0], client=admin_client)
 
     @pytest.mark.polarion("CNV-10524")

--- a/tests/virt/node/workload_density/test_swap.py
+++ b/tests/virt/node/workload_density/test_swap.py
@@ -188,8 +188,11 @@ class TestVMCanUseSwap:
     @pytest.mark.polarion("CNV-11259")
     def test_migrate_vm_using_swap(
         self,
+        admin_client,
         node_with_max_memory_labeled_for_swap_test,
         vm_for_swap_usage_test,
         migration_policy_with_allow_auto_converge,
     ):
-        migrate_vm_and_verify(vm=vm_for_swap_usage_test, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN)
+        migrate_vm_and_verify(
+            vm=vm_for_swap_usage_test, client=admin_client, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN
+        )

--- a/tests/virt/node/workload_density/test_swap.py
+++ b/tests/virt/node/workload_density/test_swap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import shlex
 from typing import TYPE_CHECKING

--- a/tests/virt/node/workload_density/test_swap.py
+++ b/tests/virt/node/workload_density/test_swap.py
@@ -186,13 +186,11 @@ class TestVMCanUseSwap:
 
     @pytest.mark.dependency(depends=["test_virt_launcher_pod_use_swap"])
     @pytest.mark.polarion("CNV-11259")
-    def test_migrate_vm_using_swap(
-        self,
-        admin_client,
-        node_with_max_memory_labeled_for_swap_test,
-        vm_for_swap_usage_test,
-        migration_policy_with_allow_auto_converge,
-    ):
+    @pytest.mark.usefixtures(
+        "node_with_max_memory_labeled_for_swap_test",
+        "migration_policy_with_allow_auto_converge",
+    )
+    def test_migrate_vm_using_swap(self, admin_client, vm_for_swap_usage_test):
         migrate_vm_and_verify(
             vm=vm_for_swap_usage_test, client=admin_client, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN
         )

--- a/tests/virt/node/workload_density/test_swap.py
+++ b/tests/virt/node/workload_density/test_swap.py
@@ -1,5 +1,6 @@
 import logging
 import shlex
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.daemonset import DaemonSet
@@ -12,6 +13,9 @@ from tests.virt.utils import build_node_affinity_dict
 from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC, TIMEOUT_20MIN, Images
 from utilities.infra import ExecCommandOnPod
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, running_vm
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -190,7 +194,7 @@ class TestVMCanUseSwap:
         "node_with_max_memory_labeled_for_swap_test",
         "migration_policy_with_allow_auto_converge",
     )
-    def test_migrate_vm_using_swap(self, admin_client, vm_for_swap_usage_test):
+    def test_migrate_vm_using_swap(self, admin_client: DynamicClient, vm_for_swap_usage_test: VirtualMachineForTests):
         migrate_vm_and_verify(
             vm=vm_for_swap_usage_test, client=admin_client, check_ssh_connectivity=True, timeout=TIMEOUT_20MIN
         )

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -131,12 +131,8 @@ class TestUpgradeVirt:
     @pytest.mark.polarion("CNV-12018")
     @pytest.mark.order(before=MIGRATION_BEFORE_UPGRADE_TEST_ORDERING)
     @pytest.mark.dependency(name=f"{VIRT_NODE_ID_PREFIX}::test_vm_post_copy_migration_before_upgrade")
-    def test_vm_post_copy_migration_before_upgrade(
-        self,
-        admin_client,
-        post_copy_migration_policy_for_upgrade,
-        vm_for_post_copy_upgrade,
-    ):
+    @pytest.mark.usefixtures("post_copy_migration_policy_for_upgrade")
+    def test_vm_post_copy_migration_before_upgrade(self, admin_client, vm_for_post_copy_upgrade):
         migrate_vm_and_verify(vm=vm_for_post_copy_upgrade, client=admin_client, check_ssh_connectivity=True)
         assert_migration_post_copy_mode(vm=vm_for_post_copy_upgrade)
 

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
@@ -22,6 +23,11 @@ from tests.virt.utils import assert_migration_post_copy_mode, verify_guest_boot_
 from utilities.constants import DATA_SOURCE_NAME, DEPENDENCY_SCOPE_SESSION
 from utilities.exceptions import ResourceValueError
 from utilities.virt import migrate_vm_and_verify, vm_console_run_commands
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -132,7 +138,11 @@ class TestUpgradeVirt:
     @pytest.mark.order(before=MIGRATION_BEFORE_UPGRADE_TEST_ORDERING)
     @pytest.mark.dependency(name=f"{VIRT_NODE_ID_PREFIX}::test_vm_post_copy_migration_before_upgrade")
     @pytest.mark.usefixtures("post_copy_migration_policy_for_upgrade")
-    def test_vm_post_copy_migration_before_upgrade(self, admin_client, vm_for_post_copy_upgrade):
+    def test_vm_post_copy_migration_before_upgrade(
+        self,
+        admin_client: DynamicClient,
+        vm_for_post_copy_upgrade: VirtualMachineForTests,
+    ):
         migrate_vm_and_verify(vm=vm_for_post_copy_upgrade, client=admin_client, check_ssh_connectivity=True)
         assert_migration_post_copy_mode(vm=vm_for_post_copy_upgrade)
 
@@ -143,7 +153,9 @@ class TestUpgradeVirt:
         name=MIGRATION_BEFORE_UPGRADE_TEST_NODE_ID,
         scope=DEPENDENCY_SCOPE_SESSION,
     )
-    def test_migration_before_upgrade(self, admin_client, virt_migratable_vms):
+    def test_migration_before_upgrade(
+        self, admin_client: DynamicClient, virt_migratable_vms: list[VirtualMachineForTests]
+    ):
         for vm in virt_migratable_vms:
             migrate_vm_and_verify(vm=vm, client=admin_client, wait_for_interfaces=False, check_ssh_connectivity=False)
 
@@ -261,7 +273,9 @@ class TestUpgradeVirt:
         depends=[IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID, MIGRATION_BEFORE_UPGRADE_TEST_NODE_ID],
         scope=DEPENDENCY_SCOPE_SESSION,
     )
-    def test_migration_after_upgrade(self, admin_client, virt_migratable_vms):
+    def test_migration_after_upgrade(
+        self, admin_client: DynamicClient, virt_migratable_vms: list[VirtualMachineForTests]
+    ):
         for vm in virt_migratable_vms:
             migrate_vm_and_verify(vm=vm, client=admin_client, wait_for_interfaces=False, check_ssh_connectivity=False)
 
@@ -339,8 +353,8 @@ class TestUpgradeVirt:
     )
     def test_vm_post_copy_migration_after_upgrade(
         self,
-        admin_client,
-        vm_for_post_copy_upgrade,
+        admin_client: DynamicClient,
+        vm_for_post_copy_upgrade: VirtualMachineForTests,
     ):
         migrate_vm_and_verify(vm=vm_for_post_copy_upgrade, client=admin_client, check_ssh_connectivity=True)
         assert_migration_post_copy_mode(vm=vm_for_post_copy_upgrade)

--- a/tests/virt/upgrade/test_upgrade_virt.py
+++ b/tests/virt/upgrade/test_upgrade_virt.py
@@ -133,10 +133,11 @@ class TestUpgradeVirt:
     @pytest.mark.dependency(name=f"{VIRT_NODE_ID_PREFIX}::test_vm_post_copy_migration_before_upgrade")
     def test_vm_post_copy_migration_before_upgrade(
         self,
+        admin_client,
         post_copy_migration_policy_for_upgrade,
         vm_for_post_copy_upgrade,
     ):
-        migrate_vm_and_verify(vm=vm_for_post_copy_upgrade, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=vm_for_post_copy_upgrade, client=admin_client, check_ssh_connectivity=True)
         assert_migration_post_copy_mode(vm=vm_for_post_copy_upgrade)
 
     @pytest.mark.ocp_upgrade
@@ -146,9 +147,9 @@ class TestUpgradeVirt:
         name=MIGRATION_BEFORE_UPGRADE_TEST_NODE_ID,
         scope=DEPENDENCY_SCOPE_SESSION,
     )
-    def test_migration_before_upgrade(self, virt_migratable_vms):
+    def test_migration_before_upgrade(self, admin_client, virt_migratable_vms):
         for vm in virt_migratable_vms:
-            migrate_vm_and_verify(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
+            migrate_vm_and_verify(vm=vm, client=admin_client, wait_for_interfaces=False, check_ssh_connectivity=False)
 
     """ Post-upgrade tests """
 
@@ -264,9 +265,9 @@ class TestUpgradeVirt:
         depends=[IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID, MIGRATION_BEFORE_UPGRADE_TEST_NODE_ID],
         scope=DEPENDENCY_SCOPE_SESSION,
     )
-    def test_migration_after_upgrade(self, virt_migratable_vms):
+    def test_migration_after_upgrade(self, admin_client, virt_migratable_vms):
         for vm in virt_migratable_vms:
-            migrate_vm_and_verify(vm=vm, wait_for_interfaces=False, check_ssh_connectivity=False)
+            migrate_vm_and_verify(vm=vm, client=admin_client, wait_for_interfaces=False, check_ssh_connectivity=False)
 
     @pytest.mark.ocp_upgrade
     @pytest.mark.polarion("CNV-12571")
@@ -342,7 +343,8 @@ class TestUpgradeVirt:
     )
     def test_vm_post_copy_migration_after_upgrade(
         self,
+        admin_client,
         vm_for_post_copy_upgrade,
     ):
-        migrate_vm_and_verify(vm=vm_for_post_copy_upgrade, check_ssh_connectivity=True)
+        migrate_vm_and_verify(vm=vm_for_post_copy_upgrade, client=admin_client, check_ssh_connectivity=True)
         assert_migration_post_copy_mode(vm=vm_for_post_copy_upgrade)

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -129,7 +129,7 @@ def verify_stress_ng_pid_not_changed(vm, initial_pid, windows=False):
     )
 
 
-def migrate_and_verify_multi_vms(client, vm_list):
+def migrate_and_verify_multi_vms(client: DynamicClient, vm_list: list[VirtualMachineForTests]) -> None:
     vms_dict = {}
     failed_migrations_list = []
 

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -129,14 +129,14 @@ def verify_stress_ng_pid_not_changed(vm, initial_pid, windows=False):
     )
 
 
-def migrate_and_verify_multi_vms(vm_list):
+def migrate_and_verify_multi_vms(client, vm_list):
     vms_dict = {}
     failed_migrations_list = []
 
     for vm in vm_list:
         vms_dict[vm.name] = {
             "node_before": vm.vmi.node,
-            "vm_mig": migrate_vm_and_verify(vm=vm, wait_for_migration_success=False),
+            "vm_mig": migrate_vm_and_verify(vm=vm, client=client, wait_for_migration_success=False),
         }
 
     for vm in vm_list:

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1908,19 +1908,19 @@ def wait_for_cloud_init_complete(vm, timeout=TIMEOUT_4MIN):
 
 def migrate_vm_and_verify(
     vm: VirtualMachineForTests | BaseVirtualMachine,
-    client: DynamicClient | None = None,
+    client: DynamicClient,
     timeout: int = TIMEOUT_12MIN,
     wait_for_interfaces: bool = True,
     check_ssh_connectivity: bool = False,
     wait_for_migration_success: bool = True,
 ) -> VirtualMachineInstanceMigration | None:
-    """
-    Create a migration instance. You may choose to wait for migration
-    success or not.
+    """Migrate VM and verify migration success.
 
     Args:
         vm (VirtualMachine): VM to be migrated.
-        client (DynamicClient, default=None): Client to use for migration.
+        client (DynamicClient): Client to use for migration.
+            Note: Only Cluster Admin (admin_client) can migrate VM.
+            Namespace Admin (unprivileged_client) cannot migrate VM (unless assigned kubevirt.io:migrate RoleBinding).
         timeout (int, default=12 minutes): Maximum time to wait for the migration to finish.
         wait_for_interfaces (bool, default=True): Wait for VM network interfaces after migration completes.
         check_ssh_connectivity (bool, default=False): Verify SSH connectivity to the VM after migration completes.


### PR DESCRIPTION
##### What this PR does / why we need it:
modified `migrate_vm_and_verify` func client arg to be mandatory
and update relevant calls in functions and tests

Assisted-by: Cursor Agent (Composer 2.5)

##### Which issue(s) this PR fixes:
Aligns migration tests with default client deprecation in python-wrapper repo
https://redhat.atlassian.net/browse/CNV-68519

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-88319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated live-migration, storage-migration, networking connectivity, and multi-VM migration tests/fixtures to pass an explicit admin client into migrate-and-verify workflows.
  * Improved test typing across many modules by using type-only imports and adding clearer fixture/test signatures and wiring (including fixture activation via `usefixtures` where applicable).

* **Refactor / Documentation**
  * Updated the migrate-and-verify helper to require a non-optional client parameter and documented migration permission expectations more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->