### PR TITLE
fix: architecture suffix for the fedora-container-image artifact

### DIFF
--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -51,12 +51,12 @@ jobs:
         run: |
           mkdir -p artifacts
           podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image.tar"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-container-image
-          path: artifacts/fedora-image.tar
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
           retention-days: 5
           compression-level: 0


### PR DESCRIPTION
This change introduces a suffix to the built artifact to facilitate multi-architecture image testing. Without this modification, a race condition occurs when the jobs for s390x and x86_64 run in parallel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to generate and upload architecture-specific container image artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->