### PR TITLE
net, tests, stuntime: Increase ping granularity

### DIFF
--- a/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
@@ -6,7 +6,7 @@ secondary network, for both IPv4 and IPv6, for regression detection.
 Stuntime is defined as the connectivity gap from last successful reply before loss
 to first successful reply after recovery.
 
-Stuntime is measured using ICMP ping from client to server in 0.1s intervals.
+Stuntime is measured using continuous ICMP ping from client to server.
 The under-test VMs are configured with a secondary Linux bridge interface,
 on which IPv4/IPv6 static addresses will be defined according to the environment the test runs on.
 

--- a/tests/network/libs/stuntime.py
+++ b/tests/network/libs/stuntime.py
@@ -15,7 +15,7 @@ SERVER_VM_LABEL: Final[tuple[str, str]] = (STUNTIME_LABEL_KEY, "server")
 CLIENT_VM_LABEL: Final[tuple[str, str]] = (STUNTIME_LABEL_KEY, "client")
 STUNTIME_THRESHOLD_SECONDS: Final[float] = 5.0
 STUNTIME_PING_LOG_PATH: Final[str] = "/tmp/stuntime-ping.log"
-PING_INTERVAL_SECONDS: Final[float] = 0.1
+PING_INTERVAL_SECONDS: Final[float] = 0.01
 DEFAULT_COMMAND_TIMEOUT_SECONDS: Final[int] = 10
 
 
@@ -139,5 +139,5 @@ def _compute_stuntime(lost_packets: int) -> float:
     """
     # Add +1 to account for the gap from last successful reply before loss to first successful reply after recovery
     stuntime = 0.0 if lost_packets == 0 else (lost_packets + 1) * PING_INTERVAL_SECONDS
-    LOGGER.info(f"Stuntime: {stuntime:.1f}s (from {lost_packets} lost packets)")
+    LOGGER.info(f"Stuntime: {stuntime:.2f}s (from {lost_packets} lost packets)")
     return stuntime

--- a/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
@@ -6,7 +6,7 @@ secondary network, for both IPv4 and IPv6, for regression detection.
 Stuntime is defined as the connectivity gap from last successful reply before loss
 to first successful reply after recovery.
 
-Stuntime is measured using ICMP ping from client to server in 0.1s intervals.
+Stuntime is measured using continuous ICMP ping from client to server.
 The under-test VMs are configured on an OVN localnet secondary network, with a single interface,
 on which IPv4/IPv6 static addresses will be defined according to the environment the test runs on.
 


### PR DESCRIPTION
##### What this PR does / why we need it:
At 0.1s ping interval, any stuntime below 100ms reads as "0.0s" — we can't distinguish between truly seamless migration and one that drops packets for up to 99ms.

The finer interval reveals these differences: e.g., L2 bridge client migration `between_non_server_nodes` measured 0.02s (1 lost packet) in Jenkins #5600 — invisible at 0.1s resolution.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced network connectivity testing with increased monitoring frequency (10x per second)
  * Improved stuntime logging precision for more granular diagnostic visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->