### PR TITLE
Block test_vmi_reports_ip_on_secondary_interface_without_vlan due to CNV-90600

### DIFF
--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -56,6 +56,7 @@ def test_connectivity_post_migration_between_localnet_vms(
                 assert is_tcp_connection(server=server, client=client)
 
 
+@pytest.mark.jira("CNV-90600", run=False)
 @pytest.mark.single_nic
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet")


### PR DESCRIPTION
Test fails due to product bug where VMI does not correctly report IP addresses on secondary interface without VLAN.


Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked a test to be skipped from the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->