### PR TITLE
net, tests, stuntime: Add remaining l2bridge migration stuntime scenarios

### DIFF
--- a/tests/network/l2_bridge/migration_stuntime/conftest.py
+++ b/tests/network/l2_bridge/migration_stuntime/conftest.py
@@ -12,7 +12,7 @@ from libs.net.vmspec import lookup_iface_status_ip
 from libs.vm.affinity import new_pod_affinity
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.l2_bridge.libl2bridge import secondary_network_vm
-from tests.network.libs.stuntime import SERVER_VM_LABEL, ContinuousPing
+from tests.network.libs.stuntime import CLIENT_VM_LABEL, SERVER_VM_LABEL, ContinuousPing
 
 STUNTIME_BRIDGE_IFACE_NAME: Final[str] = "stuntime-bridge"
 
@@ -24,9 +24,15 @@ def l2_bridge_stuntime_nad(
     bridge_nncp: libnncp.NodeNetworkConfigurationPolicy,
 ) -> Generator[libnad.NetworkAttachmentDefinition]:
     nad_name = "l2-bridge-nad"
+    bridge_name = bridge_nncp.desired_state_spec.interfaces[0].name  # type: ignore[index]
     config = libnad.NetConfig(
         name=nad_name,
-        plugins=[libnad.CNIPluginBridgeConfig(bridge=bridge_nncp.desired_state_spec.interfaces[0].name)],  # type: ignore[index]
+        plugins=[
+            libnad.CNIPluginBridgeConfig(
+                bridge=bridge_name,
+                disableContainerInterface=True,
+            )
+        ],
     )
     with libnad.NetworkAttachmentDefinition(
         name=nad_name,
@@ -79,6 +85,7 @@ def stuntime_client_vm(
             f"{random_ipv6_address(net_seed=0, host_address=2)}/64",
         ],
         affinity=new_pod_affinity(label=SERVER_VM_LABEL),
+        labels=dict([CLIENT_VM_LABEL]),
     ) as client_vm:
         client_vm.start(wait=True)
         client_vm.wait_for_agent_connected()

--- a/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
@@ -18,8 +18,8 @@ STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob
 
 import pytest
 
-from libs.vm.affinity import new_pod_anti_affinity
-from tests.network.libs.stuntime import SERVER_VM_LABEL, STUNTIME_THRESHOLD_SECONDS, measure_stuntime
+from libs.vm.affinity import new_pod_affinity, new_pod_anti_affinity
+from tests.network.libs.stuntime import CLIENT_VM_LABEL, SERVER_VM_LABEL, STUNTIME_THRESHOLD_SECONDS, measure_stuntime
 from utilities.virt import migrate_vm_and_verify
 
 pytestmark = [pytest.mark.tier3]
@@ -31,7 +31,7 @@ Parametrize:
         - ipv6 [Markers: ipv6]
 
 Preconditions:
