### PR TITLE
Role aggregation opt out STD

### DIFF
--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -29,7 +29,7 @@ class TestRoleAggregationDisabled:
             pytest.param("view", marks=pytest.mark.polarion("CNV-16263")),
         ],
     )
-    def test_vm_list_forbidden_when_aggregation_disabled(self):
+    def test_vm_list_forbidden_when_aggregation_disabled(self, role):
         """
         [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
         from listing virtualization resources when role aggregation is disabled.

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -2,10 +2,6 @@
 Role-based access control (RBAC) tests
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/CNV-63822-role-aggregation-opt-out.md
-
-Markers:
-    - arm64
-    - post_upgrade
 """
 
 import pytest
@@ -15,16 +11,24 @@ __test__ = False
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
-class TestRoleAggregationDisabledRBACEnforcement:
+class TestRoleAggregationDisabled:
     """
     Tests for RBAC enforcement when role aggregation is disabled.
 
     Preconditions:
         - HyperConverged CR spec.roleAggregationStrategy set to "Manual" (role aggregation disabled)
         - Unprivileged user created via HTPasswd identity provider
+        - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
     """
 
-    @pytest.mark.polarion("CNV-16028")
+    @pytest.mark.parametrize(
+        "role",
+        [
+            pytest.param("admin", marks=pytest.mark.polarion("CNV-16028")),
+            pytest.param("edit", marks=pytest.mark.polarion("CNV-16262")),
+            pytest.param("view", marks=pytest.mark.polarion("CNV-16263")),
+        ],
+    )
     def test_vm_list_forbidden_when_aggregation_disabled(self):
         """
         [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
@@ -32,9 +36,6 @@ class TestRoleAggregationDisabledRBACEnforcement:
 
         Parametrize:
             - role: [admin, edit, view]
-
-        Preconditions:
-            - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
 
         Steps:
             1. Attempt to list VirtualMachine resources in the namespace using the unprivileged

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -11,6 +11,8 @@ import pytest
 
 __test__ = False
 
+pytestmark = pytest.mark.post_upgrade
+
 
 class TestRoleAggregationDisabledRBACEnforcement:
     """
@@ -21,7 +23,6 @@ class TestRoleAggregationDisabledRBACEnforcement:
         - Unprivileged user created via HTPasswd identity provider
     """
 
-    @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-16028")
     def test_vm_list_forbidden_when_aggregation_disabled(self):
         """
@@ -45,29 +46,59 @@ class TestRoleAggregationDisabledRBACEnforcement:
 
 class TestRoleAggregationReenabledAccess:
     """
-    Tests for access restoration when role aggregation is enabled.
+    Tests for role-specific access when role aggregation is enabled.
 
     Preconditions:
         - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault" (role aggregation enabled)
         - Unprivileged user created via HTPasswd identity provider
+        - VirtualMachine resource created in the test namespace
     """
 
-    @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-16029")
-    def test_access_restored_when_aggregation_reenabled(self):
+    def test_admin_can_delete_vm_when_aggregation_reenabled(self):
         """
-        Test that an unprivileged user with a standard OpenShift role can list virtualization
-        resources when role aggregation is enabled.
-
-        Parametrize:
-            - role: [admin, edit, view]
+        Test that an unprivileged user with the admin role can delete a VirtualMachine
+        resource when role aggregation is enabled.
 
         Preconditions:
-            - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
+            - Namespace with a RoleBinding granting the unprivileged user the admin ClusterRole
+            - Separate VirtualMachine resource created for deletion
 
         Steps:
-            1. Attempt to list VirtualMachine resources in the namespace using the unprivileged
-               user's credentials
+            1. Delete the VirtualMachine resource using the unprivileged user's credentials
+
+        Expected:
+            - VirtualMachine is deleted successfully
+        """
+
+    @pytest.mark.polarion("CNV-16030")
+    def test_edit_can_start_vm_when_aggregation_reenabled(self):
+        """
+        Test that an unprivileged user with the edit role can start a VirtualMachine
+        when role aggregation is enabled.
+
+        Preconditions:
+            - Namespace with a RoleBinding granting the unprivileged user the edit ClusterRole
+            - VirtualMachine resource in halted state
+
+        Steps:
+            1. Start the VirtualMachine using the unprivileged user's credentials
+
+        Expected:
+            - VirtualMachine start operation succeeds
+        """
+
+    @pytest.mark.polarion("CNV-16031")
+    def test_view_can_list_vms_when_aggregation_reenabled(self):
+        """
+        Test that an unprivileged user with the view role can list VirtualMachine
+        resources when role aggregation is enabled.
+
+        Preconditions:
+            - Namespace with a RoleBinding granting the unprivileged user the view ClusterRole
+
+        Steps:
+            1. List VirtualMachine resources in the namespace using the unprivileged user's credentials
 
         Expected:
             - VirtualMachine resources are listed successfully

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -4,6 +4,7 @@ Role-based access control (RBAC) tests
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/CNV-63822-role-aggregation-opt-out.md
 
 Markers:
+    - arm64
     - post_upgrade
 """
 
