### PR TITLE
net, localnet: De-quarantine IPv6 visibility test

### DIFF
--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -11,7 +11,6 @@ from tests.network.localnet.liblocalnet import (
     LOCALNET_BR_EX_INTERFACE,
     LOCALNET_BR_EX_INTERFACE_NO_VLAN,
 )
-from utilities.constants import QUARANTINED
 from utilities.virt import migrate_vm_and_verify
 
 
@@ -61,10 +60,6 @@ def test_connectivity_post_migration_between_localnet_vms(
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet")
 @pytest.mark.polarion("CNV-12363")
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: The requested IPv6 address is assigned but not visible in VMI: CNV-80582",
-    run=False,
-)
 def test_vmi_reports_ip_on_secondary_interface_without_vlan(
     localnet_running_vms,
 ):


### PR DESCRIPTION
##### What this PR does / why we need it:

De-quarantines `test_vmi_reports_ip_on_secondary_interface_without_vlan` after the IPv6 address visibility issue in VMI has been fixed.

The product bug [1] has been resolved by the KubeVirt fix [2] and its backport [3].

[1] https://issues.redhat.com/browse/CNV-80582
[2] https://github.com/kubevirt/kubevirt/pull/17536
[3] https://github.com/kubevirt/kubevirt/pull/17876

##### Which issue(s) this PR fixes:


##### Special notes for reviewer:

Per de-quarantine guidelines, Jenkins verification with 25 consecutive runs is pending.

##### jira-ticket:

https://redhat.atlassian.net/browse/CNV-87546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Re-enabled a test for virtual machine interface IP address reporting on secondary network interfaces without VLAN configuration. The test was previously marked as expected to fail but is now running under normal execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->