### PR TITLE
fix(ci): install bws CLI in component-builder-publish workflow

### DIFF
--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -39,6 +39,15 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
         with:
           version: "0.11.21"
+      - name: Install Bitwarden Secrets Manager CLI
+        env:
+          BWS_VERSION: "2.1.0"
+        run: |
+          curl -fsSL "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip" -o bws.zip
+          unzip -o bws.zip -d /usr/local/bin
+          chmod +x /usr/local/bin/bws
+          rm bws.zip
+          bws --version
       - name: Create VM
         working-directory: ./containers/fedora
         env:


### PR DESCRIPTION
##### What this PR does / why we need it:
The `Component Builder Publish` workflow's "Create VM" step fails because the `bws` CLI (Bitwarden Secrets Manager) is not installed on the runner.

The step runs `get_fedora_password.py` → `get_cnv_tests_secret_by_name()` → `_run_bws_cli()` which shells out to `bws`. Since `bws` was never installed in the workflow, it fails with:
```
FileNotFoundError: [Errno 2] No such file or directory: 'bws'
```
After 60s of retries, the job times out.

This PR adds a step to download and install `bws` v2.1.0 (from `bitwarden/sdk-sm` releases) before the "Create VM" step.

Failed run: https://github.com/RedHatQE/openshift-virtualization-tests/actions/runs/27749404734/job/82095776200

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The PR check workflow (`component-builder.yml`) does not need this because it sets `NO_SECRETS: "true"`, which skips the `bws` call entirely.

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to include installation of Bitwarden Secrets Manager CLI version 2.1.0 during initial setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->