@@ -11,7 +12,7 @@ import pytest
 
 __test__ = False
 
-pytestmark = pytest.mark.post_upgrade
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
 class TestRoleAggregationDisabledRBACEnforcement:
@@ -70,7 +71,7 @@ class TestRoleAggregationReenabledAccess:
             - Delete-collection operation succeeds
         """
 
-    @pytest.mark.polarion("CNV-16030")
+    @pytest.mark.polarion("CNV-16260")
     def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self):
         """
         Test that an unprivileged user with the edit role can create a VirtualMachine
@@ -87,7 +88,7 @@ class TestRoleAggregationReenabledAccess:
             - Dry-run create operation succeeds
         """
 
-    @pytest.mark.polarion("CNV-16031")
+    @pytest.mark.polarion("CNV-16261")
     def test_view_can_list_vms_when_aggregation_reenabled(self):
         """
         Test that an unprivileged user with the view role can list VirtualMachine

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -16,9 +16,8 @@ class TestRoleAggregationDisabled:
     Tests for RBAC enforcement when role aggregation is disabled.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "Manual" (role aggregation disabled)
+        - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault" (role aggregation enabled)
         - Unprivileged user created via HTPasswd identity provider
-        - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
     """
 
     @pytest.mark.parametrize(
@@ -37,8 +36,14 @@ class TestRoleAggregationDisabled:
         Parametrize:
             - role: [admin, edit, view]
 
+        Preconditions:
+            - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
+
         Steps:
-            1. Attempt to list VirtualMachine resources in the namespace using the unprivileged
+            1. List VirtualMachine resources in the namespace using the unprivileged
+               user's credentials and verify the operation succeeds
+            2. Set HyperConverged CR spec.roleAggregationStrategy to "Manual" (disable role aggregation)
+            3. Attempt to list VirtualMachine resources in the namespace using the unprivileged
                user's credentials
 
         Expected:

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -1,5 +1,5 @@
 """
-Role-based access control (RBAC) tests
+Role Aggregation Opt-Out RBAC Enforcement Tests
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/CNV-63822-role-aggregation-opt-out.md
 
@@ -47,7 +47,7 @@ class TestRoleAggregationDisabled:
 
         Steps:
             1. Set HyperConverged CR spec.roleAggregationStrategy to "Manual" (disable role aggregation)
-            2. Wait for the kubevirt.io aggregated role labels to be removed from the user
+            2. Wait for the aggregation labels to be removed from the kubevirt.io ClusterRoles
             3. Attempt to list VirtualMachine resources in the namespace using the unprivileged
                user's credentials
 
@@ -64,7 +64,7 @@ class TestRoleAggregationReenabledAccess:
         - HyperConverged CR spec.roleAggregationStrategy set to "Manual" (role aggregation disabled)
         - RoleBinding granting the unprivileged user the respective ClusterRole in the namespace
         - HyperConverged CR spec.roleAggregationStrategy restored to "AggregateToDefault" (role aggregation re-enabled)
-        - Wait for the kubevirt.io aggregated role labels to be added to the user
+        - Wait for the aggregation labels to be restored on the kubevirt.io ClusterRoles
     """
 
     @pytest.mark.polarion("CNV-16029")

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -21,6 +21,7 @@ class TestRoleAggregationDisabledRBACEnforcement:
         - Unprivileged user created via HTPasswd identity provider
     """
 
+    @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-16028")
     def test_vm_list_forbidden_when_aggregation_disabled(self):
         """
@@ -51,6 +52,7 @@ class TestRoleAggregationReenabledAccess:
         - Unprivileged user created via HTPasswd identity provider
     """
 
