### PR TITLE
[VIRT] Restart descheduler-operator before running tests

### DIFF
--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -26,7 +26,7 @@ from tests.virt.utils import (
     get_boot_time_for_multiple_vms,
     get_non_terminated_pods,
 )
-from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC
+from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC, NamespacesNames
 from utilities.infra import wait_for_pods_deletion
 from utilities.virt import wait_for_migration_finished
 
@@ -36,17 +36,34 @@ LOGGER = logging.getLogger(__name__)
 LOCALHOST = "localhost"
 
 
+@pytest.fixture(scope="package")
+def descheduler_operator_reconciled():
+    """Restart descheduler-operator deployment to trigger reconciliation.
+
+    Workaround for the issue when descheduler is installed before other OpenShift operators.
+    After restart, the operator reconciles and adds all namespaces with prefix "openshift-"
+    to the protected list.
+    """
+    LOGGER.info("Restarting descheduler-operator deployment to trigger reconciliation")
+    deployment = Deployment(
+        name="descheduler-operator",
+        namespace=NamespacesNames.OPENSHIFT_KUBE_DESCHEDULER_OPERATOR,
+    )
+    initial_replicas = deployment.instance.spec.replicas
+    deployment.scale_replicas(replica_count=0)
+    deployment.wait_for_replicas(deployed=False)
+    deployment.scale_replicas(replica_count=initial_replicas)
+    deployment.wait_for_replicas()
+
+
 @pytest.fixture(scope="module")
-def descheduler_long_lifecycle_profile(admin_client, namespace):
+def descheduler_long_lifecycle_profile(admin_client, descheduler_operator_reconciled):
     with create_kube_descheduler(
         admin_client=admin_client,
         profiles=["LongLifecycle"],
         profile_customizations={
             "devLowNodeUtilizationThresholds": "High",  # underutilized <40%, overutilized >70%
             "devEnableEvictionsInBackground": True,
-            "namespaces": {
-                "included": [namespace.name],
-            },
         },
     ) as kd:
         yield kd
@@ -55,8 +72,8 @@ def descheduler_long_lifecycle_profile(admin_client, namespace):
 @pytest.fixture(scope="module")
 def descheduler_kubevirt_relieve_and_migrate_profile(
     admin_client,
-    namespace,
     schedulable_nodes,
+    descheduler_operator_reconciled,
     nodes_taints_before_descheduler_test_run,
 ):
     with create_kube_descheduler(
@@ -64,9 +81,6 @@ def descheduler_kubevirt_relieve_and_migrate_profile(
         profiles=["KubeVirtRelieveAndMigrate"],
         profile_customizations={
             "devActualUtilizationProfile": "PrometheusCPUCombined",
-            "namespaces": {
-                "included": [namespace.name],
-            },
         },
     ) as kd:
         yield kd

--- a/tests/virt/node/descheduler/conftest.py
+++ b/tests/virt/node/descheduler/conftest.py
@@ -37,13 +37,16 @@ LOCALHOST = "localhost"
 
 
 @pytest.fixture(scope="module")
-def descheduler_long_lifecycle_profile(admin_client):
+def descheduler_long_lifecycle_profile(admin_client, namespace):
     with create_kube_descheduler(
         admin_client=admin_client,
         profiles=["LongLifecycle"],
         profile_customizations={
             "devLowNodeUtilizationThresholds": "High",  # underutilized <40%, overutilized >70%
             "devEnableEvictionsInBackground": True,
+            "namespaces": {
+                "included": [namespace.name],
+            },
         },
     ) as kd:
         yield kd
@@ -52,6 +55,7 @@ def descheduler_long_lifecycle_profile(admin_client):
 @pytest.fixture(scope="module")
 def descheduler_kubevirt_relieve_and_migrate_profile(
     admin_client,
+    namespace,
     schedulable_nodes,
     nodes_taints_before_descheduler_test_run,
 ):
@@ -60,6 +64,9 @@ def descheduler_kubevirt_relieve_and_migrate_profile(
         profiles=["KubeVirtRelieveAndMigrate"],
         profile_customizations={
             "devActualUtilizationProfile": "PrometheusCPUCombined",
+            "namespaces": {
+                "included": [namespace.name],
+            },
         },
     ) as kd:
         yield kd


### PR DESCRIPTION
Add descheduler_operator_reconciled fixture that restarts the descheduler-operator deployment before creating KubeDescheduler objects.

This ensures the operator reconciles after all OpenShift operators are installed, properly protecting all "openshift-*" namespaces from eviction. Without this, descheduler evicts pods from openshift-cnv namespace.

Co-Authored-By: Claude Sonnet 4.5

##### What this PR does / why we need it:
Adds a module-scoped fixture that restarts the descheduler-operator deployment to trigger reconciliation, ensuring proper namespace protection before running descheduler tests.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced descheduler test suite with improved operator reconciliation verification to ensure consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->