### PR TITLE
[VIRT] Fix fixture scope race condition in node labeller tests

### DIFF
--- a/tests/virt/node/node_labeller/test_node_labeller_annotation.py
+++ b/tests/virt/node/node_labeller/test_node_labeller_annotation.py
@@ -39,7 +39,7 @@ def worker1_supported_cpu_models_labels(worker_node1):
     return node_cpu_models_labels
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture()
 def labelled_worker_node1(worker1_supported_cpu_models_labels, worker_node1):
     updated_label = worker1_supported_cpu_models_labels[0]
     LOGGER.info(f"Updating node {worker_node1.name} label {updated_label}")


### PR DESCRIPTION
Change labelled_worker_node1 from class to function scope to prevent race where kubevirt reconciles label before skip annotation is applied.

Co-Authored-By: Claude Sonnet 4.5

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture scope configuration for improved test isolation and execution behavior.

---

**Note:** This release contains only internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->