### PR TITLE
[net] Verifier test for bug fix - have RestartRequired condition set when default interface is attached

### DIFF
--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -55,6 +55,7 @@ class Devices:
     disks: list[SpecDisk] | None = None
     interfaces: list[Interface] | None = None
     rng: dict[Any, Any] | None = None
+    autoattachPodInterface: bool | None = None  # noqa: N815
 
 
 @dataclass

--- a/tests/network/primary_network/attach_primary/conftest.py
+++ b/tests/network/primary_network/attach_primary/conftest.py
@@ -1,0 +1,36 @@
+"""Fixtures for VM network attachment tests."""
+
+from collections.abc import Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import Devices
+from libs.vm.vm import BaseVirtualMachine
+
+
+@pytest.fixture()
+def vm_without_pod_interface(namespace: Namespace, unprivileged_client: DynamicClient) -> Generator[BaseVirtualMachine]:
+    """
+    Create and start a VM with `autoattachPodInterface: false` and no interfaces/networks.
+
+    Yields:
+        BaseVirtualMachine: Running VM with autoattachPodInterface disabled
+    """
+    spec = base_vmspec()
+
+    # Set no interfaces/networks and autoattachPodInterface to false
+    spec.template.spec.domain.devices = Devices(autoattachPodInterface=False)
+    spec.template.spec.networks = []
+
+    with fedora_vm(
+        namespace=namespace.name,
+        name="vm-no-pod-interface",
+        client=unprivileged_client,
+        spec=spec,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm

--- a/tests/network/primary_network/attach_primary/libattach.py
+++ b/tests/network/primary_network/attach_primary/libattach.py
@@ -1,0 +1,70 @@
+"""Helper functions for VM primary network attachment tests."""
+
+import logging
+
+from ocp_resources.resource import ResourceEditor
+
+from libs.vm.vm import BaseVirtualMachine
+
+LOGGER = logging.getLogger(__name__)
+
+
+def assert_restart_required_condition_not_set(vm: BaseVirtualMachine) -> None:
+    """
+    Assert that the RestartRequired condition is not set on the VM.
+
+    The condition is considered not set if either:
+    - The condition does not exist
+    - The condition exists but its status is False
+
+    Args:
+        vm: The VM to check
+
+    Raises:
+        AssertionError: If the RestartRequired condition exists with status True
+    """
+    conditions = vm.instance.status.conditions or []
+    restart_required_conditions = [condition for condition in conditions if condition["type"] == "RestartRequired"]
+
+    if restart_required_conditions:
+        condition = restart_required_conditions[0]
+        assert condition["status"] == vm.Condition.Status.FALSE, (
+            f"VM {vm.name} has RestartRequired condition set to {condition['status']}: {condition}"
+        )
+
+
+def add_pod_interface_and_network(vm: BaseVirtualMachine) -> None:
+    """
+    Add a pod interface and network to a VM.
+
+    Args:
+        vm: The VM to add the pod interface and network to
+    """
+    LOGGER.info(f"Adding pod interface and network to VM {vm.name}")
+    patch = {
+        vm: {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "domain": {
+                            "devices": {
+                                "interfaces": [
+                                    {
+                                        "name": "default",
+                                        "masquerade": {},
+                                    }
+                                ]
+                            }
+                        },
+                        "networks": [
+                            {
+                                "name": "default",
+                                "pod": {},
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    }
+    ResourceEditor(patches=patch).update()

--- a/tests/network/primary_network/attach_primary/test_attach_network.py
+++ b/tests/network/primary_network/attach_primary/test_attach_network.py
@@ -1,0 +1,37 @@
+"""
+Test VM network attachment behavior - RestartRequired condition
+
+Jira: https://redhat.atlassian.net/browse/CNV-87822 # <skip-jira-utils-check>
+"""
+
+import pytest
+
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.primary_network.attach_primary import libattach
+
+
+@pytest.mark.polarion("CNV-16026")
+@pytest.mark.single_nic
+def test_restart_required_when_pod_network_attached(vm_without_pod_interface: BaseVirtualMachine) -> None:
+    """
+    Test that adding a pod interface to a running VM sets RestartRequired condition.
+    Verifies the scenario exposed by a bug.
+
+    Preconditions:
+        - Running VM with no interfaces/networks and `autoattachPodInterface: false`
+
+    Steps:
+        1. Add a pod interface and network to the VM spec
+        2. Check that RestartRequired condition is set in VM status
+
+    Expected:
+        - VM reports RestartRequired condition after pod network is added to spec
+    """
+
+    libattach.assert_restart_required_condition_not_set(vm=vm_without_pod_interface)
+    libattach.add_pod_interface_and_network(vm=vm_without_pod_interface)
+    vm_without_pod_interface.wait_for_condition(
+        condition="RestartRequired",
+        status=vm_without_pod_interface.Condition.Status.TRUE,
+        timeout=10,
+    )


### PR DESCRIPTION
##### What this PR does / why we need it:
Add a default interface to a VM which is created with no interfaces, and verify the RestartRequired condition is set.
This verifies the fix for bug CNV-69394.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-87822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional VM setting to control automatic pod-interface attachment.
  * VMs now signal when attaching a pod network to a running VM requires a restart.

* **Tests**
  * Added end-to-end tests and fixtures validating pod-interface attachment and restart-required signaling.
  * Added test helpers for asserting the restart-required condition and for attaching a pod interface/network in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->