-    - Shared under-test server VM on Linux bridge secondary network, for the IP family from ip_family parametrization.
+    - Shared under-test server VM on Linux bridge secondary network, for the parametrized IP family.
     - Shared under-test client VM on Linux bridge secondary network, for that same IP family,
       initially running on the same node as the server VM.
 """
@@ -56,7 +56,7 @@ class TestMigrationStuntime:
         VM migrates from the node hosting the server VM into a different node.
 
         Preconditions:
-            - Under-test server VM on Linux bridge secondary network, for the IP family from ip_family parametrization.
+            - Under-test server VM on Linux bridge secondary network, for the parametrized IP family.
             - Under-test client VM on Linux bridge secondary network, for that same IP family,
               running on the same node as the server VM.
             - Ping initiated from the client to the server.
@@ -78,13 +78,15 @@ class TestMigrationStuntime:
         )
 
     @pytest.mark.polarion("CNV-15253")
-    def test_client_migrates_between_non_server_nodes(self):
+    def test_client_migrates_between_non_server_nodes(
+        self, admin_client, l2_bridge_ip_family, stuntime_client_vm, l2_bridge_active_ping
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the client VM migrates between nodes
         while the client and server VMs remain on different nodes.
 
         Preconditions:
-            - Under-test server VM on Linux bridge secondary network, for the IP family from ip_family parametrization.
+            - Under-test server VM on Linux bridge secondary network, for the parametrized IP family.
             - Under-test client VM on Linux bridge secondary network, for that same IP family,
               running on a worker node other than the node hosting the server VM.
             - Ping initiated from the client to the server.
@@ -98,15 +100,22 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        migrate_vm_and_verify(vm=stuntime_client_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=l2_bridge_active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15254")
-    def test_client_migrates_to_server_node(self):
+    def test_client_migrates_to_server_node(
+        self, admin_client, l2_bridge_ip_family, stuntime_client_vm, l2_bridge_active_ping
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the client VM migrates
         from a node other than the node hosting the server VM onto the node hosting the server VM.
 
         Preconditions:
-            - Under-test server VM on Linux bridge secondary network, for the IP family from ip_family parametrization.
+            - Under-test server VM on Linux bridge secondary network, for the parametrized IP family.
             - Under-test client VM on Linux bridge secondary network, for that same IP family,
               running on a worker node other than the node hosting the server VM.
             - Ping initiated from the client to the server.
@@ -120,15 +129,23 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        stuntime_client_vm.set_template_affinity(affinity=new_pod_affinity(label=SERVER_VM_LABEL))
+        migrate_vm_and_verify(vm=stuntime_client_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=l2_bridge_active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15255")
-    def test_server_migrates_off_client_node(self):
+    def test_server_migrates_off_client_node(
+        self, admin_client, l2_bridge_ip_family, stuntime_server_vm, l2_bridge_active_ping
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the server
         VM migrates from the node hosting the client VM into a different node.
 
         Preconditions:
-            - Under-test server VM on Linux bridge secondary network, for the IP family from ip_family parametrization.
+            - Under-test server VM on Linux bridge secondary network, for the parametrized IP family.
             - Under-test client VM on Linux bridge secondary network, for that same IP family,
               running on the same node as the server VM.
             - Ping initiated from the client to the server.
@@ -142,15 +159,23 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        stuntime_server_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=CLIENT_VM_LABEL))
+        migrate_vm_and_verify(vm=stuntime_server_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=l2_bridge_active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15256")
-    def test_server_migrates_between_non_client_nodes(self):
+    def test_server_migrates_between_non_client_nodes(
+        self, admin_client, l2_bridge_ip_family, stuntime_server_vm, l2_bridge_active_ping
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the server VM migrates between nodes
         while the client and server VMs remain on different nodes.
 
         Preconditions:
-            - Under-test server VM on Linux bridge secondary network, for the IP family from ip_family parametrization.
+            - Under-test server VM on Linux bridge secondary network, for the parametrized IP family.
             - Under-test client VM on Linux bridge secondary network, for that same IP family,
               running on a worker node other than the node hosting the server VM (before and after migration).
             - Ping initiated from the client to the server.
@@ -164,15 +189,23 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
+        stuntime_server_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=CLIENT_VM_LABEL))
+        migrate_vm_and_verify(vm=stuntime_server_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=l2_bridge_active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )
 
     @pytest.mark.polarion("CNV-15257")
-    def test_server_migrates_to_client_node(self):
+    def test_server_migrates_to_client_node(
+        self, admin_client, l2_bridge_ip_family, stuntime_server_vm, l2_bridge_active_ping
+    ):
         """
         Test that measured stuntime does not exceed the global threshold when the server VM migrates from a node
         other than the node hosting the client VM onto the node hosting the client VM.
 
         Preconditions:
-            - Under-test server VM on Linux bridge secondary network, for the IP family from ip_family parametrization.
+            - Under-test server VM on Linux bridge secondary network, for the parametrized IP family.
             - Under-test client VM on Linux bridge secondary network, for that same IP family,
               running on a worker node other than the node hosting the server VM.
             - Ping initiated from the client to the server.
@@ -186,9 +219,9 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
-
-    test_client_migrates_between_non_server_nodes.__test__ = False
-    test_client_migrates_to_server_node.__test__ = False
-    test_server_migrates_off_client_node.__test__ = False
-    test_server_migrates_between_non_client_nodes.__test__ = False
-    test_server_migrates_to_client_node.__test__ = False
+        stuntime_server_vm.set_template_affinity(affinity=new_pod_affinity(label=CLIENT_VM_LABEL))
+        migrate_vm_and_verify(vm=stuntime_server_vm, client=admin_client)
+        measured_stuntime = measure_stuntime(active_ping=l2_bridge_active_ping)
+        assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (
+            f"Stuntime {measured_stuntime}s exceeds threshold ({STUNTIME_THRESHOLD_SECONDS}s)"
+        )


### PR DESCRIPTION
##### Short description:
Complete L2 bridge stuntime coverage for both IP families.

##### More details:

##### What this PR does / why we need it:
Add remaining stuntime measurement tests for Linux bridge with both IPv4 and IPv6 coverage, through different migration directions.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
 - Single parametrized class with class-level l2_bridge_ip_family parametrize to group all scenarios per IP family. VMs depend on l2_bridge_ip_family so they're recreated per group, giving each IP family fresh VMs with clean network state (4 VMs total).
 - The client VM's affinity towards the server (last client migration scenario) is not cleared before server migration tests — server affinity is set independently and the client's affinity has no effect on server scheduling for this matter.
 - Add disableContainerInterface=True to the Linux bridge NAD to match the documented configuration and let kubevirt manage the interface directly during migration.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-80577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced L2 bridge migration test coverage with parameterized IPv4 and IPv6 scenarios.
  * Enabled all migration stuntime measurement tests to run by default.
  * Improved test configuration with explicit VM placement control across migration scenarios.
  * Expanded stuntime measurement testing with multiple scenario variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->