### PR TITLE
Improve test analysis of failed migrations

### DIFF
--- a/JOB_INSIGHT_PROMPT.md
+++ b/JOB_INSIGHT_PROMPT.md
@@ -212,7 +212,12 @@ Pattern guidance:
 - **Live migration failure:** Wrong migration policy, anti-affinity, or insufficient
   target node resources in test setup is `CODE ISSUE`; valid configuration plus
   `virt-controller` or `virt-handler` failure is `PRODUCT BUG`; node drain or
-  network partition is `INFRASTRUCTURE`
+  network partition is `INFRASTRUCTURE`. **CRITICAL: Do NOT infer migration cause
+  from migration object name alone.** Migration names like `kubevirt-workload-update-*`
+  do NOT prove the workload-update-controller triggered the migration. Read the test
+  source code and correlate migration timing with test operations (hot-plug, live
+  migration API calls, etc.). A migration immediately following a hot-plug action
+  (NIC or disk) is likely caused by the hot-plug, not by workload updates.
 - **SSH connectivity failure:** Read the test code to determine how SSH is used.
   Wrong credentials, missing `virtctl` binary, no retry logic, or missing
   `wait_for_ssh_connectivity()` before running commands is `CODE ISSUE`.


### PR DESCRIPTION
The name of the migration resource object doesn't necessarily indicate what triggered it. When migration needs to be checked, it should be done in the context of the the action that preceded it, e.g. hot-plugging (of network, disk etc.).


Assisted-by: Claude Code

##### What this PR does / why we need it:
This change was suggested after I corrected the tool's misclassification of a hot-plug test failure.
The tool initially blamed workload updates, but the migration was actually triggered by the
NIC hot-plug operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated live migration failure guidance with critical warnings against inferring migration causes from object names alone.
  * Added instructions to correlate migration timing with test operations.
  * Clarified that migrations immediately following hot-plug operations are likely caused by the hot-plug action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->