### PR TITLE
fix: improve smoke test conftest-hierarchy tracing in CodeRabbit instructions

### DIFF
--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -79,7 +79,17 @@ jobs:
                  Do NOT limit impact to tests that import the modified symbol only.
               7. **Smoke test impact:** Intersect the affected set from step 6 with smoke-marked tests.
                  Run: `rg -l '@pytest.mark.smoke' tests/`
+                 VERIFY the above command returned actual file paths before concluding False.
                  Set True ONLY if a smoke-marked file also appears in the affected set from 6b-6e.
+                 For each smoke-marked file, ALSO check its conftest.py hierarchy (parent directory
+                 conftest.py files up to the repo root) for imports of modified utilities/libs symbols.
+                 A smoke test is affected if ANY conftest.py in its hierarchy imports a transitively
+                 modified symbol — even when the test file itself has no direct import.
+                 This includes autouse fixtures: if a conftest.py defines an autouse fixture that
+                 calls or imports a modified function, ALL tests in that directory (and below) are affected.
+                 Example check: for each smoke_file, scan dirname(smoke_file)/conftest.py,
+                 dirname(dirname(smoke_file))/conftest.py, etc. for modified symbol imports
+                 and autouse fixtures that depend on modified symbols.
               8. **Gating test impact:** Intersect the affected set from step 6 with gating-marked tests.
                  Run: `rg -l '@pytest.mark.gating' tests/`
                  Set True if a gating-marked file also appears in the affected set from 6b-6e.

--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -80,13 +80,11 @@ jobs:
               7. **Smoke test impact:** Intersect the affected set from step 6 with smoke-marked tests.
                  Run: `rg -l '@pytest.mark.smoke' tests/`
                  VERIFY the above command returned actual file paths before concluding False.
-                 Set True ONLY if a smoke-marked file also appears in the affected set from 6b-6e.
-                 For each smoke-marked file, ALSO check its conftest.py hierarchy (parent directory
-                 conftest.py files up to the repo root) for imports of modified utilities/libs symbols.
-                 A smoke test is affected if ANY conftest.py in its hierarchy imports a transitively
-                 modified symbol — even when the test file itself has no direct import.
-                 This includes autouse fixtures: if a conftest.py defines an autouse fixture that
-                 calls or imports a modified function, ALL tests in that directory (and below) are affected.
+                 Set True if either condition is met:
+                 - a smoke-marked file appears in the affected set from 6b-6e, OR
+                 - any conftest.py in the smoke test's parent-directory hierarchy (up to repo root)
+                   imports or calls a modified utilities/libs symbol — including autouse fixtures
+                   that depend on modified functions. ALL tests in that directory and below are affected.
                  Example check: for each smoke_file, scan dirname(smoke_file)/conftest.py,
                  dirname(dirname(smoke_file))/conftest.py, etc. for modified symbol imports
                  and autouse fixtures that depend on modified symbols.


### PR DESCRIPTION
##### What this PR does / why we need it:
Addresses the gap discovered in #4954 where smoke-marked tests were incorrectly concluded as unaffected by utility changes.

### Root cause
Step 7 of the test execution plan instructions only checked whether a smoke-marked **test file** directly imported a modified symbol. It did not scan the `conftest.py` hierarchy of each smoke test for transitive imports or autouse fixtures — which is the actual dependency path in this repo.

### Changes
Three additions to step 7:
1. **VERIFY guard** — require the `rg` command to return actual file paths before concluding `False`
2. **conftest hierarchy check** — for each smoke-marked file, scan parent conftest.py files up to the repo root for imports of modified utilities/libs symbols
3. **autouse fixture check** — if a conftest.py defines an autouse fixture that imports/calls a modified function, ALL tests in that directory and below are affected

### Example dependency path this fix catches
```
tests/storage/cdi_clone/test_clone.py  (smoke-marked)
  → tests/storage/conftest.py          (conftest in hierarchy)
    → from utilities.hco import wait_for_hco_conditions   ← modified in PR #4954
```

##### Which issue(s) this PR fixes:
Reported in: #4954 (CodeRabbit review comment)

##### Special notes for reviewer:
Only changes a YAML workflow instruction text — no code changes.

##### jira-ticket:

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal testing workflow verification procedures for development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->