### PR TITLE
Remove CNV-87184 skip fixture - issue resolved as not a bug

### DIFF
--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -46,11 +46,5 @@ def cluster_has_rhcos10_or_above(workers_rhcos_version):
 
 
 @pytest.fixture(scope="session")
-def skip_when_hco_metrics_scraping_bug_open(cluster_has_rhcos10_or_above):
-    if cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-87184"):
-        pytest.xfail(reason="CNV-87184: HCO metrics scraping fails with 401 Unauthorized on RHCOS 10+")
-
-
-@pytest.fixture(scope="session")
 def is_postcopy_migration_bug_open(cluster_has_rhcos10_or_above):
     return cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-84023")

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -94,7 +94,6 @@ class TestVirtHCOSingleStackIpv6:
     @pytest.mark.ipv6
     @pytest.mark.polarion("CNV-11740")
     @pytest.mark.s390x
-    @pytest.mark.usefixtures("skip_when_hco_metrics_scraping_bug_open")
     def test_metric_kubevirt_hco_single_stack_ipv6(self, prometheus):
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -59,7 +59,6 @@ class TestMetricsWindows:
 @pytest.mark.polarion("CNV-10438")
 @pytest.mark.s390x
 @pytest.mark.conformance
-@pytest.mark.usefixtures("skip_when_hco_metrics_scraping_bug_open")
 def test_cnv_installation_with_hco_cr_metrics(
     prometheus,
 ):


### PR DESCRIPTION
##### What this PR does / why we need it:
CNV-87184 resolved as not a bug, removing the jira marker for it.

##### jira-ticket:
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed skip conditions from hyperconverged operator metrics tests, enabling previously conditional tests to run unconditionally.
  * Affected tests include general metrics and CNV installation validation.

* **Chores**
  * Removed obsolete test fixture that was handling conditional test skipping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/5012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->