### PR TITLE
net, sriov: Memory hot-plug STD

### DIFF
--- a/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
+++ b/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
@@ -1,0 +1,62 @@
+"""
+SR-IOV VM memory hot-plug tests.
+
+Jira: https://redhat.atlassian.net/browse/CNV-69778 # <skip-jira-utils-check>
+"""
+
+import pytest
+
+
+@pytest.mark.sriov
+@pytest.mark.incremental
+class TestSriovMemoryHotplug:
+    """
+    Tests for SR-IOV VM memory hot-plug.
+
+    Preconditions:
+        - Running under-test VM with SR-IOV interface, 1Gi initial
+          memory, and 4Gi maxGuest configured
+        - Running reference VM with SR-IOV interface on the same
+          SR-IOV network
+    """
+
+    @pytest.mark.polarion("CNV-16278")
+    def test_vmi_status(self):
+        """
+        Test that after memory hot-plug on SR-IOV VM, the VMI status reflects the
+        new memory and the SR-IOV interface is present in the VMI status.
+
+        Preconditions:
+            - A running under-test VM with an SR-IOV interface, 1Gi initial
+              memory, and 4Gi maxGuest configured
+
+        Steps:
+            1. Hot-plug memory to 3Gi on the under-test VM
+
+        Expected:
+            - VMI status of the under-test VM shows actual guest memory
+              increased to 3Gi
+            - SR-IOV interface is present in the VMI status of the under-test
+              VM with guest-agent as an info source
+        """
+
+    @pytest.mark.polarion("CNV-16279")
+    def test_connectivity(self):
+        """
+        Test that SR-IOV connectivity is preserved after memory hot-plug.
+
+        Preconditions:
+            - Under-test VM after memory hot-plug with SR-IOV interface present
+            - A running reference VM with an SR-IOV interface on the same
+              SR-IOV network
+
+        Steps:
+            1. Poll TCP connection from the under-test VM to the reference VM over the SR-IOV interface
+
+        Expected:
+            - TCP connectivity between the under-test VM and the reference VM
+              over the SR-IOV interface is eventually preserved after memory hotplug
+        """
+
+
+__test__ = False


### PR DESCRIPTION
##### What this PR does / why we need it:
Add STD for SR-IOV VM memory hot-plug tests.

Two placeholder tests cover:
- Guest OS memory and VMI interface info after hot-plug
- TCP connectivity over SR-IOV after migration

##### Which issue(s) this PR fixes: 
The scenario is motivated by observed NIC loss after live migration triggered by memory hot-plug on SR-IOV VMs.
https://redhat.atlassian.net/browse/CNV-69778
https://redhat.atlassian.net/browse/CNV-69974

##### Special notes for reviewer:
- Skip Jira check is added to mentioned ticket since the tests require backporting to 4.22-4.19 
- Using incremental - `test_connectivity` depends on `test_vm_info`: no point checking TCP if the NIC is missing post-migration
- Polarion IDs will be added once the scenarios are agreed on

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-78566
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added an SR-IOV VM memory hot-plug pytest module covering:
    * Verification that the VMI/guest reflects the updated memory allocation and interface status after hot-plug.
    * Validation that TCP connectivity over the SR-IOV interface is successfully established and remains preserved following the hot-plug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->