### PR TITLE
Fix s390x DataSource name in instance-type OS matrix

### DIFF
--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -6,6 +6,7 @@ from typing import Any
 from ocp_resources.template import Template
 
 from utilities.constants import (
+    ARM_64,
     CONTAINER_DISK_IMAGE_PATH_STR,
     DATA_SOURCE_NAME,
     DATA_SOURCE_STR,
@@ -295,7 +296,9 @@ def generate_linux_instance_type_os_matrix(
         data_source_name = _format_data_source_name(preference_name=preference)
         preference_config: dict[str, Any] = {
             PREFERENCE_STR: arch_preference,
-            DATA_SOURCE_NAME: f"{data_source_name}-{arch_suffix}" if arch_suffix else data_source_name,
+            DATA_SOURCE_NAME: (
+                f"{data_source_name}-{arch_suffix}" if arch_suffix == ARM_64 else data_source_name
+            ),
         }
 
         if preference == latest_os:

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -296,9 +296,7 @@ def generate_linux_instance_type_os_matrix(
         data_source_name = _format_data_source_name(preference_name=preference)
         preference_config: dict[str, Any] = {
             PREFERENCE_STR: arch_preference,
-            DATA_SOURCE_NAME: (
-                f"{data_source_name}-{arch_suffix}" if arch_suffix == ARM_64 else data_source_name
-            ),
+            DATA_SOURCE_NAME: (f"{data_source_name}-{arch_suffix}" if arch_suffix == ARM_64 else data_source_name),
         }
 
         if preference == latest_os:


### PR DESCRIPTION
Currently, `generate_linux_instance_type_os_matrix()` appends the architecture suffix to `DATA_SOURCE_NAME` whenever `arch_suffix` is provided (for example,` rhel9-s390x `on s390x clusters).

However, on s390x clusters, DataSources use the standard datasource naming format (for example, rhel9), while the architecture information is represented in the ClusterPreference name (for example, rhel.9.s390x).

This PR updates the datasource naming logic to append the architecture suffix only for ARM_64, while continuing to use the existing naming convention for other architecture.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
