### PR TITLE
uv lock:Update the wrapper version in the project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
   "xmltodict>=0.14.2",
   "python-simple-logger>=2.0.13",
   "pytest-html>=4.1.1",
-  "openshift-python-wrapper>=11.0.128",
+  "openshift-python-wrapper==11.0.131",
   "cachetools>=6.2.2",
   "dacite>=1.9.2",
   "python-dotenv>=1.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
   "xmltodict>=0.14.2",
   "python-simple-logger>=2.0.13",
   "pytest-html>=4.1.1",
-  "openshift-python-wrapper==11.0.131",
+  "openshift-python-wrapper>=11.0.131",
   "cachetools>=6.2.2",
   "dacite>=1.9.2",
   "python-dotenv>=1.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1402,7 +1402,7 @@ requires-dist = [
     { name = "kubernetes", specifier = ">=34.1.0" },
     { name = "netaddr", specifier = ">=1.3.0" },
     { name = "openshift-python-utilities", specifier = ">=6.0.0" },
-    { name = "openshift-python-wrapper", specifier = "==11.0.131" },
+    { name = "openshift-python-wrapper", specifier = ">=11.0.131" },
     { name = "openstacksdk", specifier = ">=4.1.0" },
     { name = "pexpect", specifier = ">=4.9.0" },
     { name = "podman", specifier = ">=5.2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1280,7 +1280,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/11/8c/5a03b7c28670dd355
 
 [[package]]
 name = "openshift-python-wrapper"
-version = "11.0.128"
+version = "11.0.131"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloup" },
@@ -1300,7 +1300,7 @@ dependencies = [
     { name = "timeout-sampler" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/85/2a7e5c2ee00779680bb28097467e7220260c2cb9998804db21da154e3f16/openshift_python_wrapper-11.0.128.tar.gz", hash = "sha256:94ea1e7a6ef289f4ae51e62165260aca4bd78451f582f94a198c0b1530d82876", size = 7666160, upload-time = "2026-05-06T10:52:17.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/db386e0e7e849c1b3dc8b359729cb403536e596d2e013c4867786df1e4d9/openshift_python_wrapper-11.0.131.tar.gz", hash = "sha256:93af774230fef6b2bab369710f268ff63ac5d3b948bdefc524388dcb63bf9954", size = 7679443, upload-time = "2026-05-27T09:28:09.935Z" }
 
 [[package]]
 name = "openshift-python-wrapper-data-collector"

--- a/uv.lock
+++ b/uv.lock
@@ -1402,7 +1402,7 @@ requires-dist = [
     { name = "kubernetes", specifier = ">=34.1.0" },
     { name = "netaddr", specifier = ">=1.3.0" },
     { name = "openshift-python-utilities", specifier = ">=6.0.0" },
-    { name = "openshift-python-wrapper", specifier = ">=11.0.128" },
+    { name = "openshift-python-wrapper", specifier = "==11.0.131" },
     { name = "openstacksdk", specifier = ">=4.1.0" },
     { name = "pexpect", specifier = ">=4.9.0" },
     { name = "podman", specifier = ">=5.2.0" },


### PR DESCRIPTION
##### What this PR does / why we need it:
This is update of the wrapper version for https://github.com/RedHatQE/openshift-virtualization-tests/pull/4780 Automation of predictable names for PVC/DV after snapshot restore

##### Which issue(s) this PR fixes:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/4780

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the OpenShift Python wrapper dependency to a pinned minimum version (now >=11.0.131). This change standardizes the package requirement across installations and reduces variation in runtime behavior caused by differing dependency ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->