### PR TITLE
net: NAD live-update non-migratable VM test

### DIFF
--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -306,8 +306,24 @@ def _vmi_condition_not_set(existing_conditions: list[ResourceField], required_co
     )
 
 
+def patch_nad_references(vm: BaseVirtualMachine, nad_name_by_net: dict[str, str]) -> None:
+    """Patch network NAD references without waiting for the change to be applied.
+
+    The caller is responsible for waiting on the appropriate VMI condition after this call.
+
+    Args:
+        vm: The virtual machine to update.
+        nad_name_by_net: Mapping of spec network name to new NAD name.
+    """
+    networks = deepcopy(vm.template_spec.networks) or []
+    for network in networks:
+        if network.name in nad_name_by_net and network.multus:
+            network.multus.networkName = nad_name_by_net[network.name]
+    vm.set_networks(networks=networks)
+
+
 def update_nad_references(vm: BaseVirtualMachine, nad_name_by_net: dict[str, str]) -> None:
-    """Update secondary network NAD references and wait for the change to be fully applied.
+    """Update network NAD references and wait for the change to be fully applied.
 
     Patches the VM spec atomically, then waits for the MigrationRequired condition to
     appear (change detected) and disappear (migration completed).
@@ -317,10 +333,6 @@ def update_nad_references(vm: BaseVirtualMachine, nad_name_by_net: dict[str, str
         nad_name_by_net: Mapping of spec network name to new NAD name.
     """
     resource_version = vm.vmi.instance.metadata.resourceVersion
-    networks = deepcopy(vm.template_spec.networks) or []
-    for network in networks:
-        if network.name in nad_name_by_net and network.multus:
-            network.multus.networkName = nad_name_by_net[network.name]
-    vm.set_networks(networks=networks)
+    patch_nad_references(vm=vm, nad_name_by_net=nad_name_by_net)
     wait_for_vmi_condition_status(vm=vm, condition="MigrationRequired", resource_version=resource_version)
     wait_for_no_vmi_condition(vm=vm, condition="MigrationRequired")

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -10,6 +10,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 class VMSpec:
     template: Template
     runStrategy: str = VirtualMachine.RunStrategy.HALTED  # noqa: N815
+    dataVolumeTemplates: list[dict[str, Any]] | None = None  # noqa: N815
 
 
 @dataclass
@@ -156,6 +157,12 @@ class Volume:
     name: str
     containerDisk: ContainerDisk | None = None  # noqa: N815
     cloudInitNoCloud: CloudInitNoCloud | None = None  # noqa: N815
+    dataVolume: DataVolumeRef | None = None  # noqa: N815
+
+
+@dataclass
+class DataVolumeRef:
+    name: str
 
 
 @dataclass

--- a/tests/network/l2_bridge/nad_ref_change/conftest.py
+++ b/tests/network/l2_bridge/nad_ref_change/conftest.py
@@ -4,18 +4,18 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 
-from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
+from libs.net.ip import random_cidr_addresses_by_family
 from libs.net.netattachdef import NetworkAttachmentDefinition
-from libs.net.vmspec import lookup_iface_status, wait_for_ifaces_status
+from libs.net.vmspec import wait_for_ifaces_status
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.l2_bridge.libl2bridge import LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2
 from tests.network.l2_bridge.nad_ref_change.lib_helpers import (
-    GUEST_IFACE_1,
-    GUEST_IFACE_2,
     NET_SEED,
+    non_migratable_bridge_vm,
     two_secondary_bridge_vm,
+    verify_baseline_connectivity,
 )
-from tests.network.libs.connectivity import ARP_ISOLATION_SYSCTL_CMD, poll_tcp_connectivity
+from tests.network.libs.connectivity import ARP_ISOLATION_SYSCTL_CMD
 
 
 @pytest.fixture(scope="module")
@@ -82,27 +82,39 @@ def baseline_connectivity(
     under_test_vm_two_ifaces: BaseVirtualMachine,
     ref_vm: BaseVirtualMachine,
 ) -> None:
-    """Verify baseline connectivity before the NAD reference change.
+    verify_baseline_connectivity(client_vm=under_test_vm_two_ifaces, ref_vm=ref_vm)
 
-    Asserts that the under-test VM can reach the reference VM on VLAN-A (iface-1)
-    and cannot reach it on VLAN-B (iface-2) before any NAD update is applied.
-    """
-    for server_ip in filter_link_local_addresses(
-        ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=LINUX_BRIDGE_IFACE_NAME_1).ipAddresses
-    ):
-        poll_tcp_connectivity(
-            client_vm=under_test_vm_two_ifaces,
-            server_vm=ref_vm,
-            server_ip=str(server_ip),
-            server_bind_dev=GUEST_IFACE_1,
+
+@pytest.fixture()
+def non_migratable_under_test_vm(
+    namespace: Namespace,
+    unprivileged_client: DynamicClient,
+    bridge_nad_a: NetworkAttachmentDefinition,
+) -> Generator[BaseVirtualMachine]:
+    iface_a_ips = random_cidr_addresses_by_family(net_seed=NET_SEED, host_address=5)
+    with non_migratable_bridge_vm(
+        namespace=namespace.name,
+        name="non-migratable-under-test-vm",
+        client=unprivileged_client,
+        nad_names=[bridge_nad_a.name],
+        ip_addresses=[iface_a_ips],
+        iface_names=[LINUX_BRIDGE_IFACE_NAME_1],
+        runcmd=ARP_ISOLATION_SYSCTL_CMD,
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        wait_for_ifaces_status(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],
+            },
         )
-    for server_ip in filter_link_local_addresses(
-        ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=LINUX_BRIDGE_IFACE_NAME_2).ipAddresses
-    ):
-        poll_tcp_connectivity(
-            client_vm=under_test_vm_two_ifaces,
-            server_vm=ref_vm,
-            server_ip=str(server_ip),
-            server_bind_dev=GUEST_IFACE_2,
-            expect_connectivity=False,
-        )
+        yield vm
+
+
+@pytest.fixture()
+def non_migratable_baseline_connectivity(
+    ref_vm: BaseVirtualMachine,
+    non_migratable_under_test_vm: BaseVirtualMachine,
+) -> None:
+    verify_baseline_connectivity(client_vm=non_migratable_under_test_vm, ref_vm=ref_vm)

--- a/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
+++ b/tests/network/l2_bridge/nad_ref_change/lib_helpers.py
@@ -1,16 +1,26 @@
 from typing import Final
 
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.datavolume import DataVolume
+from pytest_testconfig import config as py_config
 
+from libs.net.ip import filter_link_local_addresses
+from libs.net.vmspec import lookup_iface_status
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.spec import (
     CloudInitNoCloud,
+    DataVolumeRef,
     Devices,
+    Disk,
     Interface,
     Multus,
     Network,
+    SpecDisk,
+    VMSpec,
+    Volume,
 )
 from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.l2_bridge.libl2bridge import LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2
 from tests.network.libs import cloudinit
 from tests.network.libs.cloudinit import primary_iface_cloud_init
 from tests.network.libs.connectivity import poll_tcp_connectivity
@@ -73,6 +83,37 @@ def assert_no_connectivity(
     )
 
 
+def verify_baseline_connectivity(
+    client_vm: BaseVirtualMachine,
+    ref_vm: BaseVirtualMachine,
+) -> None:
+    """Verify baseline connectivity: client reaches ref on VLAN-A, not on VLAN-B.
+
+    Args:
+        client_vm: VM initiating the connections.
+        ref_vm: Reference VM with interfaces on both VLANs.
+    """
+    for server_ip in filter_link_local_addresses(
+        ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=LINUX_BRIDGE_IFACE_NAME_1).ipAddresses
+    ):
+        poll_tcp_connectivity(
+            client_vm=client_vm,
+            server_vm=ref_vm,
+            server_ip=str(server_ip),
+            server_bind_dev=GUEST_IFACE_1,
+        )
+    for server_ip in filter_link_local_addresses(
+        ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=LINUX_BRIDGE_IFACE_NAME_2).ipAddresses
+    ):
+        poll_tcp_connectivity(
+            client_vm=client_vm,
+            server_vm=ref_vm,
+            server_ip=str(server_ip),
+            server_bind_dev=GUEST_IFACE_2,
+            expect_connectivity=False,
+        )
+
+
 def two_secondary_bridge_vm(
     namespace: str,
     name: str,
@@ -99,6 +140,70 @@ def two_secondary_bridge_vm(
         iface_names: Logical interface names for the VM spec, aligned with nad_names.
         runcmd: Commands to run on first boot via cloud-init runcmd. None means no extra commands.
     """
+    spec = _bridge_vm_spec(
+        nad_names=nad_names,
+        ip_addresses=ip_addresses,
+        iface_names=iface_names,
+        runcmd=runcmd,
+    )
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
+
+
+def non_migratable_bridge_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    nad_names: list[str],
+    ip_addresses: list[list[str]],
+    iface_names: list[str],
+    runcmd: list[str] | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with secondary bridge interfaces backed by an RWO DataVolume template.
+
+    The DataVolume is embedded as a dataVolumeTemplate so the VM owns and creates it.
+    The RWO access mode of the backing PVC makes the VM non-live-migratable.
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name.
+        client: Kubernetes dynamic client.
+        nad_names: NAD names for the secondary interfaces, in spec order.
+        ip_addresses: Per-interface CIDR address lists, aligned with nad_names.
+        iface_names: Logical interface names for the VM spec, aligned with nad_names.
+        runcmd: Commands to run on first boot via cloud-init runcmd. None means no extra commands.
+    """
+    data_volume = DataVolume(
+        name="non-migratable-dv",
+        namespace=namespace,
+        source_dict={"blank": {}},
+        access_modes=DataVolume.AccessMode.RWO,
+        size="20Gi",
+        storage_class=py_config["default_storage_class"],
+        api_name="storage",
+        client=client,
+    )
+    spec = _bridge_vm_spec(
+        nad_names=nad_names,
+        ip_addresses=ip_addresses,
+        iface_names=iface_names,
+        runcmd=runcmd,
+    )
+    data_volume.to_dict()
+    spec.dataVolumeTemplates = [data_volume.res]
+    spec.template.spec = add_volume_disk(
+        vmi_spec=spec.template.spec,
+        disk=SpecDisk(name=data_volume.name, disk=Disk(bus="virtio")),
+        volume=Volume(name=data_volume.name, dataVolume=DataVolumeRef(name=data_volume.name)),
+    )
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
+
+
+def _bridge_vm_spec(
+    nad_names: list[str],
+    ip_addresses: list[list[str]],
+    iface_names: list[str],
+    runcmd: list[str] | None = None,
+) -> VMSpec:
     spec = base_vmspec()
     spec.template.spec.domain.devices = Devices(
         interfaces=[
@@ -126,4 +231,4 @@ def two_secondary_bridge_vm(
         )
     )
     spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
-    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
+    return spec

--- a/tests/network/l2_bridge/nad_ref_change/test_nad_ref_change.py
+++ b/tests/network/l2_bridge/nad_ref_change/test_nad_ref_change.py
@@ -14,7 +14,12 @@ Preconditions:
 import pytest
 
 from libs.net.ip import filter_link_local_addresses
-from libs.net.vmspec import lookup_iface_status, update_nad_references
+from libs.net.vmspec import (
+    lookup_iface_status,
+    patch_nad_references,
+    update_nad_references,
+    wait_for_vmi_condition_status,
+)
 from tests.network.l2_bridge.libl2bridge import LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2
 from tests.network.l2_bridge.nad_ref_change.lib_helpers import (
     GUEST_IFACE_1,
@@ -211,8 +216,16 @@ class TestRunningVMLinuxBridgeVlanChange:
                 )
 
 
+@pytest.mark.jira("CNV-87878", run=False)
+@pytest.mark.usefixtures("non_migratable_baseline_connectivity")
 @pytest.mark.polarion("CNV-15947")
-def test_non_migratable_vm_nad_change_not_applied():
+def test_non_migratable_vm_nad_change_not_applied(
+    subtests,
+    non_migratable_under_test_vm,
+    ref_vm,
+    bridge_nad_a,
+    bridge_nad_b,
+):
     """
     [NEGATIVE] Test that changing the NAD reference on a non-migratable VM does not
     silently succeed — the VM remains connected to the original network.
@@ -232,6 +245,29 @@ def test_non_migratable_vm_nad_change_not_applied():
         - Non-migratable under-test VM retains connectivity to the reference VM on NAD-VLAN-A
         - Non-migratable under-test VM has no connectivity to the reference VM on NAD-VLAN-B
     """
-
-
-test_non_migratable_vm_nad_change_not_applied.__test__ = False
+    patch_nad_references(
+        vm=non_migratable_under_test_vm, nad_name_by_net={LINUX_BRIDGE_IFACE_NAME_1: bridge_nad_b.name}
+    )
+    wait_for_vmi_condition_status(vm=non_migratable_under_test_vm, condition="RestartRequired")
+    for server_ip in filter_link_local_addresses(
+        ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=LINUX_BRIDGE_IFACE_NAME_1).ipAddresses
+    ):
+        with subtests.test(msg=f"IPv{server_ip.version} on {bridge_nad_a.name}"):
+            assert_connectivity(
+                client_vm=non_migratable_under_test_vm,
+                server_vm=ref_vm,
+                server_ip=str(server_ip),
+                server_bind_dev=GUEST_IFACE_1,
+                client_bind_dev=GUEST_IFACE_1,
+            )
+    for server_ip in filter_link_local_addresses(
+        ip_addresses=lookup_iface_status(vm=ref_vm, iface_name=LINUX_BRIDGE_IFACE_NAME_2).ipAddresses
+    ):
+        with subtests.test(msg=f"IPv{server_ip.version} on {bridge_nad_b.name}"):
+            assert_no_connectivity(
+                client_vm=non_migratable_under_test_vm,
+                server_vm=ref_vm,
+                server_ip=str(server_ip),
+                server_bind_dev=GUEST_IFACE_2,
+                client_bind_dev=GUEST_IFACE_1,
+            )


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds `test_non_migratable_vm_nad_change_not_applied`: verifies that updating the NAD reference on a non-migratable VM does not apply live and the VM reports a `RestartRequired` condition and retains connectivity to the original VLAN-A.

To support this, the PR also:
 - Extends the typed VM spec with `DataVolumeRef` volume support and `dataVolumeTemplates`; adds a `non_migratable_bridge_vm` factory that embeds an RWO DataVolume as a `dataVolumeTemplate` so the VM owns 
it and the RWO PVC prevents live migration
- Extracts `patch_nad_references` from `update_nad_references` as a patch-only variant for non-migratable VMs, where the expected post-change condition is `RestartRequired` rather than live migration

 
##### Which issue(s) this PR fixes: -

##### Special notes for reviewer:
The test is quarantined via @pytest.mark.jira("CNV-87878", run=False): the `RestartRequired` condition is not yet wired up in KubeVirt.

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-89745
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added DataVolume template support to VM spec utilities, enabling creation of non-migratable test VMs.
  * Introduced a helper to patch NAD/network references in VM specs to drive NAD reference-change scenarios.

* **Bug Fixes**
  * Updated the NAD reference update flow to apply spec/network patching before waiting for VMI migration-required state.
  * Improved connectivity validation to assert expected TCP reachability per VLAN (success on VLAN-A, no connectivity on VLAN-B).

* **Tests**
  * Added fixtures for a non-migratable under-test VM and baseline connectivity checks.
  * Updated the non-migratable NAD-change test to use the new fixtures and per-IP subtest assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->