### PR TITLE
[Storage] DV stop status functions

### DIFF
--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from ocp_resources.datavolume import DataVolume
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities.constants import Images
 from utilities.constants.storage import REGISTRY_STR
 from utilities.constants.timeouts import TIMEOUT_40MIN
@@ -40,7 +41,7 @@ def fedora_dv_with_filesystem_volume_mode(
         volume_mode=DataVolume.VolumeMode.FILE,
         client=unprivileged_client,
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 
@@ -60,7 +61,7 @@ def fedora_dv_with_block_volume_mode(
         volume_mode=DataVolume.VolumeMode.BLOCK,
         client=unprivileged_client,
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -6,6 +6,7 @@ import pytest
 from ocp_resources.datavolume import DataVolume
 
 from tests.os_params import FEDORA_LATEST
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from tests.storage.utils import (
     assert_pvc_snapshot_clone_annotation,
     assert_use_populator,
@@ -89,7 +90,10 @@ def test_successful_vm_restart_with_cloned_dv(
             cdv.wait_for_status(status=DataVolume.Status.PENDING_POPULATION, timeout=TIMEOUT_1MIN)
             cdv.pvc.wait()
         else:
-            cdv.wait_for_dv_success()
+            cdv.wait_for_dv_success(
+                stop_status_func=dv_stop_status_restart_threshold,
+                dv=cdv,
+            )
         with create_vm_from_dv(
             client=unprivileged_client,
             dv=cdv,
@@ -207,7 +211,10 @@ def test_successful_snapshot_clone(
         source_pvc_namespace=data_volume_snapshot_capable_storage_scope_function.namespace,
         storage_class=storage_class,
     ) as cdv:
-        cdv.wait_for_dv_success()
+        cdv.wait_for_dv_success(
+            stop_status_func=dv_stop_status_restart_threshold,
+            dv=cdv,
+        )
         if OS_FLAVOR_WINDOWS not in data_volume_snapshot_capable_storage_scope_function.name:
             with create_vm_from_dv(
                 client=unprivileged_client,

--- a/tests/storage/stop_status_utils.py
+++ b/tests/storage/stop_status_utils.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ocp_resources.datavolume import DataVolume
+
+LOGGER = logging.getLogger(__name__)
+
+
+def dv_stop_status_restart_threshold(dv: DataVolume, restart_count_threshold: int = 3) -> bool:
+    """Function for detecting excessive DV restarts.
+
+    Args:
+        dv: The DataVolume to check.
+        restart_count_threshold: The threshold for restart count (default: 3).
+
+    Returns:
+        True if restarts exceed threshold.
+
+    Example::
+        dv.wait_for_dv_success(
+            stop_status_func=dv_stop_status_restart_threshold,
+            dv=dv,
+            restart_count_threshold=4,
+        )
+    """
+    dv_status = getattr(dv.instance, "status", None)
+    restart_count = getattr(dv_status, "restartCount", 0) or 0
+    if restart_count >= restart_count_threshold:
+        LOGGER.error(f"DV {dv.name} has {restart_count} restarts, stopping")
+        return True
+    return False


### PR DESCRIPTION
##### What this PR does / why we need it:
In `DataVolume` object, you can pass `stop_status_func` and `stop_status_func_kwargs` into `.wait_for_dv_success` method and make it fail sooner than the set timeout. The `stop_status_func` is passed in the sampler and checked every second so you can inject checking DV status or if the DV creation restarted 3 times, etc. and stop it preliminary based on real status, not timeout. 

This will reduce the time for some storage tests because the method won't have to solely wait for timeout to fail.

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-28143

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clone and DataVolume readiness handling by detecting excessive restart attempts.
  * Prevented readiness checks from waiting indefinitely when restart thresholds are reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->