### PR TITLE
fix: enforce `# <skip-jira-utils-check>` on Jira lines in CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -121,6 +121,15 @@ reviews:
           newly added test functions in that same file are considered covered.
           The @pytest.mark.polarion decorator alone does NOT satisfy this requirement.
 
+          **Jira skip-marker enforcement:**
+          When a `Jira:` line appears in a test docstring for traceability, it MUST
+          also include `# <skip-jira-utils-check>` as an inline comment on the same line.
+          This is required so the project's jira-utils checker skips traceability references.
+          - Correct:   `Jira: https://redhat.atlassian.net/browse/CNV-87822  # <skip-jira-utils-check>`
+          - Incorrect: `Jira: https://redhat.atlassian.net/browse/CNV-80580`
+          This does NOT apply to `STP:` or `RFE:` lines — only `Jira:` lines need the marker.
+          Flag a missing `# <skip-jira-utils-check>` on a `Jira:` line as HIGH severity.
+
           Pass if no new test files and no new test functions are added in this PR.
 
   # Auto-review configuration

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -551,7 +551,7 @@ class TestVmiSyncTotal:
     """
     Tests for kubevirt_vmi_sync_total metric.
 
-    Jira: https://redhat.atlassian.net/browse/CNV-80580
+    Jira: https://redhat.atlassian.net/browse/CNV-80580  # <skip-jira-utils-check>
 
     Preconditions:
         - Running VM


### PR DESCRIPTION
##### What this PR does / why we need it:

The project's jira-utils checker validates Jira IDs across the codebase. When test docstrings include `Jira:` lines for traceability (not quarantine/xfail), those references trigger false positives unless they have a `# <skip-jira-utils-check>` inline comment.

This PR:
1. Adds a **Jira skip-marker enforcement** instruction to the `.coderabbit.yaml` "STP link required" custom check, so CodeRabbit flags any `Jira:` line in test docstrings that is missing `# <skip-jira-utils-check>` (HIGH severity). Only applies to `Jira:` lines — `STP:` and `RFE:` lines are unaffected.
2. Fixes the one existing violation in `tests/observability/metrics/test_vms_metrics.py`.

##### Which issue(s) this PR fixes:
Fixes #5257

##### Special notes for reviewer:

##### jira-ticket:
NONE

Co-authored-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the code review configuration to strengthen documentation/traceability enforcement for newly added test docstrings, specifically requiring a Jira inline “skip” marker when a Jira traceability line is present.
* **Documentation**
  * Added the required Jira skip directive to a test docstring to satisfy the updated traceability rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
