### PR TITLE
feat(analyzer): decorator ranges, pure-deletion narrowing, safe-line checks

### DIFF
--- a/scripts/tests_analyzer/README.md
+++ b/scripts/tests_analyzer/README.md
@@ -52,6 +52,7 @@ This enables CI pipelines to skip expensive test suites when changes don't affec
   - Uses git diff to identify which specific fixtures/functions were modified
   - Computes transitive fixture dependencies
   - Only triggers if marked test uses at least one affected fixture
+  - Changes to `pytest_plugins` variable trigger all dependent tests (structural change)
 
 ### SKIP tests if:
 - No marked test dependencies are affected
@@ -64,6 +65,19 @@ This enables CI pipelines to skip expensive test suites when changes don't affec
 - Computes transitive impact (fixtures that depend on modified fixtures)
 - Only triggers marked tests that actually use affected fixtures
 - Falls back to conservative behavior if git diff fails
+
+### Opaque conftest import narrowing:
+- When a conftest opaquely imports a changed file (e.g., `from module import *` or re-exports), the analyzer performs symbol-level narrowing before flagging all tests
+- Checks whether any fixture in the conftest actually calls a modified symbol
+- Falls back to file-level flagging only when symbol-level analysis is inconclusive
+
+### Symbol extraction from diffs:
+- Decorator lines are included in symbol line ranges, so marker-only changes (e.g., adding `@pytest.mark.polarion`) correctly map to the decorated function or class
+- Pure-deletion hunks extract deleted `def`/`class` names for symbol-level narrowing instead of triggering a conservative full-file fallback
+
+### Safe-line heuristic:
+- Lines that do not map to any symbol are checked against a set of safe patterns before triggering a full-file fallback
+- Recognized safe patterns: `TYPE_CHECKING` guards, `__all__` assignments, closing parentheses/brackets, and import continuation lines
 
 **Note:** Infrastructure (utilities/, libs/) and conftest.py changes only trigger marked tests if they are actually imported/used by a marked test. Blanket rules that triggered on ANY infrastructure or conftest change have been removed to reduce false positives.
 

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2838,6 +2838,17 @@ def _parse_diff_for_functions(diff_content: str) -> set[str]:
                         has_changes_in_function = True
                         pending_decorator_change = False
                     has_changes_in_function = True
+        elif pending_decorator_change and line.startswith(" "):
+            # Context line (unchanged) following a decorator change —
+            # bind pending decorator to the function on this context line
+            context_stripped = line[1:].strip()
+            context_func = re.match(pattern=r"(?:async\s+)?def\s+(\w+)\s*\(", string=context_stripped)
+            if context_func:
+                if current_function and has_changes_in_function:
+                    modified.add(current_function)
+                current_function = context_func.group(1)
+                has_changes_in_function = True
+                pending_decorator_change = False
 
     if current_function and (has_changes_in_function or pending_decorator_change):
         modified.add(current_function)

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2754,18 +2754,21 @@ def _parse_diff_for_functions(diff_content: str) -> set[str]:
     modified = set()
     current_function = None
     has_changes_in_function = False
+    pending_decorator_change = False
 
     for line in diff_content.splitlines():
         if line.startswith("@@"):
-            if current_function and has_changes_in_function:
+            if current_function and (has_changes_in_function or pending_decorator_change):
                 modified.add(current_function)
 
             match = re.search(pattern=r"@@.*@@\s*(?:async\s+)?def\s+(\w+)", string=line)
             if match:
                 current_function = match.group(1)
                 has_changes_in_function = False
+                pending_decorator_change = False
             else:
                 current_function = None
+                pending_decorator_change = False
             continue
 
         if line.startswith(("+", "-")) and not line.startswith(("+++", "---", "@@")):
@@ -2774,15 +2777,25 @@ def _parse_diff_for_functions(diff_content: str) -> set[str]:
                 # Check if this line defines a new function — reset tracking
                 func_match = re.match(pattern=r"(?:async\s+)?def\s+(\w+)\s*\(", string=stripped)
                 if func_match:
-                    # Save previous function if it had changes
+                    # Save previous function if it had real (non-decorator) changes
                     if current_function and has_changes_in_function:
                         modified.add(current_function)
+                    # Pending decorator belongs to the NEW function, not the old one
                     current_function = func_match.group(1)
                     has_changes_in_function = True
+                    pending_decorator_change = False
+                elif stripped.startswith("@"):
+                    # Decorator line — defer until we know if it belongs to
+                    # the current function or a newly appended one
+                    pending_decorator_change = True
                 else:
+                    # Regular code change — commit any pending decorator
+                    if pending_decorator_change:
+                        has_changes_in_function = True
+                        pending_decorator_change = False
                     has_changes_in_function = True
 
