### PR TITLE
[4.20] net, bgp: wait for network operator readiness before BGP setup

### DIFF
--- a/tests/network/libs/bgp.py
+++ b/tests/network/libs/bgp.py
@@ -9,23 +9,21 @@ import ocp_resources.network_config_openshift_io as openshift_nc
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.bgp_session_state import BGPSessionState
-from ocp_resources.deployment import Deployment
+from ocp_resources.cluster_operator import ClusterOperator
 from ocp_resources.frr_configuration import FRRConfiguration
-from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.route_advertisements import RouteAdvertisements
 from timeout_sampler import retry
 
-from utilities.constants import NET_UTIL_CONTAINER_IMAGE
-from utilities.infra import get_resources_by_name_prefix
+from utilities.constants import DEFAULT_RESOURCE_CONDITIONS, NET_UTIL_CONTAINER_IMAGE
+from utilities.infra import get_resources_by_name_prefix, wait_for_consistent_resource_conditions
 from utilities.network import IpNotFound
 
 _CLUSTER_FRR_ASN: Final[int] = 64512
 _EXTERNAL_FRR_ASN: Final[int] = 64000
 _EXTERNAL_FRR_IMAGE: Final[str] = "quay.io/frrouting/frr:9.1.2"
 _IPERF3_IMAGE: Final[str] = "quay.io/networkstatic/iperf3"
-_FRR_DEPLOYMENT_NAME: Final[str] = "frr-k8s-webhook-server"
 _FRR_NS_NAME: Final[str] = "openshift-frr-k8s"
 POD_SECONDARY_IFACE_NAME: Final[str] = "net1"
 EXTERNAL_FRR_POD_LABEL: Final[dict] = {"role": "frr-external"}
@@ -41,16 +39,13 @@ class ExternalFrrPodInfo:
 def enable_route_advertisements_in_cluster(
     network_resource: openshift_nc.Network, client: DynamicClient
 ) -> Generator[None]:
-    """Enables route advertisements in the cluster network resource and deploys the FRR deployment.
+    """Enables route advertisements in the cluster network resource and deploys FRR.
 
     Within the context, the cluster network resource is patched to enable
     additional routing capabilities with FRR and to enable route advertisements for OVN-Kubernetes.
-    The FRR deployment is then created in the designated namespace and waits for its replicas to be ready.
+    Waits for the network ClusterOperator to stabilize before proceeding.
 
-    After the context is exited, the changes are reverted and the FRR namespace is cleaned up.
-    The cleanup is expected by the un-patching of the changes (ResourceEditor cleanup).
-    However, it has been observed that the NS is not removed
-    and therefore an explicit delete on the NS is performed.
+    After the context is exited, the changes are reverted.
 
     Args:
         network_resource (openshift_nc.Network): The cluster network resource to be patched.
@@ -69,12 +64,13 @@ def enable_route_advertisements_in_cluster(
     }
 
     with ResourceEditor(patches=patch):
-        deployment = Deployment(name=_FRR_DEPLOYMENT_NAME, namespace=_FRR_NS_NAME, client=client)
-        deployment.wait_for_replicas()
-
+        wait_for_consistent_resource_conditions(
+            dynamic_client=client,
+            resource_kind=ClusterOperator,
+            resource_name=network_resource.kind.lower(),
+            expected_conditions=DEFAULT_RESOURCE_CONDITIONS,
+        )
         yield
-
-    Namespace(name=_FRR_NS_NAME, client=client).clean_up()
 
 
 def create_cudn_route_advertisements(name: str, match_labels: dict, client: DynamicClient) -> RouteAdvertisements:

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -401,19 +401,19 @@ def get_daemonset_by_name(admin_client, daemonset_name, namespace_name):
 
 
 def wait_for_consistent_resource_conditions(
-    dynamic_client,
-    expected_conditions,
-    resource_kind,
-    stop_conditions=None,
-    condition_key1="type",
-    condition_key2="status",
-    namespace=None,
-    total_timeout=TIMEOUT_10MIN,
-    polling_interval=5,
-    consecutive_checks_count=10,
-    exceptions_dict=None,
-    resource_name=None,
-):
+    dynamic_client: DynamicClient,
+    expected_conditions: dict[str, str],
+    resource_kind: type[Resource],
+    stop_conditions: dict[str, str] | None = None,
+    condition_key1: str = "type",
+    condition_key2: str = "status",
+    namespace: str | None = None,
+    total_timeout: int = TIMEOUT_10MIN,
+    polling_interval: int = 5,
+    consecutive_checks_count: int = 10,
+    exceptions_dict: dict[type[Exception], list[str]] | None = None,
+    resource_name: str | None = None,
+) -> None:
     """This function awaits certain conditions of a given resource_kind (HCO, CSV, etc.).
 
     Using TimeoutSampler loop and poll the CR (of the resource_kind type) and attempt to match the expected conditions


### PR DESCRIPTION
##### What this PR does / why we need it:

- replace brittle Deployment name wait (frr-k8s-statuscleaner) with wait_for_consistent_resource_conditions on ClusterOperator/network, ensuring FRR CRDs and webhooks are ready before creating FRRConfiguration
- remove explicit FRR namespace cleanup, relying on CNO to handle revert
- add type annotations to wait_for_consistent_resource_conditions

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

manual cherry-pick of #4876 (automated one is failed)

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-78491