+    @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-16029")
     def test_access_restored_when_aggregation_reenabled(self):
         """

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -51,41 +51,40 @@ class TestRoleAggregationReenabledAccess:
     Preconditions:
         - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault" (role aggregation enabled)
         - Unprivileged user created via HTPasswd identity provider
-        - VirtualMachine resource created in the test namespace
     """
 
     @pytest.mark.polarion("CNV-16029")
-    def test_admin_can_delete_vm_when_aggregation_reenabled(self):
+    def test_admin_can_delete_vm_collection_when_aggregation_reenabled(self):
         """
-        Test that an unprivileged user with the admin role can delete a VirtualMachine
-        resource when role aggregation is enabled.
+        Test that an unprivileged user with the admin role can perform a delete-collection
+        call on VirtualMachine resources when role aggregation is enabled.
 
         Preconditions:
             - Namespace with a RoleBinding granting the unprivileged user the admin ClusterRole
-            - Separate VirtualMachine resource created for deletion
 
         Steps:
-            1. Delete the VirtualMachine resource using the unprivileged user's credentials
+            1. Issue a raw DELETE request to the VirtualMachine collection API endpoint
+               using the unprivileged user's credentials
 
         Expected:
-            - VirtualMachine is deleted successfully
+            - Delete-collection operation succeeds
         """
 
     @pytest.mark.polarion("CNV-16030")
-    def test_edit_can_start_vm_when_aggregation_reenabled(self):
+    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self):
         """
-        Test that an unprivileged user with the edit role can start a VirtualMachine
-        when role aggregation is enabled.
+        Test that an unprivileged user with the edit role can create a VirtualMachine
+        using a server-side dry-run when role aggregation is enabled.
 
         Preconditions:
             - Namespace with a RoleBinding granting the unprivileged user the edit ClusterRole
-            - VirtualMachine resource in halted state
 
         Steps:
-            1. Start the VirtualMachine using the unprivileged user's credentials
+            1. Create a VirtualMachine using server-side dry-run with the unprivileged
+               user's credentials
 
         Expected:
-            - VirtualMachine start operation succeeds
+            - Dry-run create operation succeeds
         """
 
     @pytest.mark.polarion("CNV-16031")

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -1,0 +1,101 @@
+"""
+Tests for RBAC enforcement when role aggregation is disabled.
+
+STP: https://issues.redhat.com/browse/CNV-63822
+"""
+
+import pytest
+
+__test__ = False
+
+
+class TestRoleAggregationRBACEnforcement:
+    """
+    Tests for RBAC enforcement when role aggregation is disabled.
+
+    STP: https://issues.redhat.com/browse/CNV-63822
+
+    Preconditions:
+        - OpenShift Virtualization installed
+        - HyperConverged CR spec.roleAggregationStrategy set to "Manual" (role aggregation disabled)
+        - Unprivileged user created via HTPasswd identity provider
+    """
+
+    @pytest.mark.polarion("CNV-63826")
+    def test_admin_role_forbidden_when_aggregation_disabled(self):
+        """
+        [NEGATIVE] Test that an unprivileged user with project admin role is forbidden from
+        performing virtualization admin actions when role aggregation is disabled.
+
+        Preconditions:
+            - Unprivileged user created via HTPasswd identity provider
+            - Namespace where the unprivileged user has admin role
+            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+
+        Steps:
+            1. Attempt to create a VirtualMachine in the namespace using the unprivileged
+               user's credentials
+
+        Expected:
+            - Operation is rejected with a Forbidden error
+        """
+
+    @pytest.mark.polarion("CNV-63827")
+    def test_edit_role_forbidden_when_aggregation_disabled(self):
+        """
+        [NEGATIVE] Test that an unprivileged user with edit role is forbidden from performing
+        virtualization edit actions when role aggregation is disabled.
+
+        Preconditions:
+            - Unprivileged user created via HTPasswd identity provider
+            - Namespace with a RoleBinding granting the unprivileged user the edit ClusterRole
+            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+
+        Steps:
+            1. Attempt to create a VirtualMachine in the namespace using the unprivileged
+               user's credentials
+
+        Expected:
+            - Operation is rejected with a Forbidden error
+        """
+
+    @pytest.mark.polarion("CNV-63828")
+    def test_view_role_forbidden_when_aggregation_disabled(self):
+        """
+        [NEGATIVE] Test that an unprivileged user with view role is forbidden from performing
+        virtualization view actions when role aggregation is disabled.
+
+        Preconditions:
+            - Unprivileged user created via HTPasswd identity provider
+            - Namespace with a RoleBinding granting the unprivileged user the view ClusterRole
+            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+
+        Steps:
+            1. Attempt to list VirtualMachine resources in the namespace using the unprivileged
+               user's credentials
+
+        Expected:
+            - Operation is rejected with a Forbidden error
+        """
+
+    @pytest.mark.polarion("CNV-63829")
+    def test_access_restored_when_aggregation_reenabled(self):
+        """
+        Test that virtualization access is restored for unprivileged users when role aggregation
+        is re-enabled after being disabled.
+
+        Preconditions:
+            - Unprivileged user created via HTPasswd identity provider
+            - Namespace where the unprivileged user has admin role
+            - HyperConverged CR spec.roleAggregationStrategy was set to "Manual"
+              (role aggregation disabled)
+            - HyperConverged CR spec.roleAggregationStrategy changed to "AggregateToDefault"
+              (role aggregation re-enabled)
+
+        Steps:
+            1. Attempt to create a VirtualMachine in the namespace using the unprivileged
+               user's credentials
+
+        Expected:
+            - VirtualMachine is created successfully
+        """

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -9,7 +9,7 @@ import pytest
 __test__ = False
 
 
