### PR TITLE
[4.22] Remove DataSource storage class fallback from DV template helper (#4985)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2629,6 +2629,11 @@ def rwx_fs_available_storage_classes_names(cluster_storage_classes_names):
     ]
 
 
+@pytest.fixture()
+def storage_class_name_scope_function(storage_class_matrix__function__):
+    return [*storage_class_matrix__function__][0]
+
+
 @pytest.fixture(scope="session")
 def rhsm_credentials_from_bitwarden():
     return get_cnv_tests_secret_by_name(secret_name="RHSM_CREDENTIALS")

--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -15,9 +15,9 @@ NON_EXISTING_DV_NAME = "non-existing-dv"
 
 @pytest.fixture()
 def vm_from_golden_image_multi_storage(
-    request,
     unprivileged_client,
     namespace,
+    storage_class_name_scope_function,
     golden_image_data_source_multi_storage_scope_function,
 ):
     with VirtualMachineForTests(
@@ -27,6 +27,7 @@ def vm_from_golden_image_multi_storage(
         vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=golden_image_data_source_multi_storage_scope_function,
+            storage_class=storage_class_name_scope_function,
         ),
     ) as vm:
         running_vm(vm=vm)

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -497,11 +497,6 @@ def data_volume_template_metadata(multi_storage_cirros_vm):
     return multi_storage_cirros_vm.data_volume_template["metadata"]
 
 
-@pytest.fixture()
-def storage_class_name_scope_function(storage_class_matrix__function__):
-    return [*storage_class_matrix__function__][0]
-
-
 @pytest.fixture(scope="module")
 def storage_class_name_scope_module(storage_class_matrix__module__):
     return [*storage_class_matrix__module__][0]

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -564,12 +564,11 @@ def data_volume_template_dict(
 
 
 def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
-    source_dict = data_source.source.instance.to_dict()
     dv = DataVolume(
         name=utilities.infra.unique_name(name=data_source.name),
         namespace=data_source.namespace,
         size=get_dv_size_from_datasource(data_source=data_source),
-        storage_class=storage_class or source_dict["spec"].get("storageClassName"),
+        storage_class=storage_class,
         api_name="storage",
         source_ref={
             "kind": data_source.kind,


### PR DESCRIPTION
##### What this PR does / why we need it:
When calling `data_volume_template_with_source_ref_dict` we should either use it with explicit `storage_class` field, or omit the field and use the default storage class.
Relying on the storage class of the DataSources can cause miss interpretations, while also causing issues since it is not possible to match the storage class to the DataSource, if a snap shot storage class is used.

##### Which issue(s) this PR fixes:
Failing tests when snapshot storage classes are set.

##### Special notes for reviewer:
Cherry-pick from main branch, original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/4985

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-88988