### PR TITLE
fix: add multi-arch check for DATA_SOURCE_NAME suffix

### DIFF
--- a/utilities/os_utils.py
+++ b/utilities/os_utils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ocp_resources.template import Template
 
+from utilities.architecture import get_cluster_architecture
 from utilities.constants import (
     CONTAINER_DISK_IMAGE_PATH_STR,
     DATA_SOURCE_NAME,
@@ -289,13 +290,16 @@ def generate_linux_instance_type_os_matrix(
 
     latest_os = max(preferences, key=_extract_version)
     instance_types: list[dict[str, dict[str, Any]]] = []
+    is_multi_arch = len(get_cluster_architecture()) > 1
 
     for preference in preferences:
         arch_preference = f"{preference}.{arch_suffix}" if arch_suffix and add_arch_suffix else preference
         data_source_name = _format_data_source_name(preference_name=preference)
         preference_config: dict[str, Any] = {
             PREFERENCE_STR: arch_preference,
-            DATA_SOURCE_NAME: f"{data_source_name}-{arch_suffix}" if arch_suffix else data_source_name,
+            DATA_SOURCE_NAME: f"{data_source_name}-{arch_suffix}"
+            if arch_suffix and is_multi_arch
+            else data_source_name,
         }
 
         if preference == latest_os:

--- a/utilities/unittests/test_os_utils.py
+++ b/utilities/unittests/test_os_utils.py
@@ -333,8 +333,10 @@ class TestGenerateInstanceTypeRhelOsMatrix:
         rhel9_item = next(item for item in result if "rhel-9" in item)
         assert rhel9_item["rhel-9"]["latest_released"] is True
 
-    def test_arch_suffix_applied_to_preference_and_data_source(self):
+    @patch("utilities.os_utils.get_cluster_architecture")
+    def test_arch_suffix_applied_to_preference_and_data_source(self, mock_get_cluster_arch):
         """arch_suffix is appended to both the preference name and the DataSource."""
+        mock_get_cluster_arch.return_value = {"amd64", "arm64"}
         result = generate_linux_instance_type_os_matrix(
             os_name="rhel",
             preferences=[RHEL10_PREFERENCE],
@@ -345,8 +347,10 @@ class TestGenerateInstanceTypeRhelOsMatrix:
         assert config["preference"] == f"{RHEL10_PREFERENCE}.{ARM_64}"
         assert config["DATA_SOURCE_NAME"] == f"rhel10-{ARM_64}"
 
-    def test_arch_suffix_omitted_from_preference_when_add_arch_suffix_false(self):
+    @patch("utilities.os_utils.get_cluster_architecture")
+    def test_arch_suffix_omitted_from_preference_when_add_arch_suffix_false(self, mock_get_cluster_arch):
         """add_arch_suffix=False keeps the preference plain while the DataSource still gets the arch suffix."""
+        mock_get_cluster_arch.return_value = {"amd64", "arm64"}
         result = generate_linux_instance_type_os_matrix(
             os_name="centos.stream",
             preferences=[CENTOS_STREAM10_PREFERENCE],


### PR DESCRIPTION
fix: add multi-arch check for DATA_SOURCE_NAME suffix

##### What this PR does / why we need it:

The current `generate_linux_instance_type_os_matrix()` function appends the `{arch}` suffix to DataSource names without validating whether the cluster is multi-arch or single-arch.

This causes `kubernetes.dynamic.exceptions.ResourceNotFoundError: Resource DataSource openshift-virtualization-os-images/rhel9-s390x does not exist` because:
- Single-arch clusters use DataSource names **without** architecture suffixes (e.g., `rhel9`)
- Multi-arch clusters use DataSource names **with** architecture suffixes (e.g., `rhel9-s390x`, `rhel9-amd64`, `rhel9-arm64`)

This PR adds a multi-arch check before appending the `{arch}` suffix to `DATA_SOURCE_NAME`, fixing `test_vmexport_snapshot_manifests` failures on single-arch s390x clusters.

##### Which issue(s) this PR fixes:

Fixes `test_vmexport_snapshot_manifests` failures on single-arch s390x clusters

##### Special notes for reviewer:

- The fix introduces an `is_multi_arch` flag that checks `len(get_cluster_architecture()) > 1` to determine cluster type. 
- Unit tests were updated to mock `get_cluster_architecture()` to simulate multi-arch behavior and verify the suffix logic works correctly.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE

Signed-off-by: Alexander Mamani <alexander.mamani@ibm.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-architecture detection so data source names receive an architecture suffix only when the cluster reports multiple architectures, preventing incorrect or misleading naming.

* **Tests**
  * Updated unit tests to simulate multi-architecture clusters and validate the conditional naming and flag behavior under those scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->