-class TestRoleAggregationRBACEnforcement:
+class TestRoleAggregationDisabledRBACEnforcement:
     """
     Tests for RBAC enforcement when role aggregation is disabled.
 
@@ -22,53 +22,17 @@ class TestRoleAggregationRBACEnforcement:
     """
 
     @pytest.mark.polarion("CNV-63826")
-    def test_admin_role_forbidden_when_aggregation_disabled(self):
+    def test_vm_list_forbidden_when_aggregation_disabled(self):
         """
-        [NEGATIVE] Test that an unprivileged user with project admin role is forbidden from
-        performing virtualization admin actions when role aggregation is disabled.
+        [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
+        from listing virtualization resources when role aggregation is disabled.
+
+        Parametrize:
+            - role: [admin, edit, view]
 
         Preconditions:
             - Unprivileged user created via HTPasswd identity provider
-            - Namespace where the unprivileged user has admin role
-            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
-
-        Steps:
-            1. Attempt to create a VirtualMachine in the namespace using the unprivileged
-               user's credentials
-
-        Expected:
-            - Operation is rejected with a Forbidden error
-        """
-
-    @pytest.mark.polarion("CNV-63827")
-    def test_edit_role_forbidden_when_aggregation_disabled(self):
-        """
-        [NEGATIVE] Test that an unprivileged user with edit role is forbidden from performing
-        virtualization edit actions when role aggregation is disabled.
-
-        Preconditions:
-            - Unprivileged user created via HTPasswd identity provider
-            - Namespace with a RoleBinding granting the unprivileged user the edit ClusterRole
-            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
-
-        Steps:
-            1. Attempt to create a VirtualMachine in the namespace using the unprivileged
-               user's credentials
-
-        Expected:
-            - Operation is rejected with a Forbidden error
-        """
-
-    @pytest.mark.polarion("CNV-63828")
-    def test_view_role_forbidden_when_aggregation_disabled(self):
-        """
-        [NEGATIVE] Test that an unprivileged user with view role is forbidden from performing
-        virtualization view actions when role aggregation is disabled.
-
-        Preconditions:
-            - Unprivileged user created via HTPasswd identity provider
-            - Namespace with a RoleBinding granting the unprivileged user the view ClusterRole
-            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+            - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
 
         Steps:
             1. Attempt to list VirtualMachine resources in the namespace using the unprivileged
@@ -78,24 +42,37 @@ class TestRoleAggregationRBACEnforcement:
             - Operation is rejected with a Forbidden error
         """
 
