### PR TITLE
Use Fedora image for common VM preference tests

### DIFF
--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -42,7 +42,7 @@ def start_vm_with_cluster_preference(client, preference_name, namespace_name):
         name=f"rhel-vm-with-{preference_name}",
         namespace=namespace_name,
         # TODO: Add corresponding images to the VM based on preference
-        image=Images.Rhel.RHEL9_REGISTRY_GUEST_IMG,
+        image=Images.Fedora.FEDORA_CONTAINER_IMAGE,
         memory_guest=memory_guest,
         cpu_sockets=sockets,
         cpu_cores=cores,


### PR DESCRIPTION
##### What this PR does / why we need it:
The preference tests validate that KubeVirt applies CPU/memory/device preferences correctly. Fedora boots faster and
avoids teardown failures seen with 512Mi guest memory.
##### Which issue(s) this PR fixes:
tier3 tests continues to fail in teardown 
##### Special notes for reviewer:
 RHEL9 guest image cannot shutdown with
 512Mi guest memory, which is the requirement defined by the
 windows.2k8 and windows.2k12 preferences.With other windows with 2Gi guest memory RHEL9 image tests works fine and teardown happens. This causes VMIs to
  remain in Running phase indefinitely after VM deletion, blocking
  namespace cleanup and failing teardown with ResourceTeardownError.
so replacing with a lighter image, so that we get only legit failures due to preferences.
##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-88839
t3 lane failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use an alternative VM image for test execution.

**Note:** This is a test-only change with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->