### PR TITLE
Quarantine: iuo gating test_add_custom_data_import_cron_template_disable_spec

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -10,6 +10,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     get_template_dict_by_name,
     get_templates_by_type_from_hco_status,
 )
+from utilities.constants import QUARANTINED
 from utilities.hco import (
     update_hco_templates_spec,
     wait_for_auto_boot_config_stabilization,
@@ -87,6 +88,11 @@ class TestCustomTemplates:
             ssp_spec_templates_scope_function=ssp_spec_templates_scope_function,
         )
 
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Teardown AssertionError in verify_boot_sources_reimported after re-enabling"
+        " enableCommonBootImageImport spec, CNV-88015",
+        run=False,
+    )
     @pytest.mark.dependency(name="test_add_custom_data_import_cron_template_disable_spec")
     @pytest.mark.polarion("CNV-7914")
     def test_add_custom_data_import_cron_template_disable_spec(


### PR DESCRIPTION
##### What this PR does / why we need it:

Quarantines test failing in [test-pytest-cnv-4.22-iuo-gating):

- **`test_add_custom_data_import_cron_template_disable_spec`** — ERROR at teardown: `AssertionError` in `verify_boot_sources_reimported` after re-enabling `enableCommonBootImageImport` spec

Quarantined with `@pytest.mark.xfail(reason=QUARANTINED, run=False)` per [quarantine guidelines](docs/QUARANTINE_GUIDELINES.md).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

Both test bodies pass — failures are in fixture setup/teardown.

##### jira-ticket:
CNV-88015

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Marked a custom template import test as expected-to-fail and disabled its execution to quarantine known test issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/5016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->