### PR TITLE
Add STD for kubevirt_vmi_sync_total metric test

### DIFF
--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -544,3 +544,71 @@ class TestVmCreatedByPodTotal:
             metric_name=KUBEVIRT_VM_CREATED_BY_POD_TOTAL.format(namespace=vm_for_test.namespace),
             expected_value=str(vm_created_pod_total_initial_metric_value + 1),
         )
+
+
+@pytest.mark.incremental
+class TestVmiSyncTotal:
+    """
+    Tests for kubevirt_vmi_sync_total metric.
+
+    Jira: https://redhat.atlassian.net/browse/CNV-80580
+
+    Preconditions:
+        - Running VM
+        - Prometheus access configured
+    """
+
+    __test__ = False
+
+    @pytest.mark.polarion("CNV-16271")
+    def test_kubevirt_vmi_sync_total(self):
+        """
+        Test that kubevirt_vmi_sync_total metric is reported by both
+        virt-controller and virt-handler after a VM starts.
+
+        Steps:
+            1. Query Prometheus for kubevirt_vmi_sync_total with the VM's
+               namespace and name
+
+        Expected:
+            - Two metric entries are returned — one from virt-controller
+              and one from virt-handler — each with a value greater than 0
+        """
+
+    @pytest.mark.polarion("CNV-16272")
+    def test_kubevirt_vmi_sync_total_increases_after_migration(self):
+        """
+        Test that kubevirt_vmi_sync_total metric value increases after
+        a VM live migration.
+
+        Preconditions:
+            - Running VM
+            - Initial kubevirt_vmi_sync_total values recorded
+
+        Steps:
+            1. Live migrate the VM
+            2. Query Prometheus for kubevirt_vmi_sync_total with the VM's
+               namespace and name
+
+        Expected:
+            - Metric values from both virt-controller and virt-handler
+              are greater than the values recorded before migration
+        """
+
+    @pytest.mark.polarion("CNV-16273")
+    def test_kubevirt_vmi_sync_total_cleared_after_vm_deletion(self):
+        """
+        Test that kubevirt_vmi_sync_total metric entry is removed
+        after the VM is deleted.
+
+        Preconditions:
+            - VM with kubevirt_vmi_sync_total metric reported
+
+        Steps:
+            1. Delete the VM
+            2. Query Prometheus for kubevirt_vmi_sync_total with the
+               deleted VM's namespace and name
+
+        Expected:
+            - Metric value is None
+        """


### PR DESCRIPTION
##### What this PR does / why we need it:
Add test description for verifying that the kubevirt_vmi_sync_total metric is reported by both virt-controller and virt-handler after a VM starts. This metric was introduced in CNV-80580 to detect reconcile storms.

Jira: CNV-89660

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-89662


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added disabled test scaffolding for VM synchronization metrics to document expected monitoring behavior across VM lifecycle events (startup, live migration, deletion). These are placeholder tests with descriptive steps but no executable assertions yet, intended to guide future implementation and verification of monitoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->