-    if current_function and has_changes_in_function:
+    if current_function and (has_changes_in_function or pending_decorator_change):
         modified.add(current_function)
 
     return modified

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -1228,13 +1228,29 @@ def _extract_symbol_imports_from_file(file_path: Path, repo_root: Path) -> dict[
     return symbol_imports
 
 
+def _symbol_start_line(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> int:
+    """Return the start line of a symbol, including its decorators.
+
+    Args:
+        node: AST node for a function, async function, or class definition.
+
+    Returns:
+        Line number of the first decorator if present, otherwise the ``def``/``class`` line.
+    """
+    if node.decorator_list:
+        return node.decorator_list[0].lineno
+    return node.lineno
+
+
 def _build_line_to_symbol_map(source: str) -> SymbolMap:
     """Build a hierarchical mapping from line ranges to symbols.
 
     Parses the AST of the given source to identify top-level definitions
     (functions, async functions, classes, and module-level assignments) and
-    their line ranges. For classes, also extracts member-level line ranges
-    and intra-class call graphs.
+    their line ranges.  Decorator lines are included in the range so that
+    changes to markers (e.g. ``@pytest.mark.s390x``) map to the decorated
+    symbol.  For classes, also extracts member-level line ranges and
+    intra-class call graphs.
 
     Args:
         source: Python source code text.
@@ -1248,15 +1264,15 @@ def _build_line_to_symbol_map(source: str) -> SymbolMap:
 
     for node in ast.iter_child_nodes(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            symbols.append((node.lineno, node.end_lineno or node.lineno, node.name))
+            symbols.append((_symbol_start_line(node=node), node.end_lineno or node.lineno, node.name))
 
         elif isinstance(node, ast.ClassDef):
-            symbols.append((node.lineno, node.end_lineno or node.lineno, node.name))
+            symbols.append((_symbol_start_line(node=node), node.end_lineno or node.lineno, node.name))
             # Extract class members with line ranges
             members: dict[str, tuple[int, int]] = {}
             for child in ast.iter_child_nodes(node):
                 if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    members[child.name] = (child.lineno, child.end_lineno or child.lineno)
+                    members[child.name] = (_symbol_start_line(node=child), child.end_lineno or child.lineno)
             # Build intra-class call graph
             internal_calls = _build_intra_class_call_graph(class_node=node)
             class_members[node.name] = ClassMemberInfo(
@@ -1488,6 +1504,43 @@ def _diff_has_deletions(diff_content: str) -> bool:
     return any(line.startswith("-") and not line.startswith("---") for line in diff_content.splitlines())
 
 
+def _extract_deleted_symbols_from_diff(diff_content: str) -> set[str]:
+    """Extract names of functions and classes that were deleted in a diff.
+
+    Scans deletion lines (``-``) for ``def`` and ``class`` statements to
+    identify symbols that were removed.  This avoids the need to fetch
+    and parse the old file source.
+
+    Note:
+        When a class with methods is deleted, both the class name *and* its member
+        method names are returned as separate symbols.  This may cause broader
+        dependency matching than strictly necessary (a member name like ``setup``
+        could collide with an unrelated top-level function), but is acceptable
+        because over-reporting is safer than under-reporting for test selection.
+
+    Args:
+        diff_content: Unified diff text.
+
+    Returns:
+        Set of deleted function/class names.
+    """
+    deleted_symbols: set[str] = set()
+    for line in diff_content.splitlines():
+        if not line.startswith("-") or line.startswith("---"):
+            continue
+        stripped = line[1:].strip()
+        # Match function definitions
+        func_match = re.match(pattern=r"(?:async\s+)?def\s+(\w+)\s*\(", string=stripped)
+        if func_match:
+            deleted_symbols.add(func_match.group(1))
+            continue
+        # Match class definitions
+        class_match = re.match(pattern=r"class\s+(\w+)[\s:(]", string=stripped)
+        if class_match:
+            deleted_symbols.add(class_match.group(1))
+    return deleted_symbols
+
+
 def _get_diff_content(
     file_path: Path,
     base_branch: str,
@@ -1690,8 +1743,8 @@ def _extract_modified_symbols(
 
     Returns:
         ``SymbolClassification`` with modified and new symbol sets, or
-        ``None`` when symbol-level analysis is not possible (diff failure,
-        pure deletion, or parse errors).  A ``None`` return signals the
+        ``None`` when symbol-level analysis is not possible (diff failure
+        or parse errors).  A ``None`` return signals the
         caller to fall back to file-level dependency tracking.
 
         When some changed lines fall outside any named symbol (e.g. import
@@ -1721,7 +1774,10 @@ def _extract_modified_symbols(
         if has_deletions:
             if file_status == "renamed":
                 return SymbolClassification(modified_symbols=set(), new_symbols=set())
-            return None  # Pure deletion — cannot safely narrow impact
+            # Pure deletion — extract deleted symbol names from the diff
+            # to enable symbol-level narrowing instead of conservative fallback
+            deleted_symbols = _extract_deleted_symbols_from_diff(diff_content=diff_content)
+            return SymbolClassification(modified_symbols=deleted_symbols, new_symbols=set())
         return SymbolClassification(modified_symbols=set(), new_symbols=set())
 
     try:
@@ -1777,7 +1833,25 @@ def _extract_modified_symbols(
             # or potentially impactful executable code.
             if line_number <= len(source_lines):
                 line_content = source_lines[line_number - 1].strip()
-                if not line_content or line_content.startswith(("#", "import ", "from ", '"""', "'''", '"', "'")):
+                if not line_content or line_content.startswith((
+                    "#",
+                    "import ",
+                    "from ",
+                    '"""',
+                    "'''",
+                    '"',
+                    "'",
+                    "if TYPE_CHECKING:",
+                    "if typing.TYPE_CHECKING:",
+                    ")",  # Closing paren of multi-line import; safe because
+                    # the opening line (e.g. "setup(") would trigger fallback.
+                    "__all__",
+                )):
+                    has_unattributed = True
+                elif re.match(pattern=r"^[A-Za-z_]\w*(?:\s+as\s+\w+)?\s*,\s*$", string=line_content):
+                    # Import continuation line (e.g. "TIMEOUT_2MIN," inside
+                    # a multi-line "from ... import (...)" block).
+                    # Trailing comma is required to avoid matching bare identifiers.
                     has_unattributed = True
                 else:
                     # Executable module-level code — conservative fallback

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2741,7 +2741,16 @@ def _parse_diff_for_functions(diff_content: str) -> set[str]:
         if line.startswith(("+", "-")) and not line.startswith(("+++", "---", "@@")):
             stripped = line[1:].strip()
             if stripped and not stripped.startswith("#"):
-                has_changes_in_function = True
+                # Check if this line defines a new function — reset tracking
+                func_match = re.match(pattern=r"(?:async\s+)?def\s+(\w+)\s*\(", string=stripped)
+                if func_match:
+                    # Save previous function if it had changes
+                    if current_function and has_changes_in_function:
+                        modified.add(current_function)
+                    current_function = func_match.group(1)
+                    has_changes_in_function = True
+                else:
+                    has_changes_in_function = True
 
     if current_function and has_changes_in_function:
         modified.add(current_function)

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -1835,6 +1835,7 @@ def _extract_modified_symbols(
                 line_content = source_lines[line_number - 1].strip()
                 if not line_content or line_content.startswith((
                     "#",
+                    "@",
                     "import ",
                     "from ",
                     '"""',
@@ -2334,6 +2335,7 @@ def _check_test_impact(
     pr_diffs_cache: dict[str, str] | None = None,
     pr_file_statuses: dict[str, str] | None = None,
     is_checkout: bool = False,
+    pr_head_ref: str | None = None,
 ) -> dict[str, Any] | None:
     """Check if a single test is affected by changed files (for parallel execution).
 
@@ -2367,6 +2369,8 @@ def _check_test_impact(
             to their unified diff content.
         pr_file_statuses: Optional mapping of relative file paths to their
             GitHub file status strings.
+        pr_head_ref: Optional PR head commit SHA used in remote (no-checkout)
+            mode to fetch the correct version of files from GitHub.
 
     Returns:
         Dictionary with test info if affected, ``None`` otherwise.
@@ -2449,6 +2453,7 @@ def _check_test_impact(
                 pr_diffs_cache=pr_diffs_cache,
                 file_status=file_status_conftest,
                 is_checkout=is_checkout,
+                pr_head_ref=pr_head_ref,
             )
 
             # None signals structural change (e.g., pytest_plugins modified)
@@ -2612,6 +2617,7 @@ def _extract_modified_items_from_conftest(
     pr_diffs_cache: dict[str, str] | None = None,
     file_status: str | None = None,
     is_checkout: bool = False,
+    pr_head_ref: str | None = None,
 ) -> tuple[set[str] | None, set[str] | None]:
     """Extract modified fixtures and functions from conftest.py.
 
@@ -2628,6 +2634,8 @@ def _extract_modified_items_from_conftest(
             to their unified diff content.
         file_status: Optional file status from GitHub PR files API
             (``"added"``, ``"modified"``, ``"removed"``, ``"renamed"``).
+        pr_head_ref: Optional PR head commit SHA used in remote (no-checkout)
+            mode to fetch the correct version of files from GitHub.
 
     Returns:
         Tuple of (modified_fixtures, modified_functions) containing only
@@ -2682,6 +2690,7 @@ def _extract_modified_items_from_conftest(
             pr_diffs_cache=pr_diffs_cache,
             file_status=file_status,
             is_checkout=is_checkout,
+            pr_head_ref=pr_head_ref,
         )
         if classification is None or "pytest_plugins" in (classification.modified_symbols | classification.new_symbols):
             # pytest_plugins controls plugin/fixture loading — signal to caller
@@ -3675,6 +3684,7 @@ class MarkerTestAnalyzer:
                     pr_diffs_cache=pr_diffs_cache,
                     pr_file_statuses=pr_file_statuses,
                     is_checkout=self.is_checkout,
+                    pr_head_ref=pr_head_ref,
                 ): node_id
                 for node_id, marked_test in self.marked_tests.items()
             }

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -1843,8 +1843,11 @@ def _extract_modified_symbols(
                     "'",
                     "if TYPE_CHECKING:",
                     "if typing.TYPE_CHECKING:",
-                    ")",  # Closing paren of multi-line import; safe because
-                    # the opening line (e.g. "setup(") would trigger fallback.
+                    ")",  # Closing paren of multi-line import/expression.
+                    # If the opening line (e.g. "setup(") is also changed,
+                    # it triggers fallback before we reach ")".  A standalone
+                    # ")" diff without its opener is rare but possible (e.g.
+                    # reformatting); accepted as low-risk over-narrowing.
                     "__all__",
                 )):
                     has_unattributed = True
@@ -1852,6 +1855,12 @@ def _extract_modified_symbols(
                     # Import continuation line (e.g. "TIMEOUT_2MIN," inside
                     # a multi-line "from ... import (...)" block).
                     # Trailing comma is required to avoid matching bare identifiers.
+                    # NOTE: This also matches identifiers inside module-level tuples/lists
+                    # (e.g. "HandlerA," in a registry tuple).  In practice, such
+                    # constructs are ast.Assign nodes whose line ranges are tracked
+                    # in the symbol map, so their inner lines are attributed before
+                    # reaching this branch.  The regex only fires for truly
+                    # unattributed lines (outside all symbol ranges).
                     has_unattributed = True
                 else:
                     # Executable module-level code — conservative fallback

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2407,6 +2407,13 @@ def _check_test_impact(
                 is_checkout=is_checkout,
             )
 
+            # None signals structural change (e.g., pytest_plugins modified)
+            # — flag test unconditionally since fixture loading may change
+            if modified_fixtures is None:
+                test_affected = True
+                matching_deps.append(f"{changed_file.relative_to(repo_root)} (pytest_plugins changed — structural)")
+                continue
+
             # Get all transitively affected fixtures
             affected_fixtures = _get_affected_fixtures_helper(
                 modified_fixtures=modified_fixtures, modified_functions=modified_functions, fixtures_dict=fixtures_dict
@@ -2561,7 +2568,7 @@ def _extract_modified_items_from_conftest(
     pr_diffs_cache: dict[str, str] | None = None,
     file_status: str | None = None,
     is_checkout: bool = False,
-) -> tuple[set[str], set[str]]:
+) -> tuple[set[str] | None, set[str] | None]:
     """Extract modified fixtures and functions from conftest.py.
 
     Filters out purely new functions and fixtures that did not exist in
@@ -2619,6 +2626,29 @@ def _extract_modified_items_from_conftest(
             if changed_file.exists():
                 return all_fixtures, set()
             return set(), set()
+
+        # Check for critical module-level variables (e.g., pytest_plugins)
+        # that affect pytest's fixture/plugin loading and are invisible
+        # to function-level diff tracking.
+        classification = _extract_modified_symbols(
+            file_path=changed_file,
+            base_branch=base_branch,
+            repo_root=repo_root,
+            github_pr_info=github_pr_info,
+            pr_diffs_cache=pr_diffs_cache,
+            file_status=file_status,
+            is_checkout=is_checkout,
+        )
+        if classification is None or "pytest_plugins" in (classification.modified_symbols | classification.new_symbols):
+            # pytest_plugins controls plugin/fixture loading — signal to caller
+            # that ALL tests depending on this conftest should be flagged.
+            # Return None to indicate structural change (distinct from empty set
+            # which means "no impact").
+            logger.info(
+                msg="pytest_plugins modified in conftest — structural change",
+                extra={"file": str(changed_file)},
+            )
+            return None, None
 
         # Filter out purely new functions/fixtures (additive-change detection)
         if modified_function_names and file_status not in ("added", "renamed"):

--- a/scripts/tests_analyzer/pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/pytest_marker_analyzer.py
@@ -2186,7 +2186,51 @@ def _check_conftest_pathway(
         # Check if conftest opaquely imports the changed file
         opaque_set = conftest_opaque_deps.get(conftest_path, set())
         if changed_file in opaque_set:
-            # Can't determine which symbols — conservative: flag test
+            # Try symbol-level narrowing before falling back to file-level
+            classification = modified_symbols_cache.get(changed_file)
+            if (
+                classification is not None
+                and not classification.modified_symbols
+                and classification.new_symbols
+                and not classification.has_unattributed_changes
+            ):
+                # Only new symbols added — cannot break existing tests
+                conftest_resolved = True
+                continue
+            if classification is not None and not classification.modified_symbols:
+                # Empty modified_symbols without new_symbols — could be pure deletion
+                # or unmapped module-level edits; fall back to conservative behavior
+                matching_deps.append(
+                    f"{changed_file.relative_to(repo_root)} (opaque import via {conftest_path.relative_to(repo_root)})"
+                )
+                return True, matching_deps
+            if classification is not None and classification.modified_symbols:
+                if classification.has_unattributed_changes:
+                    # Module-level changes with opaque import — conservative fallback
+                    matching_deps.append(
+                        f"{changed_file.relative_to(repo_root)} "
+                        f"(opaque import via {conftest_path.relative_to(repo_root)})"
+                    )
+                    return True, matching_deps
+                fixture_match = False
+                for fixture_name, fixture in fixtures_dict.items():
+                    if (
+                        fixture.file_path == conftest_path
+                        and fixture_name in used_fixtures
+                        and fixture.function_calls & classification.modified_symbols
+                    ):
+                        symbols_str = ", ".join(sorted(fixture.function_calls & classification.modified_symbols))
+                        matching_deps.append(
+                            f"{changed_file.relative_to(repo_root)} (via fixture {fixture_name}: {symbols_str})"
+                        )
+                        fixture_match = True
+                        break
+                if fixture_match:
+                    return True, matching_deps
+                # No fixture calls modified symbols — pathway resolved as safe
+                conftest_resolved = True
+                continue
+            # classification is None — diff failed, fall back to file-level
             matching_deps.append(
                 f"{changed_file.relative_to(repo_root)} (opaque import via {conftest_path.relative_to(repo_root)})"
             )

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -1394,13 +1394,14 @@ class TestExtractModifiedSymbolsUnattributed:
 
         assert result is None, "Executable module-level code should trigger conservative fallback"
 
-    def test_decorator_lines_outside_symbol_range_are_safe(self, tmp_path: Path) -> None:
-        """Decorator lines outside a function's AST range are safe, not a conservative fallback.
+    def test_new_decorated_function_classified_as_new_symbol(self, tmp_path: Path) -> None:
+        """A newly added decorated function should be classified as a new symbol.
 
-        Python's AST sets lineno at the 'def' line, not at the first decorator.
-        When a decorated function is added, the decorator lines (e.g. @pytest.mark.some_marker)
-        fall outside the symbol map's line range.  These must be treated as safe
-        (like imports or comments), not as executable module-level code.
+        When a diff adds a decorated function (decorator + def + body), all
+        changed lines fall within the function's symbol range because
+        ``_symbol_start_line`` includes decorators.  The function should be
+        classified as a *new* symbol (not modified), and no conservative
+        fallback should occur.
         """
         source = textwrap.dedent("""\
             import pytest
@@ -1412,8 +1413,8 @@ class TestExtractModifiedSymbolsUnattributed:
         file_path = tmp_path / "module.py"
         file_path.write_text(source)
 
-        # Diff that adds the decorator line (line 3), which is outside the AST
-        # range of test_new_feature (whose lineno is 4, the 'def' line)
+        # Diff that adds the decorated function (lines 3-5).  _symbol_start_line
+        # includes the decorator, so the symbol range covers all changed lines.
         diff_content = (
             "--- a/module.py\n"
             "+++ b/module.py\n"
@@ -1436,7 +1437,11 @@ class TestExtractModifiedSymbolsUnattributed:
                 github_pr_info=None,
             )
 
-        assert result is not None, "Decorator lines should not trigger conservative fallback"
+        assert result is not None, "Decorated new function should not trigger conservative fallback"
+        assert "test_new_feature" in result.new_symbols, "Newly added decorated function should be in new_symbols"
+        assert "test_new_feature" not in result.modified_symbols, (
+            "Newly added function should not appear in modified_symbols"
+        )
 
     def test_line_number_beyond_source_returns_none(self, tmp_path: Path) -> None:
         """When changed line number exceeds source length, returns None (conservative)."""

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -2700,7 +2700,7 @@ class TestDecoratorLineRange:
 
     def test_class_with_decorators_includes_decorator_lines(self) -> None:
         """Decorator lines are included in the class's line range."""
-        source = "@pytest.mark.polarion('CNV-1234')\nclass TestFoo:\n    def test_bar(self):\n        pass\n"
+        source = "@pytest.mark.polarion('FAKE-1234')\nclass TestFoo:\n    def test_bar(self):\n        pass\n"
         symbol_map = _build_line_to_symbol_map(source=source)
         assert symbol_map.top_level[0] == (1, 4, "TestFoo"), "Class range should start at first decorator line"
 

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -22,6 +22,7 @@ from scripts.tests_analyzer.pytest_marker_analyzer import (
     _collect_test_attribute_accesses,
     _collect_test_function_calls,
     _expand_modified_members_transitively,
+    _extract_deleted_symbols_from_diff,
     _extract_modified_items_from_conftest,
     _extract_modified_symbols,
     _get_modified_function_names,
@@ -1137,8 +1138,8 @@ class TestExtractModifiedSymbolsUnattributed:
 
         assert result is None
 
-    def test_pure_deletion_still_returns_none(self, tmp_path: Path) -> None:
-        """When diff is pure deletion (no added lines), still returns None."""
+    def test_pure_deletion_returns_empty_classification(self, tmp_path: Path) -> None:
+        """When diff is pure deletion of non-symbol lines, returns empty SymbolClassification."""
         file_path = tmp_path / "module.py"
         file_path.write_text("def foo(): pass\n")
 
@@ -1156,8 +1157,9 @@ class TestExtractModifiedSymbolsUnattributed:
                 github_pr_info=None,
             )
 
-        # Pure deletion should return None (conservative fallback)
-        assert result is None
+        # Pure deletion now returns SymbolClassification (not None) to enable symbol narrowing
+        assert result is not None
+        assert result.modified_symbols == set()  # No def/class in deleted lines
 
     def test_executable_module_level_code_returns_none(self, tmp_path: Path) -> None:
         """When unmapped line is executable code (e.g. function call), returns None (conservative)."""
@@ -2228,3 +2230,380 @@ class TestCheckConftestPathwayTransitive:
         )
         assert len(matching_deps) == 1
         assert "lookup_iface_status" in matching_deps[0]
+
+
+class TestExtractDeletedSymbolsFromDiff:
+    """Tests for _extract_deleted_symbols_from_diff extracting function/class names."""
+
+    def test_deleted_function(self) -> None:
+        """Detects deleted function definitions."""
+        diff = (
+            "@@ -10,5 +10,0 @@\n"
+            "-def skip_no_reencrypt_route(upload_proxy_route):\n"
+            "-    if upload_proxy_route.termination != 'reencrypt':\n"
+            "-        pytest.skip('Skip testing.')\n"
+        )
+        result = _extract_deleted_symbols_from_diff(diff_content=diff)
+        assert result == {"skip_no_reencrypt_route"}
+
+    def test_deleted_async_function(self) -> None:
+        """Detects deleted async function definitions."""
+        diff = "@@ -1,3 +1,0 @@\n-async def fetch_data(url):\n-    return await get(url)\n"
+        result = _extract_deleted_symbols_from_diff(diff_content=diff)
+        assert result == {"fetch_data"}
+
+    def test_deleted_class_and_members(self) -> None:
+        """Deleted class and its member methods are both extracted as symbols."""
+        diff = "@@ -1,4 +1,0 @@\n-class OldHelper:\n-    def method(self):\n-        pass\n"
+        result = _extract_deleted_symbols_from_diff(diff_content=diff)
+        assert result == {"OldHelper", "method"}
+
+    def test_no_deletions_returns_empty(self) -> None:
+        """No deletion lines produces empty set."""
+        diff = "@@ -1,2 +1,3 @@\n context\n+new_line\n context\n"
+        result = _extract_deleted_symbols_from_diff(diff_content=diff)
+        assert result == set()
+
+    def test_file_header_not_matched(self) -> None:
+        """--- file header is not treated as a deletion."""
+        diff = "--- a/old_file.py\n+++ b/new_file.py\n@@ -1,1 +1,1 @@\n-old_content\n+new_content\n"
+        result = _extract_deleted_symbols_from_diff(diff_content=diff)
+        assert result == set()
+
+    def test_mixed_deletions_and_additions(self) -> None:
+        """Only deleted symbol definitions are captured, not added ones."""
+        diff = "@@ -1,4 +1,4 @@\n-def old_func():\n-    pass\n+def new_func():\n+    pass\n"
+        result = _extract_deleted_symbols_from_diff(diff_content=diff)
+        assert result == {"old_func"}
+
+
+class TestPureDeletionSymbolNarrowing:
+    """Tests that pure-deletion diffs enable symbol-level narrowing."""
+
+    def test_pure_deletion_returns_classification_not_none(self, tmp_path: Path) -> None:
+        """When a diff only deletes a function, returns SymbolClassification with the deleted symbol."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            def remaining_func():
+                pass
+        """)
+        file_path = tmp_path / "module.py"
+        file_path.write_text(source)
+
+        # Diff that only deletes a function (no additions)
+        diff_content = "@@ -3,4 +3,0 @@\n-def deleted_func():\n-    if True:\n-        pytest.skip()\n"
+        mock_result = type("Result", (), {"returncode": 0, "stdout": diff_content, "stderr": ""})()
+        with patch(
+            "scripts.tests_analyzer.pytest_marker_analyzer.subprocess.run",
+            return_value=mock_result,
+        ):
+            result = _extract_modified_symbols(
+                file_path=file_path,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+
+        assert result is not None, "Should return SymbolClassification, not None (was the old bug)"
+        assert result.modified_symbols == {"deleted_func"}
+        assert result.new_symbols == set()
+
+    def test_pure_deletion_no_symbols_returns_empty_classification(self, tmp_path: Path) -> None:
+        """When a diff deletes only non-symbol lines, returns empty classification."""
+        source = textwrap.dedent("""\
+            import os
+
+            def my_func():
+                pass
+        """)
+        file_path = tmp_path / "module.py"
+        file_path.write_text(source)
+
+        # Diff that deletes only a comment/blank line (no function/class defs)
+        diff_content = "@@ -1,2 +1,1 @@\n-# old comment\n"
+        mock_result = type("Result", (), {"returncode": 0, "stdout": diff_content, "stderr": ""})()
+        with patch(
+            "scripts.tests_analyzer.pytest_marker_analyzer.subprocess.run",
+            return_value=mock_result,
+        ):
+            result = _extract_modified_symbols(
+                file_path=file_path,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+
+        assert result is not None, "Should return SymbolClassification, not None"
+        assert result.modified_symbols == set()
+
+
+class TestTypeCheckingLineSafety:
+    """Tests that if TYPE_CHECKING: lines are treated as safe unmapped lines."""
+
+    def test_type_checking_guard_is_safe(self, tmp_path: Path) -> None:
+        """if TYPE_CHECKING: line should NOT cause conservative fallback."""
+        source = textwrap.dedent("""\
+            from __future__ import annotations
+
+            from typing import TYPE_CHECKING
+
+            if TYPE_CHECKING:
+                from some_module import SomeType
+
+            CONSTANT = 42
+
+            def my_func():
+                pass
+        """)
+        file_path = tmp_path / "module.py"
+        file_path.write_text(source)
+
+        # Diff that adds TYPE_CHECKING guard (lines 3-6 are additions)
+        diff_content = (
+            "@@ -1,2 +1,7 @@\n"
+            " from __future__ import annotations\n"
+            " \n"
+            "+from typing import TYPE_CHECKING\n"
+            "+\n"
+            "+if TYPE_CHECKING:\n"
+            "+    from some_module import SomeType\n"
+            "+\n"
+        )
+        mock_result = type("Result", (), {"returncode": 0, "stdout": diff_content, "stderr": ""})()
+        with patch(
+            "scripts.tests_analyzer.pytest_marker_analyzer.subprocess.run",
+            return_value=mock_result,
+        ):
+            result = _extract_modified_symbols(
+                file_path=file_path,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+
+        assert result is not None, (
+            "Should return SymbolClassification, not None \u2014 if TYPE_CHECKING: should be treated as safe"
+        )
+        assert result.has_unattributed_changes is True
+
+    def test_typing_type_checking_guard_is_safe(self, tmp_path: Path) -> None:
+        """if typing.TYPE_CHECKING: line should NOT cause conservative fallback."""
+        source = textwrap.dedent("""\
+            import typing
+
+            if typing.TYPE_CHECKING:
+                from some_module import SomeType
+
+            def my_func():
+                pass
+        """)
+        file_path = tmp_path / "module.py"
+        file_path.write_text(source)
+
+        diff_content = (
+            "@@ -1,1 +1,5 @@\n+import typing\n+\n+if typing.TYPE_CHECKING:\n+    from some_module import SomeType\n+\n"
+        )
+        mock_result = type("Result", (), {"returncode": 0, "stdout": diff_content, "stderr": ""})()
+        with patch(
+            "scripts.tests_analyzer.pytest_marker_analyzer.subprocess.run",
+            return_value=mock_result,
+        ):
+            result = _extract_modified_symbols(
+                file_path=file_path,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+
+        assert result is not None, (
+            "Should return SymbolClassification, not None \u2014 if typing.TYPE_CHECKING: should be treated as safe"
+        )
+        assert result.has_unattributed_changes is True
+
+
+class TestDecoratorLineRange:
+    """Tests that decorator lines are included in symbol line ranges."""
+
+    def test_function_with_decorators_includes_decorator_lines(self) -> None:
+        """Decorator lines are included in the function's line range."""
+        source = "@pytest.mark.smoke\n@pytest.mark.s390x\ndef test_something():\n    pass\n"
+        symbol_map = _build_line_to_symbol_map(source=source)
+        # Decorator at line 1 should be included in the range
+        assert symbol_map.top_level[0] == (1, 4, "test_something"), (
+            "Function range should start at first decorator line"
+        )
+
+    def test_class_with_decorators_includes_decorator_lines(self) -> None:
+        """Decorator lines are included in the class's line range."""
+        source = "@pytest.mark.polarion('CNV-1234')\nclass TestFoo:\n    def test_bar(self):\n        pass\n"
+        symbol_map = _build_line_to_symbol_map(source=source)
+        assert symbol_map.top_level[0] == (1, 4, "TestFoo"), "Class range should start at first decorator line"
+
+    def test_function_without_decorators_unchanged(self) -> None:
+        """Functions without decorators start at def keyword."""
+        source = "def plain_function():\n    return 1\n"
+        symbol_map = _build_line_to_symbol_map(source=source)
+        assert symbol_map.top_level[0] == (1, 2, "plain_function"), (
+            "Function without decorators should start at def line"
+        )
+
+    def test_class_member_with_decorator_includes_decorator_lines(self) -> None:
+        """Class member decorator lines are included in member line range."""
+        source = "class Foo:\n    @pytest.fixture\n    def my_fixture(self):\n        return 1\n"
+        symbol_map = _build_line_to_symbol_map(source=source)
+        members = symbol_map.class_members["Foo"].members
+        assert members["my_fixture"] == (2, 4), "Member range should start at decorator line"
+
+    def test_decorator_change_maps_to_function(self, tmp_path: Path) -> None:
+        """Decorator-only diff change maps to the decorated function."""
+        source = (
+            "import pytest\n"
+            "\n"
+            "@pytest.mark.smoke\n"
+            "@pytest.mark.s390x\n"
+            "def test_something():\n"
+            "    pass\n"
+            "\n"
+            "def test_other():\n"
+            "    pass\n"
+        )
+        diff = (
+            "--- a/tests/example/test_file.py\n"
+            "+++ b/tests/example/test_file.py\n"
+            "@@ -3,6 +3,7 @@\n"
+            " @pytest.mark.smoke\n"
+            "+@pytest.mark.s390x\n"
+            " def test_something():\n"
+            "     pass\n"
+        )
+        source_file = tmp_path / "tests" / "example" / "test_file.py"
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text(source)
+
+        with (
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._get_diff_content",
+                return_value=diff,
+            ),
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._fetch_file_at_ref",
+                return_value=source,
+            ),
+        ):
+            result = _extract_modified_symbols(
+                file_path=source_file,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+        assert result is not None, "Should return SymbolClassification, not None"
+        assert "test_something" in result.modified_symbols, "Decorator change should map to test_something"
+        assert "test_other" not in result.modified_symbols, "Unmodified function should not be in modified symbols"
+
+
+class TestImportContinuationSafety:
+    """Tests that multi-line import continuation lines are treated as safe."""
+
+    def test_import_continuation_line_is_safe(self, tmp_path: Path) -> None:
+        """Import continuation lines do not trigger conservative fallback."""
+        source = (
+            "from utilities.constants import (\n"
+            "    TIMEOUT_1MIN,\n"
+            "    TIMEOUT_2MIN,\n"
+            ")\n"
+            "\n"
+            "def existing_func():\n"
+            "    pass\n"
+        )
+        diff = (
+            "--- a/utilities/example.py\n"
+            "+++ b/utilities/example.py\n"
+            "@@ -1,3 +1,4 @@\n"
+            " from utilities.constants import (\n"
+            "     TIMEOUT_1MIN,\n"
+            "+    TIMEOUT_2MIN,\n"
+            " )\n"
+        )
+        source_file = tmp_path / "utilities" / "example.py"
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text(source)
+
+        with (
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._get_diff_content",
+                return_value=diff,
+            ),
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._fetch_file_at_ref",
+                return_value=source,
+            ),
+        ):
+            result = _extract_modified_symbols(
+                file_path=source_file,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+        assert result is not None, "Import continuation should not trigger file-level fallback"
+        assert result.has_unattributed_changes is True
+        assert result.modified_symbols == set()
+
+    def test_import_continuation_with_alias(self, tmp_path: Path) -> None:
+        """Import continuation with 'as' alias is treated as safe."""
+        source = "from collections.abc import (\n    Generator,\n    Collection as Col,\n)\n\ndef func():\n    pass\n"
+        diff = (
+            "--- a/utilities/example.py\n"
+            "+++ b/utilities/example.py\n"
+            "@@ -1,3 +1,4 @@\n"
+            " from collections.abc import (\n"
+            "     Generator,\n"
+            "+    Collection as Col,\n"
+            " )\n"
+        )
+        source_file = tmp_path / "utilities" / "example.py"
+        source_file.parent.mkdir(parents=True, exist_ok=True)
+        source_file.write_text(source)
+
+        with (
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._get_diff_content",
+                return_value=diff,
+            ),
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._fetch_file_at_ref",
+                return_value=source,
+            ),
+        ):
+            result = _extract_modified_symbols(
+                file_path=source_file,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+        assert result is not None, "Import continuation with alias should not trigger fallback"
+
+    def test_closing_paren_is_safe(self, tmp_path: Path) -> None:
+        """Closing parenthesis of multi-line import is treated as safe."""
+        source = "from os.path import (\n    join,\n)\n\ndef func():\n    pass\n"
+        diff = "--- a/utils.py\n+++ b/utils.py\n@@ -1,2 +1,3 @@\n from os.path import (\n+    join,\n )\n"
+        source_file = tmp_path / "utils.py"
+        source_file.write_text(source)
+
+        with (
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._get_diff_content",
+                return_value=diff,
+            ),
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._fetch_file_at_ref",
+                return_value=source,
+            ),
+        ):
+            result = _extract_modified_symbols(
+                file_path=source_file,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+        assert result is not None, "Closing paren should not trigger file-level fallback"

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -2623,3 +2623,67 @@ class TestImportContinuationSafety:
                 github_pr_info=None,
             )
         assert result is not None, "Closing paren should not trigger file-level fallback"
+
+
+class TestParseDiffForFunctionsContextReset:
+    """Tests that _parse_diff_for_functions resets context on new function definitions."""
+
+    def test_appended_function_not_attributed_to_context(self) -> None:
+        """New function appended after context function is attributed correctly."""
+        diff = (
+            "@@ -50,6 +50,15 @@ def existing_fixture():\n"
+            "     return dv\n"
+            " \n"
+            " \n"
+            "+def new_fixture():\n"
+            '+    """Brand new fixture."""\n'
+            "+    return something\n"
+        )
+        result = _parse_diff_for_functions(diff_content=diff)
+        assert "new_fixture" in result, "Appended function should be in modified set"
+        assert "existing_fixture" not in result, (
+            "Context function should NOT be in modified set when only new code is appended after it"
+        )
+
+    def test_modified_context_function_still_detected(self) -> None:
+        """When both the context function and an appended function are modified."""
+        diff = (
+            "@@ -50,6 +50,15 @@ def existing_fixture():\n"
+            "-    return old_dv\n"
+            "+    return new_dv\n"
+            " \n"
+            " \n"
+            "+def new_fixture():\n"
+            "+    return something\n"
+        )
+        result = _parse_diff_for_functions(diff_content=diff)
+        assert "existing_fixture" in result, "Modified context function should be detected"
+        assert "new_fixture" in result, "Appended function should also be detected"
+
+    def test_deleted_function_attributed_correctly(self) -> None:
+        """Deleted function definition is attributed to the deleted function, not context."""
+        diff = (
+            "@@ -50,10 +50,3 @@ def existing_fixture():\n"
+            "     return dv\n"
+            " \n"
+            " \n"
+            "-def old_fixture():\n"
+            '-    """Old fixture to remove."""\n'
+            "-    return old_thing\n"
+        )
+        result = _parse_diff_for_functions(diff_content=diff)
+        assert "old_fixture" in result, "Deleted function should be in modified set"
+        assert "existing_fixture" not in result, (
+            "Context function should NOT be in modified set when only a subsequent function is deleted"
+        )
+
+    def test_async_function_appended(self) -> None:
+        """Async function appended after context is attributed correctly."""
+        diff = (
+            "@@ -10,3 +10,8 @@ def sync_func():\n     pass\n \n+async def new_async_func():\n+    await something()\n"
+        )
+        result = _parse_diff_for_functions(diff_content=diff)
+        assert "new_async_func" in result, "Appended async function should be in modified set"
+        assert "sync_func" not in result, (
+            "Context function should NOT be in modified set when only async function is appended after it"
+        )

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -919,9 +919,19 @@ class TestExtractModifiedItemsFromConftestDiffFailure:
         """)
         )
 
-        with patch(
-            "scripts.tests_analyzer.pytest_marker_analyzer._get_modified_function_names",
-            return_value=set(),
+        no_pytest_plugins = SymbolClassification(
+            modified_symbols={"os"},
+            new_symbols=set(),
+        )
+        with (
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._get_modified_function_names",
+                return_value=set(),
+            ),
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._extract_modified_symbols",
+                return_value=no_pytest_plugins,
+            ),
         ):
             modified_fixtures, modified_functions = _extract_modified_items_from_conftest(
                 changed_file=conftest,
@@ -977,10 +987,20 @@ class TestExtractModifiedItemsFromConftestDiffFailure:
         """)
         )
 
