### PR TITLE
Use rpm  for guest agent version query

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1147,8 +1147,9 @@ def get_node_selector_dict(node_selector):
 
 
 def get_linux_guest_agent_version(ssh_exec):
-    ssh_exec.sudo = True
-    return guest_agent_version_parser(version_string=ssh_exec.package_manager.info("qemu-guest-agent"))
+    return guest_agent_version_parser(
+        version_string=run_ssh_commands(host=ssh_exec, commands=shlex.split("rpm -q qemu-guest-agent"))[0]
+    )
 
 
 def get_linux_os_info(ssh_exec):


### PR DESCRIPTION
##### What this PR does / why we need it:
rrmngmnt uses `which` to detect package managers and  fails when which itself is missing. `which` is not installed on the CentOS Stream 10 image. Identified while doing some tests with centos-stream10. 
##### Which issue(s) this PR fixes:
this is seen during testing centos-stream10
FAILED tests/infrastructure/golden_images/update_boot_source/test_boot_sources_vm.py::test_instance_type_vm_from_auto_update_boot_source[#centos-stream10-arm64#] - RuntimeError: Can not determine package manager for Host(centos-stream10-arm64-data-source-vm-1779873870-1084452)
FAILED tests/infrastructure/golden_images/update_boot_source/test_boot_sources_vm.py::test_instance_type_vm_from_auto_update_boot_source[#fedora-arm64#] - RuntimeError: Can not determine package manager for Host(fedora-arm64-data-source-vm-1779873945-74379)
##### Special notes for reviewer:
None
##### jira-ticket:
None