### PR TITLE
[net 4.22] Adjust and remove jira references

### DIFF
--- a/tests/network/l2_bridge/bandwidth/test_bandwidth.py
+++ b/tests/network/l2_bridge/bandwidth/test_bandwidth.py
@@ -2,7 +2,7 @@
 Bandwidth throttling tests for Multus secondary network interface via bridge CNI.
 
 RFE Reference:
-https://redhat.atlassian.net/browse/RFE-7066
+https://redhat.atlassian.net/browse/RFE-7066 # <skip-jira-utils-check>
 """
 
 from typing import Final

--- a/tests/network/network_service/conftest.py
+++ b/tests/network/network_service/conftest.py
@@ -10,7 +10,6 @@ from tests.network.network_service.libservice import (
 )
 from utilities.constants import SSH_PORT_22
 from utilities.infra import get_node_selector_dict, run_virtctl_command
-from utilities.jira import is_jira_open
 from utilities.network import compose_cloud_init_data_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
@@ -75,8 +74,6 @@ def virtctl_expose_service(
         ensure_exists=True,
     )
     yield svc
-    if is_jira_open(jira_id="CNV-79964"):  # Service not deleted with VM due to bug
-        svc.clean_up()
 
 
 @pytest.fixture()


### PR DESCRIPTION
Ci raised ticket references that do not match the version under-test, which is 4.22 in this case.
This PR handles that, by removing outdated references or adding a required label.