+
+class TestRoleAggregationReenabledAccess:
+    """
+    Tests for access restoration when role aggregation is re-enabled.
+
+    STP: https://issues.redhat.com/browse/CNV-63822
+
+    Preconditions:
+        - OpenShift Virtualization installed
+        - HyperConverged CR spec.roleAggregationStrategy changed from "Manual" to
+          "AggregateToDefault" (role aggregation re-enabled)
+        - Unprivileged user created via HTPasswd identity provider
+    """
+
     @pytest.mark.polarion("CNV-63829")
     def test_access_restored_when_aggregation_reenabled(self):
         """
-        Test that virtualization access is restored for unprivileged users when role aggregation
-        is re-enabled after being disabled.
+        Test that an unprivileged user with a standard OpenShift role can list virtualization
+        resources when role aggregation is re-enabled.
+
+        Parametrize:
+            - role: [admin, edit, view]
 
         Preconditions:
             - Unprivileged user created via HTPasswd identity provider
-            - Namespace where the unprivileged user has admin role
-            - HyperConverged CR spec.roleAggregationStrategy was set to "Manual"
-              (role aggregation disabled)
-            - HyperConverged CR spec.roleAggregationStrategy changed to "AggregateToDefault"
-              (role aggregation re-enabled)
+            - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
 
         Steps:
-            1. Attempt to create a VirtualMachine in the namespace using the unprivileged
+            1. Attempt to list VirtualMachine resources in the namespace using the unprivileged
                user's credentials
 
         Expected:
-            - VirtualMachine is created successfully
+            - VirtualMachine resources are listed successfully
         """

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -21,7 +21,7 @@ class TestRoleAggregationDisabledRBACEnforcement:
         - Unprivileged user created via HTPasswd identity provider
     """
 
-    @pytest.mark.polarion("CNV-63826")
+    @pytest.mark.polarion("CNV-16028")
     def test_vm_list_forbidden_when_aggregation_disabled(self):
         """
         [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
@@ -56,7 +56,7 @@ class TestRoleAggregationReenabledAccess:
         - Unprivileged user created via HTPasswd identity provider
     """
 
-    @pytest.mark.polarion("CNV-63829")
+    @pytest.mark.polarion("CNV-16029")
     def test_access_restored_when_aggregation_reenabled(self):
         """
         Test that an unprivileged user with a standard OpenShift role can list virtualization

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -1,7 +1,9 @@
 """
-Tests for RBAC enforcement when role aggregation is disabled.
+Role-based access control (RBAC) tests
 
-STP: https://issues.redhat.com/browse/CNV-63822
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/CNV-63822-role-aggregation-opt-out.md
+
+
 """
 
 import pytest
@@ -13,10 +15,7 @@ class TestRoleAggregationDisabledRBACEnforcement:
     """
     Tests for RBAC enforcement when role aggregation is disabled.
 
-    STP: https://issues.redhat.com/browse/CNV-63822
-
     Preconditions:
-        - OpenShift Virtualization installed
         - HyperConverged CR spec.roleAggregationStrategy set to "Manual" (role aggregation disabled)
         - Unprivileged user created via HTPasswd identity provider
     """
@@ -31,7 +30,6 @@ class TestRoleAggregationDisabledRBACEnforcement:
             - role: [admin, edit, view]
 
         Preconditions:
-            - Unprivileged user created via HTPasswd identity provider
             - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
 
         Steps:
@@ -45,14 +43,10 @@ class TestRoleAggregationDisabledRBACEnforcement:
 
 class TestRoleAggregationReenabledAccess:
     """
-    Tests for access restoration when role aggregation is re-enabled.
-
-    STP: https://issues.redhat.com/browse/CNV-63822
+    Tests for access restoration when role aggregation is enabled.
 
     Preconditions:
-        - OpenShift Virtualization installed
-        - HyperConverged CR spec.roleAggregationStrategy changed from "Manual" to
-          "AggregateToDefault" (role aggregation re-enabled)
+        - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault" (role aggregation enabled)
         - Unprivileged user created via HTPasswd identity provider
     """
 
@@ -60,13 +54,12 @@ class TestRoleAggregationReenabledAccess:
     def test_access_restored_when_aggregation_reenabled(self):
         """
         Test that an unprivileged user with a standard OpenShift role can list virtualization
-        resources when role aggregation is re-enabled.
+        resources when role aggregation is enabled.
 
         Parametrize:
             - role: [admin, edit, view]
 
         Preconditions:
-            - Unprivileged user created via HTPasswd identity provider
             - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
 
         Steps:

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -3,7 +3,8 @@ Role-based access control (RBAC) tests
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/CNV-63822-role-aggregation-opt-out.md
 
-
+Markers:
+    - post_upgrade
 """
 
 import pytest

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -2,13 +2,19 @@
 Role-based access control (RBAC) tests
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-iuo/CNV-63822-role-aggregation-opt-out.md
+
+Markers:
+    - post_upgrade
+    - arm64
+
+Preconditions:
+    - Unprivileged user created via HTPasswd identity provider
+    - Namespace for RBAC testing
 """
 
 import pytest
 
 __test__ = False
-
-pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
 class TestRoleAggregationDisabled:
@@ -17,7 +23,7 @@ class TestRoleAggregationDisabled:
 
     Preconditions:
         - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault" (role aggregation enabled)
-        - Unprivileged user created via HTPasswd identity provider
+        - RoleBinding granting the unprivileged user the parametrized ClusterRole in the namespace
     """
 
     @pytest.mark.parametrize(
@@ -37,12 +43,11 @@ class TestRoleAggregationDisabled:
             - role: [admin, edit, view]
 
         Preconditions:
-            - Namespace with a RoleBinding granting the unprivileged user the parametrized ClusterRole
+            - User can list VirtualMachine resources in the namespace successfully
 
         Steps:
-            1. List VirtualMachine resources in the namespace using the unprivileged
-               user's credentials and verify the operation succeeds
-            2. Set HyperConverged CR spec.roleAggregationStrategy to "Manual" (disable role aggregation)
+            1. Set HyperConverged CR spec.roleAggregationStrategy to "Manual" (disable role aggregation)
+            2. Wait for the kubevirt.io aggregated role labels to be removed from the user
             3. Attempt to list VirtualMachine resources in the namespace using the unprivileged
                user's credentials
 
@@ -53,11 +58,13 @@ class TestRoleAggregationDisabled:
 
 class TestRoleAggregationReenabledAccess:
     """
-    Tests for role-specific access when role aggregation is enabled.
+    Tests for role-specific access when role aggregation is re-enabled.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault" (role aggregation enabled)
-        - Unprivileged user created via HTPasswd identity provider
+        - HyperConverged CR spec.roleAggregationStrategy set to "Manual" (role aggregation disabled)
+        - RoleBinding granting the unprivileged user the respective ClusterRole in the namespace
+        - HyperConverged CR spec.roleAggregationStrategy restored to "AggregateToDefault" (role aggregation re-enabled)
+        - Wait for the kubevirt.io aggregated role labels to be added to the user
     """
 
     @pytest.mark.polarion("CNV-16029")
@@ -67,7 +74,7 @@ class TestRoleAggregationReenabledAccess:
         call on VirtualMachine resources when role aggregation is enabled.
 
         Preconditions:
-            - Namespace with a RoleBinding granting the unprivileged user the admin ClusterRole
+            - Unprivileged user with the admin ClusterRole bound in the namespace
 
         Steps:
             1. Issue a raw DELETE request to the VirtualMachine collection API endpoint
@@ -84,7 +91,7 @@ class TestRoleAggregationReenabledAccess:
         using a server-side dry-run when role aggregation is enabled.
 
         Preconditions:
-            - Namespace with a RoleBinding granting the unprivileged user the edit ClusterRole
+            - Unprivileged user with the edit ClusterRole bound in the namespace
 
         Steps:
             1. Create a VirtualMachine using server-side dry-run with the unprivileged
@@ -101,7 +108,7 @@ class TestRoleAggregationReenabledAccess:
         resources when role aggregation is enabled.
 
         Preconditions:
-            - Namespace with a RoleBinding granting the unprivileged user the view ClusterRole
+            - Unprivileged user with the view ClusterRole bound in the namespace
 
         Steps:
             1. List VirtualMachine resources in the namespace using the unprivileged user's credentials


### PR DESCRIPTION
##### What this PR does / why we need it:
STD for the role aggregation opt out feature

##### Which issue(s) this PR fixes:
Adds skeleton tests for two scenarios:
1. Verifies that if the aggregation is disabled, users with generic admin/edit/view roles can't access virtualization resources
2. Verifies that if the users are given roles while the aggregation is disabled and the aggregation is enabled, the users can perform expected virtualization actions

##### Special notes for reviewer:
Edit: The PR now creates a VM and deletes a VM namespace for the edit and admin roles respectively

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-86975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new pytest module scaffold to document expected RBAC behavior when role aggregation is disabled and then re-enabled during virtualization upgrades.
  * Covers admin/edit/view access scenarios with negative and positive cases.
  * Test execution is intentionally disabled for this module to prevent it from running as part of the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->