### PR TITLE
[VIRT] Descheduler: Limit pod count to 85% to prevent VM preemption

### DIFF
--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -213,7 +213,14 @@ def unallocated_pod_count(
     node_with_least_available_memory,
 ):
     non_terminated_pod_count = len(get_non_terminated_pods(client=admin_client, node=node_with_least_available_memory))
-    return int(node_with_least_available_memory.instance.status.capacity.pods) - non_terminated_pod_count
+    capacity = int(node_with_least_available_memory.instance.status.capacity.pods)
+    # Target 85% utilization: high enough to trigger descheduler (>70%) but below scheduler preemption threshold
+    target_pod_count = int(capacity * 0.85)
+    pods_to_add = max(0, target_pod_count - non_terminated_pod_count)
+    LOGGER.info(
+        f"Node {node_with_least_available_memory.name}: current pods {non_terminated_pod_count}, will add {pods_to_add}"
+    )
+    return pods_to_add
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### What this PR does / why we need it:
VMs can be preempted by Kubernetes scheduler when node approached 100% pod capacity. Target 85% utilization instead: high enough to trigger descheduler (>70%) but below preemption threshold.

Added logging for current pod count and planned additions.

Co-authored-by: Claude Sonnet 4.5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture to simulate more realistic pod allocation scenarios by targeting approximately 85% of node capacity instead of maximum capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->