### PR TITLE
Manual cherry-pick 4.20: net: Add interface stability test after guest-agent restart (#4957) 

### DIFF
--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -23,3 +23,27 @@ class TestInterfacesStability:
         migrate_vm_and_verify(vm=running_linux_bridge_vm)
         for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
             assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))
+
+    @pytest.mark.polarion("CNV-16025")
+    def test_interfaces_stability_after_guest_agent_restart(self, running_linux_bridge_vm, stable_ips):
+        """
+        Test that interface IPs remain stable after restarting the guest agent inside the VM.
+
+        Jira: https://redhat.atlassian.net/browse/CNV-85415
+
+        Preconditions:
+            - Running Fedora VM with two secondary Linux bridge network interfaces
+            - Secondary interface IPs are stable and reported by the guest agent
+
+        Steps:
+            1. Restart the qemu-guest-agent service using systemctl inside the VM
+
+        Expected:
+            - Interface IPs reported in VMI status remain unchanged throughout the monitoring period
+        """
+        running_linux_bridge_vm.console(
+            commands=["sudo systemctl restart qemu-guest-agent.service"],
+            timeout=30,
+        )
+        for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
+            assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))

--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -29,7 +29,7 @@ class TestInterfacesStability:
         """
         Test that interface IPs remain stable after restarting the guest agent inside the VM.
 
-        Jira: https://redhat.atlassian.net/browse/CNV-85415
+        Jira: https://redhat.atlassian.net/browse/CNV-85415 # <skip-jira-utils-check>
 
         Preconditions:
             - Running Fedora VM with two secondary Linux bridge network interfaces


### PR DESCRIPTION
##### What this PR does / why we need it:
Manual cherry-pick 4.20:
net: Add interface stability test after guest-agent restart https://github.com/RedHatQE/openshift-virtualization-tests/pull/4957

##### Which issue(s) this PR fixes:
Manual cherry-pick into 4.20: add new test and jira skip comment for CI not to fail

##### Special notes for reviewer: 
Based on auto-generated cherry-pick + small refactor of skip Jira check https://github.com/RedHatQE/openshift-virtualization-tests/pull/4998/changes/718f7ca3dd428283a206dd68c073eafeb2aa8145

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-87936
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->