### PR TITLE
[4.22] Storage: Change Cirros images for RHEL from DataSource into upgrade tests

### DIFF
--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -24,18 +24,20 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
-def cirros_vm_for_upgrade_a(
+def rhel_vm_for_upgrade_a(
     upgrade_namespace_scope_session,
     admin_client,
     storage_class_for_snapshot,
-    cluster_common_node_cpu,
+    modern_cpu_for_migration,
+    rhel10_data_source_scope_session,
 ):
     with create_vm_for_snapshot_upgrade_tests(
         vm_name="snapshot-upgrade-a",
         namespace=upgrade_namespace_scope_session.name,
         client=admin_client,
         storage_class_for_snapshot=storage_class_for_snapshot,
-        cpu_model=cluster_common_node_cpu,
+        cpu_model=modern_cpu_for_migration,
+        data_source=rhel10_data_source_scope_session,
     ) as vm:
         yield vm
 
@@ -43,25 +45,27 @@ def cirros_vm_for_upgrade_a(
 @pytest.fixture(scope="session")
 def snapshots_for_upgrade_a(
     admin_client,
-    cirros_vm_for_upgrade_a,
+    rhel_vm_for_upgrade_a,
 ):
-    with create_snapshot_for_upgrade(vm=cirros_vm_for_upgrade_a, client=admin_client) as snapshot:
+    with create_snapshot_for_upgrade(vm=rhel_vm_for_upgrade_a, client=admin_client) as snapshot:
         yield snapshot
 
 
 @pytest.fixture(scope="session")
-def cirros_vm_for_upgrade_b(
+def rhel_vm_for_upgrade_b(
     upgrade_namespace_scope_session,
     admin_client,
     storage_class_for_snapshot,
-    cluster_common_node_cpu,
+    modern_cpu_for_migration,
+    rhel10_data_source_scope_session,
 ):
     with create_vm_for_snapshot_upgrade_tests(
         vm_name="snapshot-upgrade-b",
         namespace=upgrade_namespace_scope_session.name,
         client=admin_client,
         storage_class_for_snapshot=storage_class_for_snapshot,
-        cpu_model=cluster_common_node_cpu,
+        cpu_model=modern_cpu_for_migration,
+        data_source=rhel10_data_source_scope_session,
     ) as vm:
         yield vm
 
@@ -69,9 +73,9 @@ def cirros_vm_for_upgrade_b(
 @pytest.fixture(scope="session")
 def snapshots_for_upgrade_b(
     admin_client,
-    cirros_vm_for_upgrade_b,
+    rhel_vm_for_upgrade_b,
 ):
-    with create_snapshot_for_upgrade(vm=cirros_vm_for_upgrade_b, client=admin_client) as snapshot:
+    with create_snapshot_for_upgrade(vm=rhel_vm_for_upgrade_b, client=admin_client) as snapshot:
         yield snapshot
 
 

--- a/tests/storage/upgrade/constants.py
+++ b/tests/storage/upgrade/constants.py
@@ -1,0 +1,9 @@
+"""
+Upgrade storage test constants
+"""
+
+# Upgrade snapshot test file constants
+UPGRADE_FIRST_FILE_NAME = "first-file.txt"
+UPGRADE_FIRST_FILE_CONTENT = "first-file"
+UPGRADE_SECOND_FILE_NAME = "second-file.txt"
+UPGRADE_SECOND_FILE_CONTENT = "second-file"

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -3,6 +3,11 @@ import logging
 import pytest
 from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 
+from tests.storage.upgrade.constants import (
+    UPGRADE_FIRST_FILE_CONTENT,
+    UPGRADE_FIRST_FILE_NAME,
+    UPGRADE_SECOND_FILE_NAME,
+)
 from tests.storage.utils import assert_disk_bus
 from tests.upgrade_params import (
     HOTPLUG_VM_AFTER_UPGRADE_NODE_ID,
@@ -12,14 +17,14 @@ from tests.upgrade_params import (
     SNAPSHOT_RESTORE_CREATE_AFTER_UPGRADE,
     STORAGE_NODE_ID_PREFIX,
 )
-from utilities.constants import DEPENDENCY_SCOPE_SESSION, HOTPLUG_DISK_VIRTIO_BUS, LS_COMMAND
+from utilities.constants import DEPENDENCY_SCOPE_SESSION, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,
-    run_command_on_cirros_vm_and_check_output,
+    run_command_on_vm_and_check_output,
     wait_for_vm_volume_ready,
 )
-from utilities.virt import migrate_vm_and_verify
+from utilities.virt import migrate_vm_and_verify, running_vm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -43,22 +48,32 @@ class TestUpgradeStorage:
         self,
         admin_client,
         skip_if_no_storage_class_for_snapshot,
-        cirros_vm_for_upgrade_a,
+        rhel_vm_for_upgrade_a,
         snapshots_for_upgrade_a,
     ):
         with VirtualMachineRestore(
-            name=f"restore-snapshot-{cirros_vm_for_upgrade_a.name}",
+            name=f"restore-snapshot-{rhel_vm_for_upgrade_a.name}",
             namespace=snapshots_for_upgrade_a.namespace,
-            vm_name=cirros_vm_for_upgrade_a.name,
+            vm_name=rhel_vm_for_upgrade_a.name,
             snapshot_name=snapshots_for_upgrade_a.name,
             client=admin_client,
         ) as vm_restore:
+            if rhel_vm_for_upgrade_a.ready:
+                rhel_vm_for_upgrade_a.stop(wait=True)
             vm_restore.wait_restore_done()
-            cirros_vm_for_upgrade_a.start(wait=True)
-            run_command_on_cirros_vm_and_check_output(
-                vm=cirros_vm_for_upgrade_a,
-                command=LS_COMMAND,
-                expected_result="1",
+            running_vm(vm=rhel_vm_for_upgrade_a)
+            # Verify first file exists (created before snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_a,
+                command=f"cat {UPGRADE_FIRST_FILE_NAME}",
+                expected_result=UPGRADE_FIRST_FILE_CONTENT,
+            )
+
+            # Verify second file does NOT exist (created after snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_a,
+                command=f"test ! -f {UPGRADE_SECOND_FILE_NAME} && echo 'file not found'",
+                expected_result="file not found",
             )
 
     @pytest.mark.sno
@@ -108,12 +123,21 @@ class TestUpgradeStorage:
     )
     def test_vm_snapshot_restore_check_after_upgrade(
         self,
-        cirros_vm_for_upgrade_a,
+        rhel_vm_for_upgrade_a,
     ):
-        run_command_on_cirros_vm_and_check_output(
-            vm=cirros_vm_for_upgrade_a,
-            command=LS_COMMAND,
-            expected_result="1",
+        running_vm(vm=rhel_vm_for_upgrade_a)
+        # Verify first file exists (created before snapshot, should still be there after upgrade)
+        run_command_on_vm_and_check_output(
+            vm=rhel_vm_for_upgrade_a,
+            command=f"cat {UPGRADE_FIRST_FILE_NAME}",
+            expected_result=UPGRADE_FIRST_FILE_CONTENT,
+        )
+
+        # Verify second file does NOT exist (was created after snapshot, should not be present after restore)
+        run_command_on_vm_and_check_output(
+            vm=rhel_vm_for_upgrade_a,
+            command=f"test ! -f {UPGRADE_SECOND_FILE_NAME} && echo 'file not found'",
+            expected_result="file not found",
         )
 
     @pytest.mark.sno
@@ -128,21 +152,33 @@ class TestUpgradeStorage:
         scope=DEPENDENCY_SCOPE_SESSION,
     )
     def test_vm_snapshot_restore_create_after_upgrade(
-        self, admin_client, cirros_vm_for_upgrade_b, snapshots_for_upgrade_b
+        self, admin_client, rhel_vm_for_upgrade_b, snapshots_for_upgrade_b
     ):
         with VirtualMachineRestore(
-            name=f"restore-snapshot-{cirros_vm_for_upgrade_b.name}",
+            name=f"restore-snapshot-{rhel_vm_for_upgrade_b.name}",
             namespace=snapshots_for_upgrade_b.namespace,
-            vm_name=cirros_vm_for_upgrade_b.name,
+            vm_name=rhel_vm_for_upgrade_b.name,
             snapshot_name=snapshots_for_upgrade_b.name,
             client=admin_client,
         ) as vm_restore:
+            if rhel_vm_for_upgrade_b.ready:
+                rhel_vm_for_upgrade_b.stop(wait=True)
             vm_restore.wait_restore_done()
-            cirros_vm_for_upgrade_b.start(wait=True)
-            run_command_on_cirros_vm_and_check_output(
-                vm=cirros_vm_for_upgrade_b,
-                command=LS_COMMAND,
-                expected_result="1",
+
+            running_vm(vm=rhel_vm_for_upgrade_b)
+
+            # Verify first file exists (created before snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_b,
+                command=f"cat {UPGRADE_FIRST_FILE_NAME}",
+                expected_result=UPGRADE_FIRST_FILE_CONTENT,
+            )
+
+            # Verify second file does NOT exist (created after snapshot)
+            run_command_on_vm_and_check_output(
+                vm=rhel_vm_for_upgrade_b,
+                command=f"test ! -f {UPGRADE_SECOND_FILE_NAME} && echo 'file not found'",
+                expected_result="file not found",
             )
 
     @pytest.mark.polarion("CNV-5310")

--- a/tests/storage/upgrade/utils.py
+++ b/tests/storage/upgrade/utils.py
@@ -1,9 +1,19 @@
 from contextlib import contextmanager
 
+from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
 
-from tests.utils import create_cirros_vm
-from utilities.storage import write_file
+from tests.storage.upgrade.constants import (
+    UPGRADE_FIRST_FILE_CONTENT,
+    UPGRADE_FIRST_FILE_NAME,
+    UPGRADE_SECOND_FILE_CONTENT,
+    UPGRADE_SECOND_FILE_NAME,
+)
+from utilities.constants import OS_FLAVOR_RHEL, RHEL10_PREFERENCE, U1_SMALL
+from utilities.storage import data_volume_template_with_source_ref_dict, write_file_via_ssh
+from utilities.virt import VirtualMachineForTests, running_vm
 
 
 @contextmanager
@@ -13,19 +23,27 @@ def create_vm_for_snapshot_upgrade_tests(
     client,
     storage_class_for_snapshot,
     cpu_model,
+    data_source,
 ):
-    with create_cirros_vm(
-        storage_class=storage_class_for_snapshot,
+    with VirtualMachineForTests(
+        name=f"vm-{vm_name}",
         namespace=namespace,
         client=client,
-        dv_name=f"dv-{vm_name}",
-        vm_name=f"vm-{vm_name}",
+        os_flavor=OS_FLAVOR_RHEL,
+        vm_instance_type=VirtualMachineClusterInstancetype(client=client, name=U1_SMALL),
+        vm_preference=VirtualMachineClusterPreference(client=client, name=RHEL10_PREFERENCE),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=data_source,
+            storage_class=storage_class_for_snapshot,
+        ),
+        run_strategy=VirtualMachine.RunStrategy.ALWAYS,
         cpu_model=cpu_model,
     ) as vm:
-        write_file(
+        running_vm(vm=vm)
+        write_file_via_ssh(
             vm=vm,
-            filename="first-file.txt",
-            content="first-file",
+            filename=UPGRADE_FIRST_FILE_NAME,
+            content=UPGRADE_FIRST_FILE_CONTENT,
         )
         yield vm
 
@@ -40,9 +58,9 @@ def create_snapshot_for_upgrade(vm, client):
         client=client,
     ) as vm_snapshot:
         vm_snapshot.wait_snapshot_done()
-        write_file(
+        write_file_via_ssh(
             vm=vm,
-            filename="second-file.txt",
-            content="second-file",
+            filename=UPGRADE_SECOND_FILE_NAME,
+            content=UPGRADE_SECOND_FILE_CONTENT,
         )
         yield vm_snapshot

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -685,12 +685,6 @@ def run_command_on_vm_and_check_output(
     )
 
 
-def run_command_on_cirros_vm_and_check_output(vm, command, expected_result):
-    with console.Console(vm=vm) as vm_console:
-        vm_console.sendline(command)
-        vm_console.expect(expected_result, timeout=20)
-
-
 def assert_disk_serial(vm, command=shlex.split("sudo ls /dev/disk/by-id")):
     assert (
         HOTPLUG_DISK_SERIAL


### PR DESCRIPTION
##### What this PR does / why we need it:
Forwardport: https://github.com/RedHatQE/openshift-virtualization-tests/pull/2917
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded upgrade storage snapshot coverage to use RHEL-based virtual machines.
  * Added clearer checks for files that should and should not persist across snapshot restore and upgrade flows.

* **Bug Fixes**
  * Improved restore-flow handling by normalizing VM state before validation.
  * Replaced CirrOS-specific command checks with a more generic verification approach for broader test compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->