### PR TITLE
[VIRT] Add SSH retry after migration/hotplug operations

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,6 +43,7 @@ from utilities.constants import (
     TCP_TIMEOUT_30SEC,
     TIMEOUT_1MIN,
     TIMEOUT_1SEC,
+    TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_5SEC,
     TIMEOUT_10MIN,
@@ -220,17 +221,21 @@ def get_os_cpu_count(vm):
         cmd = shlex.split("echo %NUMBER_OF_PROCESSORS%")
     else:
         cmd = shlex.split("nproc")
-    return int(run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip())
+    return int(run_ssh_commands(host=vm.ssh_exec, commands=cmd, wait_timeout=TIMEOUT_2MIN)[0].strip())
 
 
 def get_os_memory_value(vm):
     if "windows" in vm.name:
         cmd = shlex.split("wmic ComputerSystem get TotalPhysicalMemory")
-        wmic_total_mem = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip().split()[1]
+        wmic_total_mem = (
+            run_ssh_commands(host=vm.ssh_exec, commands=cmd, wait_timeout=TIMEOUT_2MIN)[0].strip().split()[1]
+        )
         return f"{round(float(bitmath.Bit(int(wmic_total_mem)).to_Gib()))}Gi"
     else:
         cmd = shlex.split("lsmem | grep 'Total online'")
-        lsmem_total_mem = run_ssh_commands(host=vm.ssh_exec, commands=cmd)[0].strip().split()[-1]
+        lsmem_total_mem = (
+            run_ssh_commands(host=vm.ssh_exec, commands=cmd, wait_timeout=TIMEOUT_2MIN)[0].strip().split()[-1]
+        )
         return f"{lsmem_total_mem}i"
 
 

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -115,6 +115,7 @@ def get_stress_ng_pid(ssh_exec, windows=False):
         host=ssh_exec,
         commands=shlex.split(f"{command_prefix} bash -c 'pgrep {stress}'"),
         tcp_timeout=TCP_TIMEOUT_30SEC,
+        wait_timeout=TIMEOUT_2MIN,
     )[0].split("\n")[0]
 
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2494,6 +2494,7 @@ def fetch_pid_from_linux_vm(vm, process_name):
     cmd_res = run_ssh_commands(
         host=vm.ssh_exec,
         commands=shlex.split(f"pgrep {process_name} -x || true"),
+        wait_timeout=TIMEOUT_2MIN,
     )[0].strip()
     assert cmd_res, f"VM {vm.name}, '{process_name}' process not found"
     return int(cmd_res)
@@ -2516,6 +2517,7 @@ def fetch_pid_from_windows_vm(vm, process_name):
         host=vm.ssh_exec,
         commands=shlex.split(f"powershell -Command (Get-Process -Name {process_name.removesuffix('.exe')}).Id"),
         tcp_timeout=TCP_TIMEOUT_30SEC,
+        wait_timeout=TIMEOUT_2MIN,
     )[0].strip()
     assert cmd_res, f"Process '{process_name}' not in output: {cmd_res}"
     return int(cmd_res)
@@ -2740,7 +2742,7 @@ def get_vm_boot_time(vm: VirtualMachineForTests) -> str:
         if "windows" in vm.name  # type: ignore[operator]
         else "who -b"
     )
-    return run_ssh_commands(host=vm.ssh_exec, commands=shlex.split(boot_command))[0]
+    return run_ssh_commands(host=vm.ssh_exec, commands=shlex.split(boot_command), wait_timeout=TIMEOUT_2MIN)[0]
 
 
 def username_password_from_cloud_init(vm_volumes: list[dict[str, Any]]) -> tuple[str, str]:


### PR DESCRIPTION
Add wait_timeout=TIMEOUT_2MIN to run_ssh_commands calls in functions invoked after migration, hotplug, or pause operations to handle transient SSH connection issues.

Co-Authored-By: Claude Sonnet 4.5

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