-        with patch(
-            "scripts.tests_analyzer.pytest_marker_analyzer._get_modified_function_names",
-            return_value=set(),
-        ) as mock_get_modified:
+        no_pytest_plugins = SymbolClassification(
+            modified_symbols=set(),
+            new_symbols=set(),
+        )
+        with (
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._get_modified_function_names",
+                return_value=set(),
+            ) as mock_get_modified,
+            patch(
+                "scripts.tests_analyzer.pytest_marker_analyzer._extract_modified_symbols",
+                return_value=no_pytest_plugins,
+            ),
+        ):
             _extract_modified_items_from_conftest(
                 changed_file=conftest,
                 base_branch="main",
@@ -2687,3 +2707,23 @@ class TestParseDiffForFunctionsContextReset:
         assert "sync_func" not in result, (
             "Context function should NOT be in modified set when only async function is appended after it"
         )
+
+
+class TestPytestPluginsDetection:
+    """Tests that pytest_plugins changes are detected by symbol-level analysis."""
+
+    def test_pytest_plugins_in_symbol_map(self) -> None:
+        """pytest_plugins assignment is tracked as a top-level symbol."""
+        source = textwrap.dedent("""\
+            import pytest
+
+            pytest_plugins = [
+                "tests.fixtures.network.l2_bridge",
+                "tests.fixtures.network.cluster",
+            ]
+
+            LOGGER = logging.getLogger(__name__)
+        """)
+        symbol_map = _build_line_to_symbol_map(source=source)
+        symbol_names = {name for _, _, name in symbol_map.top_level}
+        assert "pytest_plugins" in symbol_names, "pytest_plugins assignment should be tracked as a top-level symbol"

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -2952,6 +2952,12 @@ class TestParseDiffForFunctionsContextReset:
             "Context function should NOT be in modified set when decorator belongs to appended function"
         )
 
