### PR TITLE
[4.19] tests, net, hot plug: quarantine multiple interfaces hot plug scenario

### DIFF
--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -21,7 +21,7 @@ from tests.network.l2_bridge.utils import (
     set_secondary_static_ip_address,
     wait_for_interface_hot_plug_completion,
 )
-from utilities.constants import FLAT_OVERLAY_STR, SRIOV, UNPRIVILEGED_USER
+from utilities.constants import FLAT_OVERLAY_STR, QUARANTINED, SRIOV, UNPRIVILEGED_USER
 from utilities.network import (
     IfaceNotFound,
     assert_ping_successful,
@@ -505,6 +505,10 @@ class TestHotPlugInterfaceToVmWithOnlyPrimaryInterface:
     @pytest.mark.dependency(
         name="test_multiple_interfaces_hot_plugged",
         depends=["test_vmi_spec_updated_with_hot_plugged_interface"],
+    )
+    @pytest.mark.xfail(
+        reason=(f"{QUARANTINED}: Failing due to hot plugging too many interfaces to the VM. Tracked in CNV-76670"),
+        run=False,
     )
     def test_multiple_interfaces_hot_plugged(
         self,


### PR DESCRIPTION
##### What this PR does / why we need it:
Quarantining the scenario that creates 3 additional hot-plug interfaces
will stabilize the module until a proper fix is applied in a future PR.
Backport of https://github.com/RedHatQE/openshift-virtualization-tests/pull/3455 to cnv-4.19.

##### Which issue(s) this PR fixes:
Hot-plug tests are showing flakiness because the test tries to hot-plug
too many interfaces (more than 4, which is the maximum allowed for the
VM spec used in this module). Quarantining the scenario that creates 3
additional hot-plug interfaces will stabilize the module until a proper
fix is applied.

##### Special notes for reviewer:

##### jira-ticket:
[CNV-76670](https://issues.redhat.com/browse/CNV-76670)