### PR TITLE
fix: decouple datasources arch suffix from preference arch suffix

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -4,6 +4,7 @@ from ocp_resources.datavolume import DataVolume
 
 from utilities.constants import (
     ARM_64,
+    CENTOS_STREAM10_PREFERENCE,
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
     HPP_CAPABILITIES,
     OS_FLAVOR_FEDORA,
@@ -51,6 +52,7 @@ fedora_os_list = ["fedora-42"]
 centos_os_list = ["centos-stream-9"]
 
 instance_type_rhel_os_list = [RHEL10_PREFERENCE]
+instance_type_centos_os_list = [CENTOS_STREAM10_PREFERENCE]
 instance_type_fedora_os_list = [OS_FLAVOR_FEDORA]
 
 for _dir in dir():

--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -258,7 +258,8 @@ def generate_linux_instance_type_os_matrix(
     os_name: str,
     preferences: list[str],
     arch_suffix: str | None = None,
-    add_arch_suffix: bool = True,
+    add_preference_arch_suffix: bool = True,
+    add_data_source_arch_suffix: bool = False,
 ) -> list[dict[str, dict[str, Any]]]:
     """
     Generate a list of dictionaries representing the instance type matrix for a Linux OS type.
@@ -268,9 +269,12 @@ def generate_linux_instance_type_os_matrix(
         os_name (str): The name of the OS.
         preferences (list[str]): A list of preferences for the instance types. Preference format is "<os>.<version>".
         arch_suffix: Optional architecture suffix. Example: "s390x", "arm64" . Omit to keep original preference.
-        add_arch_suffix: When True, append arch_suffix to the preference name. Set to False for OSes whose
+        add_preference_arch_suffix: When True, append arch_suffix to the preference name. Set to False for OSes whose
             ClusterPreferences have no arch suffix (e.g. centos — "centos.stream10" exists,
             "centos.stream10.arm64" does not).
+        add_data_source_arch_suffix: When True, append arch_suffix to the DataSource name. Only True on
+            multiarch clusters where SSP creates per-arch DataSources (e.g. "rhel10-arm64").
+            On homogeneous clusters DataSources are bare (e.g. "rhel10").
 
     Returns:
         list[dict[str, dict[str, Any]]]: A list of dictionaries representing the instance type matrix.
@@ -291,11 +295,13 @@ def generate_linux_instance_type_os_matrix(
     instance_types: list[dict[str, dict[str, Any]]] = []
 
     for preference in preferences:
-        arch_preference = f"{preference}.{arch_suffix}" if arch_suffix and add_arch_suffix else preference
+        arch_preference = f"{preference}.{arch_suffix}" if arch_suffix and add_preference_arch_suffix else preference
         data_source_name = _format_data_source_name(preference_name=preference)
         preference_config: dict[str, Any] = {
             PREFERENCE_STR: arch_preference,
-            DATA_SOURCE_NAME: f"{data_source_name}-{arch_suffix}" if arch_suffix else data_source_name,
+            DATA_SOURCE_NAME: f"{data_source_name}-{arch_suffix}"
+            if add_data_source_arch_suffix and arch_suffix
+            else data_source_name,
         }
 
         if preference == latest_os:

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -508,14 +508,16 @@ def generate_instance_type_matrix_dicts(os_dict: dict[str, Any], cpu_arch: str |
             "instance_type_rhel_os_list").
         cpu_arch: Optional architecture suffix.
     """
-    add_arch_suffix = cpu_arch != AMD_64
+    add_preference_arch_suffix = cpu_arch != AMD_64
+    add_data_source_arch_suffix = py_config["cluster_type"] == MULTIARCH
 
     if instance_type_rhel_os_list := os_dict.get("instance_type_rhel_os_list"):
         py_config["instance_type_rhel_os_matrix"] = generate_linux_instance_type_os_matrix(
             os_name="rhel",
             preferences=instance_type_rhel_os_list,
             arch_suffix=cpu_arch,
-            add_arch_suffix=add_arch_suffix,
+            add_preference_arch_suffix=add_preference_arch_suffix,
+            add_data_source_arch_suffix=add_data_source_arch_suffix,
         )
         py_config["latest_instance_type_rhel_os_dict"] = generate_latest_os_dict(
             os_matrix=py_config["instance_type_rhel_os_matrix"]
@@ -525,14 +527,16 @@ def generate_instance_type_matrix_dicts(os_dict: dict[str, Any], cpu_arch: str |
             os_name="fedora",
             preferences=instance_type_fedora_os_list,
             arch_suffix=cpu_arch,
-            add_arch_suffix=add_arch_suffix,
+            add_preference_arch_suffix=add_preference_arch_suffix,
+            add_data_source_arch_suffix=add_data_source_arch_suffix,
         )
     if instance_type_centos_os_list := os_dict.get("instance_type_centos_os_list"):
         py_config["instance_type_centos_os_matrix"] = generate_linux_instance_type_os_matrix(
             os_name="centos.stream",
             preferences=instance_type_centos_os_list,
             arch_suffix=cpu_arch,
-            add_arch_suffix=False,
+            add_preference_arch_suffix=False,
+            add_data_source_arch_suffix=add_data_source_arch_suffix,
         )
 
 

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from utilities.constants import ARM_64, CENTOS_STREAM10_PREFERENCE, RHEL10_PREFERENCE
+from utilities.constants import AMD_64, ARM_64, CENTOS_STREAM10_PREFERENCE, RHEL10_PREFERENCE
 from utilities.exceptions import OsDictNotFoundError
 from utilities.os_utils import (
     CENTOS_OS_MAPPING,
@@ -333,8 +333,8 @@ class TestGenerateInstanceTypeRhelOsMatrix:
         rhel9_item = next(item for item in result if "rhel-9" in item)
         assert rhel9_item["rhel-9"]["latest_released"] is True
 
-    def test_arch_suffix_applied_to_preference_and_data_source(self):
-        """arch_suffix is appended to both the preference name and the DataSource."""
+    def test_arch_suffix_applied_to_preference_not_data_source(self):
+        """On homogeneous clusters arch_suffix is appended to preference but not DataSource."""
         result = generate_linux_instance_type_os_matrix(
             os_name="rhel",
             preferences=[RHEL10_PREFERENCE],
@@ -343,28 +343,57 @@ class TestGenerateInstanceTypeRhelOsMatrix:
 
         config = result[0][f"{RHEL10_PREFERENCE}.{ARM_64}"]
         assert config["preference"] == f"{RHEL10_PREFERENCE}.{ARM_64}"
+        assert config["DATA_SOURCE_NAME"] == "rhel10"
+
+    def test_multiarch_data_source_gets_arch_suffix(self):
+        """On multiarch clusters add_data_source_arch_suffix appends arch to DataSource."""
+        result = generate_linux_instance_type_os_matrix(
+            os_name="rhel",
+            preferences=[RHEL10_PREFERENCE],
+            arch_suffix=ARM_64,
+            add_data_source_arch_suffix=True,
+        )
+
+        config = result[0][f"{RHEL10_PREFERENCE}.{ARM_64}"]
+        assert config["preference"] == f"{RHEL10_PREFERENCE}.{ARM_64}"
         assert config["DATA_SOURCE_NAME"] == f"rhel10-{ARM_64}"
 
-    def test_arch_suffix_omitted_from_preference_when_add_arch_suffix_false(self):
-        """add_arch_suffix=False keeps the preference plain while the DataSource still gets the arch suffix."""
+    def test_arch_suffix_omitted_from_preference_when_add_preference_arch_suffix_false(self):
+        """add_preference_arch_suffix=False keeps the preference plain. DataSource stays bare without add_data_source_arch_suffix."""
         result = generate_linux_instance_type_os_matrix(
             os_name="centos.stream",
             preferences=[CENTOS_STREAM10_PREFERENCE],
             arch_suffix=ARM_64,
-            add_arch_suffix=False,
+            add_preference_arch_suffix=False,
         )
 
         config = result[0][CENTOS_STREAM10_PREFERENCE]
         assert config["preference"] == CENTOS_STREAM10_PREFERENCE, "preference must not include arch suffix"
-        assert config["DATA_SOURCE_NAME"] == f"centos-stream10-{ARM_64}", "DataSource must include arch suffix"
+        assert config["DATA_SOURCE_NAME"] == "centos-stream10", (
+            "DataSource must be bare without add_data_source_arch_suffix"
+        )
 
-    def test_add_arch_suffix_false_no_arch_suffix(self):
-        """add_arch_suffix=False with no arch_suffix is a no-op."""
+    def test_multiarch_amd64_bare_preference_suffixed_data_source(self):
+        """Multiarch + amd64: preference stays bare, DataSource gets the arch suffix (the fixed regression)."""
+        result = generate_linux_instance_type_os_matrix(
+            os_name="rhel",
+            preferences=[RHEL10_PREFERENCE],
+            arch_suffix=AMD_64,
+            add_preference_arch_suffix=False,
+            add_data_source_arch_suffix=True,
+        )
+
+        config = result[0][RHEL10_PREFERENCE]
+        assert config["preference"] == RHEL10_PREFERENCE, "preference must stay bare on amd64"
+        assert config["DATA_SOURCE_NAME"] == f"rhel10-{AMD_64}", "DataSource must carry arch suffix on multiarch"
+
+    def test_add_preference_arch_suffix_false_no_arch_suffix(self):
+        """add_preference_arch_suffix=False with no arch_suffix is a no-op."""
         result_default = generate_linux_instance_type_os_matrix(
             os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE]
         )
         result_no_arch = generate_linux_instance_type_os_matrix(
-            os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE], add_arch_suffix=False
+            os_name="centos.stream", preferences=[CENTOS_STREAM10_PREFERENCE], add_preference_arch_suffix=False
         )
 
         assert result_default == result_no_arch

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -7,7 +7,15 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 import utilities.constants
-from utilities.constants import AMD_64, ARM_64, CENTOS_STREAM9_PREFERENCE, OS_FLAVOR_FEDORA, RHEL9_PREFERENCE, S390X
+from utilities.constants import (
+    AMD_64,
+    ARM_64,
+    CENTOS_STREAM9_PREFERENCE,
+    MULTIARCH,
+    OS_FLAVOR_FEDORA,
+    RHEL9_PREFERENCE,
+    S390X,
+)
 from utilities.exceptions import MissingEnvironmentVariableError, UnsupportedCPUArchitectureError
 
 # Circular dependencies are already mocked in conftest.py
@@ -1558,7 +1566,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         ]
 
     @pytest.mark.parametrize(
-        ("cpu_arch", "expected_add_arch_suffix"),
+        ("cpu_arch", "expected_add_preference_arch_suffix"),
         [
             (None, True),
             (ARM_64, True),
@@ -1577,9 +1585,10 @@ class TestGenerateInstanceTypeMatrixDicts:
         mock_generate_instance_type,
         sample_instance_type_matrix,
         cpu_arch,
-        expected_add_arch_suffix,
+        expected_add_preference_arch_suffix,
     ):
         """Test RHEL matrix generation across architecture variants."""
+        mock_py_config["cluster_type"] = AMD_64
         mock_generate_instance_type.return_value = sample_instance_type_matrix
         mock_generate_latest.return_value = sample_instance_type_matrix[0][RHEL9_PREFERENCE]
 
@@ -1590,7 +1599,8 @@ class TestGenerateInstanceTypeMatrixDicts:
             os_name="rhel",
             preferences=[RHEL9_PREFERENCE],
             arch_suffix=cpu_arch,
-            add_arch_suffix=expected_add_arch_suffix,
+            add_preference_arch_suffix=expected_add_preference_arch_suffix,
+            add_data_source_arch_suffix=False,
         )
         assert mock_py_config["instance_type_rhel_os_matrix"] == sample_instance_type_matrix
         assert mock_py_config["latest_instance_type_rhel_os_dict"] == sample_instance_type_matrix[0][RHEL9_PREFERENCE]
@@ -1605,7 +1615,8 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": OS_FLAVOR_FEDORA,
                     "preferences": [OS_FLAVOR_FEDORA],
                     "arch_suffix": None,
-                    "add_arch_suffix": True,
+                    "add_preference_arch_suffix": True,
+                    "add_data_source_arch_suffix": False,
                 },
                 "instance_type_fedora_os_matrix",
                 [{OS_FLAVOR_FEDORA: {"preference": OS_FLAVOR_FEDORA}}],
