### PR TITLE
feat: add ReportPortal manual test reporter and shared utilities

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -30,7 +30,6 @@ exclude =
     utilities/unittests/*,
     utilities/junit_ai_utils.py,
     scripts/tests_analyzer/tests/*,
-    scripts/reportportal/*/tests/*,
 
 fcn_exclude_functions =
     Path,

--- a/.flake8
+++ b/.flake8
@@ -30,6 +30,7 @@ exclude =
     utilities/unittests/*,
     utilities/junit_ai_utils.py,
     scripts/tests_analyzer/tests/*,
+    scripts/reportportal/*/tests/*,
 
 fcn_exclude_functions =
     Path,

--- a/scripts/reportportal/rp_manual_reporter/README.md
+++ b/scripts/reportportal/rp_manual_reporter/README.md
@@ -1,0 +1,328 @@
+<!-- Co-authored-by: Claude <noreply@anthropic.com> -->
+# Manual Test Reporter for ReportPortal
+
+Push manual test results for unautomated STD (Standard Test Design) placeholder tests
+to ReportPortal. These are tests marked with `__test__ = False` that are not yet automated.
+
+---
+
+## Table of Contents
+
+- [Authentication](#authentication)
+- [Launch Attributes](#launch-attributes)
+- [Usage Examples](#usage-examples)
+- [Interactive Mode](#interactive-mode)
+- [Batch YAML Format](#batch-yaml-format)
+- [Failure Recovery](#failure-recovery)
+- [CLI Reference](#cli-reference)
+
+---
+
+## Authentication
+
+The reporter authenticates with ReportPortal using an API token.
+
+1. Log in to your ReportPortal instance.
+2. Click your avatar (top-right) → **API Keys**.
+3. Generate a new key or copy an existing one.
+4. Export the connection settings as environment variables:
+
+```bash
+export REPORT_PORTAL_URL="https://your-reportportal-instance.example.com"
+export REPORT_PORTAL_PROJECT="your-project"
+export REPORT_PORTAL_TOKEN="your-api-key-here"
+```
+
+> **Tip:** Add the exports to your shell profile (`~/.bashrc`, `~/.zshrc`) so you
+> don't have to set them every session.
+
+---
+
+## Launch Attributes
+
+Every ReportPortal launch is tagged with attributes that describe the environment
+under test. Attributes can be auto-filled from a connected cluster, provided by the
+user, or set automatically.
+
+### Auto-filled from cluster (`--from-cluster`)
+
+When `--from-cluster` is passed, the tool queries the connected OpenShift cluster
+and populates these attributes automatically:
+
+| Attribute        | Description                                    | Example                          |
+|------------------|------------------------------------------------|----------------------------------|
+| `ARCH`           | CPU architecture of the cluster nodes          | `amd64`                          |
+| `OCP`            | OpenShift platform version                     | `4.22.0-ec.4`                    |
+| `CNV_XY_VER`     | CNV major.minor version                        | `4.22`                           |
+| `BUNDLE`         | Full CNV/HCO bundle version                    | `v4.22.0.rhel9-102`              |
+| `CLUSTER_NAME`   | Cluster infrastructure name                    | `bm15a-tlv2`                     |
+| `CLUSTER_DOMAIN` | Cluster base domain                            | `bm15a-tlv2.abi.cnv-qe.rhood.us`|
+| `SC`             | Default storage class                          | `OCS`                            |
+| `CHANNEL`        | HCO subscription channel                       | `candidate`                      |
+
+### User-provided (optional)
+
+| Attribute | Description                          | Examples                            |
+|-----------|--------------------------------------|-------------------------------------|
+| `TEAM`    | QE team that owns the test results. Auto-inferred from `--tests-dir` if not set. | `NETWORK`, `STORAGE`, `VIRT`, `IUO` |
+
+### User-provided tier (optional)
+
+| Attribute | Description                          | Examples             |
+|-----------|--------------------------------------|----------------------|
+| `TIER`    | Test tier level                      | `TIER-2`, `TIER-3`   |
+
+### Bundle-to-version derivation
+
+When `--bundle` is provided explicitly, `CNV_XY_VER` is automatically derived
+from the bundle version (e.g., `v4.22.0.rhel9-102` → `4.22`). This override
+takes precedence over any cluster-detected `CNV_XY_VER`.
+
+### Automatically set
+
+| Attribute    | Description                                        |
+|--------------|----------------------------------------------------|
+| `MANUAL=true`| Distinguishes manual runs from automated CI runs   |
+
+### Manual override (no cluster access)
+
+If you don't have access to the cluster, provide all required attributes as CLI flags:
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --bundle v4.22.0-test \
+    --ocp-version 4.19.0 \
+    --cnv-version 4.22 \
+    --arch amd64 \
+    --cluster-name my-cluster \
+    --cluster-domain apps.my-cluster.example.com \
+    --sc ocs-storagecluster-ceph-rbd \
+    --channel stable \
+    --tests-dir tests/network/
+```
+
+> **Note:** All 8 attributes above are mandatory. The tool will refuse to push
+> if any are missing (unless running with `--dry-run`).
+
+---
+
+## Usage Examples
+
+### Interactive mode (with cluster)
+
+Auto-fill environment attributes from the connected cluster. Team is
+auto-inferred from `--tests-dir`:
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --from-cluster \
+    --bundle v4.22.0-test \
+    --tests-dir tests/network/
+```
+
+### Interactive mode (manual attributes)
+
+Provide environment attributes manually when no cluster is connected:
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --bundle v4.22.0-test \
+    --ocp-version 4.19.0 \
+    --cnv-version 4.22 \
+    --arch amd64 \
+    --cluster-name my-cluster \
+    --cluster-domain apps.my-cluster.example.com \
+    --sc ocs-storagecluster-ceph-rbd \
+    --channel stable \
+    --tests-dir tests/network/
+```
+
+### Batch mode (from YAML)
+
+Submit pre-recorded results from a YAML file instead of going through
+the interactive prompt:
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --team NETWORK --bundle v4.22.0 --batch-file results.yaml
+```
+
+### Filter by directory
+
+Scan only a specific team's tests (team is auto-inferred from path):
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --tests-dir tests/network/ --bundle v4.22.0
+```
+
+### Filter by marker
+
+Collect only gating-marked placeholder tests:
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --bundle v4.22.0 -m gating
+```
+
+### Filter by keyword
+
+Collect only tests matching a keyword in the node ID:
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --bundle v4.22.0 -k test_connectivity
+```
+
+### Dry run
+
+Preview what would be reported without pushing anything to ReportPortal:
+
+```bash
+uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+    --bundle v4.22.0 --dry-run
+```
+
+---
+
+## Interactive Mode
+
+When no `--batch-file` is provided, the tool enters interactive mode:
+
+1. **Test discovery** — Scans the repo for STD placeholder tests (`__test__ = False`),
+   optionally filtered by `--tests-dir`, `-m` (marker), or `-k` (keyword).
+
+2. **One-by-one review** — Each test is displayed with full context:
+   - Module and class docstrings (STP links, preconditions)
+   - Test docstring (steps, expected results)
+   - Pytest markers and fixtures
+   - Polarion test case ID
+
+3. **Verdict prompt** — For each test, enter one of:
+
+   | Key | Action                                                       |
+   |-----|--------------------------------------------------------------|
+   | `p` | **Pass** — mark the test as passed (pushed to RP)            |
+   | `f` | **Fail** — mark the test as failed (pushed to RP)            |
+   | `s` | **Skip** — move to the next test without recording anything  |
+   | `q` | **Quit** — stop and push results collected so far            |
+
+4. **Defect classification** — When you mark a test as **failed**, the tool prompts
+   for a defect type:
+
+   | Code | Defect Type |
+   |------|-------------|
+   | `1` | Product Bug — confirmed defect in the product |
+   | `2` | Automation Bug — test code issue |
+   | `3` | System Issue — environment or infrastructure problem |
+   | `4` | To Investigate — failure not yet analyzed |
+   | `5` | No Defect — false alarm or expected behavior |
+
+   Invalid input is re-prompted until a valid code (1–5) is entered.
+   The defect type is attached to the RP test item as an issue.
+
+5. **Failure comment** — After selecting the defect type, the tool prompts for
+   an optional comment (e.g., a bug ID like `MOCK-12345` or a brief description).
+
+---
+
+## Batch YAML Format
+
+The batch file lists test results as a YAML document. Each entry specifies the
+full pytest node ID, a status, and an optional comment:
+
+```yaml
+results:
+  - test: "tests/storage/cbt/test_cbt.py::TestFullBackupRestore::test_full_backup_push_mode_restore"
+    status: passed
+    comment: "Verified manually on cluster xyz"
+  - test: "tests/network/upgrade/test_upgrade_network.py::TestUpgradeNetwork::test_udn_vm_state"
+    status: failed
+    comment: "Bug MOCK-12345"
+```
+
+**Fields:**
+
+| Field     | Required | Values                      | Description                        |
+|-----------|----------|-----------------------------|------------------------------------|
+| `test`    | Yes      | Full pytest node ID         | Identifies the placeholder test    |
+| `status`  | Yes      | `passed`, `failed`, `skipped` | Test verdict                     |
+| `comment` | No       | Free text                   | Bug ID, notes, or justification    |
+
+---
+
+## Failure Recovery
+
+If the push to ReportPortal fails (network error, token expiry, server outage):
+
+1. **Auto-save** — All collected results are automatically saved to a timestamped
+   file:
+   ```
+   manual_results_<timestamp>.yaml
+   ```
+   This file uses the same format as the [batch YAML](#batch-yaml-format).
+
+2. **Retry** — Once the issue is resolved, replay the saved results:
+   ```bash
+   uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+       --team STORAGE --bundle v4.22.0 --batch-file manual_results_20250612_143022.yaml
+   ```
+
+No manual work is lost — you never have to re-enter verdicts.
+
+### Recovery / Retry File
+
+Recovery files (and manually-crafted retry files) may include an optional
+`metadata` block alongside `results`. The reporter uses these fields to
+restore context that was active when the results were originally collected:
+
+```yaml
+metadata:
+  team: STORAGE
+  bundle: v4.22.0.rhel9-102
+  attributes:
+    - { key: "BUNDLE", value: "v4.22.0.rhel9-102" }
+    - { key: "CNV_XY_VER", value: "4.22" }
+  saved_at: "2025-06-12T14:30:22"
+
+results:
+  - test: "tests/storage/cbt/test_cbt.py::TestFullBackupRestore::test_full_backup_push_mode_restore"
+    status: passed
+```
+
+| Field                  | Description                                                       |
+|------------------------|-------------------------------------------------------------------|
+| `metadata.team`        | QE team name — used when `--team` is not passed on the CLI.       |
+| `metadata.bundle`      | Bundle version — used when `--bundle` is not passed on the CLI.   |
+| `metadata.attributes`  | Saved launch attributes applied as defaults for the retry launch. |
+| `metadata.saved_at`    | ISO-8601 timestamp recording when the file was auto-saved.        |
+
+---
+
+## CLI Reference
+
+| Option              | Required | Default         | Description                                          |
+|---------------------|----------|-----------------|------------------------------------------------------|
+| `--team`            | No       | Auto-inferred   | QE team name (`NETWORK`, `STORAGE`, `VIRT`, `IUO`). Auto-inferred from `--tests-dir` if not set. |
+| `--from-cluster`    | No       | `false`         | Auto-fill launch attributes from the connected cluster |
+| `--bundle`          | No*      | —               | CNV/HCO bundle version (e.g., `v4.22.0.rhel9-102`)   |
+| `--cnv-version`     | No*      | —               | CNV major.minor version (e.g., `4.22`)                |
+| `--arch`            | No*      | —               | Cluster CPU architecture (e.g., `amd64`)              |
+| `--ocp-version`     | No*      | —               | OpenShift version (e.g., `4.22.0-ec.4`)               |
+| `--cluster-name`    | No*      | —               | Cluster infrastructure name (e.g., `bm15a-tlv2`)     |
+| `--cluster-domain`  | No*      | —               | Cluster base domain (e.g., `abi.cnv-qe.rhood.us`)    |
+| `--sc`              | No*      | —               | Default storage class label (e.g., `OCS`)             |
+| `--channel`         | No*      | —               | HCO subscription channel (e.g., `candidate`)          |
+| `--tier`            | No       | —               | Test tier level (e.g., `TIER-2`, `TIER-3`)            |
+| `--batch-file`      | No       | —               | Path to YAML file with pre-recorded results           |
+| `--tests-dir`       | No       | `tests`         | Directory to scan for placeholder tests               |
+| `-m` / `--marker`   | No       | —               | Filter tests by pytest marker expression              |
+| `-k` / `--keyword`  | No       | —               | Filter tests by keyword in node ID                    |
+| `--rp-url`          | No       | env `REPORT_PORTAL_URL`    | ReportPortal base URL              |
+| `--rp-project`      | No       | env `REPORT_PORTAL_PROJECT` | ReportPortal project name         |
+| `--rp-token`        | No       | env `REPORT_PORTAL_TOKEN`  | ReportPortal API token             |
+| `--dry-run`         | No       | `false`         | Preview results without pushing to ReportPortal       |
+
+> **\*** These flags are required when `--from-cluster` is not used. With
+> `--from-cluster`, they are auto-filled but can still be passed to override
+> specific values.

--- a/scripts/reportportal/rp_manual_reporter/__init__.py
+++ b/scripts/reportportal/rp_manual_reporter/__init__.py
@@ -1,0 +1,1 @@
+# Co-authored-by: Claude <noreply@anthropic.com>

--- a/scripts/reportportal/rp_manual_reporter/cluster_info.py
+++ b/scripts/reportportal/rp_manual_reporter/cluster_info.py
@@ -1,0 +1,167 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Auto-fill ReportPortal launch attributes from a connected cluster.
+
+Queries the OpenShift cluster for architecture, versions, storage class,
+and cluster identity.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from ocp_resources.hyperconverged import HyperConverged
+from ocp_resources.subscription import Subscription
+
+from utilities.architecture import get_cluster_architecture
+from utilities.cluster import cache_admin_client
+from utilities.exceptions import UnsupportedCPUArchitectureError
+from utilities.infra import get_clusterversion, get_infrastructure
+from utilities.storage import get_default_storage_class
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ClusterAttributes:
+    """Launch attributes auto-filled from a connected cluster.
+
+    Attributes:
+        arch: CPU architecture (e.g., "amd64").
+        ocp_version: OpenShift version (e.g., "4.22.0-ec.4").
+        cnv_xy_version: CNV major.minor version (e.g., "4.22").
+        bundle: Full CNV bundle version (e.g., "v4.22.0.rhel9-102").
+        cluster_name: Cluster infrastructure name (e.g., "bm15a-tlv2").
+        cluster_domain: Cluster base domain (e.g., "bm15a-tlv2.abi.cnv-qe.rhood.us").
+        storage_class: Default storage class label (e.g., "OCS").
+        channel: HCO subscription channel (e.g., "candidate").
+    """
+
+    arch: str | None = None
+    ocp_version: str | None = None
+    cnv_xy_version: str | None = None
+    bundle: str | None = None
+    cluster_name: str | None = None
+    cluster_domain: str | None = None
+    storage_class: str | None = None
+    channel: str | None = None
+
+
+def _extract_domain_from_api_url(api_url: str) -> str:
+    """Extract the cluster domain from an API server URL.
+
+    Parses the hostname from the URL and strips the ``api.`` prefix.
+
+    Args:
+        api_url: Full API server URL, e.g.
+            ``"https://api.bm15a-tlv2.abi.cnv-qe.rhood.us:6443"``.
+
+    Returns:
+        Domain portion after ``api.``, e.g.
+        ``"bm15a-tlv2.abi.cnv-qe.rhood.us"``.
+    """
+    hostname = urlparse(api_url).hostname or ""
+    api_prefix = "api."
+    if hostname.startswith(api_prefix):
+        return hostname.removeprefix(api_prefix)
+    return hostname
+
+
+def get_cluster_attributes() -> ClusterAttributes:
+    """Query the connected OpenShift cluster for launch attributes.
+
+    Returns:
+        ClusterAttributes with as many fields filled as possible.
+        Fields that couldn't be determined are left as None.
+    """
+    attrs = ClusterAttributes()
+
+    # Get admin client first — needed by most queries
+    try:
+        client = cache_admin_client()
+    except (OSError, AttributeError, TypeError) as exc:
+        LOGGER.warning(f"Failed to connect to cluster: {exc}")
+        return attrs
+
+    # Architecture
+    try:
+        arch_set = get_cluster_architecture()
+        attrs.arch = "multiarch" if len(arch_set) > 1 else next(iter(arch_set))
+    except (AttributeError, KeyError, TypeError, UnsupportedCPUArchitectureError) as exc:
+        LOGGER.warning(f"Failed to get cluster architecture: {exc}")
+
+    # OCP version
+    try:
+        cluster_version = get_clusterversion(client=client)
+        attrs.ocp_version = cluster_version.instance.status.desired.version
+    except (AttributeError, KeyError, TypeError) as exc:
+        LOGGER.warning(f"Failed to get OCP version: {exc}")
+
+    # CNV version (HCO)
+    try:
+        hco = HyperConverged(
+            client=client,
+            namespace="openshift-cnv",
+            name="kubevirt-hyperconverged",
+        )
+        if hco.exists:
+            hco_version = hco.instance.status.versions[0].version
+            attrs.bundle = f"v{hco_version}"
+            version_parts = hco_version.split(".")
+            if len(version_parts) >= 2:
+                attrs.cnv_xy_version = f"{version_parts[0]}.{version_parts[1]}"
+    except (AttributeError, KeyError, IndexError, TypeError) as exc:
+        LOGGER.warning(f"Failed to get CNV/HCO version: {exc}")
+
+    # Cluster name and domain
+    try:
+        infra = get_infrastructure(admin_client=client)
+        attrs.cluster_name = infra.instance.status.infrastructureName
+        api_url = infra.instance.status.apiServerURL
+        if api_url:
+            attrs.cluster_domain = _extract_domain_from_api_url(api_url=api_url)
+    except (AttributeError, KeyError, TypeError) as exc:
+        LOGGER.warning(f"Failed to get cluster infrastructure info: {exc}")
+
+    # Default storage class
+    try:
+        default_sc = get_default_storage_class(client=client)
+        attrs.storage_class = default_sc.name if default_sc else None
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        LOGGER.warning(f"Failed to get default storage class: {exc}")
+
+    # HCO subscription channel
+    try:
+        for sub in Subscription.get(client=client, namespace="openshift-cnv"):
+            if "hco" in sub.name.lower() or "kubevirt" in sub.name.lower():
+                attrs.channel = sub.instance.spec.channel
+                break
+    except (AttributeError, KeyError, TypeError) as exc:
+        LOGGER.warning(f"Failed to get subscription channel: {exc}")
+
+    LOGGER.info(f"Cluster attributes: {attrs}")
+    return attrs
+
+
+def cluster_attributes_to_launch_attrs(cluster_attrs: ClusterAttributes) -> list[dict[str, str]]:
+    """Convert cluster attributes to RP launch attribute format.
+
+    Args:
+        cluster_attrs: Attributes from the connected cluster.
+
+    Returns:
+        List of attribute dicts for RPClient, excluding None values.
+    """
+    mapping: dict[str, Any] = {
+        "ARCH": cluster_attrs.arch,
+        "OCP": cluster_attrs.ocp_version,
+        "CNV_XY_VER": cluster_attrs.cnv_xy_version,
+        "BUNDLE": cluster_attrs.bundle,
+        "CLUSTER_NAME": cluster_attrs.cluster_name,
+        "CLUSTER_DOMAIN": cluster_attrs.cluster_domain,
+        "SC": cluster_attrs.storage_class,
+        "CHANNEL": cluster_attrs.channel,
+    }
+    return [{"key": key, "value": value} for key, value in mapping.items() if value is not None]

--- a/scripts/reportportal/rp_manual_reporter/collector.py
+++ b/scripts/reportportal/rp_manual_reporter/collector.py
@@ -1,0 +1,493 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Collector for STD placeholder tests with full context.
+
+Extends std_placeholder_stats test discovery to extract docstrings,
+markers, fixtures, and Polarion IDs for each placeholder test.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from scripts.reportportal.rp_utils.naming import node_id_to_rp_name
+from scripts.std_placeholder_stats.std_placeholder_stats import scan_placeholder_tests
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PlaceholderTestDetail:
+    """Full context for an STD placeholder test.
+
+    Attributes:
+        file_path: Path to the test file relative to the repo root.
+        class_name: Enclosing test class name, or None for standalone tests.
+        method_name: Test method/function name.
+        module_docstring: Module-level docstring (STP link, shared preconditions).
+        class_docstring: Class-level docstring (class preconditions).
+        test_docstring: Test function docstring (Steps, Expected).
+        module_markers: Module-level pytestmark markers.
+        class_markers: Markers on the class definition.
+        class_fixtures: Fixtures from @pytest.mark.usefixtures on the class.
+        test_markers: Markers on the test function.
+        polarion_id: Polarion test case ID from @pytest.mark.polarion.
+        node_id: Pytest-style node ID.
+        rp_name: Dotted ReportPortal item name.
+    """
+
+    file_path: str
+    class_name: str | None
+    method_name: str
+    module_docstring: str | None = None
+    class_docstring: str | None = None
+    test_docstring: str | None = None
+    module_markers: list[str] = field(default_factory=list)
+    class_markers: list[str] = field(default_factory=list)
+    # NOTE: Only class-level @pytest.mark.usefixtures is collected.
+    # Module-level and function-level usefixtures are not modeled here
+    # because scan_placeholder_tests only yields class+method structure,
+    # and function-level usefixtures are rare in STD placeholders.
+    class_fixtures: list[str] = field(default_factory=list)
+    test_markers: list[str] = field(default_factory=list)
+    polarion_id: str | None = None
+    node_id: str = ""
+    rp_name: str = ""
+
+
+def _extract_docstring(node: ast.AST) -> str | None:
+    """Extract docstring from an AST node.
+
+    Checks whether the first statement in the node's body is an
+    ``ast.Expr`` containing a string ``ast.Constant``.
+
+    Args:
+        node: An AST module, class, or function definition node.
+
+    Returns:
+        The docstring text, or None if no docstring is present.
+    """
+    body = getattr(node, "body", None)
+    if not body:
+        return None
+
+    first_stmt = body[0]
+    if (
+        isinstance(first_stmt, ast.Expr)
+        and isinstance(first_stmt.value, ast.Constant)
+        and isinstance(first_stmt.value.value, str)
+    ):
+        return first_stmt.value.value
+
+    return None
+
+
+def _is_pytest_mark_attr(node: ast.expr) -> tuple[bool, str | None]:
+    """Check if an AST node represents ``pytest.mark.MARKER``.
+
+    Args:
+        node: An AST expression node (Attribute chain).
+
+    Returns:
+        A tuple of (is_pytest_mark, marker_name).
+    """
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "mark"
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "pytest"
+    ):
+        return True, node.attr
+    return False, None
+
+
+def _safe_arg_repr(arg: ast.expr) -> str:
+    """Convert a decorator argument AST node to its string representation.
+
+    Uses ``ast.literal_eval`` for simple constant nodes and falls back
+    to ``ast.dump`` for complex expressions that cannot be evaluated.
+
+    Args:
+        arg: An AST expression node from a decorator's arguments.
+
+    Returns:
+        String representation of the argument.
+    """
+    try:
+        return str(ast.literal_eval(arg))
+    except ValueError:
+        return ast.dump(arg)
+
+
+def _extract_markers(decorators: list[ast.expr]) -> list[str]:
+    """Extract pytest marker names from decorator nodes.
+
+    Handles both bare markers (``@pytest.mark.MARKER``) and called
+    markers (``@pytest.mark.MARKER(args)``).
+
+    Args:
+        decorators: List of decorator AST expression nodes.
+
+    Returns:
+        List of marker strings, e.g. ``["smoke", "polarion(MOCK-1234)"]``.
+    """
+    markers: list[str] = []
+
+    for decorator in decorators:
+        if isinstance(decorator, ast.Attribute):
+            is_mark, marker_name = _is_pytest_mark_attr(node=decorator)
+            if is_mark and marker_name is not None:
+                markers.append(marker_name)
+
+        elif isinstance(decorator, ast.Call):
+            is_mark, marker_name = _is_pytest_mark_attr(node=decorator.func)
+            if is_mark and marker_name is not None:
+                args_repr = ", ".join(_safe_arg_repr(arg=arg) for arg in decorator.args)
+                if args_repr:
+                    markers.append(f"{marker_name}({args_repr})")
+                else:
+                    markers.append(marker_name)
+
+    return markers
+
+
+def _extract_usefixtures(decorators: list[ast.expr]) -> list[str]:
+    """Extract fixture names from ``@pytest.mark.usefixtures(...)`` decorators.
+
+    Args:
+        decorators: List of decorator AST expression nodes.
+
+    Returns:
+        List of fixture name strings.
+    """
+    fixtures: list[str] = []
+
+    for decorator in decorators:
+        if not isinstance(decorator, ast.Call):
+            continue
+
+        is_mark, marker_name = _is_pytest_mark_attr(node=decorator.func)
+        if is_mark and marker_name == "usefixtures":
+            for arg in decorator.args:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    fixtures.append(arg.value)
+
+    return fixtures
+
+
+def _extract_polarion_id(decorators: list[ast.expr]) -> str | None:
+    """Extract Polarion test case ID from ``@pytest.mark.polarion("MOCK-XXXXX")``.
+
+    Args:
+        decorators: List of decorator AST expression nodes.
+
+    Returns:
+        The Polarion ID string, or None if not found.
+    """
+    for decorator in decorators:
+        if not isinstance(decorator, ast.Call):
+            continue
+
+        is_mark, marker_name = _is_pytest_mark_attr(node=decorator.func)
+        if is_mark and marker_name == "polarion":
+            if (
+                len(decorator.args) == 1
+                and isinstance(decorator.args[0], ast.Constant)
+                and isinstance(decorator.args[0].value, str)
+            ):
+                return decorator.args[0].value
+
+    return None
+
+
+def _extract_marker_name_from_element(element: ast.expr) -> str | None:
+    """Extract a marker name from a single pytestmark list element.
+
+    Handles both ``pytest.mark.MARKER`` (Attribute) and
+    ``pytest.mark.MARKER(...)`` (Call) forms.
+
+    Args:
+        element: An AST expression node from the pytestmark list.
+
+    Returns:
+        The marker name string, or None if not a pytest marker.
+    """
+    if isinstance(element, ast.Attribute):
+        is_mark, marker_name = _is_pytest_mark_attr(node=element)
+        if is_mark:
+            return marker_name
+
+    elif isinstance(element, ast.Call):
+        is_mark, marker_name = _is_pytest_mark_attr(node=element.func)
+        if is_mark:
+            return marker_name
+
+    return None
+
+
+def _extract_module_markers(tree: ast.Module) -> list[str]:
+    """Extract module-level ``pytestmark`` markers from the AST module.
+
+    Handles both single marker assignment and list of markers::
+
+        pytestmark = pytest.mark.usefixtures("my_fixture")
+        pytestmark = [pytest.mark.smoke, pytest.mark.tier1]
+
+    Args:
+        tree: The parsed AST module.
+
+    Returns:
+        List of marker name strings.
+    """
+    markers: list[str] = []
+
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+
+        for target in node.targets:
+            if not (isinstance(target, ast.Name) and target.id == "pytestmark"):
+                continue
+
+            if isinstance(node.value, ast.List):
+                for element in node.value.elts:
+                    marker_name = _extract_marker_name_from_element(element=element)
+                    if marker_name is not None:
+                        markers.append(marker_name)
+            else:
+                marker_name = _extract_marker_name_from_element(element=node.value)
+                if marker_name is not None:
+                    markers.append(marker_name)
+
+    return markers
+
+
+def _safe_eval_bool_expr(expr: str) -> bool:
+    """Safely evaluate a boolean expression containing only True/False/and/or/not.
+
+    Uses AST parsing to validate the expression contains no unsafe nodes
+    before evaluation. Rejects function calls, attribute access, imports, etc.
+
+    Args:
+        expr: Boolean expression string (e.g., ``"True and not False"``).
+
+    Returns:
+        Result of the boolean expression.
+
+    Raises:
+        TypeError: If the expression contains disallowed AST nodes.
+    """
+    tree = ast.parse(source=expr, mode="eval")
+    safe_nodes = (ast.Expression, ast.BoolOp, ast.UnaryOp, ast.Not, ast.And, ast.Or, ast.Constant)
+    for node in ast.walk(tree):
+        if not isinstance(node, safe_nodes):
+            raise TypeError(f"Disallowed AST node in expression: {type(node).__name__}")
+        if isinstance(node, ast.Constant) and not isinstance(node.value, bool):
+            raise TypeError(f"Disallowed constant in expression: {node.value!r}")
+    compiled = compile(source=tree, filename="<marker>", mode="eval")
+    return eval(compiled)
+
+
+def _matches_marker_filter(detail: PlaceholderTestDetail, marker_filter: str) -> bool:
+    """Check if a placeholder test matches a marker filter expression.
+
+    Supports simple marker names and ``and``/``or``/``not`` boolean expressions.
+    Markers are matched against module, class, and test-level markers.
+
+    Args:
+        detail: The placeholder test to check.
+        marker_filter: Pytest-style marker expression (e.g., ``"gating"``,
+            ``"smoke and not tier3"``).
+
+    Returns:
+        True if the test matches the expression.
+    """
+    all_markers = set()
+    for marker_str in detail.module_markers + detail.class_markers + detail.test_markers:
+        # Strip args: "parametrize(...)" → "parametrize"
+        paren_idx = marker_str.find("(")
+        bare_name = marker_str[:paren_idx] if paren_idx != -1 else marker_str
+        all_markers.add(bare_name.lower())
+
+    # Build expression: replace marker names with True/False using word boundaries
+    expr = marker_filter.lower()
+    for marker_name in sorted(all_markers, key=len, reverse=True):
+        if marker_name not in ("and", "or", "not"):
+            expr = re.sub(pattern=rf"\b{re.escape(marker_name)}\b", repl="True", string=expr)
+
+    # Replace remaining unknown markers with False
+    expr = re.sub(
+        pattern=r"\b(?!and\b|or\b|not\b|True\b|False\b)[a-zA-Z_][a-zA-Z0-9_]*\b",
+        repl="False",
+        string=expr,
+    )
+
+    try:
+        return _safe_eval_bool_expr(expr=expr)
+    except (SyntaxError, ValueError, TypeError):  # fmt: skip
+        LOGGER.warning(f"Could not evaluate marker expression: {marker_filter!r}")
+        return False
+
+
+def _matches_keyword_filter(detail: PlaceholderTestDetail, keyword_filter: str) -> bool:
+    """Check if a placeholder test matches a keyword filter.
+
+    Matches the keyword against the test's node ID (case-insensitive).
+
+    Args:
+        detail: The placeholder test to check.
+        keyword_filter: Keyword substring to match.
+
+    Returns:
+        True if the keyword is found in the node ID.
+    """
+    return keyword_filter.lower() in detail.node_id.lower()
+
+
+def collect_placeholder_details(
+    tests_dir: Path,
+    marker_filter: str | None = None,
+    keyword_filter: str | None = None,
+) -> list[PlaceholderTestDetail]:
+    """Collect placeholder tests with full context, optionally filtered.
+
+    Re-parses each file discovered by ``scan_placeholder_tests`` to extract
+    docstrings, markers, fixtures, and Polarion IDs for every placeholder test.
+
+    Args:
+        tests_dir: Path to the tests directory to scan.
+        marker_filter: Optional pytest-style marker expression to filter by.
+        keyword_filter: Optional keyword substring to match against node IDs.
+
+    Returns:
+        List of ``PlaceholderTestDetail`` objects sorted by ``node_id``.
+    """
+    placeholder_files = scan_placeholder_tests(tests_dir=tests_dir)
+    details: list[PlaceholderTestDetail] = []
+
+    for placeholder_file in placeholder_files:
+        file_path = Path(placeholder_file.file_path)
+        full_path = tests_dir.parent / file_path
+
+        try:
+            source = full_path.read_text(encoding="utf-8")
+            tree = ast.parse(source=source)
+        except (OSError, SyntaxError) as exc:
+            raise RuntimeError(f"Failed to read/parse placeholder file {full_path}: {exc}") from exc
+
+        module_docstring = _extract_docstring(node=tree)
+        module_markers = _extract_module_markers(tree=tree)
+
+        # Build lookup of class nodes and standalone function nodes
+        class_nodes: dict[str, ast.ClassDef] = {}
+        standalone_functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                class_nodes[node.name] = node
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                standalone_functions[node.name] = node
+
+        # Process class-based placeholder tests
+        for placeholder_class in placeholder_file.classes:
+            class_node = class_nodes.get(placeholder_class.name)
+            if class_node is None:
+                raise RuntimeError(
+                    f"Scanner/AST mismatch: class '{placeholder_class.name}' reported by "
+                    f"scan_placeholder_tests but not found in AST of {full_path}"
+                )
+
+            class_docstring = _extract_docstring(node=class_node)
+            class_markers = _extract_markers(decorators=class_node.decorator_list)
+            class_fixtures = _extract_usefixtures(decorators=class_node.decorator_list)
+
+            # Build method lookup for this class
+            method_nodes: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {
+                method.name: method
+                for method in class_node.body
+                if isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+
+            for method_name in placeholder_class.test_methods:
+                method_node = method_nodes.get(method_name)
+                if method_node is None:
+                    raise RuntimeError(
+                        f"Scanner/AST mismatch: method '{method_name}' in class "
+                        f"'{placeholder_class.name}' reported by scan_placeholder_tests "
+                        f"but not found in AST of {full_path}"
+                    )
+                test_docstring = _extract_docstring(node=method_node)
+                test_markers = _extract_markers(decorators=method_node.decorator_list)
+                polarion_id = _extract_polarion_id(decorators=method_node.decorator_list)
+
+                node_id = f"{placeholder_file.file_path}::{placeholder_class.name}::{method_name}"
+                rp_name = node_id_to_rp_name(node_id=node_id)
+
+                details.append(
+                    PlaceholderTestDetail(
+                        file_path=placeholder_file.file_path,
+                        class_name=placeholder_class.name,
+                        method_name=method_name,
+                        module_docstring=module_docstring,
+                        class_docstring=class_docstring,
+                        test_docstring=test_docstring,
+                        module_markers=module_markers,
+                        class_markers=class_markers,
+                        class_fixtures=class_fixtures,
+                        test_markers=test_markers,
+                        polarion_id=polarion_id,
+                        node_id=node_id,
+                        rp_name=rp_name,
+                    )
+                )
+
+        # Process standalone placeholder tests
+        for test_name in placeholder_file.standalone_tests:
+            func_node = standalone_functions.get(test_name)
+            if func_node is None:
+                raise RuntimeError(
+                    f"Scanner/AST mismatch: standalone test '{test_name}' reported by "
+                    f"scan_placeholder_tests but not found in AST of {full_path}"
+                )
+            test_docstring = _extract_docstring(node=func_node)
+            test_markers = _extract_markers(decorators=func_node.decorator_list)
+            polarion_id = _extract_polarion_id(decorators=func_node.decorator_list)
+
+            node_id = f"{placeholder_file.file_path}::{test_name}"
+            rp_name = node_id_to_rp_name(node_id=node_id)
+
+            details.append(
+                PlaceholderTestDetail(
+                    file_path=placeholder_file.file_path,
+                    class_name=None,
+                    method_name=test_name,
+                    module_docstring=module_docstring,
+                    class_docstring=None,
+                    test_docstring=test_docstring,
+                    module_markers=module_markers,
+                    class_markers=[],
+                    class_fixtures=[],
+                    test_markers=test_markers,
+                    polarion_id=polarion_id,
+                    node_id=node_id,
+                    rp_name=rp_name,
+                )
+            )
+
+    LOGGER.info(f"Collected {len(details)} placeholder tests from {tests_dir}")
+
+    if marker_filter:
+        details = [detail for detail in details if _matches_marker_filter(detail=detail, marker_filter=marker_filter)]
+        LOGGER.info(f"After marker filter '{marker_filter}': {len(details)} tests")
+
+    if keyword_filter:
+        details = [
+            detail for detail in details if _matches_keyword_filter(detail=detail, keyword_filter=keyword_filter)
+        ]
+        LOGGER.info(f"After keyword filter '{keyword_filter}': {len(details)} tests")
+
+    return sorted(details, key=lambda detail: detail.node_id)

--- a/scripts/reportportal/rp_manual_reporter/collector.py
+++ b/scripts/reportportal/rp_manual_reporter/collector.py
@@ -369,18 +369,11 @@ def collect_placeholder_details(
     placeholder_files = scan_placeholder_tests(tests_dir=tests_dir)
     details: list[PlaceholderTestDetail] = []
 
-    # Derive project root: file_path is relative to root (e.g., tests/network/test_foo.py)
-    # and tests_dir is a subdirectory of root (e.g., <root>/tests or <root>/tests/network).
-    # Walk up from tests_dir until we find "tests" to locate the project root.
-    resolved_tests_dir = tests_dir.resolve()
-    project_root = resolved_tests_dir
-    while project_root.name != "tests" and project_root != project_root.parent:
-        project_root = project_root.parent
-    project_root = project_root.parent  # Go above the "tests" directory
-
     for placeholder_file in placeholder_files:
         file_path = Path(placeholder_file.file_path)
-        full_path = project_root / file_path
+        # file_path is relative to tests_dir.parent (see scan_placeholder_tests line 311:
+        # relative_path = str(test_file.relative_to(tests_dir.parent)))
+        full_path = tests_dir.parent / file_path
 
         try:
             source = full_path.read_text(encoding="utf-8")

--- a/scripts/reportportal/rp_manual_reporter/collector.py
+++ b/scripts/reportportal/rp_manual_reporter/collector.py
@@ -369,9 +369,18 @@ def collect_placeholder_details(
     placeholder_files = scan_placeholder_tests(tests_dir=tests_dir)
     details: list[PlaceholderTestDetail] = []
 
+    # Derive project root: file_path is relative to root (e.g., tests/network/test_foo.py)
+    # and tests_dir is a subdirectory of root (e.g., <root>/tests or <root>/tests/network).
+    # Walk up from tests_dir until we find "tests" to locate the project root.
+    resolved_tests_dir = tests_dir.resolve()
+    project_root = resolved_tests_dir
+    while project_root.name != "tests" and project_root != project_root.parent:
+        project_root = project_root.parent
+    project_root = project_root.parent  # Go above the "tests" directory
+
     for placeholder_file in placeholder_files:
         file_path = Path(placeholder_file.file_path)
-        full_path = tests_dir.parent / file_path
+        full_path = project_root / file_path
 
         try:
             source = full_path.read_text(encoding="utf-8")

--- a/scripts/reportportal/rp_manual_reporter/env.example
+++ b/scripts/reportportal/rp_manual_reporter/env.example
@@ -1,0 +1,25 @@
+# ReportPortal Manual Reporter — Environment Variables
+#
+# Copy this file to .env and fill in your values, then export them before running.
+# These match the envvar= parameters on the CLI options in rp_manual_reporter.py.
+#
+# CLI flags (override env vars):
+#   --rp-url        ReportPortal URL
+#   --rp-project    RP project name
+#   --rp-token      RP API token
+#
+# Example usage:
+#   export REPORT_PORTAL_URL="https://your-reportportal-instance.com"
+#   export REPORT_PORTAL_PROJECT="your-project"
+#   export REPORT_PORTAL_TOKEN="your-api-token"
+#   uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter
+#
+# Or pass values directly:
+#   uv run python -m scripts.reportportal.rp_manual_reporter.rp_manual_reporter \
+#     --rp-url "https://your-reportportal-instance.com" \
+#     --rp-project "your-project" \
+#     --rp-token "your-api-token"
+
+REPORT_PORTAL_URL=""
+REPORT_PORTAL_PROJECT=""
+REPORT_PORTAL_TOKEN=""

--- a/scripts/reportportal/rp_manual_reporter/rp_manual_reporter.py
+++ b/scripts/reportportal/rp_manual_reporter/rp_manual_reporter.py
@@ -332,7 +332,12 @@ def _load_batch_file(batch_path: Path) -> tuple[list[dict[str, Any]], dict[str, 
             raise click.ClickException(f"Batch result entry must be a dict, got: {type(entry).__name__}")
         if "test" not in entry:
             raise click.ClickException(f"Batch entry missing required 'test' key: {entry}")
-        status = entry.get("status", "").upper()
+        raw_status = entry.get("status", "")
+        if not isinstance(raw_status, str):
+            raise click.ClickException(
+                f"Invalid status type for test '{entry.get('test')}': expected string, got {type(raw_status).__name__}"
+            )
+        status = raw_status.upper()
         if status not in _VALID_STATUSES:
             raise click.ClickException(
                 f"Invalid status '{entry.get('status')}' for test '{entry.get('test')}'. "
@@ -652,7 +657,6 @@ def main(
 
         collected_count = len(collected_tests)
         click.echo(message=f"Found {collected_count} placeholder tests.\n")
-        results, skipped_count = _run_interactive_mode(tests=collected_tests)
 
     # ── 4. Validate required launch attributes (skip in dry-run) ──
     required_attr_keys = {
@@ -675,6 +679,9 @@ def main(
                 f"Missing required launch attributes: {missing_names}\n"
                 f"Provide them via CLI flags ({missing_flags}) or use --from-cluster."
             )
+
+    if not batch_file:
+        results, skipped_count = _run_interactive_mode(tests=collected_tests)
 
     # ── 5. Print summary ──
     pass_count = sum(1 for result in results if result["status"] == "PASSED")

--- a/scripts/reportportal/rp_manual_reporter/rp_manual_reporter.py
+++ b/scripts/reportportal/rp_manual_reporter/rp_manual_reporter.py
@@ -1,0 +1,775 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Manual Test Reporter for ReportPortal.
+
+Interactive CLI that collects __test__ = False placeholder tests,
+shows full test context (docstrings, markers, preconditions) one-by-one,
+lets the tester mark each as pass/fail/skip, and pushes results to
+ReportPortal as a new launch.
+
+Supports batch mode via YAML file for non-interactive use and failure retry.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import click
+import requests
+import yaml
+from simple_logger.logger import get_logger
+
+from scripts.reportportal.rp_manual_reporter.cluster_info import (
+    cluster_attributes_to_launch_attrs,
+    get_cluster_attributes,
+)
+from scripts.reportportal.rp_manual_reporter.collector import (
+    PlaceholderTestDetail,
+    collect_placeholder_details,
+)
+from scripts.reportportal.rp_utils.naming import node_id_to_rp_name
+from scripts.reportportal.rp_utils.rp_client import RPClient
+
+LOGGER = get_logger(name=__name__)
+
+
+TERMINAL_WIDTH = 80
+
+_VALID_STATUSES = {"PASSED", "FAILED", "SKIPPED"}
+
+
+class PartialPushError(Exception):
+    """Raised when a push to ReportPortal fails after some items were already pushed.
+
+    Attributes:
+        pushed_count: Number of items successfully pushed before the failure.
+        launch_uuid: UUID of the partially-filled launch.
+    """
+
+    def __init__(self, message: str, pushed_count: int, launch_uuid: str) -> None:
+        super().__init__(message)
+        self.pushed_count = pushed_count
+        self.launch_uuid = launch_uuid
+
+
+_DEFECT_TYPES: dict[str, tuple[str, str]] = {
+    "1": ("pb001", "Product Bug"),
+    "2": ("ab001", "Automation Bug"),
+    "3": ("si001", "System Issue"),
+    "4": ("ti001", "To Investigate"),
+    "5": ("nd001", "No Defect"),
+}
+
+
+def _build_launch_attributes(
+    team: str | None = None,
+    bundle: str | None = None,
+    cnv_version: str | None = None,
+    arch: str | None = None,
+    ocp_version: str | None = None,
+    cluster_name: str | None = None,
+    cluster_domain: str | None = None,
+    storage_class: str | None = None,
+    channel: str | None = None,
+    tier: str | None = None,
+    cluster_attrs: list[dict[str, str]] | None = None,
+) -> list[dict[str, str]]:
+    """Build launch attribute list from CLI args and optional cluster attributes.
+
+    Cluster-derived attributes serve as defaults; explicit CLI values
+    override them.  ``TEAM`` and ``MANUAL`` are always present.
+
+    Args:
+        team: Team name (e.g. ``NETWORK``).
+        bundle: Bundle version string.
+        cnv_version: CNV X.Y version override.
+        arch: Architecture override.
+        ocp_version: OCP version override.
+        cluster_name: Cluster name override.
+        cluster_domain: Cluster domain override.
+        storage_class: Storage-class label override.
+        channel: Channel override.
+        tier: Tier label (e.g. ``TIER-2``).
+        cluster_attrs: Attributes auto-populated from ``--from-cluster``.
+
+    Returns:
+        Final list of ``{"key": ..., "value": ...}`` dicts.
+    """
+    # Start from cluster attrs (as a mutable copy) or empty list
+    attrs_by_key: dict[str, str] = {}
+    if cluster_attrs:
+        for attr in cluster_attrs:
+            attrs_by_key[attr["key"]] = attr["value"]
+
+    # Map explicit CLI overrides to their RP attribute keys
+    overrides: dict[str, str | None] = {
+        "BUNDLE": bundle,
+        "CNV_XY_VER": cnv_version,
+        "ARCH": arch,
+        "OCP": ocp_version,
+        "CLUSTER_NAME": cluster_name,
+        "CLUSTER_DOMAIN": cluster_domain,
+        "SC": storage_class,
+        "CHANNEL": channel,
+    }
+
+    for key, value in overrides.items():
+        if value is not None:
+            attrs_by_key[key] = value
+
+    # Auto-derive CNV_XY_VER from BUNDLE
+    # When bundle is explicitly provided (CLI arg), always override cluster-derived CNV_XY_VER
+    # When bundle comes from cluster only, derive if CNV_XY_VER is missing
+    if "BUNDLE" in attrs_by_key and (bundle is not None or "CNV_XY_VER" not in attrs_by_key):
+        bundle_val = attrs_by_key["BUNDLE"].lstrip("v")
+        parts = bundle_val.split(".")
+        if len(parts) >= 2:
+            attrs_by_key["CNV_XY_VER"] = f"{parts[0]}.{parts[1]}"
+
+    # Mandatory attributes
+    if team:
+        attrs_by_key["TEAM"] = team.upper()
+    attrs_by_key["MANUAL"] = "true"
+
+    if tier is not None:
+        attrs_by_key["TIER"] = tier.upper()
+
+    return [{"key": key, "value": value} for key, value in attrs_by_key.items()]
+
+
+def _display_test_detail(test: PlaceholderTestDetail, index: int, total: int) -> None:
+    """Display a single test's full context to stdout.
+
+    Renders the test header, markers, fixtures, docstrings, and
+    separator lines using a fixed-width terminal format.
+
+    Args:
+        test: Placeholder test detail to display.
+        index: 1-based index of the current test.
+        total: Total number of tests.
+    """
+    header_line = "═" * TERMINAL_WIDTH
+    separator_line = "─" * TERMINAL_WIDTH
+
+    # Header block
+    click.echo(message=f"\n{header_line}")
+    if test.class_name:
+        click.echo(message=f"[{index}/{total}] {test.file_path}")
+        click.echo(message=f"       {test.class_name}::{test.method_name}")
+    else:
+        click.echo(message=f"[{index}/{total}] {test.file_path}")
+        click.echo(message=f"       {test.method_name}")
+    click.echo(message=header_line)
+    click.echo()
+
+    # Module markers
+    if test.module_markers:
+        formatted_markers = ", ".join(f"@{marker}" for marker in test.module_markers)
+        click.echo(message=f"Module markers: {formatted_markers}")
+
+    # Class info
+    if test.class_name:
+        click.echo(message=f"Class:          {test.class_name}")
+
+    # Class fixtures
+    if test.class_fixtures:
+        formatted_fixtures = ", ".join(f'"{fixture}"' for fixture in test.class_fixtures)
+        click.echo(message=f"Class fixtures: @usefixtures({formatted_fixtures})")
+
+    # Class markers
+    if test.class_markers:
+        formatted_class_markers = ", ".join(f"@{marker}" for marker in test.class_markers)
+        click.echo(message=f"Class markers:  {formatted_class_markers}")
+
+    # Test markers
+    if test.test_markers:
+        formatted_test_markers = ", ".join(f"@{marker}" for marker in test.test_markers)
+        click.echo(message=f"Test markers:   {formatted_test_markers}")
+
+    # Polarion ID
+    if test.polarion_id:
+        click.echo(message=f"Polarion:       {test.polarion_id}")
+
+    # Module docstring (STP / preconditions)
+    if test.module_docstring and test.module_docstring.strip():
+        click.echo()
+        click.echo(message="Module:")
+        for line in test.module_docstring.strip().splitlines():
+            click.echo(message=f"  {line}")
+
+    # Class docstring
+    if test.class_docstring and test.class_docstring.strip():
+        click.echo()
+        click.echo(message="Class docs:")
+        for line in test.class_docstring.strip().splitlines():
+            click.echo(message=f"  {line}")
+
+    # Test docstring
+    if test.test_docstring and test.test_docstring.strip():
+        click.echo()
+        click.echo(message="Description:")
+        for line in test.test_docstring.strip().splitlines():
+            click.echo(message=f"  {line}")
+
+    click.echo()
+    click.echo(message=separator_line)
+
+
+def _run_interactive_mode(tests: list[PlaceholderTestDetail]) -> tuple[list[dict[str, Any]], int]:
+    """Run interactive test result collection.
+
+    Presents each placeholder test one-by-one and collects a verdict
+    from the tester via the terminal.
+
+    Args:
+        tests: List of placeholder tests to present.
+
+    Returns:
+        Tuple of (results list, skipped count). Results contain only
+        PASSED/FAILED entries; skipped tests are counted but not recorded.
+    """
+    results: list[dict[str, Any]] = []
+    skipped_count = 0
+    total = len(tests)
+
+    for index, test in enumerate(tests, start=1):
+        _display_test_detail(test=test, index=index, total=total)
+
+        while True:
+            choice = (
+                click
+                .prompt(
+                    "Result (p=pass, f=fail, s=skip, q=quit)",
+                    type=str,
+                )
+                .strip()
+                .lower()
+            )
+
+            if choice == "p":
+                results.append({"test": test.node_id, "status": "PASSED", "comment": ""})
+                break
+            elif choice == "f":
+                while True:
+                    click.echo(message="Defect type:")
+                    for key, (_, label) in _DEFECT_TYPES.items():
+                        click.echo(message=f"  {key}. {label}")
+                    defect_choice = click.prompt(
+                        "Choose (1-5, default=4)",
+                        type=str,
+                        default="4",
+                        show_default=False,
+                    ).strip()
+                    if defect_choice in _DEFECT_TYPES:
+                        break
+                    click.echo(message=f"Invalid choice '{defect_choice}'. Use 1-5.")
+                issue_type, issue_type_label = _DEFECT_TYPES[defect_choice]
+                comment = click.prompt("Comment (optional)", default="", show_default=False)
+                results.append({
+                    "test": test.node_id,
+                    "status": "FAILED",
+                    "comment": comment,
+                    "issue_type": issue_type,
+                    "issue_type_label": issue_type_label,
+                })
+                break
+            elif choice == "s":
+                skipped_count += 1
+                break
+            elif choice == "q":
+                click.echo(message="Quitting — returning results collected so far.")
+                return results, skipped_count
+            else:
+                click.echo(message="Invalid choice. Use p/f/s/q.")
+
+    return results, skipped_count
+
+
+def _load_batch_file(batch_path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Load test results and metadata from a batch YAML file.
+
+    Expected format::
+
+        metadata:
+            team: NETWORK
+            bundle: v4.22.0
+        results:
+          - test: "tests/foo/test_bar.py::TestClass::test_method"
+            status: passed
+            comment: "optional"
+
+    Args:
+        batch_path: Path to the YAML file.
+
+    Returns:
+        Tuple of (results list, metadata dict). Metadata may contain
+        ``team``, ``bundle``, and ``attributes`` from a previous
+        session's saved file.
+
+    Raises:
+        click.ClickException: If the file format is invalid or a status
+            value is unrecognised.
+    """
+    try:
+        raw = yaml.safe_load(batch_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise click.ClickException(f"Failed to read batch file {batch_path}: {exc}") from exc
+
+    if not isinstance(raw, dict) or "results" not in raw:
+        raise click.ClickException(f"Batch file {batch_path} must contain a top-level 'results' key")
+
+    raw_results = raw["results"]
+    if not isinstance(raw_results, list):
+        raise click.ClickException(
+            f"Batch file {batch_path}: 'results' must be a list, got {type(raw_results).__name__}"
+        )
+
+    results: list[dict[str, Any]] = []
+    for entry in raw_results:
+        if not isinstance(entry, dict):
+            raise click.ClickException(f"Batch result entry must be a dict, got: {type(entry).__name__}")
+        if "test" not in entry:
+            raise click.ClickException(f"Batch entry missing required 'test' key: {entry}")
+        status = entry.get("status", "").upper()
+        if status not in _VALID_STATUSES:
+            raise click.ClickException(
+                f"Invalid status '{entry.get('status')}' for test '{entry.get('test')}'. "
+                f"Must be one of: {', '.join(sorted(_VALID_STATUSES))}"
+            )
+        result_entry: dict[str, Any] = {
+            "test": entry["test"],
+            "status": status,
+            "comment": entry.get("comment", ""),
+        }
+        if entry.get("issue_type"):
+            result_entry["issue_type"] = entry["issue_type"]
+            result_entry["issue_type_label"] = entry.get("issue_type_label", "")
+        results.append(result_entry)
+
+    metadata: dict[str, Any] = {}  # values can be str or list[dict]
+    raw_metadata = raw.get("metadata", {})
+    if isinstance(raw_metadata, dict):
+        for key in ("team", "bundle"):
+            if raw_metadata.get(key):
+                metadata[key] = str(raw_metadata[key])
+        saved_attrs = raw_metadata.get("attributes")
+        if isinstance(saved_attrs, list):
+            metadata["attributes"] = saved_attrs
+
+    LOGGER.info(f"Loaded {len(results)} results from batch file {batch_path}")
+    return results, metadata
+
+
+def _save_results_for_retry(
+    results: list[dict[str, Any]],
+    team: str,
+    bundle: str | None,
+    attributes: list[dict[str, str]] | None = None,
+) -> Path:
+    """Save test results to a YAML file for later retry.
+
+    The file is written to the current directory with a timestamped
+    name so that multiple retry files can coexist.
+
+    Args:
+        results: List of result dicts to save.
+        team: Team name.
+        bundle: Bundle version.
+        attributes: Launch attributes to preserve for retry.
+
+    Returns:
+        Path to the saved YAML file.
+    """
+    timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
+    filename = f"manual_results_{timestamp}.yaml"
+    output_path = Path.cwd() / filename
+
+    payload: dict[str, Any] = {
+        "metadata": {
+            "team": team,
+            "bundle": bundle,
+            "attributes": attributes or [],
+            "saved_at": datetime.now(tz=UTC).isoformat(),
+        },
+        "results": results,
+    }
+
+    yaml_content = yaml.dump(data=payload, default_flow_style=False, sort_keys=False)
+    output_path.write_text(data=yaml_content, encoding="utf-8")
+    LOGGER.info(f"Saved {len(results)} results to {output_path}")
+    return output_path
+
+
+def _push_results_to_rp(
+    rp_client: RPClient,
+    results: list[dict[str, Any]],
+    launch_name: str,
+    attributes: list[dict[str, str]],
+    tests: list[PlaceholderTestDetail] | None = None,
+    description: str = "",
+) -> str:
+    """Push test results to ReportPortal.
+
+    Creates a launch, populates it with test items (one per result),
+    and finishes the launch.
+
+    Args:
+        rp_client: Authenticated RPClient instance.
+        results: List of result dicts with test, status, comment.
+        launch_name: Name for the RP launch.
+        attributes: Launch attributes.
+        tests: Optional list of placeholder test details for Polarion ID
+            lookup. When provided, matching tests get a
+            ``polarion-testcase-id`` attribute on their RP item.
+        description: Launch description.
+
+    Returns:
+        The launch UUID.
+    """
+    # Build a node_id → polarion_id lookup from collected tests
+    polarion_lookup: dict[str, str] = {}
+    if tests:
+        for test in tests:
+            if test.polarion_id:
+                polarion_lookup[test.node_id] = test.polarion_id
+
+    launch_uuid = rp_client.create_launch(name=launch_name, attributes=attributes, description=description)
+
+    pushed_count = 0
+    try:
+        for result in results:
+            item_name = node_id_to_rp_name(node_id=result["test"])
+            item_attrs: list[dict[str, str]] | None = None
+
+            polarion_id = polarion_lookup.get(result["test"])
+            if polarion_id:
+                item_attrs = [{"key": "polarion-testcase-id", "value": polarion_id}]
+
+            item_uuid = rp_client.start_test_item(
+                launch_uuid=launch_uuid,
+                name=item_name,
+                description=result.get("comment", ""),
+                attributes=item_attrs,
+            )
+            issue: dict[str, str] | None = None
+            if result.get("issue_type"):
+                issue = {"issueType": result["issue_type"], "comment": result.get("comment", "")}
+            rp_client.finish_test_item(item_uuid=item_uuid, status=result["status"], issue=issue)
+            pushed_count += 1
+    except requests.RequestException as exc:
+        raise PartialPushError(
+            f"Failed after pushing {pushed_count}/{len(results)} items: {exc}",
+            pushed_count=pushed_count,
+            launch_uuid=launch_uuid,
+        ) from exc
+
+    try:
+        rp_client.finish_launch(launch_uuid=launch_uuid)
+    except requests.RequestException as exc:
+        raise PartialPushError(
+            f"All {len(results)} items pushed but finish_launch failed: {exc}",
+            pushed_count=len(results),
+            launch_uuid=launch_uuid,
+        ) from exc
+    LOGGER.info(f"Pushed {len(results)} results to launch {launch_uuid}")
+    return launch_uuid
+
+
+@click.command(
+    help="Manual Test Reporter for ReportPortal",
+    epilog="Collects manual test results for __test__ = False STD placeholder tests and pushes to ReportPortal.",
+)
+@click.option("--bundle", type=str, default=None, help="Bundle version prefix (e.g., v4.22.0.rhel9-102)")
+@click.option(
+    "--team",
+    type=str,
+    default=None,
+    help="Team name (e.g., NETWORK, STORAGE, VIRT). Auto-inferred from --tests-dir if not set.",
+)
+@click.option("--tier", type=str, default=None, help="Tier label (e.g., TIER-2)")
+@click.option(
+    "--tests-dir",
+    type=click.Path(exists=True, path_type=Path),
+    default=Path("tests"),
+    help="Tests directory to scan (e.g., tests/network/)",
+)
+@click.option(
+    "-m", "--marker", type=str, default=None, help="Pytest marker expression (e.g., 'gating', 'smoke and not tier3')"
+)
+@click.option(
+    "-k", "--keyword", type=str, default=None, help="Keyword filter on test node IDs (e.g., 'test_connectivity')"
+)
+@click.option("--from-cluster", is_flag=True, default=False, help="Auto-fill attributes from connected cluster")
+@click.option("--arch", type=str, default=None, help="Override architecture")
+@click.option("--ocp-version", type=str, default=None, help="Override OCP version")
+@click.option("--cnv-version", type=str, default=None, help="Override CNV X.Y version")
+@click.option("--cluster-name", type=str, default=None, help="Override cluster name")
+@click.option("--cluster-domain", type=str, default=None, help="Override cluster domain")
+@click.option("--sc", type=str, default=None, help="Override storage class label")
+@click.option("--channel", type=str, default=None, help="Override channel")
+@click.option(
+    "--rp-url", type=str, envvar="REPORT_PORTAL_URL", default=None, help="ReportPortal URL (env: REPORT_PORTAL_URL)"
+)
+@click.option(
+    "--rp-project",
+    type=str,
+    envvar="REPORT_PORTAL_PROJECT",
+    default=None,
+    help="RP project name (env: REPORT_PORTAL_PROJECT)",
+)
+@click.option("--rp-token", type=str, envvar="REPORT_PORTAL_TOKEN", default=None, help="RP API token")
+@click.option(
+    "--batch-file",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Batch YAML file with pre-filled results",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Show what would be pushed without pushing")
+def main(
+    bundle: str | None,
+    team: str | None,
+    tier: str | None,
+    tests_dir: Path,
+    marker: str | None,
+    keyword: str | None,
+    from_cluster: bool,
+    arch: str | None,
+    ocp_version: str | None,
+    cnv_version: str | None,
+    cluster_name: str | None,
+    cluster_domain: str | None,
+    sc: str | None,
+    channel: str | None,
+    rp_url: str | None,
+    rp_project: str | None,
+    rp_token: str | None,
+    batch_file: Path | None,
+    dry_run: bool,
+) -> None:
+    """Collect manual test results and push to ReportPortal.
+
+    In interactive mode, each placeholder test is shown with full
+    context and the tester marks it pass/fail/skip.  In batch mode a
+    YAML file supplies pre-filled verdicts.
+    """
+    # ── 0. Infer team from tests_dir if not provided ──
+    if not team:
+        resolved_parts = tests_dir.resolve().parts
+        try:
+            tests_index = list(resolved_parts).index("tests")
+            if tests_index + 1 < len(resolved_parts):
+                team = resolved_parts[tests_index + 1].upper()
+                click.echo(message=f"Inferred team: {team} (from {tests_dir})")
+        except ValueError:
+            pass  # "tests" not found in path — no inference possible
+
+    # ── 1. Resolve cluster attributes ──
+    cluster_attrs: list[dict[str, str]] | None = None
+    if from_cluster:
+        raw_cluster = get_cluster_attributes()
+        cluster_attrs = cluster_attributes_to_launch_attrs(cluster_attrs=raw_cluster)
+        click.echo(message=f"Loaded {len(cluster_attrs)} attributes from connected cluster.")
+
+    # ── 2. Build launch attributes ──
+    attributes = _build_launch_attributes(
+        team=team,
+        bundle=bundle,
+        cnv_version=cnv_version,
+        arch=arch,
+        ocp_version=ocp_version,
+        cluster_name=cluster_name,
+        cluster_domain=cluster_domain,
+        storage_class=sc,
+        channel=channel,
+        tier=tier,
+        cluster_attrs=cluster_attrs,
+    )
+
+    # If bundle wasn't provided via CLI, extract from built attributes (may come from cluster)
+    if not bundle:
+        for attr in attributes:
+            if attr["key"] == "BUNDLE":
+                bundle = attr["value"]
+                break
+
+    # ── 3. Collect results ──
+    collected_tests: list[PlaceholderTestDetail] | None = None
+    collected_count = 0
+    skipped_count = 0
+
+    if batch_file:
+        results, batch_metadata = _load_batch_file(batch_path=batch_file)
+        skipped_count = sum(1 for entry in results if entry["status"] == "SKIPPED")
+        results = [entry for entry in results if entry["status"] != "SKIPPED"]
+        collected_count = len(results) + skipped_count
+        # Fill team/bundle from batch metadata if not provided via CLI
+        batch_team = batch_metadata.get("team")
+        batch_bundle = batch_metadata.get("bundle")
+        if not team and batch_team:
+            team = batch_team
+            click.echo(message=f"Using team from batch file: {team}")
+        if not bundle and batch_bundle:
+            bundle = batch_bundle
+            click.echo(message=f"Using bundle from batch file: {bundle}")
+        # Use saved attributes from retry file as base (if present)
+        saved_attrs = batch_metadata.get("attributes")
+        if isinstance(saved_attrs, list) and not cluster_attrs:
+            cluster_attrs = saved_attrs
+            click.echo(message=f"Restored {len(saved_attrs)} attributes from batch file.")
+        # Rebuild attributes with batch metadata merged in
+        attributes = _build_launch_attributes(
+            team=team,
+            bundle=bundle,
+            cnv_version=cnv_version,
+            arch=arch,
+            ocp_version=ocp_version,
+            cluster_name=cluster_name,
+            cluster_domain=cluster_domain,
+            storage_class=sc,
+            channel=channel,
+            tier=tier,
+            cluster_attrs=cluster_attrs,
+        )
+    else:
+        filter_parts = []
+        if marker:
+            filter_parts.append(f"-m '{marker}'")
+        if keyword:
+            filter_parts.append(f"-k '{keyword}'")
+        filter_msg = f" (filters: {', '.join(filter_parts)})" if filter_parts else ""
+        click.echo(message=f"Scanning {tests_dir} for placeholder tests{filter_msg}...")
+        collected_tests = collect_placeholder_details(
+            tests_dir=tests_dir,
+            marker_filter=marker,
+            keyword_filter=keyword,
+        )
+
+        if not collected_tests:
+            click.echo(message="No placeholder tests found.")
+            sys.exit(0)
+
+        collected_count = len(collected_tests)
+        click.echo(message=f"Found {collected_count} placeholder tests.\n")
+        results, skipped_count = _run_interactive_mode(tests=collected_tests)
+
+    # ── 4. Validate required launch attributes (skip in dry-run) ──
+    required_attr_keys = {
+        "BUNDLE": "--bundle",
+        "OCP": "--ocp-version",
+        "CNV_XY_VER": "--cnv-version",
+        "ARCH": "--arch",
+        "CLUSTER_NAME": "--cluster-name",
+        "CLUSTER_DOMAIN": "--cluster-domain",
+        "SC": "--sc",
+        "CHANNEL": "--channel",
+    }
+    if not dry_run:
+        present_keys = {attr["key"] for attr in attributes}
+        missing = {key: flag for key, flag in required_attr_keys.items() if key not in present_keys}
+        if missing:
+            missing_names = ", ".join(sorted(missing.keys()))
+            missing_flags = ", ".join(sorted(missing.values()))
+            raise click.ClickException(
+                f"Missing required launch attributes: {missing_names}\n"
+                f"Provide them via CLI flags ({missing_flags}) or use --from-cluster."
+            )
+
+    # ── 5. Print summary ──
+    pass_count = sum(1 for result in results if result["status"] == "PASSED")
+    failed_results = [result for result in results if result["status"] == "FAILED"]
+    fail_count = len(failed_results)
+    click.echo(message="\n── Summary ──")
+    click.echo(message=f"Collected: {collected_count} tests")
+    click.echo(message=f"  PASSED:  {pass_count}")
+    click.echo(message=f"  FAILED:  {fail_count}")
+    if failed_results:
+        defect_counts: dict[str, int] = {}
+        for result in failed_results:
+            label = result.get("issue_type_label", "Unclassified")
+            defect_counts[label] = defect_counts.get(label, 0) + 1
+        for label, count in sorted(defect_counts.items()):
+            click.echo(message=f"    {label}: {count}")
+    click.echo(message=f"  Skipped: {skipped_count}")
+
+    if not results:
+        click.echo(message="\nNo results to push.")
+        sys.exit(0)
+
+    # ── 6. Dry-run summary ──
+    if dry_run:
+        click.echo(message="\nAttributes:")
+        for attr in attributes:
+            click.echo(message=f"  {attr['key']} = {attr['value']}")
+        click.echo(message="\nNo data was pushed to ReportPortal.")
+        sys.exit(0)
+
+    # ── 7. Validate RP connection settings ──
+    if not rp_url:
+        raise click.ClickException("REPORT_PORTAL_URL env var or --rp-url required.")
+    if not rp_project:
+        raise click.ClickException("REPORT_PORTAL_PROJECT env var or --rp-project required.")
+    if not rp_token:
+        raise click.ClickException("REPORT_PORTAL_TOKEN env var or --rp-token required.")
+
+    # ── 8. Push to ReportPortal ──
+    team_label = team.upper() if team else "ALL"
+    launch_name = f"Manual - {team_label}"
+    if bundle:
+        launch_name = f"{launch_name} - {bundle}"
+
+    try:
+        client = RPClient(base_url=rp_url, project=rp_project, token=rp_token)
+        launch_uuid = _push_results_to_rp(
+            rp_client=client,
+            results=results,
+            launch_name=launch_name,
+            attributes=attributes,
+            tests=collected_tests,
+            description=f"Manual test results for {team_label}",
+        )
+        click.echo(message=f"\n✓ Launch created successfully (UUID: {launch_uuid})")
+        click.echo(message=f"  View in ReportPortal: {rp_url}/ui/#{rp_project}/launches/all")
+
+    except PartialPushError as exc:
+        LOGGER.error(str(exc))
+        unpushed_start = exc.pushed_count
+        remaining = results[unpushed_start:]
+        click.echo(message=f"\n✗ Push failed after {exc.pushed_count}/{len(results)} items.", err=True)
+        if remaining:
+            saved_path = _save_results_for_retry(
+                results=remaining,
+                team=team_label,
+                bundle=bundle,
+                attributes=attributes,
+            )
+            click.echo(message=f"  {len(remaining)} unpushed results saved to: {saved_path}", err=True)
+            click.echo(message=f"  Retry with: --batch-file {saved_path}", err=True)
+        else:
+            click.echo(
+                message=f"  All items pushed but launch not finished. Launch UUID: {exc.launch_uuid}",
+                err=True,
+            )
+            click.echo(
+                message="  The launch may need manual finishing in ReportPortal.",
+                err=True,
+            )
+        sys.exit(1)
+
+    except requests.RequestException as exc:
+        LOGGER.error(f"Failed to push results to ReportPortal: {exc}")
+        saved_path = _save_results_for_retry(
+            results=results,
+            team=team_label,
+            bundle=bundle,
+            attributes=attributes,
+        )
+        click.echo(message=f"\n✗ Push failed: {exc}", err=True)
+        click.echo(message=f"  Results saved to: {saved_path}", err=True)
+        click.echo(message=f"  Retry with: --batch-file {saved_path}", err=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reportportal/rp_manual_reporter/rp_manual_reporter.py
+++ b/scripts/reportportal/rp_manual_reporter/rp_manual_reporter.py
@@ -681,6 +681,7 @@ def main(
             )
 
     if not batch_file:
+        assert collected_tests is not None, "collected_tests must be set when not using batch file"
         results, skipped_count = _run_interactive_mode(tests=collected_tests)
 
     # ── 5. Print summary ──

--- a/scripts/reportportal/rp_manual_reporter/tests/__init__.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/__init__.py
@@ -1,0 +1,1 @@
+# Co-authored-by: Claude <noreply@anthropic.com>

--- a/scripts/reportportal/rp_manual_reporter/tests/__init__.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/__init__.py
@@ -1,4 +1,1 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
-import os
-
-os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_manual_reporter/tests/__init__.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/__init__.py
@@ -1,1 +1,4 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
+import os
+
+os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_manual_reporter/tests/conftest.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/conftest.py
@@ -1,6 +1,0 @@
-# Co-authored-by: Claude <noreply@anthropic.com>
-"""Conftest for rp_manual_reporter tests.
-
-Prevents pytest from discovering the project's top-level conftest.py
-which requires an OpenShift cluster connection.
-"""

--- a/scripts/reportportal/rp_manual_reporter/tests/conftest.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/conftest.py
@@ -5,19 +5,14 @@ from collections.abc import Generator
 
 import pytest
 
-# Snapshot original state before mutation
-_ORIGINAL_ARCH = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
-
-# Set early (module-level) so the env var is available during collection,
-# before session-scoped fixtures run.
-os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
+from scripts.reportportal.tests_common import ORIGINAL_ARCH
 
 
 @pytest.fixture(autouse=True, scope="session")
 def _mock_cluster_architecture() -> Generator[None]:
     """Restore original architecture env var after tests complete."""
     yield
-    if _ORIGINAL_ARCH is None:
+    if ORIGINAL_ARCH is None:
         os.environ.pop("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", None)
     else:
-        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = _ORIGINAL_ARCH
+        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = ORIGINAL_ARCH

--- a/scripts/reportportal/rp_manual_reporter/tests/conftest.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/conftest.py
@@ -1,0 +1,10 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Conftest for rp_manual_reporter tests.
+
+Prevents pytest from discovering the project's top-level conftest.py
+which requires an OpenShift cluster connection.
+"""
+
+import os
+
+os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_manual_reporter/tests/conftest.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/conftest.py
@@ -4,7 +4,3 @@
 Prevents pytest from discovering the project's top-level conftest.py
 which requires an OpenShift cluster connection.
 """
-
-import os
-
-os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_manual_reporter/tests/conftest.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/conftest.py
@@ -5,6 +5,9 @@ from collections.abc import Generator
 
 import pytest
 
+# Snapshot original state before mutation
+_ORIGINAL_ARCH = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
+
 # Set early (module-level) so the env var is available during collection,
 # before session-scoped fixtures run.
 os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
@@ -12,11 +15,9 @@ os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
 
 @pytest.fixture(autouse=True, scope="session")
 def _mock_cluster_architecture() -> Generator[None]:
-    """Set architecture env var to avoid cluster connection in tests."""
-    old_value = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
-    os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = "amd64"
+    """Restore original architecture env var after tests complete."""
     yield
-    if old_value is None:
+    if _ORIGINAL_ARCH is None:
         os.environ.pop("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", None)
     else:
-        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = old_value
+        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = _ORIGINAL_ARCH

--- a/scripts/reportportal/rp_manual_reporter/tests/conftest.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Conftest for rp_manual_reporter tests."""
+
+import os
+from collections.abc import Generator
+
+import pytest
+
+# Set early (module-level) so the env var is available during collection,
+# before session-scoped fixtures run.
+os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _mock_cluster_architecture() -> Generator[None]:
+    """Set architecture env var to avoid cluster connection in tests."""
+    old_value = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
+    os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = "amd64"
+    yield
+    if old_value is None:
+        os.environ.pop("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", None)
+    else:
+        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = old_value

--- a/scripts/reportportal/rp_manual_reporter/tests/pytest.ini
+++ b/scripts/reportportal/rp_manual_reporter/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# Isolate these tests from the project's top-level conftest.py
+# which requires an OpenShift cluster connection.

--- a/scripts/reportportal/rp_manual_reporter/tests/pytest.ini
+++ b/scripts/reportportal/rp_manual_reporter/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 # Isolate these tests from the project's top-level conftest.py
 # which requires an OpenShift cluster connection.
+confcutdir = .

--- a/scripts/reportportal/rp_manual_reporter/tests/test_collector.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/test_collector.py
@@ -1,5 +1,8 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
-"""Tests for scripts.reportportal.rp_manual_reporter.collector module."""
+"""Tests for scripts.reportportal.rp_manual_reporter.collector module.
+
+Coverage: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5207
+"""
 
 from __future__ import annotations
 

--- a/scripts/reportportal/rp_manual_reporter/tests/test_collector.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/test_collector.py
@@ -1,7 +1,7 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
 """Tests for scripts.reportportal.rp_manual_reporter.collector module.
 
-Coverage: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5207
+RFE: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5207
 """
 
 from __future__ import annotations

--- a/scripts/reportportal/rp_manual_reporter/tests/test_collector.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/test_collector.py
@@ -1,0 +1,405 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Tests for scripts.reportportal.rp_manual_reporter.collector module."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.reportportal.rp_manual_reporter.collector import (
+    PlaceholderTestDetail,
+    _extract_docstring,
+    _extract_markers,
+    _extract_module_markers,
+    _extract_polarion_id,
+    _extract_usefixtures,
+    _matches_keyword_filter,
+    _matches_marker_filter,
+    _safe_eval_bool_expr,
+    collect_placeholder_details,
+    node_id_to_rp_name,
+)
+from scripts.reportportal.rp_manual_reporter.rp_manual_reporter import _build_launch_attributes
+from scripts.reportportal.rp_manual_reporter.tests.utils import (
+    MockPlaceholderClass,
+    MockPlaceholderFile,
+    make_detail,
+)
+
+
+class TestNodeIdToRpName:
+    def test_node_id_to_rp_name_basic(self) -> None:
+        """Verify basic node ID with class and method converts to dotted name."""
+        result = node_id_to_rp_name(node_id="tests/foo/test_bar.py::TestClass::test_method")
+        assert result == "tests.foo.test_bar.TestClass.test_method"
+
+    def test_node_id_to_rp_name_with_params(self) -> None:
+        """Verify parametrize suffix is preserved in conversion."""
+        result = node_id_to_rp_name(node_id="tests/foo/test_bar.py::TestClass::test_method[param]")
+        assert result == "tests.foo.test_bar.TestClass.test_method[param]"
+
+    def test_node_id_to_rp_name_standalone(self) -> None:
+        """Verify standalone function (no class) converts correctly."""
+        result = node_id_to_rp_name(node_id="tests/foo/test_bar.py::test_func")
+        assert result == "tests.foo.test_bar.test_func"
+
+
+class TestExtractDocstring:
+    def test_extract_docstring(self) -> None:
+        """Verify docstring is extracted from a function AST node."""
+        source = textwrap.dedent('''\
+            def test_example():
+                """This is the docstring."""
+                pass
+        ''')
+        tree = ast.parse(source=source)
+        func_node = tree.body[0]
+        result = _extract_docstring(node=func_node)
+        assert result == "This is the docstring."
+
+    def test_extract_docstring_no_docstring(self) -> None:
+        """Verify None returned when function has no docstring."""
+        source = textwrap.dedent("""\
+            def test_example():
+                pass
+        """)
+        tree = ast.parse(source=source)
+        func_node = tree.body[0]
+        result = _extract_docstring(node=func_node)
+        assert result is None
+
+
+class TestExtractMarkers:
+    def test_extract_markers(self) -> None:
+        """Verify bare pytest.mark decorators are extracted."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            @pytest.mark.smoke
+            @pytest.mark.tier1
+            def test_example():
+                pass
+        """)
+        tree = ast.parse(source=source)
+        func_node = tree.body[1]
+        result = _extract_markers(decorators=func_node.decorator_list)
+        assert result == ["smoke", "tier1"]
+
+    def test_extract_markers_with_args(self) -> None:
+        """Verify called markers include their arguments."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            @pytest.mark.parametrize("x", [1, 2])
+            def test_example(x):
+                pass
+        """)
+        tree = ast.parse(source=source)
+        func_node = tree.body[1]
+        result = _extract_markers(decorators=func_node.decorator_list)
+        assert len(result) == 1
+        assert result[0].startswith("parametrize(")
+
+
+class TestExtractUsefixtures:
+    def test_extract_usefixtures(self) -> None:
+        """Verify fixture names extracted from usefixtures decorator."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            @pytest.mark.usefixtures("fix1", "fix2")
+            class TestExample:
+                pass
+        """)
+        tree = ast.parse(source=source)
+        class_node = tree.body[1]
+        result = _extract_usefixtures(decorators=class_node.decorator_list)
+        assert result == ["fix1", "fix2"]
+
+
+class TestExtractPolarionId:
+    def test_extract_polarion_id(self) -> None:
+        """Verify Polarion ID extracted from polarion marker."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            @pytest.mark.polarion("MOCK-1234")
+            def test_example():
+                pass
+        """)
+        tree = ast.parse(source=source)
+        func_node = tree.body[1]
+        result = _extract_polarion_id(decorators=func_node.decorator_list)
+        assert result == "MOCK-1234"
+
+    def test_extract_polarion_id_no_marker(self) -> None:
+        """Verify None returned when no polarion marker present."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            @pytest.mark.smoke
+            def test_example():
+                pass
+        """)
+        tree = ast.parse(source=source)
+        func_node = tree.body[1]
+        result = _extract_polarion_id(decorators=func_node.decorator_list)
+        assert result is None
+
+
+class TestExtractModuleMarkers:
+    def test_extract_module_markers(self) -> None:
+        """Verify module-level pytestmark list markers are extracted."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            pytestmark = [pytest.mark.foo, pytest.mark.bar]
+        """)
+        tree = ast.parse(source=source)
+        result = _extract_module_markers(tree=tree)
+        assert result == ["foo", "bar"]
+
+
+class TestCollectPlaceholderDetails:
+    def test_collect_placeholder_details(self, tmp_path: Path) -> None:
+        """Verify full placeholder detail collection from a temp test file."""
+        # Create directory structure matching expected layout
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+
+        sub_dir = tests_dir / "network"
+        sub_dir.mkdir()
+
+        test_file = sub_dir / "test_example.py"
+        test_file.write_text(
+            textwrap.dedent('''\
+            """Module docstring for STP link."""
+
+            import pytest
+
+            __test__ = False
+
+            pytestmark = [pytest.mark.tier1]
+
+            class TestMyFeature:
+                """Class docstring."""
+
+                @pytest.mark.polarion("MOCK-9999")
+                def test_my_case(self):
+                    """Test docstring with steps."""
+                    pass
+        ''')
+        )
+
+        mock_placeholder = MockPlaceholderFile(
+            file_path="tests/network/test_example.py",
+            classes=[
+                MockPlaceholderClass(
+                    name="TestMyFeature",
+                    test_methods=["test_my_case"],
+                ),
+            ],
+        )
+
+        with patch(
+            "scripts.reportportal.rp_manual_reporter.collector.scan_placeholder_tests",
+            return_value=[mock_placeholder],
+        ):
+            details = collect_placeholder_details(tests_dir=tests_dir)
+
+        assert len(details) == 1
+        detail = details[0]
+        assert isinstance(detail, PlaceholderTestDetail)
+        assert detail.file_path == "tests/network/test_example.py"
+        assert detail.class_name == "TestMyFeature"
+        assert detail.method_name == "test_my_case"
+        assert detail.module_docstring == "Module docstring for STP link."
+        assert detail.class_docstring == "Class docstring."
+        assert detail.test_docstring == "Test docstring with steps."
+        assert detail.module_markers == ["tier1"]
+        assert detail.polarion_id == "MOCK-9999"
+        assert detail.node_id == "tests/network/test_example.py::TestMyFeature::test_my_case"
+        assert detail.rp_name == "tests.network.test_example.TestMyFeature.test_my_case"
+
+
+class TestMatchesMarkerFilter:
+    def test_simple_marker_match(self) -> None:
+        """Verify simple marker name matches."""
+        detail = make_detail(test_markers=["gating"])
+        assert _matches_marker_filter(detail=detail, marker_filter="gating") is True
+
+    def test_simple_marker_no_match(self) -> None:
+        """Verify non-matching marker returns False."""
+        detail = make_detail(test_markers=["tier1"])
+        assert _matches_marker_filter(detail=detail, marker_filter="gating") is False
+
+    def test_marker_in_module_markers(self) -> None:
+        """Verify marker found in module-level markers."""
+        detail = make_detail(module_markers=["gating"])
+        assert _matches_marker_filter(detail=detail, marker_filter="gating") is True
+
+    def test_marker_in_class_markers(self) -> None:
+        """Verify marker found in class-level markers."""
+        detail = make_detail(class_markers=["smoke"])
+        assert _matches_marker_filter(detail=detail, marker_filter="smoke") is True
+
+    def test_boolean_and_expression(self) -> None:
+        """Verify 'and' boolean expression matches when both markers present."""
+        detail = make_detail(test_markers=["gating", "tier1"])
+        assert _matches_marker_filter(detail=detail, marker_filter="gating and tier1") is True
+
+    def test_boolean_and_expression_partial(self) -> None:
+        """Verify 'and' expression fails when only one marker present."""
+        detail = make_detail(test_markers=["gating"])
+        assert _matches_marker_filter(detail=detail, marker_filter="gating and tier1") is False
+
+    def test_boolean_not_expression(self) -> None:
+        """Verify 'not' expression excludes tests with the marker."""
+        detail = make_detail(test_markers=["gating"])
+        assert _matches_marker_filter(detail=detail, marker_filter="gating and not tier3") is True
+
+    def test_marker_with_args_stripped(self) -> None:
+        """Verify markers with args like 'parametrize(...)' are stripped to bare name."""
+        detail = make_detail(test_markers=["parametrize('x', [1, 2])"])
+        assert _matches_marker_filter(detail=detail, marker_filter="parametrize") is True
+
+
+class TestMatchesKeywordFilter:
+    def test_keyword_match(self) -> None:
+        """Verify keyword substring matches node ID."""
+        detail = make_detail(node_id="tests/network/test_bridge.py::TestBridge::test_connectivity")
+        assert _matches_keyword_filter(detail=detail, keyword_filter="test_connectivity") is True
+
+    def test_keyword_no_match(self) -> None:
+        """Verify non-matching keyword returns False."""
+        detail = make_detail(node_id="tests/network/test_bridge.py::TestBridge::test_connectivity")
+        assert _matches_keyword_filter(detail=detail, keyword_filter="test_migration") is False
+
+    def test_keyword_case_insensitive(self) -> None:
+        """Verify keyword matching is case-insensitive."""
+        detail = make_detail(node_id="tests/network/test_bridge.py::TestBridge::test_connectivity")
+        assert _matches_keyword_filter(detail=detail, keyword_filter="TestBridge") is True
+
+    def test_keyword_partial_match(self) -> None:
+        """Verify partial keyword matches."""
+        detail = make_detail(node_id="tests/network/test_bridge.py::TestBridge::test_connectivity")
+        assert _matches_keyword_filter(detail=detail, keyword_filter="bridge") is True
+
+
+class TestBuildLaunchAttributeKeys:
+    """Verify that _build_launch_attributes emits the correct attribute keys.
+
+    Tests the key naming contract (ARCH not ARCHITECTURE, OCP not OCP_VERSION)
+    via _build_launch_attributes which is importable without cluster dependencies.
+    """
+
+    def test_explicit_attrs_emit_short_keys(self) -> None:
+        """Verify explicit CLI args produce RP-compatible short key names."""
+        result = _build_launch_attributes(
+            team="NETWORK",
+            bundle="v4.22.0",
+            cnv_version="4.22",
+            arch="amd64",
+            ocp_version="4.22.0",
+            cluster_name="bm15a",
+            cluster_domain="bm15a.example.com",
+            storage_class="ocs-storagecluster-ceph-rbd",
+            channel="candidate",
+        )
+        keys = {attr["key"] for attr in result}
+
+        assert "ARCH" in keys
+        assert "OCP" in keys
+        assert "CNV_XY_VER" in keys
+        assert "SC" in keys
+        assert "BUNDLE" in keys
+        assert "TEAM" in keys
+        assert "ARCHITECTURE" not in keys
+        assert "OCP_VERSION" not in keys
+        assert "CNV_VERSION" not in keys
+        assert "STORAGE_CLASS" not in keys
+
+
+class TestSafeEvalBoolExpr:
+    def test_simple_true(self) -> None:
+        """Verify simple True expression evaluates correctly."""
+        assert _safe_eval_bool_expr(expr="True") is True
+
+    def test_simple_false(self) -> None:
+        """Verify simple False expression evaluates correctly."""
+        assert _safe_eval_bool_expr(expr="False") is False
+
+    def test_and_expression(self) -> None:
+        """Verify and expression evaluates correctly."""
+        assert _safe_eval_bool_expr(expr="True and False") is False
+
+    def test_not_expression(self) -> None:
+        """Verify not expression evaluates correctly."""
+        assert _safe_eval_bool_expr(expr="not False") is True
+
+    def test_complex_expression(self) -> None:
+        """Verify complex boolean expression evaluates correctly."""
+        assert _safe_eval_bool_expr(expr="True and not False or False") is True
+
+    def test_rejects_function_call(self) -> None:
+        """Verify function calls are rejected."""
+        with pytest.raises(TypeError, match="Disallowed AST node"):
+            _safe_eval_bool_expr(expr="__import__('os')")
+
+    def test_rejects_attribute_access(self) -> None:
+        """Verify attribute access is rejected."""
+        with pytest.raises(TypeError, match="Disallowed AST node"):
+            _safe_eval_bool_expr(expr="True.__class__")
+
+    def test_rejects_string_constant(self) -> None:
+        """Verify non-boolean constants are rejected."""
+        with pytest.raises(TypeError, match="Disallowed constant"):
+            _safe_eval_bool_expr(expr="'injection'")
+
+    def test_rejects_numeric_constant(self) -> None:
+        """Verify numeric constants are rejected."""
+        with pytest.raises(TypeError, match="Disallowed constant"):
+            _safe_eval_bool_expr(expr="42")
+
+
+class TestBuildLaunchAttributes:
+    def test_cnv_version_derived_from_bundle(self) -> None:
+        """Verify CNV_XY_VER is auto-derived from BUNDLE when not explicitly set."""
+        result = _build_launch_attributes(bundle="v4.22.0.rhel9-102")
+        attrs_by_key = {attr["key"]: attr["value"] for attr in result}
+        assert attrs_by_key["CNV_XY_VER"] == "4.22"
+
+    def test_bundle_derived_cnv_xy_ver_overrides_explicit_cnv_version(self) -> None:
+        """Bundle-derived CNV_XY_VER overrides explicit --cnv-version.
+
+        When both --bundle and --cnv-version are provided, CNV_XY_VER is
+        derived from the bundle string because the bundle is the
+        authoritative version source.
+        """
+        result = _build_launch_attributes(
+            bundle="v4.22.0",
+            cnv_version="4.21",
+        )
+        attrs_by_key = {attr["key"]: attr["value"] for attr in result}
+        assert attrs_by_key["CNV_XY_VER"] == "4.22"
+
+    def test_cluster_cnv_version_kept_without_explicit_bundle(self) -> None:
+        """Verify cluster-derived CNV_XY_VER is kept when bundle is not explicit."""
+        result = _build_launch_attributes(
+            cluster_attrs=[
+                {"key": "BUNDLE", "value": "v4.22.0"},
+                {"key": "CNV_XY_VER", "value": "4.21"},
+            ],
+        )
+        attrs_by_key = {attr["key"]: attr["value"] for attr in result}
+        assert attrs_by_key["CNV_XY_VER"] == "4.21"
+
+    def test_cnv_version_not_derived_without_bundle(self) -> None:
+        """Verify CNV_XY_VER is not set when BUNDLE is missing."""
+        result = _build_launch_attributes()
+        attrs_by_key = {attr["key"]: attr["value"] for attr in result}
+        assert "CNV_XY_VER" not in attrs_by_key

--- a/scripts/reportportal/rp_manual_reporter/tests/utils.py
+++ b/scripts/reportportal/rp_manual_reporter/tests/utils.py
@@ -1,0 +1,47 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Test utilities for rp_manual_reporter collector tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from scripts.reportportal.rp_manual_reporter.collector import PlaceholderTestDetail
+from scripts.reportportal.rp_utils.naming import node_id_to_rp_name
+
+
+@dataclass
+class MockPlaceholderClass:
+    """Mock of PlaceholderClass from std_placeholder_stats."""
+
+    name: str
+    test_methods: list[str] = field(default_factory=list)
+    disabled_methods: list[str] = field(default_factory=list)
+
+
+@dataclass
+class MockPlaceholderFile:
+    """Mock of PlaceholderFile from std_placeholder_stats."""
+
+    file_path: str
+    classes: list[MockPlaceholderClass] = field(default_factory=list)
+    standalone_tests: list[str] = field(default_factory=list)
+    disabled_standalone_tests: list[str] = field(default_factory=list)
+
+
+def make_detail(
+    node_id: str = "tests/net/test_a.py::TestA::test_one",
+    module_markers: list[str] | None = None,
+    class_markers: list[str] | None = None,
+    test_markers: list[str] | None = None,
+) -> PlaceholderTestDetail:
+    """Create a PlaceholderTestDetail with minimal fields for testing."""
+    return PlaceholderTestDetail(
+        file_path="tests/net/test_a.py",
+        class_name="TestA",
+        method_name="test_one",
+        node_id=node_id,
+        rp_name=node_id_to_rp_name(node_id=node_id),
+        module_markers=module_markers or [],
+        class_markers=class_markers or [],
+        test_markers=test_markers or [],
+    )

--- a/scripts/reportportal/rp_utils/README.md
+++ b/scripts/reportportal/rp_utils/README.md
@@ -1,0 +1,64 @@
+<!-- Co-authored-by: Claude <noreply@anthropic.com> -->
+# ReportPortal Shared Utilities
+
+Shared library used by `rp_manual_reporter`.
+
+---
+
+## Modules
+
+### `rp_client.py` — RPClient
+
+Thread-safe HTTP client for the ReportPortal REST API. Handles authentication,
+pagination, and launch/item CRUD operations.
+
+```python
+from scripts.reportportal.rp_utils.rp_client import RPClient
+
+client = RPClient(
+    base_url="https://reportportal.example.com",
+    project="my-project",
+    token="my-api-token",
+)
+```
+
+#### API
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `get_launches(bundle_prefix)` | `list[dict]` | Fetch launches whose BUNDLE attribute value **contains** `bundle_prefix` (uses RP `filter.cnt.attributeValue`) |
+| `get_test_items(launch_id)` | `list[dict]` | Fetch all STEP-level test items for a launch |
+| `create_launch(name, attributes, description)` | `str` (UUID) | Start a new launch, returns launch UUID |
+| `finish_launch(launch_uuid)` | `None` | Finish a launch |
+| `start_test_item(launch_uuid, name, description, attributes)` | `str` (UUID) | Start a test item under a launch, returns item UUID |
+| `finish_test_item(item_uuid, status, issue)` | `None` | Finish a test item with status and optional defect issue |
+| `update_launch(launch_id, attributes, description)` | `None` | Update launch attributes (uses numeric launch ID) |
+
+#### Pagination
+
+`get_launches()` and `get_test_items()` automatically paginate through all results
+using the RP filter API. Page size defaults to 300 items.
+
+---
+
+### `naming.py` — Node ID Conversion
+
+Converts pytest node IDs to ReportPortal test item names.
+
+```python
+from scripts.reportportal.rp_utils.naming import node_id_to_rp_name
+
+rp_name = node_id_to_rp_name(node_id="tests/network/test_foo.py::TestBar::test_baz[param1]")
+# Returns: "tests.network.test_foo.TestBar.test_baz[param1]"
+```
+
+The conversion replaces path separators (`/`) and pytest separators (`::`) with dots,
+while preserving parameter suffixes (`[...]`) unchanged.
+
+---
+
+## Running Tests
+
+```bash
+uv run tox -e rp-utils-tests
+```

--- a/scripts/reportportal/rp_utils/__init__.py
+++ b/scripts/reportportal/rp_utils/__init__.py
@@ -1,0 +1,1 @@
+# Co-authored-by: Claude <noreply@anthropic.com>

--- a/scripts/reportportal/rp_utils/naming.py
+++ b/scripts/reportportal/rp_utils/naming.py
@@ -1,0 +1,38 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Shared naming utilities for ReportPortal tools.
+
+Provides conversion between pytest node IDs and ReportPortal item names.
+"""
+
+from __future__ import annotations
+
+
+def node_id_to_rp_name(node_id: str) -> str:
+    """Convert a pytest node ID to ReportPortal dotted name format.
+
+    Transforms path separators and pytest delimiters into dots while
+    preserving parametrize suffixes.
+
+    Args:
+        node_id: Pytest-style node ID, e.g.
+            ``tests/foo/test_bar.py::TestClass::test_method[param]``.
+
+    Returns:
+        Dotted ReportPortal name, e.g.
+            ``tests.foo.test_bar.TestClass.test_method[param]``.
+    """
+    param_suffix = ""
+    base = node_id
+    bracket_index = node_id.find("[")
+    if bracket_index != -1:
+        param_suffix = node_id[bracket_index:]
+        base = node_id[:bracket_index]
+
+    # Remove .py from the module path (before the first ::)
+    # Using split/join to target only the file path portion
+    parts = base.split("::")
+    parts[0] = parts[0].removesuffix(".py")
+    base = ".".join(parts)
+    base = base.replace("/", ".")
+
+    return base + param_suffix

--- a/scripts/reportportal/rp_utils/rp_client.py
+++ b/scripts/reportportal/rp_utils/rp_client.py
@@ -1,0 +1,280 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""ReportPortal API client for CNV test coverage tools.
+
+Provides authenticated access to the ReportPortal REST API with
+automatic pagination support. Used by both the Manual Test Reporter
+and the CI Coverage Gate tools.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import requests
+import urllib3
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _utc_now_iso() -> str:
+    """Returns current UTC time in ISO format with Z suffix for RP compatibility."""
+    return datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+class RPClient:
+    """ReportPortal REST API client with pagination support.
+
+    Args:
+        base_url: ReportPortal instance URL (e.g., "https://reportportal.example.com").
+        project: RP project name (e.g., "cnv")
+        token: Bearer token for authentication
+    """
+
+    def __init__(self, base_url: str, project: str, token: str, verify_ssl: bool = False) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.project = project
+        self.token = token
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        })
+        self.session.verify = verify_ssl
+        if not verify_ssl:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        self.session.close()
+
+    def __enter__(self) -> RPClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def _api_url(self, path: str) -> str:
+        """Builds a full API URL for the given resource path.
+
+        Args:
+            path: Resource path relative to the project API root.
+
+        Returns:
+            Fully qualified API URL.
+        """
+        return f"{self.base_url}/api/v1/{self.project}/{path}"
+
+    def _paginate(self, url: str, params: dict[str, Any], page_size: int = 300) -> list[dict[str, Any]]:
+        """Fetches all pages from a paginated RP endpoint.
+
+        Args:
+            url: Full API URL to query.
+            params: Query parameters (filters) to include in each request.
+            page_size: Number of items per page.
+
+        Returns:
+            Accumulated list of content items from all pages.
+
+        Raises:
+            requests.HTTPError: If any page request returns a non-2xx status.
+        """
+        all_items: list[dict[str, Any]] = []
+        page_num = 1
+        total_pages = 1
+
+        while page_num <= total_pages:
+            paginated_params = {**params, "page.size": page_size, "page.page": page_num}
+            response = self.session.get(url=url, params=paginated_params, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+
+            try:
+                total_pages = data["page"]["totalPages"]
+            except (KeyError, TypeError) as exc:
+                raise requests.HTTPError(f"Unexpected RP response format: {exc}") from exc
+            LOGGER.info(f"Fetching page {page_num}/{total_pages} from {url}")
+
+            all_items.extend(data.get("content", []))
+            page_num += 1
+
+        return all_items
+
+    def create_launch(self, name: str, attributes: list[dict[str, str]], description: str = "") -> str:
+        """Creates a new launch in ReportPortal.
+
+        Args:
+            name: Launch name.
+            attributes: List of attribute dicts (e.g., [{"key": "BUNDLE", "value": "4.19"}]).
+            description: Optional launch description.
+
+        Returns:
+            The created launch UUID.
+
+        Raises:
+            requests.HTTPError: If the request fails.
+        """
+        url = self._api_url(path="launch")
+        body = {
+            "name": name,
+            "startTime": _utc_now_iso(),
+            "attributes": attributes,
+            "description": description,
+            "mode": "DEFAULT",
+        }
+        response = self.session.post(url=url, json=body, timeout=30)
+        response.raise_for_status()
+        try:
+            launch_uuid = response.json()["id"]
+        except (KeyError, TypeError) as exc:
+            raise requests.HTTPError(f"Unexpected RP response creating launch: {exc}") from exc
+        LOGGER.info(f"Created launch '{name}' with UUID {launch_uuid}")
+        return launch_uuid
+
+    def finish_launch(self, launch_uuid: str) -> None:
+        """Finishes an existing launch.
+
+        Args:
+            launch_uuid: UUID of the launch to finish.
+
+        Raises:
+            requests.HTTPError: If the request fails.
+        """
+        url = self._api_url(path=f"launch/{launch_uuid}/finish")
+        body = {"endTime": _utc_now_iso()}
+        response = self.session.put(url=url, json=body, timeout=30)
+        response.raise_for_status()
+        LOGGER.info(f"Finished launch {launch_uuid}")
+
+    def start_test_item(
+        self,
+        launch_uuid: str,
+        name: str,
+        description: str = "",
+        attributes: list[dict[str, str]] | None = None,
+    ) -> str:
+        """Start a test item (step) within a launch.
+
+        The item is created in an "in progress" state. Call
+        ``finish_test_item`` to set the final status and end time.
+
+        Args:
+            launch_uuid: Parent launch UUID.
+            name: Test item name.
+            description: Optional item description.
+            attributes: Optional list of attribute dicts.
+
+        Returns:
+            The created test item UUID.
+
+        Raises:
+            requests.HTTPError: If the request fails.
+        """
+        url = self._api_url(path="item")
+        body: dict[str, Any] = {
+            "launchUuid": launch_uuid,
+            "name": name,
+            "type": "STEP",
+            "startTime": _utc_now_iso(),
+            "hasStats": True,
+            "description": description,
+        }
+        if attributes is not None:
+            body["attributes"] = attributes
+
+        response = self.session.post(url=url, json=body, timeout=30)
+        response.raise_for_status()
+        try:
+            item_uuid = response.json()["id"]
+        except (KeyError, TypeError) as exc:
+            raise requests.HTTPError(f"Unexpected RP response starting test item: {exc}") from exc
+        LOGGER.info(f"Started test item '{name}'")
+        return item_uuid
+
+    def finish_test_item(
+        self,
+        item_uuid: str,
+        status: str,
+        issue: dict[str, str] | None = None,
+    ) -> None:
+        """Finish a test item with a final status.
+
+        Args:
+            item_uuid: UUID of the item to finish.
+            status: Final test status (e.g., ``PASSED``, ``FAILED``).
+            issue: Optional issue dict for defect linking.
+
+        Raises:
+            requests.HTTPError: If the request fails.
+        """
+        url = self._api_url(path=f"item/{item_uuid}")
+        body: dict[str, Any] = {
+            "endTime": _utc_now_iso(),
+            "status": status.upper(),
+        }
+        if issue is not None:
+            body["issue"] = issue
+
+        response = self.session.put(url=url, json=body, timeout=30)
+        response.raise_for_status()
+        LOGGER.info(f"Finished test item {item_uuid} with status {status.upper()}")
+
+    def get_launches(self, bundle_prefix: str, since_days: int = 0, page_size: int = 300) -> list[dict[str, Any]]:
+        """Fetches launches filtered by BUNDLE attribute prefix.
+
+        Args:
+            bundle_prefix: Prefix to match against BUNDLE attribute values.
+            since_days: Only fetch launches from the last N days (0 = all).
+            page_size: Number of items per page.
+
+        Returns:
+            List of launch dicts matching the filter.
+        """
+        url = self._api_url(path="launch")
+        params: dict[str, Any] = {
+            "filter.has.attributeKey": "BUNDLE",
+            "filter.cnt.attributeValue": bundle_prefix,
+        }
+        if since_days > 0:
+            since_ts = int((datetime.now(tz=UTC) - timedelta(days=since_days)).timestamp() * 1000)
+            params["filter.gte.startTime"] = since_ts
+            LOGGER.info(f"Filtering launches to last {since_days} days")
+        launches = self._paginate(url=url, params=params, page_size=page_size)
+        LOGGER.info(f"Found {len(launches)} launches matching bundle prefix '{bundle_prefix}'")
+        return launches
+
+    def get_test_items(self, launch_id: int, page_size: int = 300) -> list[dict[str, Any]]:
+        """Fetches all test items for a given launch.
+
+        Args:
+            launch_id: Launch ID to fetch items for.
+            page_size: Number of items per page.
+
+        Returns:
+            List of test item dicts.
+        """
+        url = self._api_url(path="item")
+        params: dict[str, Any] = {"filter.eq.launchId": launch_id}
+        return self._paginate(url=url, params=params, page_size=page_size)
+
+    def update_launch(self, launch_id: int, attributes: list[dict[str, str]], description: str = "") -> None:
+        """Updates an existing launch's attributes and description.
+
+        Args:
+            launch_id: ID of the launch to update.
+            attributes: New list of attribute dicts.
+            description: Updated description.
+
+        Raises:
+            requests.HTTPError: If the request fails.
+        """
+        url = self._api_url(path=f"launch/{launch_id}/update")
+        body = {
+            "attributes": attributes,
+            "description": description,
+            "mode": "DEFAULT",
+        }
+        response = self.session.put(url=url, json=body, timeout=30)
+        response.raise_for_status()
+        LOGGER.info(f"Updated launch {launch_id}")

--- a/scripts/reportportal/rp_utils/tests/__init__.py
+++ b/scripts/reportportal/rp_utils/tests/__init__.py
@@ -1,0 +1,1 @@
+# Co-authored-by: Claude <noreply@anthropic.com>

--- a/scripts/reportportal/rp_utils/tests/__init__.py
+++ b/scripts/reportportal/rp_utils/tests/__init__.py
@@ -1,4 +1,1 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
-import os
-
-os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_utils/tests/__init__.py
+++ b/scripts/reportportal/rp_utils/tests/__init__.py
@@ -1,1 +1,4 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
+import os
+
+os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_utils/tests/conftest.py
+++ b/scripts/reportportal/rp_utils/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Conftest for rp_utils tests."""
+
+import os
+from collections.abc import Generator
+
+import pytest
+
+# Set early (module-level) so the env var is available during collection,
+# before session-scoped fixtures run.
+os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _mock_cluster_architecture() -> Generator[None]:
+    """Set architecture env var to avoid cluster connection in tests."""
+    old_value = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
+    os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = "amd64"
+    yield
+    if old_value is None:
+        os.environ.pop("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", None)
+    else:
+        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = old_value

--- a/scripts/reportportal/rp_utils/tests/conftest.py
+++ b/scripts/reportportal/rp_utils/tests/conftest.py
@@ -1,0 +1,10 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Conftest for rp_utils tests.
+
+Prevents pytest from discovering the project's top-level conftest.py
+which requires an OpenShift cluster connection.
+"""
+
+import os
+
+os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_utils/tests/conftest.py
+++ b/scripts/reportportal/rp_utils/tests/conftest.py
@@ -5,19 +5,14 @@ from collections.abc import Generator
 
 import pytest
 
-# Snapshot original state before mutation
-_ORIGINAL_ARCH = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
-
-# Set early (module-level) so the env var is available during collection,
-# before session-scoped fixtures run.
-os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
+from scripts.reportportal.tests_common import ORIGINAL_ARCH
 
 
 @pytest.fixture(autouse=True, scope="session")
 def _mock_cluster_architecture() -> Generator[None]:
     """Restore original architecture env var after tests complete."""
     yield
-    if _ORIGINAL_ARCH is None:
+    if ORIGINAL_ARCH is None:
         os.environ.pop("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", None)
     else:
-        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = _ORIGINAL_ARCH
+        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = ORIGINAL_ARCH

--- a/scripts/reportportal/rp_utils/tests/conftest.py
+++ b/scripts/reportportal/rp_utils/tests/conftest.py
@@ -4,7 +4,3 @@
 Prevents pytest from discovering the project's top-level conftest.py
 which requires an OpenShift cluster connection.
 """
-
-import os
-
-os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")

--- a/scripts/reportportal/rp_utils/tests/conftest.py
+++ b/scripts/reportportal/rp_utils/tests/conftest.py
@@ -5,6 +5,9 @@ from collections.abc import Generator
 
 import pytest
 
+# Snapshot original state before mutation
+_ORIGINAL_ARCH = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
+
 # Set early (module-level) so the env var is available during collection,
 # before session-scoped fixtures run.
 os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
@@ -12,11 +15,9 @@ os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")
 
 @pytest.fixture(autouse=True, scope="session")
 def _mock_cluster_architecture() -> Generator[None]:
-    """Set architecture env var to avoid cluster connection in tests."""
-    old_value = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
-    os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = "amd64"
+    """Restore original architecture env var after tests complete."""
     yield
-    if old_value is None:
+    if _ORIGINAL_ARCH is None:
         os.environ.pop("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", None)
     else:
-        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = old_value
+        os.environ["OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH"] = _ORIGINAL_ARCH

--- a/scripts/reportportal/rp_utils/tests/conftest.py
+++ b/scripts/reportportal/rp_utils/tests/conftest.py
@@ -1,6 +1,0 @@
-# Co-authored-by: Claude <noreply@anthropic.com>
-"""Conftest for rp_utils tests.
-
-Prevents pytest from discovering the project's top-level conftest.py
-which requires an OpenShift cluster connection.
-"""

--- a/scripts/reportportal/rp_utils/tests/pytest.ini
+++ b/scripts/reportportal/rp_utils/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# Isolate these tests from the project's top-level conftest.py
+# which requires an OpenShift cluster connection.

--- a/scripts/reportportal/rp_utils/tests/pytest.ini
+++ b/scripts/reportportal/rp_utils/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 # Isolate these tests from the project's top-level conftest.py
 # which requires an OpenShift cluster connection.
+confcutdir = .

--- a/scripts/reportportal/rp_utils/tests/test_rp_client.py
+++ b/scripts/reportportal/rp_utils/tests/test_rp_client.py
@@ -1,0 +1,236 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Tests for scripts.reportportal.rp_utils.rp_client module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from scripts.reportportal.rp_utils.rp_client import RPClient, _utc_now_iso
+
+
+@pytest.fixture()
+def rp_client() -> RPClient:
+    """Create an RPClient instance with test credentials."""
+    return RPClient(
+        base_url="https://rp.example.com",
+        project="test-project",
+        token="test-token",
+    )
+
+
+class TestUtcNowIso:
+    def test_utc_now_iso(self) -> None:
+        """Verify _utc_now_iso returns string ending with Z."""
+        result = _utc_now_iso()
+        assert isinstance(result, str)
+        assert result.endswith("Z")
+
+
+class TestApiUrl:
+    def test_api_url(self, rp_client: RPClient) -> None:
+        """Verify _api_url builds the correct URL from base, project, and path."""
+        url = rp_client._api_url(path="launch")
+        assert url == "https://rp.example.com/api/v1/test-project/launch"
+
+
+class TestCreateLaunch:
+    def test_create_launch(self, rp_client: RPClient) -> None:
+        """Verify create_launch sends correct POST body and returns launch UUID."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "abc-123-uuid"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(rp_client.session, "post", return_value=mock_response) as mock_post:
+            result = rp_client.create_launch(
+                name="test-launch",
+                attributes=[{"key": "BUNDLE", "value": "4.19"}],
+                description="my desc",
+            )
+
+        assert result == "abc-123-uuid"
+        call_kwargs = mock_post.call_args
+        body = call_kwargs.kwargs["json"]
+        assert body["name"] == "test-launch"
+        assert body["attributes"] == [{"key": "BUNDLE", "value": "4.19"}]
+        assert body["description"] == "my desc"
+        assert body["mode"] == "DEFAULT"
+
+    def test_create_launch_http_error(self, rp_client: RPClient) -> None:
+        """Verify create_launch raises HTTPError on 500 response."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
+
+        with patch.object(rp_client.session, "post", return_value=mock_response):
+            with pytest.raises(requests.HTTPError, match="500 Server Error"):
+                rp_client.create_launch(
+                    name="fail-launch",
+                    attributes=[],
+                )
+
+
+class TestFinishLaunch:
+    def test_finish_launch(self, rp_client: RPClient) -> None:
+        """Verify finish_launch sends PUT to the correct endpoint."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(rp_client.session, "put", return_value=mock_response) as mock_put:
+            rp_client.finish_launch(launch_uuid="uuid-99")
+
+        call_kwargs = mock_put.call_args
+        url = call_kwargs.kwargs["url"]
+        assert url.endswith("/launch/uuid-99/finish")
+
+
+class TestStartTestItem:
+    def test_start_test_item_without_attributes(self, rp_client: RPClient) -> None:
+        """Verify start_test_item omits attributes key when not provided."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "item-7"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(rp_client.session, "post", return_value=mock_response) as mock_post:
+            result = rp_client.start_test_item(
+                launch_uuid="uuid-1",
+                name="test_foo",
+            )
+
+        assert result == "item-7"
+        body = mock_post.call_args.kwargs["json"]
+        assert "attributes" not in body
+        assert "status" not in body
+        assert body["launchUuid"] == "uuid-1"
+        assert body["type"] == "STEP"
+        assert body["hasStats"] is True
+
+    def test_start_test_item_with_attributes(self, rp_client: RPClient) -> None:
+        """Verify start_test_item includes attributes when provided."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"id": "item-8"}
+        mock_response.raise_for_status = MagicMock()
+
+        attrs = [{"key": "polarion-testcase-id", "value": "MOCK-1234"}]
+        with patch.object(rp_client.session, "post", return_value=mock_response) as mock_post:
+            result = rp_client.start_test_item(
+                launch_uuid="uuid-1",
+                name="test_bar",
+                attributes=attrs,
+            )
+
+        assert result == "item-8"
+        body = mock_post.call_args.kwargs["json"]
+        assert body["attributes"] == attrs
+        assert body["launchUuid"] == "uuid-1"
+
+
+class TestFinishTestItem:
+    def test_finish_test_item(self, rp_client: RPClient) -> None:
+        """Verify finish_test_item sends PUT with status and endTime."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(rp_client.session, "put", return_value=mock_response) as mock_put:
+            rp_client.finish_test_item(item_uuid="item-7", status="passed")
+
+        call_kwargs = mock_put.call_args
+        url = call_kwargs.kwargs["url"]
+        assert url.endswith("/item/item-7")
+        body = call_kwargs.kwargs["json"]
+        assert body["status"] == "PASSED"
+        assert "endTime" in body
+        assert "issue" not in body
+
+    def test_finish_test_item_with_issue(self, rp_client: RPClient) -> None:
+        """Verify finish_test_item includes issue when provided."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        issue = {"issueType": "pb001", "comment": "MOCK-12345"}
+        with patch.object(rp_client.session, "put", return_value=mock_response) as mock_put:
+            rp_client.finish_test_item(item_uuid="item-8", status="failed", issue=issue)
+
+        body = mock_put.call_args.kwargs["json"]
+        assert body["status"] == "FAILED"
+        assert body["issue"] == issue
+
+
+class TestGetLaunches:
+    def test_get_launches(self, rp_client: RPClient) -> None:
+        """Verify get_launches paginates across 2 pages and returns all items."""
+        page1_response = MagicMock()
+        page1_response.json.return_value = {
+            "content": [{"id": 1, "name": "launch-1"}],
+            "page": {"totalPages": 2},
+        }
+        page1_response.raise_for_status = MagicMock()
+
+        page2_response = MagicMock()
+        page2_response.json.return_value = {
+            "content": [{"id": 2, "name": "launch-2"}],
+            "page": {"totalPages": 2},
+        }
+        page2_response.raise_for_status = MagicMock()
+
+        with patch.object(rp_client.session, "get", side_effect=[page1_response, page2_response]):
+            launches = rp_client.get_launches(bundle_prefix="4.19")
+
+        assert len(launches) == 2
+        assert launches[0]["id"] == 1
+        assert launches[1]["id"] == 2
+
+    def test_paginate_empty_results(self, rp_client: RPClient) -> None:
+        """Verify pagination with empty content returns empty list."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "content": [],
+            "page": {"totalPages": 1},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(rp_client.session, "get", return_value=mock_response):
+            launches = rp_client.get_launches(bundle_prefix="4.99")
+
+        assert launches == []
+
+
+class TestGetTestItems:
+    def test_get_test_items(self, rp_client: RPClient) -> None:
+        """Verify get_test_items passes correct filter params."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "content": [{"id": 10, "name": "test_foo"}],
+            "page": {"totalPages": 1},
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(rp_client.session, "get", return_value=mock_response) as mock_get:
+            items = rp_client.get_test_items(launch_id=5)
+
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs["params"]
+        assert params["filter.eq.launchId"] == 5
+        assert len(items) == 1
+
+
+class TestUpdateLaunch:
+    def test_update_launch(self, rp_client: RPClient) -> None:
+        """Verify update_launch sends correct PUT body."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        attrs = [{"key": "BUNDLE", "value": "4.20"}]
+        with patch.object(rp_client.session, "put", return_value=mock_response) as mock_put:
+            rp_client.update_launch(
+                launch_id=10,
+                attributes=attrs,
+                description="updated",
+            )
+
+        call_kwargs = mock_put.call_args
+        body = call_kwargs.kwargs["json"]
+        assert body["attributes"] == attrs
+        assert body["description"] == "updated"
+        assert body["mode"] == "DEFAULT"

--- a/scripts/reportportal/rp_utils/tests/test_rp_client.py
+++ b/scripts/reportportal/rp_utils/tests/test_rp_client.py
@@ -1,8 +1,12 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
-"""Tests for scripts.reportportal.rp_utils.rp_client module."""
+"""Tests for scripts.reportportal.rp_utils.rp_client module.
+
+Coverage: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5207
+"""
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,13 +16,15 @@ from scripts.reportportal.rp_utils.rp_client import RPClient, _utc_now_iso
 
 
 @pytest.fixture()
-def rp_client() -> RPClient:
+def rp_client() -> Generator[RPClient]:
     """Create an RPClient instance with test credentials."""
-    return RPClient(
+    client = RPClient(
         base_url="https://rp.example.com",
         project="test-project",
         token="test-token",
     )
+    yield client
+    client.close()
 
 
 class TestUtcNowIso:

--- a/scripts/reportportal/rp_utils/tests/test_rp_client.py
+++ b/scripts/reportportal/rp_utils/tests/test_rp_client.py
@@ -1,7 +1,7 @@
 # Co-authored-by: Claude <noreply@anthropic.com>
 """Tests for scripts.reportportal.rp_utils.rp_client module.
 
-Coverage: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5207
+RFE: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5207
 """
 
 from __future__ import annotations

--- a/scripts/reportportal/tests_common.py
+++ b/scripts/reportportal/tests_common.py
@@ -1,0 +1,19 @@
+# Co-authored-by: Claude <noreply@anthropic.com>
+"""Shared test bootstrap for ReportPortal test packages.
+
+Sets ``OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH`` early enough that
+module-level imports in ``cluster_info.py`` can resolve without a live
+cluster connection.  Snapshot/restore is handled by the fixture so the
+process-global state is left clean after the test session.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Snapshot BEFORE any mutation so teardown can restore faithfully.
+ORIGINAL_ARCH: str | None = os.environ.get("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH")
+
+# Set immediately at import time — must happen before pytest collection
+# triggers module-level imports that call get_cluster_architecture().
+os.environ.setdefault("OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH", "amd64")


### PR DESCRIPTION
##### What this PR does / why we need it:

Add two packages under `scripts/reportportal/`:

1. **rp_manual_reporter** — interactive CLI for testers to push manual results for `__test__ = False` placeholder tests to ReportPortal. Shows full test context (docstrings, markers, preconditions). Supports batch YAML mode and failure recovery.

2. **rp_utils** — shared ReportPortal API client with pagination, bearer token auth, and BUNDLE prefix matching.

52 unit tests across 2 test suites (rp-utils-tests, rp-manual-reporter-tests).

Coverage gate functionality has been moved to a dedicated repo: [openshift-virtualization-coverage-reports](https://github.com/RedHatQE/openshift-virtualization-coverage-reports).

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

The `rp_coverage_gate` package that was previously part of this PR has been extracted to a standalone repo for independent deployment as a Kubernetes CronJob + static file server.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ReportPortal “Manual Reporter” CLI to submit placeholder test verdicts via interactive prompts or batch YAML, including retry-file export/import for partial pushes.
  * Added cluster-derived launch-attribute auto-population and AST-based placeholder test discovery with marker/docstring/ID context.
  * Added shared ReportPortal utilities for authenticated API operations and pytest node-id → ReportPortal naming.
* **Documentation**
  * Documented the Manual Reporter CLI, shared utilities, and provided an environment-variable template.
* **Tests**
  * Added unit/end-to-end coverage for collection, naming, and client behavior, with isolated pytest configurations and safer test environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->