### PR TITLE
Update project `main` to reference cnv 5.0

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -104,6 +104,7 @@ reviews:
       - "WIP"
     base_branches:
       - main
+      - cnv-4.22
       - cnv-4.21
       - cnv-4.20
       - cnv-4.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ strict_concatenate = true
 
 
 [project]
-name = "openshift-virtualization-tests-4.22"
+name = "openshift-virtualization-tests-5.0"
 requires-python = ">=3.14"
-version = "4.22"
+version = "5.0"
 description = "Tests for Openshift Virtualization"
 authors = [{ "name" = "openshift-virtualization-tests" }]
 dependencies = [

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -13,7 +13,6 @@ from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
-    DISABLE_MDEV_CONFIGURATION,
     ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
     EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
     FG_ENABLED,
@@ -289,19 +288,12 @@ def jira_86102_open():
     return is_jira_open(jira_id="CNV-86102")
 
 
-@pytest.fixture(scope="session")
-def jira_86639_open():
-    return is_jira_open(jira_id="CNV-86639")
-
-
 @pytest.fixture()
-def expected_value(request, is_s390x_cluster, jira_86639_open):
+def expected_value(request, is_s390x_cluster):
     expected = request.param.copy()
     if expected == EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES and is_s390x_cluster:
         expected |= S390X_SPECIFIC_KUBEVIRT_FEATUREGATES
     if expected == HCO_DEFAULT_FEATUREGATES:
         if py_config["cluster_type"] == MULTIARCH:
             expected[ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT] = FG_ENABLED
-        if jira_86639_open:
-            expected[DISABLE_MDEV_CONFIGURATION] = FG_ENABLED
     return expected

--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -29,7 +29,6 @@ pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
     pytest.mark.usefixtures("evpn_setup_ready"),
-    pytest.mark.jira("CNV-86961", run=False),
 ]
 
 

--- a/tests/network/flat_overlay/test_multi_network_policy.py
+++ b/tests/network/flat_overlay/test_multi_network_policy.py
@@ -29,7 +29,7 @@ def test_positive_egress_multi_network_policy(
 
 @pytest.mark.polarion("CNV-10645")
 @pytest.mark.s390x
-@pytest.mark.jira("CNV-83350", run=False)
+@pytest.mark.jira("CNV-88747", run=False)
 def test_negative_ingress_multi_network_policy(
     vma_flat_overlay,
     vmb_flat_overlay_ip_address,

--- a/tests/network/l2_bridge/bandwidth/test_bandwidth.py
+++ b/tests/network/l2_bridge/bandwidth/test_bandwidth.py
@@ -2,7 +2,7 @@
 Bandwidth throttling tests for Multus secondary network interface via bridge CNI.
 
 RFE Reference:
-https://redhat.atlassian.net/browse/RFE-7066
+https://redhat.atlassian.net/browse/RFE-7066 # <skip-jira-utils-check>
 """
 
 from typing import Final

--- a/tests/network/network_service/conftest.py
+++ b/tests/network/network_service/conftest.py
@@ -10,7 +10,6 @@ from tests.network.network_service.libservice import (
 )
 from utilities.constants import SSH_PORT_22
 from utilities.infra import get_node_selector_dict, run_virtctl_command
-from utilities.jira import is_jira_open
 from utilities.network import compose_cloud_init_data_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
@@ -75,8 +74,6 @@ def virtctl_expose_service(
         ensure_exists=True,
     )
     yield svc
-    if is_jira_open(jira_id="CNV-79964"):  # Service not deleted with VM due to bug
-        svc.clean_up()
 
 
 @pytest.fixture()

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@ deps =
     python-utility-scripts
 commands =
 #TODO remove 5.0.0 when the branch is created
-    pyutils-jira --cloud --url https://redhat.atlassian.net --target-versions "vfuture,4.22.0,4.22.z,5.0.0" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
+    pyutils-jira --cloud --url https://redhat.atlassian.net --target-versions "vfuture,5.0.0,5.0.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
 
 #Unused code
 [testenv:unused-code]

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,6 @@ setenv =
 deps =
     python-utility-scripts
 commands =
-#TODO remove 5.0.0 when the branch is created
     pyutils-jira --cloud --url https://redhat.atlassian.net --target-versions "vfuture,5.0.0,5.0.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
 
 #Unused code

--- a/uv.lock
+++ b/uv.lock
@@ -1137,8 +1137,8 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/5d/7d0652c649da05ffbe6e610e8d642fd88f1274a3f16cf8fe06df75a4c17f/openshift_python_wrapper_data_collector-2.0.15.tar.gz", hash = "sha256:f58c353daf3a360cfee9349b79f191180bf66d7b87a5f54301f240d63248f6cc", size = 8212, upload-time = "2025-07-20T08:20:54.645Z" }
 
 [[package]]
-name = "openshift-virtualization-tests-4-22"
-version = "4.22"
+name = "openshift-virtualization-tests-5-0"
+version = "5.0"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
##### What this PR does / why we need it:
After branching 4.22, the `main` branch is now following cnv 5.0
Updated project files to reflect the changes.

Add branch cnv-4.22 to coderabbit config

Includes fixes from:
- https://github.com/RedHatQE/openshift-virtualization-tests/pull/5032
- https://github.com/RedHatQE/openshift-virtualization-tests/pull/5053
- https://github.com/RedHatQE/openshift-virtualization-tests/pull/5063

##### Which issue(s) this PR fixes:
None

##### Special notes for reviewer:
None

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package name/version to 5.0.
  * Updated auto-review configuration to ignore an additional PR title keyword.
  * Removed obsolete issue-tracking version entries from CI config.

* **Tests**
  * Removed one test fixture and adjusted another’s signature.
  * Eliminated Jira-dependent cleanup/conditional logic in fixtures.
  * Updated several test markers and reference comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/5041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->