### PR TITLE
[4.21][storage] Fix flaky CDI import tests by watching DataVolume conditions

### DIFF
--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -10,9 +10,6 @@ from ocp_resources.datavolume import DataVolume
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.storage.cdi_import.utils import (
-    wait_dv_and_get_importer,
-)
 from tests.storage.constants import (
     CIRROS_QCOW2_IMG,
     HTTP,
@@ -24,11 +21,12 @@ from tests.storage.utils import (
     assert_num_files_in_pod,
     assert_use_populator,
     get_file_url,
-    wait_for_importer_container_message,
+    wait_for_dv_condition_message,
 )
 from utilities.constants import (
     QUARANTINED,
     TIMEOUT_1MIN,
+    TIMEOUT_2MIN,
     TIMEOUT_5MIN,
     Images,
 )
@@ -215,16 +213,14 @@ def test_successful_import_basic_auth(
     indirect=True,
 )
 def test_wrong_content_type(
-    admin_client,
     dv_from_http_import,
 ):
-    wait_for_importer_container_message(
-        importer_pod=wait_dv_and_get_importer(
-            dv=dv_from_http_import,
-            admin_client=admin_client,
-        ),
-        msg=ErrorMsg.EXIT_STATUS_2,
+    dv_from_http_import.wait_for_status(
+        status=DataVolume.Status.IMPORT_IN_PROGRESS,
+        timeout=TIMEOUT_2MIN,
+        stop_status=DataVolume.Status.SUCCEEDED,
     )
+    wait_for_dv_condition_message(dv=dv_from_http_import, expected_message=ErrorMsg.EXIT_STATUS_2)
 
 
 @pytest.mark.sno
@@ -256,16 +252,14 @@ def test_wrong_content_type(
 )
 @pytest.mark.s390x
 def test_unpack_compressed(
-    admin_client,
     dv_from_http_import,
 ):
-    wait_for_importer_container_message(
-        importer_pod=wait_dv_and_get_importer(
-            dv=dv_from_http_import,
-            admin_client=admin_client,
-        ),
-        msg=ErrorMsg.EXIT_STATUS_2,
+    dv_from_http_import.wait_for_status(
+        status=DataVolume.Status.IMPORT_IN_PROGRESS,
+        timeout=TIMEOUT_2MIN,
+        stop_status=DataVolume.Status.SUCCEEDED,
     )
+    wait_for_dv_condition_message(dv=dv_from_http_import, expected_message=ErrorMsg.EXIT_STATUS_2)
 
 
 @pytest.mark.sno
@@ -297,13 +291,16 @@ def test_unpack_compressed(
 )
 @pytest.mark.s390x
 def test_certconfigmap_incorrect_cert(
-    admin_client,
     https_config_map,
     dv_from_http_import,
 ):
-    wait_for_importer_container_message(
-        importer_pod=wait_dv_and_get_importer(dv=dv_from_http_import, admin_client=admin_client),
-        msg=ErrorMsg.CERTIFICATE_SIGNED_UNKNOWN_AUTHORITY,
+    dv_from_http_import.wait_for_status(
+        status=DataVolume.Status.IMPORT_IN_PROGRESS,
+        timeout=TIMEOUT_2MIN,
+        stop_status=DataVolume.Status.SUCCEEDED,
+    )
+    wait_for_dv_condition_message(
+        dv=dv_from_http_import, expected_message=ErrorMsg.CERTIFICATE_SIGNED_UNKNOWN_AUTHORITY
     )
 
 

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -7,12 +7,8 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.resource import Resource
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
-from tests.storage.utils import (
-    get_importer_pod,
-    wait_for_importer_container_message,
-)
-from utilities.constants import OS_FLAVOR_FEDORA, QUARANTINED, REGISTRY_STR, TIMEOUT_5MIN, Images
-from utilities.ssp import wait_for_condition_message_value
+from tests.storage.utils import wait_for_dv_condition_message
+from utilities.constants import OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_5MIN, Images
 from utilities.storage import ErrorMsg, check_disk_count_in_vm, create_dv, create_vm_from_dv
 from utilities.virt import running_vm
 
@@ -38,11 +34,7 @@ LOGGER = logging.getLogger(__name__)
         ),
     ],
 )
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: need to check the DV message instead of importer pod; tracked in CNV-86085",
-    run=False,
-)
-def test_disk_image_not_conform_to_registy_disk(
+def test_disk_image_not_conform_to_registry_disk(
     admin_client, dv_name, url, namespace, storage_class_matrix__function__
 ):
     with create_dv(
@@ -58,11 +50,7 @@ def test_disk_image_not_conform_to_registy_disk(
             timeout=TIMEOUT_5MIN,
             stop_status=DataVolume.Status.SUCCEEDED,
         )
-        importer_pod = get_importer_pod(client=admin_client, namespace=dv.namespace)
-        wait_for_importer_container_message(
-            importer_pod=importer_pod,
-            msg=ErrorMsg.DISK_IMAGE_IN_CONTAINER_NOT_FOUND,
-        )
+        wait_for_dv_condition_message(dv=dv, expected_message=ErrorMsg.DISK_IMAGE_IN_CONTAINER_NOT_FOUND)
 
 
 @pytest.mark.sno
@@ -150,7 +138,7 @@ def test_public_registry_data_volume_low_capacity(unprivileged_client, namespace
             timeout=TIMEOUT_5MIN,
             stop_status=DataVolume.Status.SUCCEEDED,
         )
-        wait_for_condition_message_value(resource=dv, expected_message=ErrorMsg.DATA_VOLUME_TOO_SMALL)
+        wait_for_dv_condition_message(dv=dv, expected_message=ErrorMsg.DATA_VOLUME_TOO_SMALL)
     # positive flow
     with create_dv(
         client=unprivileged_client,

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -1,8 +1,8 @@
 import ast
 import logging
 import shlex
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Generator
 
 import requests
 from kubernetes.dynamic import DynamicClient
@@ -12,7 +12,6 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.daemonset import DaemonSet
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.hostpath_provisioner import HostPathProvisioner
-from ocp_resources.pod import Pod
 from ocp_resources.resource import Resource
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.route import Route
@@ -36,11 +35,13 @@ from utilities.constants import (
     CDI_UPLOADPROXY,
     LS_COMMAND,
     TIMEOUT_2MIN,
+    TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_20SEC,
     TIMEOUT_30MIN,
     Images,
 )
+from utilities.exceptions import DataVolumeConditionMessageNotFoundError
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (
     get_pod_by_name_prefix,
@@ -278,40 +279,50 @@ def get_importer_pod(
         raise
 
 
-def wait_for_importer_container_message(importer_pod, msg):
-    LOGGER.info(f"Wait for {importer_pod.name} container to show message: {msg}")
-    try:
-        sampled_msg = TimeoutSampler(
-            wait_timeout=120,
-            sleep=5,
-            func=lambda: (
-                importer_container_status_reason(importer_pod) == Pod.Status.CRASH_LOOPBACK_OFF
-                and msg
-                in importer_pod.instance.status
-                .containerStatuses[0]
-                .get("lastState", {})
-                .get("terminated", {})
-                .get("message", "")
-            ),
-        )
-        for sample in sampled_msg:
-            if sample:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(f"{importer_pod.name} did not get message: {msg}")
-        raise
-
-
-def importer_container_status_reason(pod):
+def wait_for_dv_condition_message(dv: DataVolume, expected_message: str, timeout: int = TIMEOUT_5MIN) -> None:
     """
-    Get status for why importer pod container is waiting or terminated
-    (for container status running there is no 'reason' key)
+    Wait for DataVolume condition to contain expected message.
+
+    Uses substring matching (not exact match) because CDI messages
+    often include variable context like timestamps, pod names, or URLs.
+
+    Monitors ADDED and MODIFIED events. DELETED events cause immediate failure.
+    Other event types are logged and ignored.
+
+    Example:
+        Expected: "certificate signed by unknown authority"
+        Actual message: "Unable to connect: ... x509: certificate signed by unknown authority"
+
+    Args:
+        dv: DataVolume resource to monitor for condition messages
+        expected_message: Expected message substring to find in condition messages
+        timeout: Timeout in seconds for the operation, default is TIMEOUT_5MIN.
+
+    Raises:
+        DataVolumeConditionMessageNotFoundError: If expected message not found within timeout
+            or if the DataVolume is deleted during monitoring.
     """
-    container_state = pod.instance.status.containerStatuses[0].state
-    if container_state.waiting:
-        return container_state.waiting.reason
-    if container_state.terminated:
-        return container_state.terminated.reason
+    LOGGER.info(f"Watching {dv.name} for message: {expected_message} for up to {timeout} seconds.")
+    last_conditions: list[dict[str, str]] = []
+    deleted = False
+    for event in dv.watcher(timeout=timeout):
+        event_type = event["type"]
+        if event_type == "DELETED":
+            deleted = True
+            break
+        if event_type not in ("ADDED", "MODIFIED"):
+            LOGGER.info(f"Ignoring {event_type} event for DataVolume {dv.name}")
+            continue
+        last_conditions = (event["object"].status or {}).get("conditions", [])
+        if any(expected_message in condition.get("message", "") for condition in last_conditions):
+            LOGGER.info(f"Found expected message in {dv.name}: {expected_message}")
+            return
+
+    reason = f"DataVolume '{dv.name}' was deleted" if deleted else f"Timed out after {timeout} seconds"
+    LOGGER.error(f"{reason} while waiting for message: {expected_message}")
+    raise DataVolumeConditionMessageNotFoundError(
+        dv_name=dv.name, expected_message=expected_message, last_conditions=last_conditions
+    )
 
 
 def assert_pvc_snapshot_clone_annotation(pvc, storage_class):

--- a/utilities/exceptions.py
+++ b/utilities/exceptions.py
@@ -67,6 +67,22 @@ class StorageCheckupConditionTimeoutExpiredError(Exception):
     pass
 
 
+class DataVolumeConditionMessageNotFoundError(Exception):
+    def __init__(
+        self, dv_name: str, expected_message: str, last_conditions: list[dict[str, str]] | None = None
+    ) -> None:
+        self.dv_name = dv_name
+        self.expected_message = expected_message
+        self.last_conditions = last_conditions
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        msg = f"Expected message '{self.expected_message}' not found in DataVolume '{self.dv_name}' conditions."
+        if self.last_conditions:
+            msg += f" Last seen conditions: {self.last_conditions}"
+        return msg
+
+
 class StorageMigrationError(Exception):
     pass
 

--- a/utilities/unittests/test_exceptions.py
+++ b/utilities/unittests/test_exceptions.py
@@ -8,6 +8,7 @@ import pytest
 
 from utilities.exceptions import (
     ClusterSanityError,
+    DataVolumeConditionMessageNotFoundError,
     MissingEnvironmentVariableError,
     MissingResourceException,
     OsDictNotFoundError,
@@ -157,6 +158,69 @@ class TestOsDictNotFoundError:
         """Test OsDictNotFoundError can be raised"""
         with pytest.raises(OsDictNotFoundError):
             raise OsDictNotFoundError("Test error")
+
+
+class TestDataVolumeConditionMessageNotFoundError:
+    """Test cases for DataVolumeConditionMessageNotFoundError exception"""
+
+    def test_data_volume_condition_message_not_found_error_init(self):
+        """Test DataVolumeConditionMessageNotFoundError initialization"""
+        dv_name = "test-dv"
+        expected_message = "Test message"
+        error = DataVolumeConditionMessageNotFoundError(dv_name=dv_name, expected_message=expected_message)
+        assert error.dv_name == dv_name
+        assert error.expected_message == expected_message
+        assert error.last_conditions is None
+
+    def test_data_volume_condition_message_not_found_error_init_with_conditions(self):
+        """Test DataVolumeConditionMessageNotFoundError initialization with last conditions"""
+        dv_name = "test-dv"
+        expected_message = "Test message"
+        last_conditions = [{"type": "Ready", "message": "some other message"}]
+        error = DataVolumeConditionMessageNotFoundError(
+            dv_name=dv_name, expected_message=expected_message, last_conditions=last_conditions
+        )
+        assert error.last_conditions == last_conditions
+
+    def test_data_volume_condition_message_not_found_error_str(self):
+        """Test DataVolumeConditionMessageNotFoundError string representation"""
+        dv_name = "test-dv"
+        expected_message = "Test message"
+        error = DataVolumeConditionMessageNotFoundError(dv_name=dv_name, expected_message=expected_message)
+        expected = f"Expected message '{expected_message}' not found in DataVolume '{dv_name}' conditions."
+        assert str(error) == expected
+
+    def test_data_volume_condition_message_not_found_error_str_with_conditions(self):
+        """Test DataVolumeConditionMessageNotFoundError string includes last conditions when provided"""
+        dv_name = "test-dv"
+        expected_message = "Test message"
+        last_conditions = [{"type": "Ready", "message": "Import complete"}]
+        error = DataVolumeConditionMessageNotFoundError(
+            dv_name=dv_name, expected_message=expected_message, last_conditions=last_conditions
+        )
+        error_str = str(error)
+        assert expected_message in error_str
+        assert dv_name in error_str
+        assert "Import complete" in error_str
+
+    def test_data_volume_condition_message_not_found_error_args(self):
+        """Test DataVolumeConditionMessageNotFoundError populates args via super().__init__()"""
+        dv_name = "test-dv"
+        expected_message = "Test message"
+        error = DataVolumeConditionMessageNotFoundError(dv_name=dv_name, expected_message=expected_message)
+        # Verify args is populated (not empty tuple)
+        assert len(error.args) == 1
+        assert error.args[0] == str(error)
+
+    def test_data_volume_condition_message_not_found_error_raise_and_catch(self):
+        """Test DataVolumeConditionMessageNotFoundError can be raised and caught"""
+        dv_name = "test-dv"
+        expected_message = "Test message"
+        with pytest.raises(DataVolumeConditionMessageNotFoundError) as exc_info:
+            raise DataVolumeConditionMessageNotFoundError(dv_name=dv_name, expected_message=expected_message)
+        assert exc_info.value.dv_name == dv_name
+        assert exc_info.value.expected_message == expected_message
+        assert isinstance(exc_info.value, Exception)
 
 
 class TestStorageSanityError:


### PR DESCRIPTION
##### Short description:
Manual backport of https://github.com/RedHatQE/openshift-virtualization-tests/pull/4727

Replaces the flaky `wait_for_importer_container_message` (which polled importer pod `containerStatuses[0]`) with `wait_for_dv_condition_message`, a watcher-based approach that monitors DataVolume conditions directly.

##### More details:
- The old function assumed the importer container was always at index 0, which broke when sidecars were present
- Polling with TimeoutSampler could miss rapid state transitions between 5-second intervals
- Looking at DV conditions (not pod status) is where users and developers naturally check when a DV isn't converging

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:
- De-quarantined `test_disk_image_not_conform_to_registry_disk` (CNV-86085), which was quarantined specifically because it needed DV conditions instead of importer pod status
- Fixed typo in test name: `registy` → `registry`

##### Special notes for reviewer:
Assisted by Claude Code

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
CNV-86358