### PR TITLE
utils: add client to create_dv and assert_pvc_snapshot_clone_annotation

### DIFF
--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -330,7 +330,7 @@ def assert_pvc_snapshot_clone_annotation(pvc, storage_class):
     clone_type_annotation_str = f"{Resource.ApiGroup.CDI_KUBEVIRT_IO}/cloneType"
     clone_type_annotation = pvc.instance["metadata"].get("annotations").get(clone_type_annotation_str)
     # For snapshot capable storage, 'csi-clone' may be set in the StorageProfile
-    expected_clone_type_annotation = StorageProfile(name=storage_class).instance.status.cloneStrategy
+    expected_clone_type_annotation = StorageProfile(name=storage_class, client=pvc.client).instance.status.cloneStrategy
     assert clone_type_annotation == expected_clone_type_annotation, (
         f"{clone_type_annotation_str}: {clone_type_annotation}, expected: '{expected_clone_type_annotation}'"
     )
@@ -451,7 +451,7 @@ def assert_num_files_in_pod(pod, expected_num_of_files):
 
 def assert_use_populator(pvc, storage_class, cluster_csi_drivers_names):
     expected_use_populator_value = (
-        StorageClass(name=storage_class).instance.get("provisioner") in cluster_csi_drivers_names
+        StorageClass(name=storage_class, client=pvc.client).instance.get("provisioner") in cluster_csi_drivers_names
     )
     assert pvc.use_populator == expected_use_populator_value
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -142,10 +142,10 @@ def create_dv(
             # Make sure URL exists
             validate_file_exists_in_url(url=url)
         if not secret:
-            secret = utilities.artifactory.get_artifactory_secret(namespace=namespace)
+            secret = utilities.artifactory.get_artifactory_secret(namespace=namespace, client=client)
             artifactory_secret = secret
         if not cert_configmap:
-            cert_created = utilities.artifactory.get_artifactory_config_map(namespace=namespace)
+            cert_created = utilities.artifactory.get_artifactory_config_map(namespace=namespace, client=client)
             cert_configmap = cert_created.name
 
     with DataVolume(


### PR DESCRIPTION
##### What this PR does / why we need it:
Missing client on files causes warning:

```
openshift-virtualization-tests/.venv/lib64/python3.14/site-packages/ocp_resources/resource.py:1636: FutureWarning: 'client' arg will be mandatory in the next major release. `config_file` and `context` args will be removed.
    super().__init__(
```

This PR fixes the warning for `create_dv` and `assert_pvc_snapshot_clone_annotation`

##### Which issue(s) this PR fixes:
`FutureWarning` showing 

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test utilities to use the test cluster client when validating storage-related behavior, improving consistency and reliability.

* **Chores**
  * Adjusted storage helper logic to retrieve secrets and config from the provided test client/namespace, ensuring correct cluster-scoped configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->