### PR TITLE
Manual cherry-pick 4.18: net: Add interface stability test after guest-agent restart

### DIFF
--- a/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
+++ b/tests/network/l2_bridge/vmi_interfaces_stability/test_interfaces_stability.py
@@ -17,10 +17,34 @@ class TestInterfacesStability:
     @pytest.mark.polarion("CNV-14339")
     def test_interfaces_stability(self, running_linux_bridge_vm, stable_ips):
         for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
-            assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=2)
+            assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))
 
     @pytest.mark.polarion("CNV-14340")
     def test_interfaces_stability_after_migration(self, running_linux_bridge_vm, stable_ips):
         migrate_vm_and_verify(vm=running_linux_bridge_vm)
         for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
-            assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=2)
+            assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))
+
+    @pytest.mark.polarion("CNV-16025")
+    def test_interfaces_stability_after_guest_agent_restart(self, running_linux_bridge_vm, stable_ips):
+        """
+        Test that interface IPs remain stable after restarting the guest agent inside the VM.
+
+        Jira: https://redhat.atlassian.net/browse/CNV-85415 # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running Fedora VM with two secondary Linux bridge network interfaces
+            - Secondary interface IPs are stable and reported by the guest agent
+
+        Steps:
+            1. Restart the qemu-guest-agent service using systemctl inside the VM
+
+        Expected:
+            - Interface IPs reported in VMI status remain unchanged throughout the monitoring period
+        """
+        running_linux_bridge_vm.console(
+            commands=["sudo systemctl restart qemu-guest-agent.service"],
+            timeout=30,
+        )
+        for vmi_obj in monitor_vmi_events(vm=running_linux_bridge_vm, timeout=STABILITY_PERIOD_IN_SECONDS):
+            assert_interfaces_stable(stable_ips=stable_ips, vmi=vmi_obj, expected_num_ifaces=len(stable_ips))


### PR DESCRIPTION
##### What this PR does / why we need it:
Manual cherry-pick into 4.18
https://github.com/RedHatQE/openshift-virtualization-tests/pull/5008
https://github.com/RedHatQE/openshift-virtualization-tests/pull/4957

##### Which issue(s) this PR fixes: Verifying IP flipping bug post guest-agent restart in cnv-4.18

##### Special notes for reviewer:
Based on
- Auto-generated cherry-pick
- Small refactor of skip Jira check
- Updated `expected_num_ifaces` as in main (caused a conflict in auto-generated cherry-pick)


##### jira-ticket: https://redhat.atlassian.net/browse/CNV-89749
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
