### PR TITLE
[Main] Storage: Change Cirros images for RHEL from DataSource into upgrade tests

### DIFF
--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -24,51 +24,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def skip_if_less_than_two_storage_classes(cluster_storage_classes):
-    if len(cluster_storage_classes) < 2:
-        pytest.skip("Need two Storage Classes at least.")
-
-
-@pytest.fixture(scope="session")
-def storage_class_for_updating_cdiconfig_scratch(
-    skip_if_less_than_two_storage_classes, cdi_config, cluster_storage_classes
-):
-    """
-    Choose one StorageClass which is not the current one for scratch space.
-    """
-    current_sc_for_scratch = cdi_config.scratch_space_storage_class_from_status
-    LOGGER.info(f"The current StorageClass for scratch space on CDIConfig is: {current_sc_for_scratch}")
-    for sc in cluster_storage_classes:
-        if sc.instance.metadata.get("name") != current_sc_for_scratch:
-            LOGGER.info(f"Candidate StorageClass: {sc.instance.metadata.name}")
-            return sc
-
-
-@pytest.fixture(scope="session")
-def override_cdiconfig_scratch_spec(
-    hyperconverged_resource_scope_session,
-    cdi_config,
-    storage_class_for_updating_cdiconfig_scratch,
-):
-    """
-    Change spec.scratchSpaceStorageClass to the selected StorageClass on CDIConfig.
-    """
-    if storage_class_for_updating_cdiconfig_scratch:
-        new_sc = storage_class_for_updating_cdiconfig_scratch.name
-
-    with update_scratch_space_sc(
-        cdi_config=cdi_config, new_sc=new_sc, hco=hyperconverged_resource_scope_session
-    ) as edited_cdi_config:
-        yield edited_cdi_config
-
-
-@pytest.fixture(scope="session")
-def skip_if_not_override_cdiconfig_scratch_space(override_cdiconfig_scratch_spec):
-    if not override_cdiconfig_scratch_spec:
-        pytest.skip("Skip test because the scratch space was not changed.")
-
-
-@pytest.fixture(scope="session")
 def rhel_vm_for_upgrade_a(
     upgrade_namespace_scope_session,
     admin_client,

--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -24,18 +24,65 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def cirros_vm_for_upgrade_a(
+def skip_if_less_than_two_storage_classes(cluster_storage_classes):
+    if len(cluster_storage_classes) < 2:
+        pytest.skip("Need two Storage Classes at least.")
+
+
+@pytest.fixture(scope="session")
+def storage_class_for_updating_cdiconfig_scratch(
+    skip_if_less_than_two_storage_classes, cdi_config, cluster_storage_classes
+):
+    """
+    Choose one StorageClass which is not the current one for scratch space.
+    """
+    current_sc_for_scratch = cdi_config.scratch_space_storage_class_from_status
+    LOGGER.info(f"The current StorageClass for scratch space on CDIConfig is: {current_sc_for_scratch}")
+    for sc in cluster_storage_classes:
+        if sc.instance.metadata.get("name") != current_sc_for_scratch:
+            LOGGER.info(f"Candidate StorageClass: {sc.instance.metadata.name}")
+            return sc
+
+
+@pytest.fixture(scope="session")
+def override_cdiconfig_scratch_spec(
+    hyperconverged_resource_scope_session,
+    cdi_config,
+    storage_class_for_updating_cdiconfig_scratch,
+):
+    """
+    Change spec.scratchSpaceStorageClass to the selected StorageClass on CDIConfig.
+    """
+    if storage_class_for_updating_cdiconfig_scratch:
+        new_sc = storage_class_for_updating_cdiconfig_scratch.name
+
+    with update_scratch_space_sc(
+        cdi_config=cdi_config, new_sc=new_sc, hco=hyperconverged_resource_scope_session
+    ) as edited_cdi_config:
+        yield edited_cdi_config
+
+
+@pytest.fixture(scope="session")
+def skip_if_not_override_cdiconfig_scratch_space(override_cdiconfig_scratch_spec):
+    if not override_cdiconfig_scratch_spec:
+        pytest.skip("Skip test because the scratch space was not changed.")
+
+
+@pytest.fixture(scope="session")
+def rhel_vm_for_upgrade_a(
     upgrade_namespace_scope_session,
     admin_client,
     storage_class_for_snapshot,
-    cluster_common_node_cpu,
+    modern_cpu_for_migration,
+    rhel10_data_source_scope_session,
 ):
     with create_vm_for_snapshot_upgrade_tests(
         vm_name="snapshot-upgrade-a",
         namespace=upgrade_namespace_scope_session.name,
         client=admin_client,
         storage_class_for_snapshot=storage_class_for_snapshot,
-        cpu_model=cluster_common_node_cpu,
+        cpu_model=modern_cpu_for_migration,
+        data_source=rhel10_data_source_scope_session,
     ) as vm:
         yield vm
 
@@ -43,25 +90,27 @@ def cirros_vm_for_upgrade_a(
 @pytest.fixture(scope="session")
 def snapshots_for_upgrade_a(
     admin_client,
-    cirros_vm_for_upgrade_a,
+    rhel_vm_for_upgrade_a,
 ):
-    with create_snapshot_for_upgrade(vm=cirros_vm_for_upgrade_a, client=admin_client) as snapshot:
+    with create_snapshot_for_upgrade(vm=rhel_vm_for_upgrade_a, client=admin_client) as snapshot:
         yield snapshot
 
 
 @pytest.fixture(scope="session")
-def cirros_vm_for_upgrade_b(
+def rhel_vm_for_upgrade_b(
     upgrade_namespace_scope_session,
     admin_client,
     storage_class_for_snapshot,
-    cluster_common_node_cpu,
+    modern_cpu_for_migration,
+    rhel10_data_source_scope_session,
 ):
     with create_vm_for_snapshot_upgrade_tests(
         vm_name="snapshot-upgrade-b",
         namespace=upgrade_namespace_scope_session.name,
         client=admin_client,
         storage_class_for_snapshot=storage_class_for_snapshot,
-        cpu_model=cluster_common_node_cpu,
+        cpu_model=modern_cpu_for_migration,
+        data_source=rhel10_data_source_scope_session,
     ) as vm:
         yield vm
 
@@ -69,9 +118,9 @@ def cirros_vm_for_upgrade_b(
 @pytest.fixture(scope="session")
 def snapshots_for_upgrade_b(
     admin_client,
-    cirros_vm_for_upgrade_b,
+    rhel_vm_for_upgrade_b,
 ):
-    with create_snapshot_for_upgrade(vm=cirros_vm_for_upgrade_b, client=admin_client) as snapshot:
+    with create_snapshot_for_upgrade(vm=rhel_vm_for_upgrade_b, client=admin_client) as snapshot:
         yield snapshot
 
 

--- a/tests/storage/upgrade/constants.py
+++ b/tests/storage/upgrade/constants.py
@@ -1,0 +1,9 @@
+"""
+Upgrade storage test constants
+"""
+
+# Upgrade snapshot test file constants
+UPGRADE_FIRST_FILE_NAME = "first-file.txt"
+UPGRADE_FIRST_FILE_CONTENT = "first-file"
+UPGRADE_SECOND_FILE_NAME = "second-file.txt"
+UPGRADE_SECOND_FILE_CONTENT = "second-file"

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -7,6 +7,11 @@ import pytest
 from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 
 from tests.storage.utils import assert_disk_bus
+from tests.storage.upgrade.constants import (
+    UPGRADE_FIRST_FILE_CONTENT,
+    UPGRADE_FIRST_FILE_NAME,
+    UPGRADE_SECOND_FILE_NAME,
+)
 from tests.upgrade_params import (
     HOTPLUG_VM_AFTER_UPGRADE_NODE_ID,
     IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
@@ -21,10 +26,10 @@ from utilities.constants.storage import HOTPLUG_DISK_VIRTIO_BUS
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,
-    run_command_on_cirros_vm_and_check_output,
+    run_command_on_vm_and_check_output,
     wait_for_vm_volume_ready,
 )
-from utilities.virt import migrate_vm_and_verify
+from utilities.virt import migrate_vm_and_verify, running_vm
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
@@ -54,22 +59,33 @@ class TestUpgradeStorage:
         self,
         admin_client,
         skip_if_no_storage_class_for_snapshot,
-        cirros_vm_for_upgrade_a,
+        rhel_vm_for_upgrade_a,
         snapshots_for_upgrade_a,
     ):
         with VirtualMachineRestore(
-            name=f"restore-snapshot-{cirros_vm_for_upgrade_a.name}",
+            client=admin_client,
+            name=f"restore-snapshot-{rhel_vm_for_upgrade_a.name}",
             namespace=snapshots_for_upgrade_a.namespace,
-            vm_name=cirros_vm_for_upgrade_a.name,
+            vm_name=rhel_vm_for_upgrade_a.name,
             snapshot_name=snapshots_for_upgrade_a.name,
             client=admin_client,
         ) as vm_restore:
+            if rhel_vm_for_upgrade_a.ready:
+                rhel_vm_for_upgrade_a.stop(wait=True)
             vm_restore.wait_restore_done()
-            cirros_vm_for_upgrade_a.start(wait=True)
-            run_command_on_cirros_vm_and_check_output(
-                vm=cirros_vm_for_upgrade_a,
-                command=LS_COMMAND,
-                expected_result="1",
+            running_vm(vm=rhel_vm_for_upgrade_a)
+            # Verify first file exists (created before snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_a,
+                command=f"cat {UPGRADE_FIRST_FILE_NAME}",
+                expected_result=UPGRADE_FIRST_FILE_CONTENT,
+            )
+
+            # Verify second file does NOT exist (created after snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_a,
+                command=f"test ! -f {UPGRADE_SECOND_FILE_NAME} && echo 'file not found'",
+                expected_result="file not found",
             )
 
     @pytest.mark.sno
@@ -119,12 +135,21 @@ class TestUpgradeStorage:
     )
     def test_vm_snapshot_restore_check_after_upgrade(
         self,
-        cirros_vm_for_upgrade_a,
+        rhel_vm_for_upgrade_a,
     ):
-        run_command_on_cirros_vm_and_check_output(
-            vm=cirros_vm_for_upgrade_a,
-            command=LS_COMMAND,
-            expected_result="1",
+        running_vm(vm=rhel_vm_for_upgrade_a)
+        # Verify first file exists (created before snapshot, should still be there after upgrade)
+        run_command_on_vm_and_check_output(
+            vm=rhel_vm_for_upgrade_a,
+            command=f"cat {UPGRADE_FIRST_FILE_NAME}",
+            expected_result=UPGRADE_FIRST_FILE_CONTENT,
+        )
+
+        # Verify second file does NOT exist (was created after snapshot, should not be present after restore)
+        run_command_on_vm_and_check_output(
+            vm=rhel_vm_for_upgrade_a,
+            command=f"test ! -f {UPGRADE_SECOND_FILE_NAME} && echo 'file not found'",
+            expected_result="file not found",
         )
 
     @pytest.mark.sno
@@ -139,21 +164,34 @@ class TestUpgradeStorage:
         scope=DEPENDENCY_SCOPE_SESSION,
     )
     def test_vm_snapshot_restore_create_after_upgrade(
-        self, admin_client, cirros_vm_for_upgrade_b, snapshots_for_upgrade_b
+        self, admin_client, rhel_vm_for_upgrade_b, snapshots_for_upgrade_b
     ):
         with VirtualMachineRestore(
-            name=f"restore-snapshot-{cirros_vm_for_upgrade_b.name}",
+            client=admin_client,
+            name=f"restore-snapshot-{rhel_vm_for_upgrade_b.name}",
             namespace=snapshots_for_upgrade_b.namespace,
-            vm_name=cirros_vm_for_upgrade_b.name,
+            vm_name=rhel_vm_for_upgrade_b.name,
             snapshot_name=snapshots_for_upgrade_b.name,
             client=admin_client,
         ) as vm_restore:
+            if rhel_vm_for_upgrade_b.ready:
+                rhel_vm_for_upgrade_b.stop(wait=True)
             vm_restore.wait_restore_done()
-            cirros_vm_for_upgrade_b.start(wait=True)
-            run_command_on_cirros_vm_and_check_output(
-                vm=cirros_vm_for_upgrade_b,
-                command=LS_COMMAND,
-                expected_result="1",
+
+            running_vm(vm=rhel_vm_for_upgrade_b)
+
+            # Verify first file exists (created before snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_b,
+                command=f"cat {UPGRADE_FIRST_FILE_NAME}",
+                expected_result=UPGRADE_FIRST_FILE_CONTENT,
+            )
+
+            # Verify second file does NOT exist (created after snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_b,
+                command=f"test ! -f {UPGRADE_SECOND_FILE_NAME} && echo 'file not found'",
+                expected_result="file not found",
             )
 
     @pytest.mark.polarion("CNV-5310")

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -20,7 +20,8 @@ from tests.upgrade_params import (
     SNAPSHOT_RESTORE_CREATE_AFTER_UPGRADE,
     STORAGE_NODE_ID_PREFIX,
 )
-from utilities.constants import DEPENDENCY_SCOPE_SESSION, HOTPLUG_DISK_VIRTIO_BUS
+from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
+from utilities.constants.storage import HOTPLUG_DISK_VIRTIO_BUS
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING
 import pytest
 from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 
-from tests.storage.utils import assert_disk_bus
 from tests.storage.upgrade.constants import (
     UPGRADE_FIRST_FILE_CONTENT,
     UPGRADE_FIRST_FILE_NAME,
     UPGRADE_SECOND_FILE_NAME,
 )
+from tests.storage.utils import assert_disk_bus
 from tests.upgrade_params import (
     HOTPLUG_VM_AFTER_UPGRADE_NODE_ID,
     IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
@@ -66,7 +66,6 @@ class TestUpgradeStorage:
             namespace=snapshots_for_upgrade_a.namespace,
             vm_name=rhel_vm_for_upgrade_a.name,
             snapshot_name=snapshots_for_upgrade_a.name,
-            client=admin_client,
         ) as vm_restore:
             if rhel_vm_for_upgrade_a.ready:
                 rhel_vm_for_upgrade_a.stop(wait=True)
@@ -170,7 +169,6 @@ class TestUpgradeStorage:
             namespace=snapshots_for_upgrade_b.namespace,
             vm_name=rhel_vm_for_upgrade_b.name,
             snapshot_name=snapshots_for_upgrade_b.name,
-            client=admin_client,
         ) as vm_restore:
             if rhel_vm_for_upgrade_b.ready:
                 rhel_vm_for_upgrade_b.stop(wait=True)

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -20,9 +20,7 @@ from tests.upgrade_params import (
     SNAPSHOT_RESTORE_CREATE_AFTER_UPGRADE,
     STORAGE_NODE_ID_PREFIX,
 )
