### PR TITLE
[storage] [T3] Enable Windows storage tests in self-validation using build-in win22 golden image

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -88,6 +88,7 @@ markers =
     ci: Mark tests as CI tests
     tier2: Mark tests as tier2
     tier3: Mark tests as tier3
+    windows: Tests that require a Windows VM or image
     ocp_interop: Interop testing with openshift
     gating: Mark tier2 tests that are part of gating job
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -859,7 +859,7 @@ def golden_image_data_volume_scope_function(request, admin_client, golden_images
         )
 
 
-@pytest.fixture
+@pytest.fixture()
 def golden_image_data_source_scope_function(
     admin_client, golden_images_namespace, golden_image_data_volume_scope_function
 ):
@@ -1583,7 +1583,7 @@ def must_gather_image_url(csv_scope_session):
     return must_gather_image[0]
 
 
-@pytest.fixture
+@pytest.fixture()
 def term_handler_scope_function():
     orig = signal(SIGTERM, getsignal(SIGINT))
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -859,12 +859,13 @@ def golden_image_data_volume_scope_function(request, admin_client, golden_images
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def golden_image_data_source_scope_function(
     admin_client, golden_images_namespace, golden_image_data_volume_scope_function
 ):
     win_ds_name = py_config.get("win_golden_image_name")
     if win_ds_name:
+        LOGGER.info(f"Using Windows golden image DataSource: {win_ds_name}")
         yield DataSource(
             namespace=golden_images_namespace.name,
             name=win_ds_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -847,18 +847,32 @@ def golden_image_data_volume_scope_module(request, admin_client, golden_images_n
 
 @pytest.fixture()
 def golden_image_data_volume_scope_function(request, admin_client, golden_images_namespace):
-    yield from data_volume(
-        request=request,
-        namespace=golden_images_namespace,
-        storage_class=request.param["storage_class"],
-        check_dv_exists=True,
-        client=admin_client,
-    )
+    if py_config.get("win_golden_image_name"):
+        yield None
+    else:
+        yield from data_volume(
+            request=request,
+            namespace=golden_images_namespace,
+            storage_class=request.param["storage_class"],
+            check_dv_exists=True,
+            client=admin_client,
+        )
 
 
 @pytest.fixture()
-def golden_image_data_source_scope_function(admin_client, golden_image_data_volume_scope_function):
-    yield from create_or_update_data_source(admin_client=admin_client, dv=golden_image_data_volume_scope_function)
+def golden_image_data_source_scope_function(
+    admin_client, golden_images_namespace, golden_image_data_volume_scope_function
+):
+    win_ds_name = py_config.get("win_golden_image_name")
+    if win_ds_name:
+        yield DataSource(
+            namespace=golden_images_namespace.name,
+            name=win_ds_name,
+            client=admin_client,
+            ensure_exists=True,
+        )
+    else:
+        yield from create_or_update_data_source(admin_client=admin_client, dv=golden_image_data_volume_scope_function)
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -1,9 +1,58 @@
 import pytest
 from ocp_resources.datavolume import DataVolume
+from pytest_testconfig import py_config
 
-from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
-from utilities.constants import REGISTRY_STR, Images
+from tests.storage.constants import (
+    QUAY_FEDORA_CONTAINER_IMAGE,
+    WIN2022_GOLDEN_IMAGE_OS_VERSION,
+    WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS,
+)
+from utilities.constants import REGISTRY_STR, Images, NamespacesNames
 from utilities.storage import create_dv, data_volume
+
+
+@pytest.fixture()
+def windows_source_dv_scope_function(
+    request,
+    namespace,
+    storage_class_matrix__function__,
+):
+    win_ds_name = py_config.get("win_golden_image_name")
+    if win_ds_name:
+        storage_class = next(iter(storage_class_matrix__function__))
+        with create_dv(
+            dv_name="dv-source-gi",
+            namespace=namespace.name,
+            size=Images.Windows.DEFAULT_DV_SIZE,
+            storage_class=storage_class,
+            client=namespace.client,
+            source_ref={
+                "kind": "DataSource",
+                "name": win_ds_name,
+                "namespace": NamespacesNames.OPENSHIFT_VIRTUALIZATION_OS_IMAGES,
+            },
+        ) as dv:
+            dv.wait_for_dv_success()
+            yield dv
+    else:
+        yield from data_volume(
+            request=request,
+            namespace=namespace,
+            storage_class_matrix=storage_class_matrix__function__,
+            client=namespace.client,
+        )
+
+
+@pytest.fixture()
+def vm_params(request):
+    if py_config.get("win_golden_image_name"):
+        return {
+            "vm_name": f"vm-win-{WIN2022_GOLDEN_IMAGE_OS_VERSION}-clone",
+            "template_labels": WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS,
+            "os_version": WIN2022_GOLDEN_IMAGE_OS_VERSION,
+            "ssh": True,
+        }
+    return request.param
 
 
 @pytest.fixture()

--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from ocp_resources.datavolume import DataVolume
-from pytest_testconfig import py_config
+from pytest_testconfig import config as py_config
 
 from tests.storage.constants import (
     QUAY_FEDORA_CONTAINER_IMAGE,

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -144,8 +144,9 @@ def test_successful_vm_restart_with_cloned_dv(
 
 
 @pytest.mark.tier3
+@pytest.mark.windows
 @pytest.mark.parametrize(
-    ("data_volume_multi_storage_scope_function", "vm_params"),
+    ("windows_source_dv_scope_function", "vm_params"),
     [
         pytest.param(
             {
@@ -163,11 +164,11 @@ def test_successful_vm_restart_with_cloned_dv(
             marks=pytest.mark.polarion("CNV-3638"),
         ),
     ],
-    indirect=["data_volume_multi_storage_scope_function"],
+    indirect=["windows_source_dv_scope_function", "vm_params"],
 )
 def test_successful_vm_from_cloned_dv_windows(
     unprivileged_client,
-    data_volume_multi_storage_scope_function,
+    windows_source_dv_scope_function,
     vm_params,
     namespace,
 ):
@@ -175,10 +176,10 @@ def test_successful_vm_from_cloned_dv_windows(
         client=unprivileged_client,
         source="pvc",
         dv_name="dv-target",
-        namespace=data_volume_multi_storage_scope_function.namespace,
-        size=data_volume_multi_storage_scope_function.size,
-        source_pvc=data_volume_multi_storage_scope_function.name,
-        storage_class=data_volume_multi_storage_scope_function.storage_class,
+        namespace=windows_source_dv_scope_function.namespace,
+        size=windows_source_dv_scope_function.size,
+        source_pvc=windows_source_dv_scope_function.name,
+        storage_class=windows_source_dv_scope_function.storage_class,
     ) as cdv:
         cdv.wait_for_dv_success(timeout=WINDOWS_CLONE_TIMEOUT)
         create_windows_vm_validate_guest_agent_info(

--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -22,3 +22,6 @@ QUAY_FEDORA_CONTAINER_IMAGE = f"docker://{Images.Fedora.FEDORA_CONTAINER_IMAGE}"
 
 TEST_FILE_NAME = "test-file.txt"
 TEST_FILE_CONTENT = "test-content"
+
+WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS: dict[str, str] = {"os": "win2k22", "workload": "server", "flavor": "medium"}
+WIN2022_GOLDEN_IMAGE_OS_VERSION: str = "2022"

--- a/tests/storage/memory_dump/conftest.py
+++ b/tests/storage/memory_dump/conftest.py
@@ -8,7 +8,11 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 
 from tests.storage.memory_dump.utils import wait_for_memory_dump_status_completed
 from utilities.constants import TIMEOUT_2MIN, Images
-from utilities.storage import PodWithPVC, get_containers_for_pods_with_pvc, virtctl_memory_dump
+from utilities.storage import (
+    PodWithPVC,
+    get_containers_for_pods_with_pvc,
+    virtctl_memory_dump,
+)
 from utilities.virt import running_vm, vm_instance_from_template
 
 

--- a/tests/storage/memory_dump/test_memory_dump.py
+++ b/tests/storage/memory_dump/test_memory_dump.py
@@ -10,6 +10,7 @@ from tests.storage.memory_dump.utils import wait_for_memory_dump_status_removed
 
 
 @pytest.mark.tier3
+@pytest.mark.windows
 @pytest.mark.parametrize(
     "golden_image_data_volume_scope_function, windows_vm_for_memory_dump",
     [

--- a/tests/storage/snapshots/conftest.py
+++ b/tests/storage/snapshots/conftest.py
@@ -6,11 +6,14 @@ import logging
 import shlex
 
 import pytest
+from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
 from pyhelper_utils.shell import run_ssh_commands
+from pytest_testconfig import config as py_config
 
+from tests.storage.constants import WIN2022_GOLDEN_IMAGE_OS_VERSION, WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS
 from tests.storage.snapshots.constants import WINDOWS_DIRECTORY_PATH
 from tests.storage.utils import (
     assert_windows_directory_existence,
@@ -19,6 +22,7 @@ from tests.storage.utils import (
     set_permissions,
 )
 from utilities.constants import TIMEOUT_2MIN, TIMEOUT_5SEC, TIMEOUT_10MIN, UNPRIVILEGED_USER
+from utilities.virt import vm_instance_from_template, wait_for_windows_vm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,16 +54,39 @@ def windows_vm_for_snapshot(
     unprivileged_client,
     modern_cpu_for_migration,
     storage_class_matrix_snapshot_matrix__module__,
+    golden_images_namespace,
 ):
-    with create_windows19_vm(
-        dv_name=request.param["dv_name"],
-        namespace=namespace.name,
-        client=unprivileged_client,
-        vm_name=request.param["vm_name"],
-        cpu_model=modern_cpu_for_migration,
-        storage_class=[*storage_class_matrix_snapshot_matrix__module__][0],
-    ) as vm:
-        yield vm
+    win_ds_name = py_config.get("win_golden_image_name")
+    if win_ds_name:
+        data_source = DataSource(
+            namespace=golden_images_namespace.name,
+            name=win_ds_name,
+            client=golden_images_namespace.client,
+            ensure_exists=True,
+        )
+        with vm_instance_from_template(
+            request={
+                "vm_name": request.param["vm_name"],
+                "template_labels": WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS,
+                "ssh": True,
+                "os_version": WIN2022_GOLDEN_IMAGE_OS_VERSION,
+            },
+            unprivileged_client=unprivileged_client,
+            namespace=namespace,
+            data_source=data_source,
+        ) as vm:
+            wait_for_windows_vm(vm=vm, version=WIN2022_GOLDEN_IMAGE_OS_VERSION)
+            yield vm
+    else:
+        with create_windows19_vm(
+            dv_name=request.param["dv_name"],
+            namespace=namespace.name,
+            client=unprivileged_client,
+            vm_name=request.param["vm_name"],
+            cpu_model=modern_cpu_for_migration,
+            storage_class=[*storage_class_matrix_snapshot_matrix__module__][0],
+        ) as vm:
+            yield vm
 
 
 @pytest.fixture()

--- a/tests/storage/snapshots/test_snapshots.py
+++ b/tests/storage/snapshots/test_snapshots.py
@@ -397,6 +397,7 @@ def test_fail_to_snapshot_with_unprivileged_client_dv_permissions(
     )
 
 
+@pytest.mark.windows
 @pytest.mark.parametrize(
     "windows_vm_for_snapshot",
     [
@@ -426,6 +427,7 @@ def test_online_windows_vm_successful_restore(
         )
 
 
+@pytest.mark.windows
 @pytest.mark.parametrize(
     "windows_vm_for_snapshot",
     [

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -12,6 +12,7 @@ from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClust
 from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 
+from tests.storage.constants import WIN2022_GOLDEN_IMAGE_OS_VERSION
 from tests.storage.storage_migration.constants import (
     CONTENT,
     FILE_BEFORE_STORAGE_MIGRATION,
@@ -52,6 +53,7 @@ from utilities.virt import (
     get_vm_boot_time,
     running_vm,
     vm_instance_from_template,
+    wait_for_windows_vm,
 )
 
 DEFAULT_DV_SIZE = "1Gi"
@@ -399,7 +401,6 @@ def windows_vm_with_vtpm_for_storage_migration(
 
 @pytest.fixture(scope="class")
 def windows_vm_with_vtpm_golden_image_for_storage_migration(
-    admin_client,
     unprivileged_client,
     namespace,
     modern_cpu_for_migration,
@@ -409,7 +410,7 @@ def windows_vm_with_vtpm_golden_image_for_storage_migration(
     win_ds = DataSource(
         namespace=golden_images_namespace.name,
         name=py_config.get("win_golden_image_name"),
-        client=admin_client,
+        client=golden_images_namespace.client,
         ensure_exists=True,
     )
     with VirtualMachineForTests(
@@ -426,6 +427,7 @@ def windows_vm_with_vtpm_golden_image_for_storage_migration(
         cpu_model=modern_cpu_for_migration,
     ) as vm:
         vm.start()
+        wait_for_windows_vm(vm=vm, version=WIN2022_GOLDEN_IMAGE_OS_VERSION)
         yield vm
 
 

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -10,6 +10,7 @@ from ocp_resources.multi_namespace_virtual_machine_storage_migration_plan import
 from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
 from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from pyhelper_utils.shell import run_ssh_commands
+from pytest_testconfig import config as py_config
 
 from tests.storage.storage_migration.constants import (
     CONTENT,
@@ -33,6 +34,7 @@ from utilities.constants import (
     TIMEOUT_2MIN,
     TIMEOUT_5SEC,
     U1_SMALL,
+    WINDOWS_2K22_PREFERENCE,
     Images,
 )
 from utilities.infra import create_ns
@@ -389,6 +391,38 @@ def windows_vm_with_vtpm_for_storage_migration(
         vm_instance_type=VirtualMachineClusterInstancetype(name="u1.large"),
         vm_preference=VirtualMachineClusterPreference(name="windows.11"),
         data_volume_template={"metadata": dv.res["metadata"], "spec": dv.res["spec"]},
+        cpu_model=modern_cpu_for_migration,
+    ) as vm:
+        vm.start()
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def windows_vm_with_vtpm_golden_image_for_storage_migration(
+    admin_client,
+    unprivileged_client,
+    namespace,
+    modern_cpu_for_migration,
+    source_storage_class,
+    golden_images_namespace,
+):
+    win_ds = DataSource(
+        namespace=golden_images_namespace.name,
+        name=py_config.get("win_golden_image_name"),
+        client=admin_client,
+        ensure_exists=True,
+    )
+    with VirtualMachineForTests(
+        os_flavor=OS_FLAVOR_WINDOWS,
+        name="windows-2022-vm",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        vm_instance_type=VirtualMachineClusterInstancetype(name="u1.large"),
+        vm_preference=VirtualMachineClusterPreference(name=WINDOWS_2K22_PREFERENCE),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=win_ds,
+            storage_class=source_storage_class,
+        ),
         cpu_model=modern_cpu_for_migration,
     ) as vm:
         vm.start()

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -223,7 +223,13 @@ class TestStorageClassMigrationWithVolumeHotplug:
         pytest.param(
             {"source_storage_class": py_config[STORAGE_CLASS_A]},
             {"target_storage_class": py_config[STORAGE_CLASS_B]},
-            {"vms_fixtures": ["windows_vm_with_vtpm_for_storage_migration"]},
+            {
+                "vms_fixtures": [
+                    "windows_vm_with_vtpm_golden_image_for_storage_migration"
+                    if py_config.get("win_golden_image_name")
+                    else "windows_vm_with_vtpm_for_storage_migration"
+                ]
+            },
             {"online_vm": [True]},  # Desired VM Running status for VMs in "vms_fixtures" list
             {"dv_wait_timeout": TIMEOUT_60MIN},
             id="mig_win_vm_with_vtpm",
@@ -231,6 +237,7 @@ class TestStorageClassMigrationWithVolumeHotplug:
     ],
     indirect=True,
 )
+@pytest.mark.windows
 @pytest.mark.tier3
 class TestStorageClassMigrationWindowsWithVTPM:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_WINDOWS}::test_vm_storage_class_migration_windows_vm_with_vtpm")

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -10,7 +10,7 @@ from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
-from pytest_testconfig import py_config
+from pytest_testconfig import config as py_config
 
 from tests.storage.constants import WIN2022_GOLDEN_IMAGE_OS_VERSION, WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS
 from tests.storage.utils import assert_disk_bus

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -6,10 +6,13 @@ import logging
 import shlex
 
 import pytest
+from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
+from pytest_testconfig import py_config
 
+from tests.storage.constants import WIN2022_GOLDEN_IMAGE_OS_VERSION, WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS
 from tests.storage.utils import assert_disk_bus
 from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
 from utilities.constants import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS, Images
@@ -27,6 +30,8 @@ from utilities.virt import (
     fedora_vm_body,
     migrate_vm_and_verify,
     running_vm,
+    vm_instance_from_template,
+    wait_for_windows_vm,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -78,13 +83,17 @@ def windows_dv_from_registry_scope_class(
     storage_class_matrix__class__,
 ):
     """Creates a Windows 2022 DataVolume from registry container disk."""
-    with create_windows2022_dv_from_registry(
-        dv_name="dv-windows-2022-hotplug",
-        namespace=namespace.name,
-        client=unprivileged_client,
-        storage_class=next(iter(storage_class_matrix__class__)),
-    ) as dv_dict:
-        yield dv_dict
+    win_ds_name = py_config.get("win_golden_image_name")
+    if win_ds_name:
+        yield None
+    else:
+        with create_windows2022_dv_from_registry(
+            dv_name="dv-windows-2022-hotplug",
+            namespace=namespace.name,
+            client=unprivileged_client,
+            storage_class=next(iter(storage_class_matrix__class__)),
+        ) as dv_dict:
+            yield dv_dict
 
 
 @pytest.fixture(scope="class")
@@ -93,16 +102,40 @@ def vm_instance_from_template_multi_storage_scope_class(
     namespace,
     modern_cpu_for_migration,
     windows_dv_from_registry_scope_class,
+    golden_images_namespace,
 ):
-    """Creates a Windows 2022 VM with vTPM from registry container disk."""
-    with create_windows2022_vm_with_vtpm_from_registry(
-        dv_dict=windows_dv_from_registry_scope_class,
-        namespace=namespace.name,
-        client=unprivileged_client,
-        vm_name="vm-win-2022-hotplug",
-        cpu_model=modern_cpu_for_migration,
-    ) as vm:
-        yield vm
+    """Creates a Windows 2022 VM with vTPM from registry container disk or golden image."""
+    win_ds_name = py_config.get("win_golden_image_name")
+    if win_ds_name:
+        data_source = DataSource(
+            namespace=golden_images_namespace.name,
+            name=win_ds_name,
+            client=golden_images_namespace.client,
+            ensure_exists=True,
+        )
+        with vm_instance_from_template(
+            request={
+                "vm_name": "vm-win-2022-hotplug",
+                "template_labels": WIN2022_GOLDEN_IMAGE_TEMPLATE_LABELS,
+                "ssh": True,
+                "os_version": WIN2022_GOLDEN_IMAGE_OS_VERSION,
+                "cpu_model": modern_cpu_for_migration,
+            },
+            unprivileged_client=unprivileged_client,
+            namespace=namespace,
+            data_source=data_source,
+        ) as vm:
+            wait_for_windows_vm(vm=vm, version=WIN2022_GOLDEN_IMAGE_OS_VERSION)
+            yield vm
+    else:
+        with create_windows2022_vm_with_vtpm_from_registry(
+            dv_dict=windows_dv_from_registry_scope_class,
+            namespace=namespace.name,
+            client=unprivileged_client,
+            vm_name="vm-win-2022-hotplug",
+            cpu_model=modern_cpu_for_migration,
+        ) as vm:
+            yield vm
 
 
 @pytest.fixture(scope="class")
@@ -262,6 +295,7 @@ class TestHotPlugWithSerialPersist:
 )
 @pytest.mark.usefixtures("hotplug_volume_windows_scope_class")
 @pytest.mark.tier3
+@pytest.mark.windows
 class TestHotPlugWindows:
     @pytest.mark.polarion("CNV-6525")
     @pytest.mark.dependency(name="test_windows_hotplug")


### PR DESCRIPTION
##### What this PR does / why we need it:

following https://github.com/openshift-cnv/ocp-virt-validation-checkup/pull/84 we now allowing user to run self valdiation with no dependency from artifactory 


The self-validation checkup runs `-m "conformance or windows"` but has no Artifactory access, so the existing Windows storage tests that download images from Artifactory can't run there.

This PR makes 11/22/other  Windows storage tests work in self-validation by using the `windows2022-golden-image` DataSource (already present in `openshift-virtualization-os-images`) as the VM source instead of pulling from Artifactory.

The change is opt-in: passing `--tc=win_golden_image_name:windows2022-golden-image` switches to the golden image path. Without it, everything behaves exactly as before.

**Tests covered (CNV-89353):**

| Test | Polarion |
|------|----------|
| `test_successful_vm_from_cloned_dv_windows` | CNV-3638 |
| `test_windows_hotplug` | CNV-6525 |
| `test_windows_hotplug_migrate` | CNV-11391 |
| `test_online_windows_vm_successful_restore` | CNV-8307 |
| `test_write_to_file_while_snapshot` | CNV-8536 |
| `test_windows_memory_dump` | CNV-8518 |
| `test_vm_storage_class_migration_windows_vm_with_vtpm` | CNV-11499 |
| `test_vm_storage_class_migration_windows_vm_with_vtpm_not_restarted` | CNV-12051 |
| `test_vm_storage_class_migration_windows_vm_with_vtpm_data_integrity` | CNV-12058 |
| `test_vm_storage_class_migration_windows_vm_with_vtpm_storage_class_updated` | CNV-12059 |
| `test_migrate_windows_vm_with_vtpm_after_storage_migration` | CNV-11515 |

For the storage migration tests, source and target storage class are set to the same value — self-validation environments typically have one storage class, and migrating within the same SC is still a valid test.

##### Which issue(s) this PR fixes:
[CNV-89353](https://redhat.atlassian.net/browse/CNV-89353)

##### Special notes for reviewer:
Companion PR that sets up the golden image and passes the required params to pytest: https://github.com/openshift-cnv/ocp-virt-validation-checkup/pull/84

##### jira-ticket:
[CNV-89353](https://redhat.atlassian.net/browse/CNV-89353)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new Windows test marker and applied it to Windows-specific tests.
  * Enhanced test suites to optionally provision VMs from configurable Windows golden images across clone, snapshot, hotplug, memory-dump, and migration scenarios.
  * Added/updated fixtures to conditionally use golden-image-backed sources and Windows-specific VM parameters.

* **Chores**
  * Added Windows Server 2022 constants.
  * Updated fixture signatures, imports, and test wiring to support golden-image flows and runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->