### PR TITLE
net, evpn: enable EVPN connectivity tests

### DIFF
--- a/tests/network/bgp/evpn/test_evpn_connectivity.py
+++ b/tests/network/bgp/evpn/test_evpn_connectivity.py
@@ -29,7 +29,6 @@ pytestmark = [
     pytest.mark.bgp,
     pytest.mark.ipv4,
     pytest.mark.usefixtures("evpn_setup_ready"),
-    pytest.mark.jira("CNV-86961", run=False),
 ]
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
EVPN is now GA — remove the jira quarantine marker so the tests run in CI.

##### Which issue(s) this PR fixes:
CI raised ticket references that do not match the version under-test.

##### Special notes for reviewer:

##### jira-ticket:
jira-ticket: https://redhat.atlassian.net/browse/CNV-86961