-from utilities.constants.cluster import LS_COMMAND
-from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
-from utilities.constants.storage import HOTPLUG_DISK_VIRTIO_BUS
+from utilities.constants import DEPENDENCY_SCOPE_SESSION, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,

--- a/tests/storage/upgrade/utils.py
+++ b/tests/storage/upgrade/utils.py
@@ -1,9 +1,19 @@
 from contextlib import contextmanager
 
+from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
 
-from tests.utils import create_cirros_vm
-from utilities.storage import write_file
+from tests.storage.upgrade.constants import (
+    UPGRADE_FIRST_FILE_CONTENT,
+    UPGRADE_FIRST_FILE_NAME,
+    UPGRADE_SECOND_FILE_CONTENT,
+    UPGRADE_SECOND_FILE_NAME,
+)
+from utilities.constants import OS_FLAVOR_RHEL, RHEL10_PREFERENCE, U1_SMALL
+from utilities.storage import data_volume_template_with_source_ref_dict, write_file_via_ssh
+from utilities.virt import VirtualMachineForTests, running_vm
 
 
 @contextmanager
@@ -13,19 +23,27 @@ def create_vm_for_snapshot_upgrade_tests(
     client,
     storage_class_for_snapshot,
     cpu_model,
+    data_source,
 ):
