### PR TITLE
storage, tests, cdi_upload: Verify CDI upload in primary UDN namespace

### DIFF
--- a/tests/storage/cdi_upload/conftest.py
+++ b/tests/storage/cdi_upload/conftest.py
@@ -7,7 +7,10 @@ import uuid
 
 import pytest
 from ocp_resources.datavolume import DataVolume
+from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
+from libs.net.ip import random_ipv4_address
+from libs.net.udn import create_udn_namespace
 from utilities.constants import TIMEOUT_1MIN, TIMEOUT_2MIN, Images
 from utilities.storage import check_upload_virtctl_result, create_dv, get_downloaded_artifact, virtctl_upload_dv
 
@@ -93,3 +96,25 @@ def uploaded_dv_scope_class(unprivileged_client, namespace, storage_class_name_s
         ) as upload_result:
             check_upload_virtctl_result(result=upload_result)
             yield dv
+
+
+@pytest.fixture(scope="module")
+def udn_namespace_for_dv_upload(admin_client):
+    yield from create_udn_namespace(name="test-cdi-upload-udn-ns", client=admin_client)
+
+
+@pytest.fixture(scope="module")
+def primary_udn_for_upload(admin_client, udn_namespace_for_dv_upload):
+    with Layer2UserDefinedNetwork(
+        name="layer2-udn-upload",
+        namespace=udn_namespace_for_dv_upload.name,
+        role="Primary",
+        subnets=[f"{random_ipv4_address(net_seed=0, host_address=0)}/24"],
+        ipam={"lifecycle": "Persistent"},
+        client=admin_client,
+    ) as udn:
+        udn.wait_for_condition(
+            condition="NetworkAllocationSucceeded",
+            status=udn.Condition.Status.TRUE,
+        )
+        yield udn

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -413,6 +413,45 @@ def test_virtctl_image_upload_dv_with_exist_pvc(
         )
 
 
+@pytest.mark.polarion("CNV-16270")
+@pytest.mark.usefixtures("primary_udn_for_upload", "download_image")
+def test_virtctl_image_upload_dv_in_pudn_namespace(
+    admin_client,
+    udn_namespace_for_dv_upload,
+    storage_class_name_immediate_binding_scope_module,
+):
+    """
+    Test that uploading a disk image to a DataVolume succeeds in a namespace
+    with a primary User Defined Network (UDN).
+
+    Jira: https://redhat.atlassian.net/browse/CNV-58018 # <skip-jira-utils-check>
+
+    Preconditions:
+        - Namespace with a primary UDN label
+        - Layer2 User Defined Network with role "Primary" in the namespace
+
+    Steps:
+        1. Upload a disk image to a DataVolume in the UDN namespace via virtctl
+
+    Expected:
+        - Upload completes successfully
+        - DataVolume phase is "Succeeded"
+    """
+    dv_name = f"cnv-16270-{storage_class_name_immediate_binding_scope_module}"
+    with virtctl_upload_dv(
+        client=udn_namespace_for_dv_upload.client,
+        namespace=udn_namespace_for_dv_upload.name,
+        name=dv_name,
+        size=DEFAULT_DV_SIZE,
+        image_path=LOCAL_PATH,
+        storage_class=storage_class_name_immediate_binding_scope_module,
+        insecure=True,
+    ) as res:
+        check_upload_virtctl_result(result=res)
+        dv = DataVolume(namespace=udn_namespace_for_dv_upload.name, name=dv_name, client=admin_client)
+        dv.wait_for_dv_success(timeout=TIMEOUT_1MIN)
+
+
 @pytest.mark.tier3
 @pytest.mark.parametrize(
     ("uploaded_dv_with_immediate_binding", "vm_params"),


### PR DESCRIPTION
##### What this PR does / why we need it:
Add a regression test that uploads a disk image to a DataVolume in a PUDN namespace. This tests regression for bug CNV-58018 (CDI upload proxy could not reach the uploader pod in namespaces with a primary UDN).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added module-scoped pytest fixtures to provision an isolated Layer2 UDN environment for storage upload validation, including deterministic subnet configuration and readiness checks.
  * Added an end-to-end virtctl image upload test that creates a DataVolume in the provisioned namespace, verifies the upload result, and waits for the DataVolume to reach a successful state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->