### PR TITLE
utils: replace pexpect.spawn with pty+subprocess to avoid forkpty

### DIFF
--- a/utilities/console.py
+++ b/utilities/console.py
@@ -1,7 +1,13 @@
+import fcntl
 import logging
 import os
+import pty
+import shlex
+import subprocess
+import termios
 
 import pexpect
+import pexpect.fdpexpect
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler, retry
 
@@ -58,7 +64,8 @@ class Console(object):
             password or getattr(self.vm, "login_params", {}).get("password") or self.vm.password  # type: ignore[attr-defined]
         )
         self.timeout = timeout
-        self.child = None
+        self.child: pexpect.fdpexpect.fdspawn | None = None
+        self._proc: subprocess.Popen[bytes] | None = None
         self.login_prompt = "login:"
         self.prompt = prompt if prompt else [r"#", r"\$"]
         self.kubeconfig = kubeconfig
@@ -68,13 +75,14 @@ class Console(object):
     @retry(wait_timeout=TIMEOUT_5MIN, sleep=TIMEOUT_10SEC)
     def connect(self):
         LOGGER.info(f"Connect to {self.vm.name} console")
-        self.console_eof_sampler(func=pexpect.spawn, command=self.cmd, timeout=self.timeout)
+        self.console_eof_sampler()
 
         try:
             self._connect()
         except Exception:
             LOGGER.exception(f"Failed to connect to {self.vm.name} console.")
             self.child.close()
+            self._terminate_proc()
             raise
 
         return self.child
@@ -95,8 +103,8 @@ class Console(object):
         LOGGER.info(f"{self.vm.name}: Got prompt {self.prompt}")
 
     def disconnect(self):
-        if self.child.terminated:
-            self.console_eof_sampler(func=pexpect.spawn, command=self.cmd, timeout=self.timeout)
+        if self._proc is not None and self._proc.poll() is not None:
+            self.console_eof_sampler()
 
         try:
             self.child.send("\n\n")
@@ -107,16 +115,40 @@ class Console(object):
                 self.child.expect("login:")
         finally:
             self.child.close()
+            self._terminate_proc()
 
-    def console_eof_sampler(self, func, command, timeout):
+    def _spawn_console(self) -> pexpect.fdpexpect.fdspawn:
+        """
+        Creates a pty pair and spawns virtctl via subprocess, returning an fdspawn
+        wrapping the master end.
+
+        Uses pty.openpty() + subprocess.Popen instead of pexpect.spawn to avoid
+        os.forkpty(), which is deprecated in multi-threaded processes (Python 3.12+).
+        """
+        master_fd, slave_fd = pty.openpty()
+        self._proc = subprocess.Popen(
+            shlex.split(self.cmd),
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            start_new_session=True,
+            preexec_fn=lambda: fcntl.ioctl(0, termios.TIOCSCTTY, 0),
+        )
+        os.close(slave_fd)
+        return pexpect.fdpexpect.fdspawn(fd=master_fd, encoding="utf-8", timeout=self.timeout)
+
+    def _terminate_proc(self) -> None:
+        if self._proc is not None:
+            self._proc.terminate()
+            self._proc.wait()
+            self._proc = None
+
+    def console_eof_sampler(self) -> None:
         sampler = TimeoutSampler(
             wait_timeout=TIMEOUT_5MIN,
             sleep=5,
-            func=func,
+            func=self._spawn_console,
             exceptions_dict={pexpect.exceptions.EOF: []},
-            command=command,
-            timeout=timeout,
-            encoding="utf-8",
         )
         for sample in sampler:
             if sample:


### PR DESCRIPTION
##### What this PR does / why we need it:
replace pexpect.spawn with pty+subprocess to avoid forkpty

 - Replace pexpect.spawn with pty.openpty() + subprocess.Popen to avoid deprecated os.forkpty() in Python 3.12+ multi-threaded processes
 - Add _spawn_console() to create a pty pair and wrap the subprocess in pexpect.fdpexpect.fdspawn
 - Add _terminate_proc() to cleanly shut down the subprocess, call it in both the connect error path and disconnect cleanup
 - Simplify console_eof_sampler() — remove parameters, use _spawn_console() internally

##### Which issue(s) this PR fixes:
DeprecationWarning on `test_vm_console`

##### Special notes for reviewer:
The following warning was shown:
`/tmp/pr-tests/.local/share/uv/python/cpython-3.14.5-linux-x86_64-gnu/lib/python3.14/pty.py:66: DeprecationWarning: This process (pid=110) is multi-threaded, use of forkpty() may lead to deadlocks in the child.`

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced VM console connectivity implementation for improved reliability and process management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests/pull/5043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->