-    with create_cirros_vm(
-        storage_class=storage_class_for_snapshot,
+    with VirtualMachineForTests(
+        name=f"vm-{vm_name}",
         namespace=namespace,
         client=client,
-        dv_name=f"dv-{vm_name}",
-        vm_name=f"vm-{vm_name}",
+        os_flavor=OS_FLAVOR_RHEL,
+        vm_instance_type=VirtualMachineClusterInstancetype(client=client, name=U1_SMALL),
+        vm_preference=VirtualMachineClusterPreference(client=client, name=RHEL10_PREFERENCE),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=data_source,
+            storage_class=storage_class_for_snapshot,
+        ),
+        run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         cpu_model=cpu_model,
     ) as vm:
-        write_file(
+        running_vm(vm=vm)
+        write_file_via_ssh(
             vm=vm,
-            filename="first-file.txt",
-            content="first-file",
+            filename=UPGRADE_FIRST_FILE_NAME,
+            content=UPGRADE_FIRST_FILE_CONTENT,
         )
         yield vm
 
@@ -40,9 +58,9 @@ def create_snapshot_for_upgrade(vm, client):
         client=client,
     ) as vm_snapshot:
         vm_snapshot.wait_snapshot_done()
-        write_file(
+        write_file_via_ssh(
             vm=vm,
-            filename="second-file.txt",
-            content="second-file",
+            filename=UPGRADE_SECOND_FILE_NAME,
+            content=UPGRADE_SECOND_FILE_CONTENT,
         )
         yield vm_snapshot

--- a/tests/storage/upgrade/utils.py
+++ b/tests/storage/upgrade/utils.py
@@ -11,7 +11,8 @@ from tests.storage.upgrade.constants import (
     UPGRADE_SECOND_FILE_CONTENT,
     UPGRADE_SECOND_FILE_NAME,
 )
-from utilities.constants import OS_FLAVOR_RHEL, RHEL10_PREFERENCE, U1_SMALL
+from utilities.constants.images import OS_FLAVOR_RHEL
+from utilities.constants.instance_types import RHEL10_PREFERENCE, U1_SMALL
 from utilities.storage import data_volume_template_with_source_ref_dict, write_file_via_ssh
 from utilities.virt import VirtualMachineForTests, running_vm
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -793,7 +793,7 @@ def run_command_on_vm_and_check_output(
     )
 
 
-def assert_disk_serial(vm, command=shlex.split("sudo ls /dev/disk/by-id")):
+def assert_disk_serial(vm, command=_DEFAULT_DISK_SERIAL_COMMAND):
     assert (
         HOTPLUG_DISK_SERIAL
         in run_ssh_commands(host=vm.ssh_exec, commands=command, wait_timeout=TIMEOUT_2MIN, sleep=TIMEOUT_5SEC)[0]

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -793,13 +793,7 @@ def run_command_on_vm_and_check_output(
     )
 
 
-def run_command_on_cirros_vm_and_check_output(vm, command, expected_result):
-    with console.Console(vm=vm) as vm_console:
-        vm_console.sendline(command)
-        vm_console.expect(expected_result, timeout=20)
-
-
-def assert_disk_serial(vm, command=_DEFAULT_DISK_SERIAL_COMMAND):
+def assert_disk_serial(vm, command=shlex.split("sudo ls /dev/disk/by-id")):
     assert (
         HOTPLUG_DISK_SERIAL
         in run_ssh_commands(host=vm.ssh_exec, commands=command, wait_timeout=TIMEOUT_2MIN, sleep=TIMEOUT_5SEC)[0]


### PR DESCRIPTION
##### Short description:
Forwardport: https://github.com/RedHatQE/openshift-virtualization-tests/pull/2917
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated storage snapshot-restore upgrade tests to use RHEL 10 VMs instead of CirrOS.
  * Standardized expected upgrade artifact filenames and contents via shared constants.
  * Adjusted upgrade test flows to provision the new VMs, inject the expected files over SSH, and verify presence/absence before and after restore.

* **Refactor**
  * Removed a CirrOS-specific guest command helper and replaced it with SSH-based verification utilities, including a disk-serial assertion helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->