### PR TITLE
Downsize guest load metrics VM from u1.medium to u1.small

### DIFF
--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -61,7 +61,7 @@ from utilities.constants import (
     TWO_CPU_CORES,
     TWO_CPU_SOCKETS,
     TWO_CPU_THREADS,
-    U1_MEDIUM_STR,
+    U1_SMALL,
     VIRT_TEMPLATE_VALIDATOR,
     Images,
 )
@@ -578,7 +578,7 @@ def fedora_vm_with_stress_ng(namespace, unprivileged_client, golden_images_names
         client=unprivileged_client,
         name="fedora-vm-test-with-stress-ng",
         namespace=namespace.name,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_MEDIUM_STR),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
         vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=DataSource(


### PR DESCRIPTION
##### What this PR does / why we need it:
The test VM only needs to run stress-ng to generate guest load metrics; it does not require 4Gi of memory. Using u1.small avoids ErrorUnschedulable failures on clusters with limited worker memory.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure configuration to optimize resource utilization in observability metrics testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->