### PR TITLE
Add support for comment /test-plan for an early on-demand test impact analysis

### DIFF
--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -1,10 +1,13 @@
 # description: Add comment for CodeRabbit to add tests instructions. A change-request comment will be added to the PR.
+# Triggers on the 'verified' label (post-approval) or '/test-plan' comment (on-demand during review).
 
 name: Request CodeRabbit tests instructions
 
 on:
   pull_request_target:
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 permissions:
   pull-requests: write
@@ -13,8 +16,16 @@ permissions:
 jobs:
   comment-on-commit:
     if: |
-      github.event.label.name == 'verified' &&
-      !endsWith(github.event.pull_request.user.login, '[bot]')
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.label.name == 'verified' &&
+        !endsWith(github.event.pull_request.user.login, '[bot]')
+      ) || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/test-plan') &&
+        !endsWith(github.event.comment.user.login, '[bot]')
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -23,14 +34,14 @@ jobs:
         uses: tspascoal/get-user-teams-membership@v4
         with:
           team: cnvqe-bot
-          username: ${{ github.event.pull_request.user.login }}
+          username: ${{ (github.event.pull_request || github.event.issue).user.login }}
           GITHUB_TOKEN: ${{ secrets.BOT3_TOKEN }}
 
       - name: Create or update comment
         if: steps.check-user-team.outputs.is-member != 'true'
         uses: peter-evans/create-or-update-comment@v5
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ github.event.pull_request.number || github.event.issue.number }}
           token: ${{ secrets.BOT3_TOKEN }}
           body: |
             @coderabbitai

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -112,6 +112,16 @@ It is essential to have a good commit message if you want your change to be revi
   - `jira-ticket: https://issues.redhat.com/browse/<jira_id>`
   - The card will be automatically closed once PR is merged
 
+### Request a test execution plan
+
+Comment on your GitHub PR:
+
+```bash
+/test-plan
+```
+
+This triggers CodeRabbit to analyze the PR's changed files and post an inline review comment with a test execution plan (smoke/gating impact, affected tests to run).
+
 ### Run the tests via a Jenkins job
 
 #### Build and push a container with your changes


### PR DESCRIPTION
##### What this PR does / why we need it:
The verified label is the team's signal that the PR has been code-reviewed and tested by author. At that point the workflow fires CodeRabbit to produce a test execution plan telling the reviewer/author which tests to actually run to validate the change before merging.

So the sequence today is:

1. Author opens PR
2. Reviewer reviews the code
3. Author applies /verified  - "code looks good and tested"
4. Workflow triggers CodeRabbit to generate the test execution plan
5. Author/reviewer runs the listed tests
6. PR merges
7. The problem  identified here is  step 4 comes after  author does their side of testing. The test impact analysis would be more useful during review (between steps 2 and 3) so the reviewer can factor  before signing off. everyone knows risks involved.

That's exactly what comment /test-plan solves — anyone can apply it at any point during review to get the plan early. This can be done by anyone reviewing or author without marking PR verified.

##### Which issue(s) this PR fixes:
Early access to a report showing the real test impact of their PR.
##### Special notes for reviewer:

##### jira-ticket:
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added instructions: comment "/test-plan" on a PR to request an inline test execution plan review.

* **Chores**
  * Updated CI workflow to support triggering test-plan requests from either a PR label or an on-demand PR comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->