### PR TITLE
[Storage] Remove skip_no_reencrypt_route fixture

### DIFF
--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -46,12 +46,6 @@ def get_population_method_by_provisioner(storage_class, cluster_csi_drivers_name
     )
 
 
-@pytest.fixture(scope="function")
-def skip_no_reencrypt_route(upload_proxy_route):
-    if upload_proxy_route.termination != "reencrypt":
-        pytest.skip("Skip testing. The upload proxy route is not re-encrypt.")
-
-
 @pytest.mark.sno
 @pytest.mark.polarion("CNV-2192")
 def test_successful_virtctl_upload_no_url(unprivileged_client, namespace, tmpdir):
@@ -138,7 +132,6 @@ def test_image_upload_with_overridden_url(
 def test_virtctl_image_upload_with_ca(
     unprivileged_client,
     enabled_ca,
-    skip_no_reencrypt_route,
     tmpdir,
     namespace,
 ):


### PR DESCRIPTION
##### What this PR does / why we need it:
The CDI upload proxy route defaults to `"termination: reencrypt"`, so the skip is not needed.

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Removed conditional test skip logic from upload-related tests to ensure consistent test execution across different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->