### PR TITLE
infra: Remove basic preference tests for centos

### DIFF
--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -103,10 +103,6 @@ class TestCommonVmPreference:
                 marks=pytest.mark.polarion("CNV-9895"),
             ),
             pytest.param(
-                "centos",
-                marks=pytest.mark.polarion("CNV-9896"),
-            ),
-            pytest.param(
                 "unique",
                 marks=pytest.mark.polarion("CNV-9897"),
             ),


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove tier3 tests for centos preference - the centos tests are covered by tests/infrastructure/instance_types/supported_os/test_centos_os.py.
 
##### Which issue(s) this PR fixes:
Reduce test run time and repetitive coverage

##### Special notes for reviewer:
The RHEL test also have RHEL-7 which prevents from those tests to be removed, this would take some investigation to how we can remove those as well.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE
