### PR TITLE
[IUO] Revert Mdevconfig FG workaround

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -13,7 +13,6 @@ from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
-    DISABLE_MDEV_CONFIGURATION,
     ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
     EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
     FG_ENABLED,
@@ -289,19 +288,12 @@ def jira_86102_open():
     return is_jira_open(jira_id="CNV-88764")
 
 
-@pytest.fixture(scope="session")
-def jira_86639_open():
-    return is_jira_open(jira_id="CNV-86639")
-
-
 @pytest.fixture()
-def expected_value(request, is_s390x_cluster, jira_86639_open):
+def expected_value(request, is_s390x_cluster):
     expected = request.param.copy()
     if expected == EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES and is_s390x_cluster:
         expected |= S390X_SPECIFIC_KUBEVIRT_FEATUREGATES
     if expected == HCO_DEFAULT_FEATUREGATES:
         if py_config["cluster_type"] == MULTIARCH:
             expected[ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT] = FG_ENABLED
-        if jira_86639_open:
-            expected[DISABLE_MDEV_CONFIGURATION] = FG_ENABLED
     return expected


### PR DESCRIPTION
##### What this PR does / why we need it:
FG was enabled by default in deployment job.
Reverted, and will be applied via automation.
So jira Bug can be deleted.

##### Which issue(s) this PR fixes:
Removing the workaround since I reverted the deployment jobs change.

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-86639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Cleaned up unused test fixtures and dependencies in test configuration.
  * Simplified feature gate configuration logic in test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/5032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->