### PR TITLE
[Storage] Remove skip_block_volumemode from archive import test

### DIFF
--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -92,6 +92,7 @@ def dv_from_http_import(
         content_type=request.param.get("content_type", DataVolume.ContentType.KUBEVIRT),
         cert_configmap=request.param.get("configmap_name"),
         size=request.param.get("size", DEFAULT_DV_SIZE),
+        volume_mode=request.param.get("volume_mode"),
         storage_class=storage_class_name_scope_module,
         client=namespace.client,
     ) as dv:

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -102,15 +102,13 @@ def dv_from_http_import(
 
 @pytest.fixture()
 def running_pod_with_dv_pvc(
-    storage_class_matrix__module__,
-    storage_class_name_scope_module,
     dv_from_http_import,
 ):
     """Create a running pod with DV's PVC."""
     dv_from_http_import.wait_for_dv_success()
     with create_pod_for_pvc(
         pvc=dv_from_http_import.pvc,
-        volume_mode=storage_class_matrix__module__[storage_class_name_scope_module]["volume_mode"],
+        volume_mode=dv_from_http_import.pvc.instance.spec.volumeMode,
     ) as pod:
         yield pod
 

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -123,6 +123,7 @@ def test_successful_import_image(
                 "source": HTTPS,
                 "content_type": DataVolume.ContentType.ARCHIVE,
                 "configmap_name": INTERNAL_HTTP_CONFIGMAP_NAME,
+                "volume_mode": DataVolume.VolumeMode.FILE,  # Archive type only supports Filesystem volume mode
             },
             marks=pytest.mark.polarion("CNV-2338"),
         ),
@@ -131,13 +132,7 @@ def test_successful_import_image(
 )
 @pytest.mark.sno
 @pytest.mark.s390x
-def test_successful_import_secure_archive(
-    skip_block_volumemode_scope_module, internal_http_configmap, running_pod_with_dv_pvc
-):
-    """
-    Skip block volume mode - archive does not support block mode DVs,
-    https://github.com/kubevirt/containerized-data-importer/blob/main/doc/supported_operations.md
-    """
+def test_successful_import_secure_archive(internal_http_configmap, running_pod_with_dv_pvc):
     assert_num_files_in_pod(pod=running_pod_with_dv_pvc, expected_num_of_files=3)
 
 

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -296,17 +296,6 @@ def download_image():
     get_downloaded_artifact(remote_name=f"{Images.Cdi.DIR}/{Images.Cdi.QCOW2_IMG}", local_name=LOCAL_PATH)
 
 
-def _skip_block_volumemode(storage_class_matrix):
-    storage_class = [*storage_class_matrix][0]
-    if storage_class_matrix[storage_class]["volume_mode"] == "Block":
-        pytest.skip("Test is not supported on Block volume mode")
-
-
-@pytest.fixture(scope="module")
-def skip_block_volumemode_scope_module(storage_class_matrix__module__):
-    _skip_block_volumemode(storage_class_matrix=storage_class_matrix__module__)
-
-
 @pytest.fixture()
 def default_fs_overhead(cdi_config):
     return float(cdi_config.instance.status.filesystemOverhead["global"])

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -440,9 +440,12 @@ def get_file_url(url, file_name):
 
 
 def assert_num_files_in_pod(pod, expected_num_of_files):
-    num_of_file_in_pod = pod.execute(command=shlex.split("ls -1 /pvc")).count("\n")
-    assert num_of_file_in_pod == expected_num_of_files, (
-        f"Number of file in pod is {num_of_file_in_pod}, while the expected is {expected_num_of_files}"
+    files = [
+        line for line in pod.execute(command=shlex.split("ls -1 /pvc")).splitlines() if line and line != "lost+found"
+    ]
+    num_of_files_in_pod = len(files)
+    assert num_of_files_in_pod == expected_num_of_files, (
+        f"Number of files in pod is {num_of_files_in_pod}, while the expected is {expected_num_of_files}"
     )
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

- Archive import only supports `Filesystem` volume mode, so explicitly set it on the DV instead of skipping Block volume mode at runtime
- Remove the unused `skip_block_volumemode_scope_module` fixture.
- Use PVC volume mode in `running_pod_with_dv_pvc` fixture
- Ignore 'lost+found' file that may be created by some storage providers

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:
Remove programmatic skip 

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test configuration to support volume mode settings for HTTP import scenarios.
  * Simplified test fixture dependencies to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->