### PR TITLE
[4.22][IUO] Update jira refs to 4.22

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -280,8 +280,8 @@ def updated_resource(
 
 
 @pytest.fixture(scope="session")
-def jira_76659_open():
-    return is_jira_open(jira_id="CNV-76659")
+def jira_88737_open():
+    return is_jira_open(jira_id="CNV-88737")
 
 
 @pytest.fixture(scope="session")

--- a/tests/install_upgrade_operators/deployment/conftest.py
+++ b/tests/install_upgrade_operators/deployment/conftest.py
@@ -25,6 +25,6 @@ def cnv_deployments_excluding_hpp_pool(admin_client, hco_namespace):
 
 
 @pytest.fixture()
-def xfail_if_jira_76659_open_and_migration_controller_deployment(jira_76659_open, cnv_deployment_by_name):
-    if cnv_deployment_by_name.name == KUBEVIRT_MIGRATION_CONTROLLER and jira_76659_open:
-        pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} deployment is not running due to CNV-76659 bug")
+def xfail_if_jira_88737_open_and_migration_controller_deployment(jira_88737_open, cnv_deployment_by_name):
+    if cnv_deployment_by_name.name == KUBEVIRT_MIGRATION_CONTROLLER and jira_88737_open:
+        pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} deployment is not running due to CNV-88737 bug")

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -70,7 +70,7 @@ def test_request_param(deployment_by_name, cpu_min_value):
 @pytest.mark.polarion("CNV-7675")
 def test_cnv_deployment_priority_class_name(
     cnv_deployment_by_name,
-    xfail_if_jira_76659_open_and_migration_controller_deployment,
+    xfail_if_jira_88737_open_and_migration_controller_deployment,
     jira_86102_open,
 ):
     if cnv_deployment_by_name.name.startswith(HPP_POOL):

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -29,9 +29,9 @@ def cnv_jobs(admin_client, hco_namespace):
 
 
 @pytest.fixture()
-def xfail_if_jira_76659_open_and_migration_controller_pod(jira_76659_open, cnv_pods_by_type):
-    if any(pod.name.startswith(KUBEVIRT_MIGRATION_CONTROLLER) for pod in cnv_pods_by_type) and jira_76659_open:
-        pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} pod has no priority class name due to CNV-76659 bug")
+def xfail_if_jira_88737_open_and_migration_controller_pod(jira_88737_open, cnv_pods_by_type):
+    if any(pod.name.startswith(KUBEVIRT_MIGRATION_CONTROLLER) for pod in cnv_pods_by_type) and jira_88737_open:
+        pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} pod has no priority class name due to CNV-88737 bug")
 
 
 @pytest.mark.skip_must_gather_collection
@@ -51,7 +51,7 @@ def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
 @pytest.mark.polarion("CNV-7262")
 def test_pods_priority_class_value(
     cnv_pods_by_type,
-    xfail_if_jira_76659_open_and_migration_controller_pod,
+    xfail_if_jira_88737_open_and_migration_controller_pod,
     jira_86102_open,
 ):
     if any(pod.name.startswith((HPP_POOL, HOSTPATH_PROVISIONER_CSI)) for pod in cnv_pods_by_type):

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -47,4 +47,4 @@ def cluster_has_rhcos10_or_above(workers_rhcos_version):
 
 @pytest.fixture(scope="session")
 def is_postcopy_migration_bug_open(cluster_has_rhcos10_or_above):
-    return cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-84023")
+    return cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-88738")

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -481,7 +481,7 @@ def windows_vm_for_test(windows_vm_namespace, unprivileged_client):
 @pytest.fixture(scope="class")
 def vm_for_migration_metrics_test(namespace, cpu_for_migration, is_postcopy_migration_bug_open):
     if is_postcopy_migration_bug_open:
-        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
+        pytest.xfail(reason="CNV-88738: post-copy migration fails on RHCOS 10+ nodes")
 
     name = "vm-for-migration-metrics-test"
     with VirtualMachineForTests(

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -137,7 +137,7 @@ def vm_metric_1(namespace, unprivileged_client, cluster_common_node_cpu):
 @pytest.fixture()
 def vm_metric_1_vmim(admin_client, vm_metric_1, is_postcopy_migration_bug_open):
     if is_postcopy_migration_bug_open:
-        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
+        pytest.xfail(reason="CNV-88738: post-copy migration fails on RHCOS 10+ nodes")
 
     with VirtualMachineInstanceMigration(
         name="vm-metric-1-vmim",


### PR DESCRIPTION
##### What this PR does / why we need it:
since we're changing branch, 4.22.z bugs should be duplicated to 5.0.
aligning the automation to have only 4.22.z refs.

##### Which issue(s) this PR fixes:
tox is failing
##### Special notes for reviewer:

##### jira-ticket:

