### PR TITLE
net, service: Add ClusterIP service infrastructure and connectivity test

### DIFF
--- a/tests/network/network_service/conftest.py
+++ b/tests/network/network_service/conftest.py
@@ -1,14 +1,18 @@
 import shlex
+from collections.abc import Generator
 
 import pytest
 from ocp_resources.service import Service
 
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
+from libs.net.traffic_generator import IPERF_SERVER_PORT
+from libs.vm.vm import BaseVirtualMachine
 from tests.network.network_service.libservice import (
     SERVICE_IP_FAMILY_POLICY_SINGLE_STACK,
     basic_expose_command,
+    service_vm,
 )
-from utilities.constants.networking import SSH_PORT_22
+from utilities.constants.networking import IP_FAMILY_POLICY_PREFER_DUAL_STACK, SSH_PORT_22
 from utilities.infra import get_node_selector_dict, run_virtctl_command
 from utilities.network import compose_cloud_init_data_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
@@ -86,3 +90,40 @@ def expected_num_families_in_service(request):
     ):
         return 2
     return 1
+
+
+@pytest.fixture()
+def service_server_vm(
+    namespace,
+    unprivileged_client,
+) -> Generator[BaseVirtualMachine]:
+    with service_vm(namespace=namespace.name, name="service-server-vm", client=unprivileged_client) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture()
+def service_client_vm(
+    namespace,
+    unprivileged_client,
+) -> Generator[BaseVirtualMachine]:
+    with service_vm(namespace=namespace.name, name="service-client-vm", client=unprivileged_client) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture()
+def cluster_ip_service_for_server_vm(
+    service_server_vm: BaseVirtualMachine, namespace, unprivileged_client
+) -> Generator[Service]:
+    with Service(
+        name="cluster-ip-service",
+        namespace=namespace.name,
+        selector={"vm.kubevirt.io/name": service_server_vm.name},
+        ports=[{"port": IPERF_SERVER_PORT}],
+        ip_family_policy=IP_FAMILY_POLICY_PREFER_DUAL_STACK,
+        client=unprivileged_client,
+    ) as svc:
+        yield svc

--- a/tests/network/network_service/libservice.py
+++ b/tests/network/network_service/libservice.py
@@ -1,8 +1,20 @@
+from typing import Final
+
+from kubernetes.dynamic import DynamicClient
+
+from libs.vm.affinity import new_pod_anti_affinity
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import CloudInitNoCloud, Metadata
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import NetworkData, primary_iface_cloud_init
 from utilities.constants.networking import SSH_PORT_22
 
 SERVICE_IP_FAMILY_POLICY_SINGLE_STACK = "SingleStack"
 SERVICE_IP_FAMILY_POLICY_PREFER_DUAL_STACK = "PreferDualStack"
 SERVICE_IP_FAMILY_POLICY_REQUIRE_DUAL_STACK = "RequireDualStack"
+
+SERVICE_VM_ANTI_AFFINITY_LABEL: Final[tuple[str, str]] = ("service-test", "true")
 
 
 def assert_svc_ip_params(
@@ -29,3 +41,32 @@ def basic_expose_command(
         f"expose {resource} {resource_name} --port={port} --target-port="
         f"{target_port} --type={service_type} --name={svc_name} --protocol={protocol}"
     )
+
+
+def service_vm(namespace: str, name: str, client: DynamicClient) -> BaseVirtualMachine:
+    """Fedora VM pre-configured for service connectivity tests.
+
+    Sets anti-affinity labels and injects dual-stack cloud-init when the cluster supports IPv6.
+
+    Args:
+        namespace: Namespace for the VM.
+        name: Name of the VM.
+        client: Kubernetes client.
+
+    Returns:
+        BaseVirtualMachine ready to be deployed.
+    """
+    spec = base_vmspec()
+    spec.template.metadata = spec.template.metadata or Metadata()
+    spec.template.metadata.labels = dict([SERVICE_VM_ANTI_AFFINITY_LABEL])
+    spec.template.spec.affinity = new_pod_anti_affinity(label=SERVICE_VM_ANTI_AFFINITY_LABEL)
+    if primary := primary_iface_cloud_init():
+        netdata = NetworkData(ethernets={"eth0": primary})
+        disk, volume = cloudinitdisk_storage(
+            data=CloudInitNoCloud(
+                networkData=cloudinit.asyaml(no_cloud=netdata),
+                userData=cloudinit.format_cloud_config(userdata=cloudinit.UserData(users=[])),
+            )
+        )
+        spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)

--- a/tests/network/network_service/test_service_cluster_ip.py
+++ b/tests/network/network_service/test_service_cluster_ip.py
@@ -1,0 +1,46 @@
+"""
+ClusterIP Service connectivity tests
+
+Verify TCP connectivity between VMs through a ClusterIP Kubernetes Service.
+
+Jira: https://redhat.atlassian.net/browse/CNV-89418 # <skip-jira-utils-check>
+"""
+
+import pytest
+
+from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer, VMTcpClient, is_tcp_connection
+
+
+@pytest.mark.single_nic
+@pytest.mark.polarion("CNV-16277")
+def test_tcp_connectivity_via_cluster_ip_service(
+    subtests,
+    service_server_vm,
+    service_client_vm,
+    cluster_ip_service_for_server_vm,
+):
+    """
+    Preconditions:
+        - Server VM on pod network
+        - Client VM on pod network
+        - ClusterIP Service exposing the server VM
+
+    Steps:
+        1. Start TCP server on the server VM
+        2. For each ClusterIP, establish TCP connection from client VM to server VM via the ClusterIP service
+
+    Expected:
+        - TCP connection through the ClusterIP service succeeds for all IP families
+    """
+    for service_ip in cluster_ip_service_for_server_vm.instance.spec.clusterIPs:
+        with subtests.test(msg=f"Testing connectivity via {service_ip}"):
+            with TcpServer(vm=service_server_vm, port=IPERF_SERVER_PORT) as server:
+                with VMTcpClient(
+                    vm=service_client_vm,
+                    server_ip=service_ip,
+                    server_port=IPERF_SERVER_PORT,
+                ) as client:
+                    assert is_tcp_connection(server=server, client=client), (
+                        f"TCP connection from {service_client_vm.name} to {service_server_vm.name} "
+                        f"via ClusterIP service {service_ip}:{IPERF_SERVER_PORT} failed"
+                    )


### PR DESCRIPTION
##### What this PR does / why we need it:
Add ClusterIP service infrastructure and a first connectivity test verifying a VM exposed by a ClusterIP service is reachable.

There is currently no ClusterIP service test coverage in the network segment — all existing service tests use NodePort. This introduces the infrastructure for ClusterIP testing and a baseline connectivity scenario.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
- The Service object from ocp-resources is used directly — no wrapper library needed for a simple selector + ports spec.
- No STP exists for this feature — Polarion test case CNV-16277 was created directly.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-89418


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a ClusterIP-based TCP connectivity test that verifies reachability between two virtual machines across multiple exposed ClusterIP addresses.

* **New Features**
  * Added reusable VM provisioning helpers with anti-affinity labeling to improve pod placement consistency.
  * Added fixtures to provision server/client VMs and a ClusterIP Service configured for preferred dual-stack behavior, with automatic cleanup.
  * Optionally injects Fedora CloudInit NoCloud networking (eth0) to streamline networking setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->