@@ -1617,7 +1628,8 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": OS_FLAVOR_FEDORA,
                     "preferences": [OS_FLAVOR_FEDORA],
                     "arch_suffix": AMD_64,
-                    "add_arch_suffix": False,
+                    "add_preference_arch_suffix": False,
+                    "add_data_source_arch_suffix": False,
                 },
                 "instance_type_fedora_os_matrix",
                 [{OS_FLAVOR_FEDORA: {"preference": OS_FLAVOR_FEDORA}}],
@@ -1629,7 +1641,8 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": "centos.stream",
                     "preferences": [CENTOS_STREAM9_PREFERENCE],
                     "arch_suffix": None,
-                    "add_arch_suffix": False,
+                    "add_preference_arch_suffix": False,
+                    "add_data_source_arch_suffix": False,
                 },
                 "instance_type_centos_os_matrix",
                 [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
@@ -1641,7 +1654,8 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": "centos.stream",
                     "preferences": [CENTOS_STREAM9_PREFERENCE],
                     "arch_suffix": S390X,
-                    "add_arch_suffix": False,
+                    "add_preference_arch_suffix": False,
+                    "add_data_source_arch_suffix": False,
                 },
                 "instance_type_centos_os_matrix",
                 [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
@@ -1653,7 +1667,8 @@ class TestGenerateInstanceTypeMatrixDicts:
                     "os_name": "centos.stream",
                     "preferences": [CENTOS_STREAM9_PREFERENCE],
                     "arch_suffix": ARM_64,
-                    "add_arch_suffix": False,
+                    "add_preference_arch_suffix": False,
+                    "add_data_source_arch_suffix": False,
                 },
                 "instance_type_centos_os_matrix",
                 [{CENTOS_STREAM9_PREFERENCE: {"preference": CENTOS_STREAM9_PREFERENCE}}],
