### PR TITLE
infra: Scope incremental cascade per parameter set

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -676,7 +676,10 @@ def pytest_runtest_makereport(item, call):
     """
     if call.excinfo is not None and "incremental" in item.keywords:
         parent = item.parent
-        parent._previousfailed = item
+        param_key = item.callspec.id if hasattr(item, "callspec") else ""
+        if not hasattr(parent, "_previousfailed"):
+            parent._previousfailed = {}
+        parent._previousfailed[param_key] = item
 
     outcome = yield
     report = outcome.get_result()
@@ -732,7 +735,8 @@ def pytest_runtest_setup(item):
     BASIC_LOGGER.info(f"\n{separator(symbol_='-', val=item.name)}")
     BASIC_LOGGER.info(f"{separator(symbol_='-', val='SETUP')}")
     if "incremental" in item.keywords:
-        previousfailed = getattr(item.parent, "_previousfailed", None)
+        param_key = item.callspec.id if hasattr(item, "callspec") else ""
+        previousfailed = getattr(item.parent, "_previousfailed", {}).get(param_key)
         if previousfailed is not None:
             pytest.xfail("previous test failed (%s)" % previousfailed.name)
 


### PR DESCRIPTION
##### What this PR does / why we need it:
When an incremental class is parametrized at class level, a failure in one parameter set (e.g. ipv4) should not cascade into another (e.g. ipv6) since they are independent test cycles with fresh fixtures.
This was discovered while working on PR #5026 — adding `@pytest.mark.jira("CNV-88755", run=False)` to a single test caused 6 xfails instead of just 2 skips, because `_previousfailed` is stored on the class node which is shared across all parametrize combinations.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
 - Non-parametrized incremental classes are unaffected — all their tests share the same key so behavior is identical to before.
 - Currently two incremental classes use class-level parametrize:
      - `tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py`
      - `tests/network/localnet/migration_stuntime/test_migration_stuntime.py`

##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved incremental test failure tracking for parametrized tests, so failures are tracked per-parameter set—leading to clearer xfail attribution and more reliable test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->