### PR TITLE
chore: update Fedora container image tags from 41 to 43

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -115,7 +115,7 @@ class ArchImages:
         Fedora = Fedora(
             FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2",
             FEDORA43_IMG="Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2",
-            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41",
+            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:43",
             DISK_DEMO=FEDORA_DISK_DEMO,
         )
         Fedora.LATEST_RELEASE_STR = Fedora.FEDORA43_IMG
@@ -154,7 +154,7 @@ class ArchImages:
         Windows = Windows()
         Fedora = Fedora(
             FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2",
-            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64",
+            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:43-arm64",
             DISK_DEMO=FEDORA_DISK_DEMO,
         )
         Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG
@@ -201,7 +201,7 @@ class ArchImages:
 
         Fedora = Fedora(
             FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.s390x.qcow2",
-            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41-s390x",
+            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:43-s390x",
             DISK_DEMO=FEDORA_DISK_DEMO,
         )
         Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG


### PR DESCRIPTION
##### What this PR does / why we need it:
Update `FEDORA_CONTAINER_IMAGE` entries in `utilities/constants.py` from `:41` to `:43` to match the Fedora 43 images built by PR #4322.

##### Which issue(s) this PR fixes:
Follow up on  #5272
Requires #5279

##### Special notes for reviewer:
Merge after `:43` images are published to quay.io by the `component-builder-publish` workflow.

##### jira-ticket:
NONE

Co-authored-by: Claude <noreply@anthropic.com>