### PR TITLE
Handle missing cpu-arch config gracefully in pytest fixture

### DIFF
--- a/libs/vm/factory.py
+++ b/libs/vm/factory.py
@@ -30,8 +30,13 @@ def fedora_vm(
     )
 
 
-def fedora_image() -> str:
-    return container_image(base_image=constants.Images.Fedora.FEDORA_CONTAINER_IMAGE)
+def fedora_image(arch: str | None = None) -> str:
+    if arch:
+        images = getattr(constants.ArchImages, arch.upper())
+    else:
+        images = constants.Images
+
+    return container_image(base_image=images.Fedora.FEDORA_CONTAINER_IMAGE, arch=arch)
 
 
 def _fill_vm_spec_defaults(spec: VMSpec | None) -> VMSpec:
@@ -46,7 +51,7 @@ def _fill_vm_spec_defaults(spec: VMSpec | None) -> VMSpec:
     vmi_spec.domain.devices.disks = vmi_spec.domain.devices.disks or []
     vmi_spec.volumes = vmi_spec.volumes or []
 
-    disk, volume = containerdisk_storage(image=fedora_image())
+    disk, volume = containerdisk_storage(image=fedora_image(arch=vmi_spec.architecture))
     vmi_spec.domain.devices.disks.insert(0, disk)
     vmi_spec.volumes.insert(0, volume)
 

--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -227,12 +227,12 @@ class BaseVirtualMachine(VirtualMachine):
         return obj
 
 
-def container_image(base_image: str) -> str:
+def container_image(base_image: str, arch: str | None = None) -> str:
     pull_secret = infra.generate_openshift_pull_secret_file()
     image_info = get_oc_image_info(
         image=base_image,
         pull_secret=pull_secret,
-        architecture=py_config["cpu_arch"],
+        architecture=arch or py_config["cpu_arch"],
     )
     return f"{base_image}@{image_info['digest']}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
 from libs.net.vmspec import lookup_iface_status
 from tests.utils import download_and_extract_tar
+from utilities.architecture import get_cluster_architecture
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.cluster import cache_admin_client, get_oc_whoami_username
@@ -1043,7 +1044,7 @@ def mac_pool(admin_client, hco_namespace):
 
 @pytest.fixture(scope="session")
 def nodes_cpu_architecture():
-    return py_config["cpu_arch"]
+    return py_config.get("cpu_arch")
 
 
 @pytest.fixture(scope="session")
@@ -1495,7 +1496,7 @@ def cluster_info(
         f"\tOCS version: {ocs_current_version}\n"
         f"\tCNI type: {get_cluster_cni_type(admin_client=admin_client)}\n"
         f"\tWorkers type: {workers_type}\n"
-        f"\tCluster CPU Architecture: {nodes_cpu_architecture}\n"
+        f"\tCluster CPU Architecture: {py_config["cluster_arch"]}\n"
         f"\tIPv4 cluster: {ipv4_supported_cluster()}\n"
         f"\tIPv6 cluster: {ipv6_supported_cluster()}\n"
         f"\tVirtctl version: \n\t{virtctl_client_version}\n\t{virtctl_server_version}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,6 @@ from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
 from libs.net.vmspec import lookup_iface_status
 from tests.utils import download_and_extract_tar
-from utilities.architecture import get_cluster_architecture
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
 from utilities.bitwarden import get_cnv_tests_secret_by_name
 from utilities.cluster import cache_admin_client, get_oc_whoami_username
@@ -1496,7 +1495,7 @@ def cluster_info(
         f"\tOCS version: {ocs_current_version}\n"
         f"\tCNI type: {get_cluster_cni_type(admin_client=admin_client)}\n"
         f"\tWorkers type: {workers_type}\n"
-        f"\tCluster CPU Architecture: {py_config["cluster_arch"]}\n"
+        f"\tCluster CPU Architecture: {py_config['cluster_arch']}\n"
         f"\tIPv4 cluster: {ipv4_supported_cluster()}\n"
         f"\tIPv6 cluster: {ipv6_supported_cluster()}\n"
         f"\tVirtctl version: \n\t{virtctl_client_version}\n\t{virtctl_server_version}\n"


### PR DESCRIPTION
The current implementation of checking the `cpu-arch` argument only supports a single value, however for multi-arch tests it is required to pass a list of architectures (`--cpu-arch=amd64,arm64`)."
The fixture now uses dict.get() instead of direct indexing to handle missing cpu_arch gracefully.
`cpu_arch` is not set for multi-arch cluster runs now (by design), and this fix handles the KeyError failure.

Assisted-by: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **New Features**
  * Added architecture-aware selection for Fedora container images and container image digests, ensuring VM disk/volume provisioning and images match the resolved VM architecture (including multi-arch behavior).

* **Bug Fixes**
  * Improved cluster CPU architecture reporting to use the cluster configuration directly and avoid missing/undefined values.

* **Tests**
  * Updated fixtures to handle optional CPU architecture configuration safely when the key is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->