### PR TITLE
[virt] fix test_restart_persistence_windows failing on ssh timeout

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2762,7 +2762,7 @@ def run_os_command(vm: VirtualMachineForTests, command: str) -> str | None:
         return run_ssh_commands(
             host=vm.ssh_exec,
             commands=shlex.split(command),
-            timeout=5,
+            timeout=15,
             tcp_timeout=TCP_TIMEOUT_30SEC,
         )[0]
     except ProxyCommandFailure:


### PR DESCRIPTION
##### What this PR does / why we need it:
increased command exec timeout (powershell commands might take 5+ sec to exec and report status via ssh)

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout duration for SSH command execution to improve reliability and reduce premature termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->