+    def test_parse_diff_decorator_bound_to_context_def(self) -> None:
+        """Decorator-only diff followed by context def line binds to that function."""
+        diff = "@@ -10,6 +10,7 @@ def other_func\n+@pytest.mark.tier3\n def existing_fixture():\n     pass\n"
+        result = _parse_diff_for_functions(diff_content=diff)
+        assert "existing_fixture" in result, f"Decorator change should be bound to context def line, got {result}"
+
 
 class TestPytestPluginsDetection:
     """Tests that pytest_plugins changes are detected by symbol-level analysis."""

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -1892,6 +1892,234 @@ class TestImportVisitorTypeChecking:
         assert "libs.vm.vm" in visitor.imports
 
 
+class TestCheckConftestPathwayOpaqueNarrowing:
+    """Opaque conftest imports should use symbol-level narrowing when available."""
+
+    def test_opaque_import_narrowed_by_modified_symbols(self, tmp_path: Path) -> None:
+        """When conftest opaquely imports a changed file but no fixture calls modified symbols, test is safe."""
+        repo_root = tmp_path
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        changed_file = tmp_path / "utilities" / "hco.py"
+        changed_file.parent.mkdir(parents=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_smoke.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_smoke",
+            node_id="tests/test_smoke.py::test_smoke",
+            dependencies={conftest_path},
+            fixtures={"vm_fixture"},
+            symbol_imports={},
+        )
+
+        # Conftest opaquely imports the changed file
+        conftest_opaque_deps: dict[Path, set[Path]] = {
+            conftest_path: {changed_file},
+        }
+
+        # Symbol analysis shows only verify_boot_sources was modified
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: SymbolClassification(
+                modified_symbols={"verify_boot_sources_reimported"},
+                new_symbols=set(),
+            ),
+        }
+
+        # The test's fixture does NOT call verify_boot_sources_reimported
+        fixtures_dict: dict[str, Fixture] = {
+            "vm_fixture": Fixture(
+                name="vm_fixture",
+                file_path=conftest_path,
+                function_calls={"create_vm", "wait_for_vm"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports={},
+            conftest_opaque_deps=conftest_opaque_deps,
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert not is_affected, (
+            f"Test should NOT be flagged when opaque import is narrowed and no fixture calls modified symbols, "
+            f"but got matching_deps={matching_deps}"
+        )
+
+    def test_opaque_import_flags_when_fixture_calls_modified_symbol(self, tmp_path: Path) -> None:
+        """When conftest opaquely imports a changed file AND a fixture calls the modified symbol, flag test."""
+        repo_root = tmp_path
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        changed_file = tmp_path / "utilities" / "hco.py"
+        changed_file.parent.mkdir(parents=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_hco_update.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_hco_update",
+            node_id="tests/test_hco_update.py::test_hco_update",
+            dependencies={conftest_path},
+            fixtures={"hco_fixture"},
+            symbol_imports={},
+        )
+
+        conftest_opaque_deps: dict[Path, set[Path]] = {
+            conftest_path: {changed_file},
+        }
+
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: SymbolClassification(
+                modified_symbols={"verify_boot_sources_reimported"},
+                new_symbols=set(),
+            ),
+        }
+
+        # This fixture DOES call the modified symbol
+        fixtures_dict: dict[str, Fixture] = {
+            "hco_fixture": Fixture(
+                name="hco_fixture",
+                file_path=conftest_path,
+                function_calls={"verify_boot_sources_reimported", "get_hco_cr"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports={},
+            conftest_opaque_deps=conftest_opaque_deps,
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert is_affected, "Test SHOULD be flagged when fixture calls the modified symbol"
+        assert any("via fixture hco_fixture" in dep for dep in matching_deps)
+
+    def test_opaque_import_only_new_symbols_skips(self, tmp_path: Path) -> None:
+        """When opaquely imported file has only new symbols (no modifications), test is safe."""
+        repo_root = tmp_path
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        changed_file = tmp_path / "utilities" / "hco.py"
+        changed_file.parent.mkdir(parents=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_smoke.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_smoke",
+            node_id="tests/test_smoke.py::test_smoke",
+            dependencies={conftest_path},
+            fixtures={"vm_fixture"},
+            symbol_imports={},
+        )
+
+        conftest_opaque_deps: dict[Path, set[Path]] = {
+            conftest_path: {changed_file},
+        }
+
+        # Only new symbols — nothing was modified
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: SymbolClassification(
+                modified_symbols=set(),
+                new_symbols={"new_helper_function"},
+            ),
+        }
+
+        fixtures_dict: dict[str, Fixture] = {
+            "vm_fixture": Fixture(
+                name="vm_fixture",
+                file_path=conftest_path,
+                function_calls={"create_vm"},
+            ),
+        }
+
+        is_affected, _ = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports={},
+            conftest_opaque_deps=conftest_opaque_deps,
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert not is_affected, "Test should NOT be flagged when only new symbols were added"
+
+    def test_opaque_import_no_classification_falls_back(self, tmp_path: Path) -> None:
+        """When classification is None (diff failed), fall back to conservative file-level flagging."""
+        repo_root = tmp_path
+        conftest_path = tmp_path / "tests" / "conftest.py"
+        conftest_path.parent.mkdir(parents=True)
+        conftest_path.touch()
+
+        changed_file = tmp_path / "utilities" / "hco.py"
+        changed_file.parent.mkdir(parents=True)
+        changed_file.touch()
+
+        test_file = tmp_path / "tests" / "test_smoke.py"
+        test_file.touch()
+
+        marked_test = MarkedTest(
+            file_path=test_file,
+            test_name="test_smoke",
+            node_id="tests/test_smoke.py::test_smoke",
+            dependencies={conftest_path},
+            fixtures={"vm_fixture"},
+            symbol_imports={},
+        )
+
+        conftest_opaque_deps: dict[Path, set[Path]] = {
+            conftest_path: {changed_file},
+        }
+
+        # Classification is None — diff parsing failed
+        modified_symbols_cache: dict[Path, SymbolClassification | None] = {
+            changed_file: None,
+        }
+
+        fixtures_dict: dict[str, Fixture] = {
+            "vm_fixture": Fixture(
+                name="vm_fixture",
+                file_path=conftest_path,
+                function_calls={"create_vm"},
+            ),
+        }
+
+        is_affected, matching_deps = _check_conftest_pathway(
+            changed_file=changed_file,
+            marked_test=marked_test,
+            conftest_symbol_imports={},
+            conftest_opaque_deps=conftest_opaque_deps,
+            modified_symbols_cache=modified_symbols_cache,
+            fixtures_dict=fixtures_dict,
+            repo_root=repo_root,
+        )
+
+        assert is_affected, "Test SHOULD be flagged when classification is None (conservative fallback)"
+        assert any("opaque import" in dep for dep in matching_deps)
+
+
 class TestCheckConftestPathwayTransitive:
     """Transitive conftest narrowing: conftest -> intermediate -> changed_file."""
 

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -1398,14 +1398,14 @@ class TestExtractModifiedSymbolsUnattributed:
         """Decorator lines outside a function's AST range are safe, not a conservative fallback.
 
         Python's AST sets lineno at the 'def' line, not at the first decorator.
-        When a decorated function is added, the decorator lines (e.g. @pytest.mark.polarion)
+        When a decorated function is added, the decorator lines (e.g. @pytest.mark.some_marker)
         fall outside the symbol map's line range.  These must be treated as safe
         (like imports or comments), not as executable module-level code.
         """
         source = textwrap.dedent("""\
             import pytest
 
-            @pytest.mark.polarion("CNV-1234")
+            @pytest.mark.some_marker("ID-1234")
             def test_new_feature():
                 pass
         """)
@@ -1420,7 +1420,7 @@ class TestExtractModifiedSymbolsUnattributed:
             "@@ -1,2 +1,5 @@\n"
             " import pytest\n"
             " \n"
-            '+@pytest.mark.polarion("CNV-1234")\n'
+            '+@pytest.mark.some_marker("ID-1234")\n'
             "+def test_new_feature():\n"
             "+    pass\n"
         )
@@ -2797,7 +2797,7 @@ class TestDecoratorLineRange:
 
     def test_class_with_decorators_includes_decorator_lines(self) -> None:
         """Decorator lines are included in the class's line range."""
-        source = "@pytest.mark.polarion('FAKE-1234')\nclass TestFoo:\n    def test_bar(self):\n        pass\n"
+        source = "@pytest.mark.some_marker('FAKE-1234')\nclass TestFoo:\n    def test_bar(self):\n        pass\n"
         symbol_map = _build_line_to_symbol_map(source=source)
         assert symbol_map.top_level[0] == (1, 4, "TestFoo"), "Class range should start at first decorator line"
 

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -2276,6 +2276,22 @@ class TestExtractDeletedSymbolsFromDiff:
         result = _extract_deleted_symbols_from_diff(diff_content=diff)
         assert result == {"old_func"}
 
+    def test_deleted_class_member_collides_with_toplevel(self) -> None:
+        """Deleted class members are returned as bare names, which may collide with unrelated top-level symbols."""
+        diff = (
+            "@@ -1,6 +1,0 @@\n"
+            "-class OldHelper:\n"
+            "-    def setup(self):\n"
+            "-        pass\n"
+            "-    def teardown(self):\n"
+            "-        pass\n"
+        )
+        result = _extract_deleted_symbols_from_diff(diff_content=diff)
+        # Both the class and its members are extracted as independent symbols.
+        # "setup" and "teardown" could collide with unrelated top-level fixtures,
+        # causing broader test selection — acceptable over-reporting for safety.
+        assert result == {"OldHelper", "setup", "teardown"}
+
 
 class TestPureDeletionSymbolNarrowing:
     """Tests that pure-deletion diffs enable symbol-level narrowing."""

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -692,6 +692,59 @@ class TestParseDiffForFunctions:
         result = _parse_diff_for_functions(diff_content=diff_content)
         assert result == set()
 
+    def test_new_function_added_after_existing(self) -> None:
+        diff_content = textwrap.dedent("""\
+            @@ -93,3 +96,25 @@ def uploaded_dv_scope_class(request):
+            +
+            +@pytest.fixture(scope="module")
+            +def uploaded_dv_in_udn_namespace(request):
+            +    yield from create_dv(request)
+        """)
+        result = _parse_diff_for_functions(diff_content=diff_content)
+        assert result == {"uploaded_dv_in_udn_namespace"}, "New function added after existing should be detected"
+
+    def test_new_function_added_does_not_mark_existing_as_modified(self) -> None:
+        diff_content = textwrap.dedent("""\
+            @@ -50,3 +50,10 @@ def existing_func():
+            +
+            +def brand_new_func():
+            +    do_something()
+            +    do_more()
+        """)
+        result = _parse_diff_for_functions(diff_content=diff_content)
+        assert "existing_func" not in result, (
+            "Existing function in @@ header should not be marked as modified when only new code was added"
+        )
+        assert result == {"brand_new_func"}, "Only the newly added function should be in the result"
+
+    def test_removed_function_detected(self) -> None:
+        diff_content = textwrap.dedent("""\
+            @@ -50,10 +50,3 @@ def existing_func():
+            -
+            -def removed_func():
+            -    do_something()
+            -    do_more()
+        """)
+        result = _parse_diff_for_functions(diff_content=diff_content)
+        assert "existing_func" not in result, (
+            "Existing function in @@ header should not be marked when a different function was removed"
+        )
+        assert result == {"removed_func"}, "Removed function should be detected in the diff"
+
+    def test_new_async_function_added_after_existing(self) -> None:
+        diff_content = textwrap.dedent("""\
+            @@ -93,3 +96,10 @@ def existing_func():
+            +
+            +async def new_async_handler(request):
+            +    data = await fetch()
+            +    return data
+        """)
+        result = _parse_diff_for_functions(diff_content=diff_content)
+        assert result == {"new_async_handler"}, "New async function added after existing should be detected"
+        assert "existing_func" not in result, (
+            "Existing function in @@ header should not be marked when only new async code was added"
+        )
+
 
 class TestSymbolClassificationModifiedMembers:
     def test_default_empty_dict(self):
@@ -1340,6 +1393,50 @@ class TestExtractModifiedSymbolsUnattributed:
             )
 
         assert result is None, "Executable module-level code should trigger conservative fallback"
+
+    def test_decorator_lines_outside_symbol_range_are_safe(self, tmp_path: Path) -> None:
+        """Decorator lines outside a function's AST range are safe, not a conservative fallback.
+
+        Python's AST sets lineno at the 'def' line, not at the first decorator.
+        When a decorated function is added, the decorator lines (e.g. @pytest.mark.polarion)
+        fall outside the symbol map's line range.  These must be treated as safe
+        (like imports or comments), not as executable module-level code.
+        """
+        source = textwrap.dedent("""\
+            import pytest
+
+            @pytest.mark.polarion("CNV-1234")
+            def test_new_feature():
+                pass
+        """)
+        file_path = tmp_path / "module.py"
+        file_path.write_text(source)
+
+        # Diff that adds the decorator line (line 3), which is outside the AST
+        # range of test_new_feature (whose lineno is 4, the 'def' line)
+        diff_content = (
+            "--- a/module.py\n"
+            "+++ b/module.py\n"
+            "@@ -1,2 +1,5 @@\n"
+            " import pytest\n"
+            " \n"
+            '+@pytest.mark.polarion("CNV-1234")\n'
+            "+def test_new_feature():\n"
+            "+    pass\n"
+        )
+        mock_result = type("Result", (), {"returncode": 0, "stdout": diff_content, "stderr": ""})()
+        with patch(
+            "scripts.tests_analyzer.pytest_marker_analyzer.subprocess.run",
+            return_value=mock_result,
+        ):
+            result = _extract_modified_symbols(
+                file_path=file_path,
+                base_branch="main",
+                repo_root=tmp_path,
+                github_pr_info=None,
+            )
+
+        assert result is not None, "Decorator lines should not trigger conservative fallback"
 
     def test_line_number_beyond_source_returns_none(self, tmp_path: Path) -> None:
         """When changed line number exceeds source length, returns None (conservative)."""

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -2708,6 +2708,22 @@ class TestParseDiffForFunctionsContextReset:
             "Context function should NOT be in modified set when only async function is appended after it"
         )
 
+    def test_decorator_before_appended_function(self) -> None:
+        """Decorator before appended function is not attributed to context function."""
+        diff = (
+            "@@ -50,6 +50,16 @@ def existing_fixture():\n"
+            "     return dv\n"
+            " \n"
+            '+@pytest.fixture(scope="session")\n'
+            "+def new_fixture():\n"
+            "+    return something\n"
+        )
+        result = _parse_diff_for_functions(diff_content=diff)
+        assert "new_fixture" in result, "Appended function with decorator should be in modified set"
+        assert "existing_fixture" not in result, (
+            "Context function should NOT be in modified set when decorator belongs to appended function"
+        )
+
 
 class TestPytestPluginsDetection:
     """Tests that pytest_plugins changes are detected by symbol-level analysis."""
@@ -2715,6 +2731,7 @@ class TestPytestPluginsDetection:
     def test_pytest_plugins_in_symbol_map(self) -> None:
         """pytest_plugins assignment is tracked as a top-level symbol."""
         source = textwrap.dedent("""\
+            import logging
             import pytest
 
             pytest_plugins = [

--- a/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
+++ b/scripts/tests_analyzer/tests/test_pytest_marker_analyzer.py
@@ -2956,7 +2956,7 @@ class TestParseDiffForFunctionsContextReset:
         """Decorator-only diff followed by context def line binds to that function."""
         diff = "@@ -10,6 +10,7 @@ def other_func\n+@pytest.mark.tier3\n def existing_fixture():\n     pass\n"
         result = _parse_diff_for_functions(diff_content=diff)
-        assert "existing_fixture" in result, f"Decorator change should be bound to context def line, got {result}"
+        assert result == {"existing_fixture"}, f"Decorator change should bind only to context def line, got {result}"
 
 
 class TestPytestPluginsDetection:


### PR DESCRIPTION
##### What this PR does / why we need it:
Improves the pytest marker analyzer's symbol-level diff attribution:

1. **Decorator line ranges**: `_symbol_start_line()` includes decorator lines in symbol ranges, so marker-only changes (e.g. adding `@pytest.mark.s390x`) map to the decorated symbol instead of triggering file-level fallback.

2. **Pure-deletion symbol narrowing**: Diffs that only delete code now extract deleted `def`/`class` names via `_extract_deleted_symbols_from_diff()` for symbol-level narrowing instead of returning `None` (conservative file-level fallback). This is critical for quarantine marker removal workflows.

3. **Safe unmapped line checks**: `TYPE_CHECKING` guards, closing parens `)`, `__all__`, and import continuation lines are now treated as safe unmapped lines that don't trigger conservative fallback.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
All changes are in the analyzer script and its unit tests. 119 tests pass. No changes to test infrastructure or production code.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate symbol impact detection by including decorator lines in change ranges and mapping decorator-only edits to the correct function/class.
  * Improved handling of pure deletions so removed `def`/`class` definitions are treated as meaningful modifications for narrowing.
  * Enhanced `conftest.py` impact analysis, including recognizing `pytest_plugins` changes as structural (triggering dependent tests).
* **Tests**
  * Added broader regression coverage for diff-to-symbol parsing, safe/unattributed line heuristics, and `conftest.py` narrowing behavior.
* **Documentation**
  * Updated decision-logic guidance to reflect the revised narrowing rules and `pytest_plugins` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->