@@ -1674,6 +1689,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         matrix_value,
     ):
         """Test Fedora and CentOS matrix generation call signatures."""
+        mock_py_config["cluster_type"] = AMD_64
         mock_generate_instance_type.return_value = matrix_value
 
         generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch=cpu_arch)
@@ -1692,6 +1708,7 @@ class TestGenerateInstanceTypeMatrixDicts:
         sample_instance_type_matrix,
     ):
         """Test that latest_instance_type_rhel_os_dict is populated correctly"""
+        mock_py_config["cluster_type"] = AMD_64
         mock_generate_instance_type.return_value = sample_instance_type_matrix
         expected_latest = {"preference": RHEL9_PREFERENCE, "latest_released": True}
         mock_generate_latest.return_value = expected_latest
@@ -1709,11 +1726,49 @@ class TestGenerateInstanceTypeMatrixDicts:
         mock_generate_instance_type,
     ):
         """Test that empty os_dict doesn't call any generation functions"""
+        mock_py_config["cluster_type"] = AMD_64
         os_dict = {}
         generate_instance_type_matrix_dicts(os_dict=os_dict)
 
         mock_generate_instance_type.assert_not_called()
-        assert mock_py_config == {}
+        assert mock_py_config == {"cluster_type": AMD_64}
+
+    @pytest.mark.parametrize(
+        ("cpu_arch", "expected_add_preference_arch_suffix"),
+        [
+            (AMD_64, False),
+            (ARM_64, True),
+            (S390X, True),
+        ],
+        ids=["multiarch_amd64", "multiarch_arm64", "multiarch_s390x"],
+    )
+    @patch("utilities.pytest_utils.generate_linux_instance_type_os_matrix")
+    @patch("utilities.pytest_utils.generate_latest_os_dict")
+    @patch("utilities.pytest_utils.py_config", new_callable=dict)
+    def test_multiarch_sets_data_source_arch_suffix_for_all_arches(
+        self,
+        mock_py_config,
+        mock_generate_latest,
+        mock_generate_instance_type,
+        sample_instance_type_matrix,
+        cpu_arch,
+        expected_add_preference_arch_suffix,
+    ):
+        """On multiarch clusters add_data_source_arch_suffix is True for every architecture."""
+        mock_py_config["cluster_type"] = MULTIARCH
+        mock_generate_instance_type.return_value = sample_instance_type_matrix
+        mock_generate_latest.return_value = sample_instance_type_matrix[0][RHEL9_PREFERENCE]
+
+        os_dict = {"instance_type_rhel_os_list": [RHEL9_PREFERENCE]}
+        generate_instance_type_matrix_dicts(os_dict=os_dict, cpu_arch=cpu_arch)
+
+        mock_generate_instance_type.assert_called_once_with(
+            os_name="rhel",
+            preferences=[RHEL9_PREFERENCE],
+            arch_suffix=cpu_arch,
+            add_preference_arch_suffix=expected_add_preference_arch_suffix,
+            add_data_source_arch_suffix=True,
+        )
 
 
 class TestUpdateLatestOsConfig:


### PR DESCRIPTION
##### What this PR does / why we need it:
Split the single add_arch_suffix flag into two independent controls:
- add_preference_arch_suffix: appends arch to clusterprefernces name
- add_data_source_arch_suffix: appends arch to datasources name only when cluster_type is multiarch

these should be set independently because clusterpreferences (deployed by virt-operator) and datasources(deployed by ssp) have no direct dependency

##### Which issue(s) this PR fixes:
The previous logic tied the DataSource suffix to the preference suffix which is False
for amd64, causing multiarch+amd64 to resolve to "rhel10" instead
of "rhel10-amd64"
##### Special notes for reviewer:
I missed checking with standalone arm cluster and this PR should take care of it.
##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-89104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Architecture suffixing behavior split: naming for preferences and data-source identifiers are now controlled independently to avoid unexpected per-architecture name changes.

* **Tests**
  * Expanded and updated test coverage to validate the new suffixing rules across operating systems, CPU architectures, and cluster types.

* **Chores**
  * ARM64 test configuration now includes a CentOS Stream 10 instance-type preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->