### PR TITLE
Storage: STD for Storge Calss Migration cleanup

### DIFF
--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -1,0 +1,107 @@
+"""
+Storage migration cleanup tests for MultiNamespaceVirtualMachineStorageMigrationPlan.
+
+Tests verify the retentionPolicy field functionality, which controls whether source DataVolumes/PVCs
+are kept (keepSource) or deleted (deleteSource) after successful VM storage migration.
+
+The retentionPolicy field can be configured at:
+- Namespace level for MultiNamespaceVirtualMachineStorageMigrationPlan
+- Spec level for MultiNamespaceVirtualMachineStorageMigrationPlan
+- Combination of namespace and spec level for MultiNamespaceVirtualMachineStorageMigrationPlan
+
+STP Reference:
+https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/storage_mig_cleanup.md
+"""
+
+import pytest
+
+__test__ = False
+
+
+class TestStorageMigrationRetentionPolicy:
+    """
+    Test retentionPolicy functionality for MultiNamespaceVirtualMachineStorageMigrationPlan.
+
+    Preconditions:
+      - VM with source PVC/DataVolume
+    """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_retention_policy_default_behavior(self):
+        """
+        Test that default behavior is keepSource when retentionPolicy is not specified in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Preconditions:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan without retentionPolicy field
+               (neither spec-level nor namespace-level)
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+
+        Steps:
+            1. Verify source PVC/DataVolume still exists (default behavior)
+
+        Expected:
+            - Migration completes successfully
+            - Source PVC/DataVolume is kept (default keepSource behavior)
+            - VM is running on new storage
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_namespace_level_retention_policy_delete_source(self):
+        """
+        Test namespace-level retentionPolicy=deleteSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Preconditions:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=deleteSource
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+        Steps:
+            1. Verify source PVC/DataVolume is deleted
+        Expected:
+            - Migration completes successfully
+            - Source PVC/DataVolume is deleted
+            - VM is running on new storage
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_spec_level_retention_policy_delete_source(self):
+        """
+        Test spec-level retentionPolicy=deleteSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Preconditions:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with spec-level retentionPolicy=deleteSource
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+        Steps:
+            1. Verify source PVC/DataVolume is deleted
+        Expected:
+            - Migration completes successfully
+            - Source PVC/DataVolume is deleted (spec-level policy)
+            - VM is running on new storage
+        """
+
+class TestStorageMigrationCombinedRetentionPolicy:
+    """
+    Test combination of retentionPolicy for MultiNamespaceVirtualMachineStorageMigrationPlan.
+
+    Preconditions:
+      1. Two VMs with source PVCs/DataVolumes
+      2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
+        - spec-level retentionPolicy=keepSource
+        - namespace-level retentionPolicy=deleteSource for specific namespace
+      3. Wait for all migrations to complete successfully
+      4. Verify the two VMs are using new PVCs
+
+    """
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_combined_namespace_and_spec_level_retention_policy(self):
+        """
+        Test combination of namespace-level and spec-level retentionPolicy.
+        Namespace-level policy should override spec-level policy for that namespace.
+
+        Steps:
+            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are kept (spec-level policy)
+            2. Verify source PVCs in namespaces WITH namespace-level policy=deleteSource are deleted
+
+        Expected:
+            - All migrations complete successfully
+            - Source PVCs in namespaces with namespace-level policy are deleted
+            - Source PVCs in other namespaces are kept (spec-level policy)
+        """

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -77,6 +77,7 @@ class TestStorageMigrationRetentionPolicy:
             - VM is running on new storage
         """
 
+
 class TestStorageMigrationCombinedRetentionPolicy:
     """
     Test combination of retentionPolicy for MultiNamespaceVirtualMachineStorageMigrationPlan.
@@ -90,6 +91,7 @@ class TestStorageMigrationCombinedRetentionPolicy:
       4. Verify the two VMs are using new PVCs
 
     """
+
     @pytest.mark.polarion("CNV-XXXXX")
     def test_combined_namespace_and_spec_level_retention_policy(self):
         """

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -1,10 +1,11 @@
 """
-Storage migration cleanup tests for MultiNamespaceVirtualMachineStorageMigrationPlan.
+Storage migration cleanup tests for storage migration plans.
 
 Tests verify the retentionPolicy field functionality, which controls whether source DataVolumes/PVCs
 are kept (keepSource) or deleted (deleteSource) after successful VM storage migration.
 
 The retentionPolicy field can be configured at:
+- Spec level for VirtualMachineStorageMigrationPlan (single namespace)
 - Namespace level for MultiNamespaceVirtualMachineStorageMigrationPlan
 - Spec level for MultiNamespaceVirtualMachineStorageMigrationPlan
 - Combination of namespace and spec level for MultiNamespaceVirtualMachineStorageMigrationPlan
@@ -77,6 +78,79 @@ class TestStorageMigrationRetentionPolicy:
             - VM is running on new storage
         """
 
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_namespace_level_retention_policy_keep_source(self):
+        """
+        Test namespace-level retentionPolicy=keepSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Preconditions:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=keepSource
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+        Steps:
+            1. Verify source PVC/DataVolume still exists
+        Expected:
+            - Migration completes successfully
+            - Source PVC/DataVolume is kept (namespace-level policy)
+            - VM is running on new storage
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_spec_level_retention_policy_keep_source(self):
+        """
+        Test spec-level retentionPolicy=keepSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Preconditions:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with spec-level retentionPolicy=keepSource
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+        Steps:
+            1. Verify source PVC/DataVolume still exists
+        Expected:
+            - Migration completes successfully
+            - Source PVC/DataVolume is kept (spec-level policy)
+            - VM is running on new storage
+        """
+
+
+class TestSingleNamespaceStorageMigrationRetentionPolicy:
+    """
+    Test retentionPolicy functionality for VirtualMachineStorageMigrationPlan (single namespace).
+
+    Preconditions:
+      - VM with source PVC/DataVolume
+    """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_single_namespace_retention_policy_keep_source(self):
+        """
+        Test spec-level retentionPolicy=keepSource in VirtualMachineStorageMigrationPlan.
+        Preconditions:
+            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=keepSource
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+        Steps:
+            1. Verify source PVC/DataVolume still exists
+        Expected:
+            - Migration completes successfully
+            - Source PVC/DataVolume is kept (spec-level policy)
+            - VM is running on new storage
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_single_namespace_retention_policy_delete_source(self):
+        """
+        Test spec-level retentionPolicy=deleteSource in VirtualMachineStorageMigrationPlan.
+        Preconditions:
+            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=deleteSource
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+        Steps:
+            1. Verify source PVC/DataVolume is deleted
+        Expected:
+            - Migration completes successfully
+            - Source PVC/DataVolume is deleted (spec-level policy)
+            - VM is running on new storage
+        """
+
 
 class TestStorageMigrationCombinedRetentionPolicy:
     """
@@ -106,4 +180,148 @@ class TestStorageMigrationCombinedRetentionPolicy:
             - All migrations complete successfully
             - Source PVCs in namespaces with namespace-level policy are deleted
             - Source PVCs in other namespaces are kept (spec-level policy)
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_combined_namespace_keep_spec_delete(self):
+        """
+        Test combination: namespace-level keepSource + spec-level deleteSource.
+        Spec-level policy should override namespace-level policy.
+
+        Preconditions:
+            1. Two VMs with source PVCs/DataVolumes
+            2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
+                - spec-level retentionPolicy=deleteSource
+                - namespace-level retentionPolicy=keepSource for specific namespace
+            3. Wait for all migrations to complete successfully
+            4. Verify the two VMs are using new PVCs
+
+        Steps:
+            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are deleted (spec-level policy)
+            2. Verify source PVCs in namespaces WITH namespace-level policy=keepSource are kept
+
+        Expected:
+            - All migrations complete successfully
+            - Source PVCs in namespaces with namespace-level policy are kept
+            - Source PVCs in other namespaces are deleted (spec-level policy)
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_combined_both_delete(self):
+        """
+        Test combination: namespace-level deleteSource + spec-level deleteSource.
+        Both policies agree on deletion.
+
+        Preconditions:
+            1. Two VMs with source PVCs/DataVolumes
+            2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
+                - spec-level retentionPolicy=deleteSource
+                - namespace-level retentionPolicy=deleteSource for specific namespace
+            3. Wait for all migrations to complete successfully
+            4. Verify the two VMs are using new PVCs
+
+        Steps:
+            1. Verify all source PVCs are deleted (both policies agree)
+
+        Expected:
+            - All migrations complete successfully
+            - All source PVCs are deleted
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_combined_both_keep(self):
+        """
+        Test combination: namespace-level keepSource + spec-level keepSource.
+        Both policies agree on retention.
+
+        Preconditions:
+            1. Two VMs with source PVCs/DataVolumes
+            2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
+                - spec-level retentionPolicy=keepSource
+                - namespace-level retentionPolicy=keepSource for specific namespace
+            3. Wait for all migrations to complete successfully
+            4. Verify the two VMs are using new PVCs
+
+        Steps:
+            1. Verify all source PVCs are kept (both policies agree)
+
+        Expected:
+            - All migrations complete successfully
+            - All source PVCs are kept
+        """
+
+
+class TestStorageMigrationFailureRetentionPolicy:
+    """
+    Test retentionPolicy behavior when migration fails.
+    Source volumes should be retained regardless of retentionPolicy setting.
+
+    Preconditions:
+      - VM with source PVC/DataVolume
+      - Configuration that causes migration to fail
+    """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_failed_migration_with_delete_source_policy(self):
+        """
+        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=deleteSource.
+
+        Preconditions:
+            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=deleteSource
+            2. Configure migration to fail (e.g., invalid target storage class, insufficient quota)
+            3. Wait for migration to fail
+
+        Steps:
+            1. Verify migration failed
+            2. Verify source PVC/DataVolume still exists (not deleted despite deleteSource policy)
+            3. Verify VM is still using original PVC/DataVolume
+
+        Expected:
+            - Migration fails as expected
+            - Source PVC/DataVolume is retained (safety mechanism)
+            - VM continues running on original storage
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_failed_migration_with_keep_source_policy(self):
+        """
+        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=keepSource.
+
+        Preconditions:
+            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=keepSource
+            2. Configure migration to fail (e.g., invalid target storage class, insufficient quota)
+            3. Wait for migration to fail
+
+        Steps:
+            1. Verify migration failed
+            2. Verify source PVC/DataVolume still exists
+            3. Verify VM is still using original PVC/DataVolume
+
+        Expected:
+            - Migration fails as expected
+            - Source PVC/DataVolume is retained (as per policy)
+            - VM continues running on original storage
+        """
+
+    @pytest.mark.polarion("CNV-XXXXX")
+    def test_failed_multi_namespace_migration_with_delete_source_policy(self):
+        """
+        Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource.
+
+        Preconditions:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
+                - spec-level retentionPolicy=deleteSource
+                - namespace-level retentionPolicy=deleteSource for specific namespace
+            2. Configure migration to fail for at least one VM
+            3. Wait for migration to fail
+
+        Steps:
+            1. Verify migration failed
+            2. Verify all source PVCs/DataVolumes still exist (not deleted despite deleteSource policy)
+            3. Verify VMs are still using original PVCs/DataVolumes
+
+        Expected:
+            - Migration fails as expected
+            - All source PVCs/DataVolumes are retained (safety mechanism)
+            - VMs continue running on original storage
         """

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -32,7 +32,7 @@ class TestStorageMigrationRetentionPolicy:
       - VM with source PVC/DataVolume
     """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16297")
     @pytest.mark.tier2
     def test_retention_policy_default_behavior(self):
         """
@@ -41,13 +41,13 @@ class TestStorageMigrationRetentionPolicy:
         STP Requirement: Default cleanup behavior (P1)
 
         Preconditions:
-            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan without retentionPolicy field
-               (neither plan-level nor namespace-level)
-            2. Wait for migration to complete successfully
-            3. Verify VM is using new PVC/DataVolume
+            - VM with source PVC/DataVolume
 
         Steps:
-            1. Verify source PVC/DataVolume still exists (default behavior)
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan without retentionPolicy field
+            2. Wait for migration to complete successfully
+            3. Verify VM is using new PVC/DataVolume
+            4. Check if source PVC/DataVolume exists
 
         Expected:
             - Migration completes successfully
@@ -55,7 +55,7 @@ class TestStorageMigrationRetentionPolicy:
             - VM is running on new storage
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16298")
     @pytest.mark.tier2
     def test_namespace_level_retention_policy_delete_source(self):
         """
@@ -64,18 +64,21 @@ class TestStorageMigrationRetentionPolicy:
         STP Requirement: Namespace-level cleanup policy (P0)
 
         Preconditions:
+            - VM with source PVC/DataVolume
+
+        Steps:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=deleteSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
-        Steps:
-            1. Verify source PVC/DataVolume is deleted
+            4. Check if source PVC/DataVolume exists
+
         Expected:
             - Migration completes successfully
             - Source PVC/DataVolume is deleted
             - VM is running on new storage
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16299")
     @pytest.mark.tier2
     def test_spec_level_retention_policy_delete_source(self):
         """
@@ -84,18 +87,21 @@ class TestStorageMigrationRetentionPolicy:
         STP Requirement: Plan-level cleanup policy (P0)
 
         Preconditions:
+            - VM with source PVC/DataVolume
+
+        Steps:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
-        Steps:
-            1. Verify source PVC/DataVolume is deleted
+            4. Check if source PVC/DataVolume exists
+
         Expected:
             - Migration completes successfully
             - Source PVC/DataVolume is deleted (plan-level policy)
             - VM is running on new storage
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16301")
     @pytest.mark.tier2
     def test_namespace_level_retention_policy_keep_source(self):
         """
@@ -104,18 +110,21 @@ class TestStorageMigrationRetentionPolicy:
         STP Requirement: Namespace-level cleanup policy (P0)
 
         Preconditions:
+            - VM with source PVC/DataVolume
+
+        Steps:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=keepSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
-        Steps:
-            1. Verify source PVC/DataVolume still exists
+            4. Check if source PVC/DataVolume exists
+
         Expected:
             - Migration completes successfully
             - Source PVC/DataVolume is kept (namespace-level policy)
             - VM is running on new storage
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16302")
     @pytest.mark.tier2
     def test_spec_level_retention_policy_keep_source(self):
         """
@@ -124,11 +133,14 @@ class TestStorageMigrationRetentionPolicy:
         STP Requirement: Plan-level cleanup policy (P0)
 
         Preconditions:
+            - VM with source PVC/DataVolume
+
+        Steps:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
-        Steps:
-            1. Verify source PVC/DataVolume still exists
+            4. Check if source PVC/DataVolume exists
+
         Expected:
             - Migration completes successfully
             - Source PVC/DataVolume is kept (plan-level policy)
@@ -146,7 +158,7 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
       - VM with source PVC/DataVolume
     """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16303")
     @pytest.mark.tier2
     def test_single_namespace_retention_policy_keep_source(self):
         """
@@ -155,18 +167,21 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
         STP Requirement: Plan-level cleanup policy (P0)
 
         Preconditions:
+            - VM with source PVC/DataVolume
+
+        Steps:
             1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
-        Steps:
-            1. Verify source PVC/DataVolume still exists
+            4. Check if source PVC/DataVolume exists
+
         Expected:
             - Migration completes successfully
             - Source PVC/DataVolume is kept (plan-level policy)
             - VM is running on new storage
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16304")
     @pytest.mark.tier2
     def test_single_namespace_retention_policy_delete_source(self):
         """
@@ -175,11 +190,14 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
         STP Requirement: Plan-level cleanup policy (P0)
 
         Preconditions:
+            - VM with source PVC/DataVolume
+
+        Steps:
             1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
-        Steps:
-            1. Verify source PVC/DataVolume is deleted
+            4. Check if source PVC/DataVolume exists
+
         Expected:
             - Migration completes successfully
             - Source PVC/DataVolume is deleted (plan-level policy)
@@ -195,16 +213,11 @@ class TestStorageMigrationCombinedRetentionPolicy:
     Note: Namespace-level policy overrides plan-level policy for that namespace.
 
     Preconditions:
-      1. Two VMs with source PVCs/DataVolumes
-      2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-        - plan-level retentionPolicy=keepSource
-        - namespace-level retentionPolicy=deleteSource for specific namespace
-      3. Wait for all migrations to complete successfully
-      4. Verify the two VMs are using new PVCs
+      - Two VMs with source PVCs/DataVolumes in separate namespaces
 
     """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16305")
     @pytest.mark.tier2
     def test_combined_namespace_and_spec_level_retention_policy(self):
         """
@@ -213,9 +226,14 @@ class TestStorageMigrationCombinedRetentionPolicy:
         STP Requirement: Combined namespace and plan-level cleanup policies (P0)
         Namespace-level policy overrides plan-level policy for that namespace.
 
+        Preconditions:
+            - Two VMs with source PVCs/DataVolumes in separate namespaces
+
         Steps:
-            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are kept (plan-level policy)
-            2. Verify source PVCs in namespaces WITH namespace-level policy=deleteSource are deleted
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource and namespace-level retentionPolicy=deleteSource for one namespace
+            2. Wait for all migrations to complete successfully
+            3. Verify both VMs are using new PVCs
+            4. Check if source PVCs exist in both namespaces
 
         Expected:
             - All migrations complete successfully
@@ -223,7 +241,7 @@ class TestStorageMigrationCombinedRetentionPolicy:
             - Source PVCs in other namespaces are kept (plan-level policy)
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16306")
     @pytest.mark.tier2
     def test_combined_namespace_keep_spec_delete(self):
         """
@@ -233,16 +251,13 @@ class TestStorageMigrationCombinedRetentionPolicy:
         Namespace-level policy overrides plan-level policy for that namespace.
 
         Preconditions:
-            1. Two VMs with source PVCs/DataVolumes
-            2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - plan-level retentionPolicy=deleteSource
-                - namespace-level retentionPolicy=keepSource for specific namespace
-            3. Wait for all migrations to complete successfully
-            4. Verify the two VMs are using new PVCs
+            - Two VMs with source PVCs/DataVolumes in separate namespaces
 
         Steps:
-            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are deleted (plan-level policy)
-            2. Verify source PVCs in namespaces WITH namespace-level policy=keepSource are kept
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource and namespace-level retentionPolicy=keepSource for one namespace
+            2. Wait for all migrations to complete successfully
+            3. Verify both VMs are using new PVCs
+            4. Check if source PVCs exist in both namespaces
 
         Expected:
             - All migrations complete successfully
@@ -250,7 +265,7 @@ class TestStorageMigrationCombinedRetentionPolicy:
             - Source PVCs in other namespaces are deleted (plan-level policy)
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16307")
     @pytest.mark.tier2
     def test_combined_both_delete(self):
         """
@@ -260,22 +275,20 @@ class TestStorageMigrationCombinedRetentionPolicy:
         Both policies agree on deletion.
 
         Preconditions:
-            1. Two VMs with source PVCs/DataVolumes
-            2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - plan-level retentionPolicy=deleteSource
-                - namespace-level retentionPolicy=deleteSource for specific namespace
-            3. Wait for all migrations to complete successfully
-            4. Verify the two VMs are using new PVCs
+            - Two VMs with source PVCs/DataVolumes in separate namespaces
 
         Steps:
-            1. Verify all source PVCs are deleted (both policies agree)
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource and namespace-level retentionPolicy=deleteSource for one namespace
+            2. Wait for all migrations to complete successfully
+            3. Verify both VMs are using new PVCs
+            4. Check if source PVCs exist in both namespaces
 
         Expected:
             - All migrations complete successfully
             - All source PVCs are deleted
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16308")
     @pytest.mark.tier2
     def test_combined_both_keep(self):
         """
@@ -285,15 +298,13 @@ class TestStorageMigrationCombinedRetentionPolicy:
         Both policies agree on retention.
 
         Preconditions:
-            1. Two VMs with source PVCs/DataVolumes
-            2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - plan-level retentionPolicy=keepSource
-                - namespace-level retentionPolicy=keepSource for specific namespace
-            3. Wait for all migrations to complete successfully
-            4. Verify the two VMs are using new PVCs
+            - Two VMs with source PVCs/DataVolumes in separate namespaces
 
         Steps:
-            1. Verify all source PVCs are kept (both policies agree)
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource and namespace-level retentionPolicy=keepSource for one namespace
+            2. Wait for all migrations to complete successfully
+            3. Verify both VMs are using new PVCs
+            4. Check if source PVCs exist in both namespaces
 
         Expected:
             - All migrations complete successfully
@@ -310,26 +321,25 @@ class TestStorageMigrationFailureRetentionPolicy:
 
     Preconditions:
       - VM with source PVC/DataVolume
-      - Configuration that causes migration to fail
     """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16309")
     @pytest.mark.tier2
     def test_failed_migration_with_delete_source_policy(self):
         """
-        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=deleteSource.
+        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=deleteSource. [NEGATIVE]
 
         STP Requirement: Source volumes preserved on migration failure (P2)
 
         Preconditions:
-            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
-            2. Configure migration to fail (e.g., invalid target storage class, insufficient quota)
-            3. Wait for migration to fail
+            - VM with source PVC/DataVolume
 
         Steps:
-            1. Verify migration failed
-            2. Verify source PVC/DataVolume still exists (not deleted despite deleteSource policy)
-            3. Verify VM is still using original PVC/DataVolume
+            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource and invalid target storage class
+            2. Wait for migration to fail
+            3. Check migration status
+            4. Check if source PVC/DataVolume exists
+            5. Verify VM volume references
 
         Expected:
             - Migration fails as expected
@@ -337,23 +347,23 @@ class TestStorageMigrationFailureRetentionPolicy:
             - VM continues running on original storage
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16310")
     @pytest.mark.tier2
     def test_failed_migration_with_keep_source_policy(self):
         """
-        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=keepSource.
+        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=keepSource. [NEGATIVE]
 
         STP Requirement: Source volumes preserved on migration failure (P2)
 
         Preconditions:
-            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
-            2. Configure migration to fail (e.g., invalid target storage class, insufficient quota)
-            3. Wait for migration to fail
+            - VM with source PVC/DataVolume
 
         Steps:
-            1. Verify migration failed
-            2. Verify source PVC/DataVolume still exists
-            3. Verify VM is still using original PVC/DataVolume
+            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource and invalid target storage class
+            2. Wait for migration to fail
+            3. Check migration status
+            4. Check if source PVC/DataVolume exists
+            5. Verify VM volume references
 
         Expected:
             - Migration fails as expected
@@ -361,25 +371,23 @@ class TestStorageMigrationFailureRetentionPolicy:
             - VM continues running on original storage
         """
 
-    @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.polarion("CNV-16311")
     @pytest.mark.tier2
     def test_failed_multi_namespace_migration_with_delete_source_policy(self):
         """
-        Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource.
+        Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource. [NEGATIVE]
 
         STP Requirement: Source volumes preserved on migration failure (P2)
 
         Preconditions:
-            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - plan-level retentionPolicy=deleteSource
-                - namespace-level retentionPolicy=deleteSource for specific namespace
-            2. Configure migration to fail for at least one VM
-            3. Wait for migration to fail
+            - Two VMs with source PVCs/DataVolumes in separate namespaces
 
         Steps:
-            1. Verify migration failed
-            2. Verify all source PVCs/DataVolumes still exist (not deleted despite deleteSource policy)
-            3. Verify VMs are still using original PVCs/DataVolumes
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource, namespace-level retentionPolicy=deleteSource for one namespace, and invalid target storage class
+            2. Wait for migration to fail
+            3. Check migration status for all VMs
+            4. Check if all source PVCs/DataVolumes exist
+            5. Verify VM volume references
 
         Expected:
             - Migration fails as expected

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -5,13 +5,16 @@ Tests verify the retentionPolicy field functionality, which controls whether sou
 are kept (keepSource) or deleted (deleteSource) after successful VM storage migration.
 
 The retentionPolicy field can be configured at:
-- Spec level for VirtualMachineStorageMigrationPlan (single namespace)
+- Plan level (spec) for VirtualMachineStorageMigrationPlan (single namespace)
 - Namespace level for MultiNamespaceVirtualMachineStorageMigrationPlan
-- Spec level for MultiNamespaceVirtualMachineStorageMigrationPlan
-- Combination of namespace and spec level for MultiNamespaceVirtualMachineStorageMigrationPlan
+- Plan level (spec) for MultiNamespaceVirtualMachineStorageMigrationPlan
+- Combination of namespace and plan level for MultiNamespaceVirtualMachineStorageMigrationPlan
+  (namespace-level overrides plan-level when both are configured)
 
 STP Reference:
 https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/storage_mig_cleanup.md
+
+Test Tier: Tier 2 (all tests in this module)
 """
 
 import pytest
@@ -23,17 +26,23 @@ class TestStorageMigrationRetentionPolicy:
     """
     Test retentionPolicy functionality for MultiNamespaceVirtualMachineStorageMigrationPlan.
 
+    STP Traceability: CNV-73509 (P0, P1)
+
     Preconditions:
       - VM with source PVC/DataVolume
     """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_retention_policy_default_behavior(self):
         """
-        Test that default behavior is keepSource when retentionPolicy is not specified in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Test that default behavior is keepSource when retentionPolicy is not specified.
+
+        STP Requirement: Default cleanup behavior (P1)
+
         Preconditions:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan without retentionPolicy field
-               (neither spec-level nor namespace-level)
+               (neither plan-level nor namespace-level)
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
 
@@ -47,9 +56,13 @@ class TestStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_namespace_level_retention_policy_delete_source(self):
         """
-        Test namespace-level retentionPolicy=deleteSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Test namespace-level retentionPolicy=deleteSource.
+
+        STP Requirement: Namespace-level cleanup policy (P0)
+
         Preconditions:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=deleteSource
             2. Wait for migration to complete successfully
@@ -63,25 +76,33 @@ class TestStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_spec_level_retention_policy_delete_source(self):
         """
-        Test spec-level retentionPolicy=deleteSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Test plan-level retentionPolicy=deleteSource.
+
+        STP Requirement: Plan-level cleanup policy (P0)
+
         Preconditions:
-            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with spec-level retentionPolicy=deleteSource
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
         Steps:
             1. Verify source PVC/DataVolume is deleted
         Expected:
             - Migration completes successfully
-            - Source PVC/DataVolume is deleted (spec-level policy)
+            - Source PVC/DataVolume is deleted (plan-level policy)
             - VM is running on new storage
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_namespace_level_retention_policy_keep_source(self):
         """
-        Test namespace-level retentionPolicy=keepSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Test namespace-level retentionPolicy=keepSource.
+
+        STP Requirement: Namespace-level cleanup policy (P0)
+
         Preconditions:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=keepSource
             2. Wait for migration to complete successfully
@@ -95,18 +116,22 @@ class TestStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_spec_level_retention_policy_keep_source(self):
         """
-        Test spec-level retentionPolicy=keepSource in MultiNamespaceVirtualMachineStorageMigrationPlan.
+        Test plan-level retentionPolicy=keepSource.
+
+        STP Requirement: Plan-level cleanup policy (P0)
+
         Preconditions:
-            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with spec-level retentionPolicy=keepSource
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
         Steps:
             1. Verify source PVC/DataVolume still exists
         Expected:
             - Migration completes successfully
-            - Source PVC/DataVolume is kept (spec-level policy)
+            - Source PVC/DataVolume is kept (plan-level policy)
             - VM is running on new storage
         """
 
@@ -115,39 +140,49 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
     """
     Test retentionPolicy functionality for VirtualMachineStorageMigrationPlan (single namespace).
 
+    STP Traceability: CNV-73509 (P0)
+
     Preconditions:
       - VM with source PVC/DataVolume
     """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_single_namespace_retention_policy_keep_source(self):
         """
-        Test spec-level retentionPolicy=keepSource in VirtualMachineStorageMigrationPlan.
+        Test plan-level retentionPolicy=keepSource in single namespace plan.
+
+        STP Requirement: Plan-level cleanup policy (P0)
+
         Preconditions:
-            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=keepSource
+            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
         Steps:
             1. Verify source PVC/DataVolume still exists
         Expected:
             - Migration completes successfully
-            - Source PVC/DataVolume is kept (spec-level policy)
+            - Source PVC/DataVolume is kept (plan-level policy)
             - VM is running on new storage
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_single_namespace_retention_policy_delete_source(self):
         """
-        Test spec-level retentionPolicy=deleteSource in VirtualMachineStorageMigrationPlan.
+        Test plan-level retentionPolicy=deleteSource in single namespace plan.
+
+        STP Requirement: Plan-level cleanup policy (P0)
+
         Preconditions:
-            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=deleteSource
+            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
         Steps:
             1. Verify source PVC/DataVolume is deleted
         Expected:
             - Migration completes successfully
-            - Source PVC/DataVolume is deleted (spec-level policy)
+            - Source PVC/DataVolume is deleted (plan-level policy)
             - VM is running on new storage
         """
 
@@ -156,10 +191,13 @@ class TestStorageMigrationCombinedRetentionPolicy:
     """
     Test combination of retentionPolicy for MultiNamespaceVirtualMachineStorageMigrationPlan.
 
+    STP Traceability: CNV-73509 (P0)
+    Note: Namespace-level policy overrides plan-level policy for that namespace.
+
     Preconditions:
       1. Two VMs with source PVCs/DataVolumes
       2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-        - spec-level retentionPolicy=keepSource
+        - plan-level retentionPolicy=keepSource
         - namespace-level retentionPolicy=deleteSource for specific namespace
       3. Wait for all migrations to complete successfully
       4. Verify the two VMs are using new PVCs
@@ -167,55 +205,64 @@ class TestStorageMigrationCombinedRetentionPolicy:
     """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_combined_namespace_and_spec_level_retention_policy(self):
         """
-        Test combination of namespace-level and spec-level retentionPolicy.
-        Namespace-level policy should override spec-level policy for that namespace.
+        Test combination of namespace-level and plan-level retentionPolicy.
+
+        STP Requirement: Combined namespace and plan-level cleanup policies (P0)
+        Namespace-level policy overrides plan-level policy for that namespace.
 
         Steps:
-            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are kept (spec-level policy)
+            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are kept (plan-level policy)
             2. Verify source PVCs in namespaces WITH namespace-level policy=deleteSource are deleted
 
         Expected:
             - All migrations complete successfully
             - Source PVCs in namespaces with namespace-level policy are deleted
-            - Source PVCs in other namespaces are kept (spec-level policy)
+            - Source PVCs in other namespaces are kept (plan-level policy)
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_combined_namespace_keep_spec_delete(self):
         """
-        Test combination: namespace-level keepSource + spec-level deleteSource.
-        Spec-level policy should override namespace-level policy.
+        Test combination: namespace-level keepSource + plan-level deleteSource.
+
+        STP Requirement: Combined namespace and plan-level cleanup policies (P0)
+        Namespace-level policy overrides plan-level policy for that namespace.
 
         Preconditions:
             1. Two VMs with source PVCs/DataVolumes
             2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - spec-level retentionPolicy=deleteSource
+                - plan-level retentionPolicy=deleteSource
                 - namespace-level retentionPolicy=keepSource for specific namespace
             3. Wait for all migrations to complete successfully
             4. Verify the two VMs are using new PVCs
 
         Steps:
-            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are deleted (spec-level policy)
+            1. Verify source PVCs in namespaces WITHOUT namespace-level policy are deleted (plan-level policy)
             2. Verify source PVCs in namespaces WITH namespace-level policy=keepSource are kept
 
         Expected:
             - All migrations complete successfully
-            - Source PVCs in namespaces with namespace-level policy are kept
-            - Source PVCs in other namespaces are deleted (spec-level policy)
+            - Source PVCs in namespaces with namespace-level policy are kept (namespace overrides plan)
+            - Source PVCs in other namespaces are deleted (plan-level policy)
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_combined_both_delete(self):
         """
-        Test combination: namespace-level deleteSource + spec-level deleteSource.
+        Test combination: namespace-level deleteSource + plan-level deleteSource.
+
+        STP Requirement: Combined namespace and plan-level cleanup policies (P0)
         Both policies agree on deletion.
 
         Preconditions:
             1. Two VMs with source PVCs/DataVolumes
             2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - spec-level retentionPolicy=deleteSource
+                - plan-level retentionPolicy=deleteSource
                 - namespace-level retentionPolicy=deleteSource for specific namespace
             3. Wait for all migrations to complete successfully
             4. Verify the two VMs are using new PVCs
@@ -229,15 +276,18 @@ class TestStorageMigrationCombinedRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_combined_both_keep(self):
         """
-        Test combination: namespace-level keepSource + spec-level keepSource.
+        Test combination: namespace-level keepSource + plan-level keepSource.
+
+        STP Requirement: Combined namespace and plan-level cleanup policies (P0)
         Both policies agree on retention.
 
         Preconditions:
             1. Two VMs with source PVCs/DataVolumes
             2. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - spec-level retentionPolicy=keepSource
+                - plan-level retentionPolicy=keepSource
                 - namespace-level retentionPolicy=keepSource for specific namespace
             3. Wait for all migrations to complete successfully
             4. Verify the two VMs are using new PVCs
@@ -256,18 +306,23 @@ class TestStorageMigrationFailureRetentionPolicy:
     Test retentionPolicy behavior when migration fails.
     Source volumes should be retained regardless of retentionPolicy setting.
 
+    STP Traceability: CNV-73509 (P2)
+
     Preconditions:
       - VM with source PVC/DataVolume
       - Configuration that causes migration to fail
     """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_failed_migration_with_delete_source_policy(self):
         """
         Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=deleteSource.
 
+        STP Requirement: Source volumes preserved on migration failure (P2)
+
         Preconditions:
-            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=deleteSource
+            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
             2. Configure migration to fail (e.g., invalid target storage class, insufficient quota)
             3. Wait for migration to fail
 
@@ -283,12 +338,15 @@ class TestStorageMigrationFailureRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_failed_migration_with_keep_source_policy(self):
         """
         Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=keepSource.
 
+        STP Requirement: Source volumes preserved on migration failure (P2)
+
         Preconditions:
-            1. Create VirtualMachineStorageMigrationPlan with spec-level retentionPolicy=keepSource
+            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
             2. Configure migration to fail (e.g., invalid target storage class, insufficient quota)
             3. Wait for migration to fail
 
@@ -304,13 +362,16 @@ class TestStorageMigrationFailureRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-XXXXX")
+    @pytest.mark.tier2
     def test_failed_multi_namespace_migration_with_delete_source_policy(self):
         """
         Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource.
 
+        STP Requirement: Source volumes preserved on migration failure (P2)
+
         Preconditions:
             1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with:
-                - spec-level retentionPolicy=deleteSource
+                - plan-level retentionPolicy=deleteSource
                 - namespace-level retentionPolicy=deleteSource for specific namespace
             2. Configure migration to fail for at least one VM
             3. Wait for migration to fail

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -33,7 +33,6 @@ class TestStorageMigrationRetentionPolicy:
     """
 
     @pytest.mark.polarion("CNV-16297")
-    @pytest.mark.tier2
     def test_retention_policy_default_behavior(self):
         """
         Test that default behavior is keepSource when retentionPolicy is not specified.
@@ -56,7 +55,6 @@ class TestStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16298")
-    @pytest.mark.tier2
     def test_namespace_level_retention_policy_delete_source(self):
         """
         Test namespace-level retentionPolicy=deleteSource.
@@ -79,7 +77,6 @@ class TestStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16299")
-    @pytest.mark.tier2
     def test_spec_level_retention_policy_delete_source(self):
         """
         Test plan-level retentionPolicy=deleteSource.
@@ -102,7 +99,6 @@ class TestStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16301")
-    @pytest.mark.tier2
     def test_namespace_level_retention_policy_keep_source(self):
         """
         Test namespace-level retentionPolicy=keepSource.
@@ -125,7 +121,6 @@ class TestStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16302")
-    @pytest.mark.tier2
     def test_spec_level_retention_policy_keep_source(self):
         """
         Test plan-level retentionPolicy=keepSource.
@@ -159,7 +154,6 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
     """
 
     @pytest.mark.polarion("CNV-16303")
-    @pytest.mark.tier2
     def test_single_namespace_retention_policy_keep_source(self):
         """
         Test plan-level retentionPolicy=keepSource in single namespace plan.
@@ -182,7 +176,6 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16304")
-    @pytest.mark.tier2
     def test_single_namespace_retention_policy_delete_source(self):
         """
         Test plan-level retentionPolicy=deleteSource in single namespace plan.
@@ -218,7 +211,6 @@ class TestStorageMigrationCombinedRetentionPolicy:
     """
 
     @pytest.mark.polarion("CNV-16305")
-    @pytest.mark.tier2
     def test_combined_namespace_and_spec_level_retention_policy(self):
         """
         Test combination of namespace-level and plan-level retentionPolicy.
@@ -242,7 +234,6 @@ class TestStorageMigrationCombinedRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16306")
-    @pytest.mark.tier2
     def test_combined_namespace_keep_spec_delete(self):
         """
         Test combination: namespace-level keepSource + plan-level deleteSource.
@@ -266,7 +257,6 @@ class TestStorageMigrationCombinedRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16307")
-    @pytest.mark.tier2
     def test_combined_both_delete(self):
         """
         Test combination: namespace-level deleteSource + plan-level deleteSource.
@@ -289,7 +279,6 @@ class TestStorageMigrationCombinedRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16308")
-    @pytest.mark.tier2
     def test_combined_both_keep(self):
         """
         Test combination: namespace-level keepSource + plan-level keepSource.
@@ -324,7 +313,6 @@ class TestStorageMigrationFailureRetentionPolicy:
     """
 
     @pytest.mark.polarion("CNV-16309")
-    @pytest.mark.tier2
     def test_failed_migration_with_delete_source_policy(self):
         """
         Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=deleteSource. [NEGATIVE]
@@ -348,7 +336,6 @@ class TestStorageMigrationFailureRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16310")
-    @pytest.mark.tier2
     def test_failed_migration_with_keep_source_policy(self):
         """
         Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=keepSource. [NEGATIVE]
@@ -372,7 +359,6 @@ class TestStorageMigrationFailureRetentionPolicy:
         """
 
     @pytest.mark.polarion("CNV-16311")
-    @pytest.mark.tier2
     def test_failed_multi_namespace_migration_with_delete_source_policy(self):
         """
         Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource. [NEGATIVE]

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -13,8 +13,6 @@ The retentionPolicy field can be configured at:
 
 STP Reference:
 https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/storage_mig_cleanup.md
-
-Test Tier: Tier 2 (all tests in this module)
 """
 
 import pytest
@@ -28,6 +26,11 @@ class TestStorageMigrationRetentionPolicy:
 
     STP Traceability: CNV-73509 (P0, P1)
 
+    Parametrize:
+        - migration_mode:
+            - online (VM running during migration)
+            - offline (VM stopped during migration)
+
     Preconditions:
       - VM with source PVC/DataVolume
     """
@@ -37,7 +40,7 @@ class TestStorageMigrationRetentionPolicy:
         """
         Test that default behavior is keepSource when retentionPolicy is not specified.
 
-        STP Requirement: Default cleanup behavior (P1)
+        STP Requirement: Default cleanup policy (P1)
 
         Preconditions:
             - VM with source PVC/DataVolume
@@ -49,9 +52,7 @@ class TestStorageMigrationRetentionPolicy:
             4. Check if source PVC/DataVolume exists
 
         Expected:
-            - Migration completes successfully
             - Source PVC/DataVolume is kept (default keepSource behavior)
-            - VM is running on new storage
         """
 
     @pytest.mark.polarion("CNV-16298")
@@ -71,9 +72,7 @@ class TestStorageMigrationRetentionPolicy:
             4. Check if source PVC/DataVolume exists
 
         Expected:
-            - Migration completes successfully
             - Source PVC/DataVolume is deleted
-            - VM is running on new storage
         """
 
     @pytest.mark.polarion("CNV-16299")
@@ -93,9 +92,7 @@ class TestStorageMigrationRetentionPolicy:
             4. Check if source PVC/DataVolume exists
 
         Expected:
-            - Migration completes successfully
-            - Source PVC/DataVolume is deleted (plan-level policy)
-            - VM is running on new storage
+            - Source PVC/DataVolume is deleted
         """
 
     @pytest.mark.polarion("CNV-16301")
@@ -115,9 +112,7 @@ class TestStorageMigrationRetentionPolicy:
             4. Check if source PVC/DataVolume exists
 
         Expected:
-            - Migration completes successfully
-            - Source PVC/DataVolume is kept (namespace-level policy)
-            - VM is running on new storage
+            - Source PVC/DataVolume is kept
         """
 
     @pytest.mark.polarion("CNV-16302")
@@ -137,9 +132,7 @@ class TestStorageMigrationRetentionPolicy:
             4. Check if source PVC/DataVolume exists
 
         Expected:
-            - Migration completes successfully
-            - Source PVC/DataVolume is kept (plan-level policy)
-            - VM is running on new storage
+            - Source PVC/DataVolume is kept
         """
 
 
@@ -148,6 +141,11 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
     Test retentionPolicy functionality for VirtualMachineStorageMigrationPlan (single namespace).
 
     STP Traceability: CNV-73509 (P0)
+
+    Parametrize:
+        - migration_mode:
+            - online (VM running during migration)
+            - offline (VM stopped during migration)
 
     Preconditions:
       - VM with source PVC/DataVolume
@@ -170,9 +168,7 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
             4. Check if source PVC/DataVolume exists
 
         Expected:
-            - Migration completes successfully
-            - Source PVC/DataVolume is kept (plan-level policy)
-            - VM is running on new storage
+            - Source PVC/DataVolume is kept
         """
 
     @pytest.mark.polarion("CNV-16304")
@@ -192,9 +188,7 @@ class TestSingleNamespaceStorageMigrationRetentionPolicy:
             4. Check if source PVC/DataVolume exists
 
         Expected:
-            - Migration completes successfully
-            - Source PVC/DataVolume is deleted (plan-level policy)
-            - VM is running on new storage
+            - Source PVC/DataVolume is deleted
         """
 
 
@@ -205,13 +199,19 @@ class TestStorageMigrationCombinedRetentionPolicy:
     STP Traceability: CNV-73509 (P0)
     Note: Namespace-level policy overrides plan-level policy for that namespace.
 
+    Parametrize:
+        - migration_mode:
+            - online (both VMs running during migration)
+            - offline (both VMs stopped during migration)
+            - online+offline (one VM running, one VM stopped during migration)
+
     Preconditions:
       - Two VMs with source PVCs/DataVolumes in separate namespaces
 
     """
 
     @pytest.mark.polarion("CNV-16305")
-    def test_combined_namespace_and_spec_level_retention_policy(self):
+    def test_namespace_delete_overrides_plan_keep(self):
         """
         Test combination of namespace-level and plan-level retentionPolicy.
 
@@ -228,13 +228,12 @@ class TestStorageMigrationCombinedRetentionPolicy:
             4. Check if source PVCs exist in both namespaces
 
         Expected:
-            - All migrations complete successfully
-            - Source PVCs in namespaces with namespace-level policy are deleted
-            - Source PVCs in other namespaces are kept (plan-level policy)
+            - Source PVCs in namespace with namespace-level deleteSource policy are deleted
+            - Source PVCs in namespace without namespace-level policy are kept (plan-level keepSource)
         """
 
     @pytest.mark.polarion("CNV-16306")
-    def test_combined_namespace_keep_spec_delete(self):
+    def test_namespace_keep_overrides_plan_delete(self):
         """
         Test combination: namespace-level keepSource + plan-level deleteSource.
 
@@ -251,13 +250,12 @@ class TestStorageMigrationCombinedRetentionPolicy:
             4. Check if source PVCs exist in both namespaces
 
         Expected:
-            - All migrations complete successfully
-            - Source PVCs in namespaces with namespace-level policy are kept (namespace overrides plan)
-            - Source PVCs in other namespaces are deleted (plan-level policy)
+            - Source PVCs in namespace with namespace-level keepSource policy are kept (namespace overrides plan)
+            - Source PVCs in namespace without namespace-level policy are deleted (plan-level deleteSource)
         """
 
     @pytest.mark.polarion("CNV-16307")
-    def test_combined_both_delete(self):
+    def test_namespace_and_plan_level_delete_source_retention_policy(self):
         """
         Test combination: namespace-level deleteSource + plan-level deleteSource.
 
@@ -274,12 +272,11 @@ class TestStorageMigrationCombinedRetentionPolicy:
             4. Check if source PVCs exist in both namespaces
 
         Expected:
-            - All migrations complete successfully
             - All source PVCs are deleted
         """
 
     @pytest.mark.polarion("CNV-16308")
-    def test_combined_both_keep(self):
+    def test_namespace_and_plan_level_keep_source_retention_policy(self):
         """
         Test combination: namespace-level keepSource + plan-level keepSource.
 
@@ -296,14 +293,13 @@ class TestStorageMigrationCombinedRetentionPolicy:
             4. Check if source PVCs exist in both namespaces
 
         Expected:
-            - All migrations complete successfully
             - All source PVCs are kept
         """
 
 
 class TestStorageMigrationFailureRetentionPolicy:
     """
-    Test retentionPolicy behavior when migration fails.
+    [NEGATIVE] Test retentionPolicy behavior when migration fails.
     Source volumes should be retained regardless of retentionPolicy setting.
 
     STP Traceability: CNV-73509 (P2)
@@ -315,7 +311,7 @@ class TestStorageMigrationFailureRetentionPolicy:
     @pytest.mark.polarion("CNV-16309")
     def test_failed_migration_with_delete_source_policy(self):
         """
-        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=deleteSource. [NEGATIVE]
+        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=deleteSource.
 
         STP Requirement: Source volumes preserved on migration failure (P2)
 
@@ -330,15 +326,13 @@ class TestStorageMigrationFailureRetentionPolicy:
             5. Verify VM volume references
 
         Expected:
-            - Migration fails as expected
-            - Source PVC/DataVolume is retained (safety mechanism)
-            - VM continues running on original storage
+            - Source PVC/DataVolume is retained despite deleteSource policy
         """
 
     @pytest.mark.polarion("CNV-16310")
     def test_failed_migration_with_keep_source_policy(self):
         """
-        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=keepSource. [NEGATIVE]
+        Test that source PVC/DataVolume is retained when migration fails with retentionPolicy=keepSource.
 
         STP Requirement: Source volumes preserved on migration failure (P2)
 
@@ -353,15 +347,13 @@ class TestStorageMigrationFailureRetentionPolicy:
             5. Verify VM volume references
 
         Expected:
-            - Migration fails as expected
-            - Source PVC/DataVolume is retained (as per policy)
-            - VM continues running on original storage
+            - Source PVC/DataVolume is retained
         """
 
     @pytest.mark.polarion("CNV-16311")
     def test_failed_multi_namespace_migration_with_delete_source_policy(self):
         """
-        Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource. [NEGATIVE]
+        Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource.
 
         STP Requirement: Source volumes preserved on migration failure (P2)
 
@@ -376,7 +368,5 @@ class TestStorageMigrationFailureRetentionPolicy:
             5. Verify VM volume references
 
         Expected:
-            - Migration fails as expected
-            - All source PVCs/DataVolumes are retained (safety mechanism)
-            - VMs continue running on original storage
+            - All source PVCs/DataVolumes are retained despite deleteSource policies
         """

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -5,14 +5,12 @@ Tests verify the retentionPolicy field functionality, which controls whether sou
 are kept (keepSource) or deleted (deleteSource) after successful VM storage migration.
 
 The retentionPolicy field can be configured at:
-- Plan level (spec) for VirtualMachineStorageMigrationPlan (single namespace)
 - Namespace level for MultiNamespaceVirtualMachineStorageMigrationPlan
 - Plan level (spec) for MultiNamespaceVirtualMachineStorageMigrationPlan
 - Combination of namespace and plan level for MultiNamespaceVirtualMachineStorageMigrationPlan
   (namespace-level overrides plan-level when both are configured)
 
-STP Reference:
-https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/storage_mig_cleanup.md
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/storage_mig_cleanup.md
 """
 
 import pytest
@@ -133,62 +131,6 @@ class TestStorageMigrationRetentionPolicy:
 
         Expected:
             - Source PVC/DataVolume is kept
-        """
-
-
-class TestSingleNamespaceStorageMigrationRetentionPolicy:
-    """
-    Test retentionPolicy functionality for VirtualMachineStorageMigrationPlan (single namespace).
-
-    STP Traceability: CNV-73509 (P0)
-
-    Parametrize:
-        - migration_mode:
-            - online (VM running during migration)
-            - offline (VM stopped during migration)
-
-    Preconditions:
-      - VM with source PVC/DataVolume
-    """
-
-    @pytest.mark.polarion("CNV-16303")
-    def test_single_namespace_retention_policy_keep_source(self):
-        """
-        Test plan-level retentionPolicy=keepSource in single namespace plan.
-
-        STP Requirement: Plan-level cleanup policy (P0)
-
-        Preconditions:
-            - VM with source PVC/DataVolume
-
-        Steps:
-            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
-            2. Wait for migration to complete successfully
-            3. Verify VM is using new PVC/DataVolume
-            4. Check if source PVC/DataVolume exists
-
-        Expected:
-            - Source PVC/DataVolume is kept
-        """
-
-    @pytest.mark.polarion("CNV-16304")
-    def test_single_namespace_retention_policy_delete_source(self):
-        """
-        Test plan-level retentionPolicy=deleteSource in single namespace plan.
-
-        STP Requirement: Plan-level cleanup policy (P0)
-
-        Preconditions:
-            - VM with source PVC/DataVolume
-
-        Steps:
-            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
-            2. Wait for migration to complete successfully
-            3. Verify VM is using new PVC/DataVolume
-            4. Check if source PVC/DataVolume exists
-
-        Expected:
-            - Source PVC/DataVolume is deleted
         """
 
 
@@ -319,7 +261,7 @@ class TestStorageMigrationFailureRetentionPolicy:
             - VM with source PVC/DataVolume
 
         Steps:
-            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource and invalid target storage class
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource and invalid target storage class
             2. Wait for migration to fail
             3. Check migration status
             4. Check if source PVC/DataVolume exists
@@ -340,7 +282,7 @@ class TestStorageMigrationFailureRetentionPolicy:
             - VM with source PVC/DataVolume
 
         Steps:
-            1. Create VirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource and invalid target storage class
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource and invalid target storage class
             2. Wait for migration to fail
             3. Check migration status
             4. Check if source PVC/DataVolume exists
@@ -348,25 +290,4 @@ class TestStorageMigrationFailureRetentionPolicy:
 
         Expected:
             - Source PVC/DataVolume is retained
-        """
-
-    @pytest.mark.polarion("CNV-16311")
-    def test_failed_multi_namespace_migration_with_delete_source_policy(self):
-        """
-        Test that source PVCs are retained when MultiNamespace migration fails with retentionPolicy=deleteSource.
-
-        STP Requirement: Source volumes preserved on migration failure (P2)
-
-        Preconditions:
-            - Two VMs with source PVCs/DataVolumes in separate namespaces
-
-        Steps:
-            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource, namespace-level retentionPolicy=deleteSource for one namespace, and invalid target storage class
-            2. Wait for migration to fail
-            3. Check migration status for all VMs
-            4. Check if all source PVCs/DataVolumes exist
-            5. Verify VM volume references
-
-        Expected:
-            - All source PVCs/DataVolumes are retained despite deleteSource policies
         """

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -134,6 +134,127 @@ class TestStorageMigrationRetentionPolicy:
         """
 
 
+class TestStorageMigrationRetentionPolicyCombinedMode:
+    """
+    Test retentionPolicy functionality with combined online+offline migration mode.
+
+    Verifies retention policies when migrating both a running VM (online) and a stopped VM (offline)
+    in the same plan. Covers the online+offline migration mode required by the STP for default,
+    namespace-level, and plan-level retention policy scenarios.
+
+    STP Traceability: CNV-73509 (P0, P1)
+
+    Preconditions:
+      - Running VM (online migration) with source PVC/DataVolume
+      - Stopped VM (offline migration) with source PVC/DataVolume
+    """
+
+    @pytest.mark.polarion("CNV-TODO")
+    def test_retention_policy_default_behavior_combined_mode(self):
+        """
+        Test that default behavior is keepSource with combined online+offline migration.
+
+        STP Requirement: Default cleanup policy (P1)
+
+        Preconditions:
+            - Running VM (online migration) with source PVC/DataVolume
+            - Stopped VM (offline migration) with source PVC/DataVolume
+
+        Steps:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan without retentionPolicy field
+            2. Wait for migration to complete successfully for both VMs
+            3. Verify both VMs are using new PVCs/DataVolumes
+            4. Check if source PVCs/DataVolumes exist for both VMs
+
+        Expected:
+            - Source PVCs/DataVolumes are kept for both VMs (default keepSource behavior)
+        """
+
+    @pytest.mark.polarion("CNV-TODO")
+    def test_namespace_level_retention_policy_delete_source_combined_mode(self):
+        """
+        Test namespace-level retentionPolicy=deleteSource with combined online+offline migration.
+
+        STP Requirement: Namespace-level cleanup policy (P0)
+
+        Preconditions:
+            - Running VM (online migration) with source PVC/DataVolume
+            - Stopped VM (offline migration) with source PVC/DataVolume
+
+        Steps:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=deleteSource
+            2. Wait for migration to complete successfully for both VMs
+            3. Verify both VMs are using new PVCs/DataVolumes
+            4. Check if source PVCs/DataVolumes exist for both VMs
+
+        Expected:
+            - Source PVCs/DataVolumes are deleted for both VMs
+        """
+
+    @pytest.mark.polarion("CNV-TODO")
+    def test_namespace_level_retention_policy_keep_source_combined_mode(self):
+        """
+        Test namespace-level retentionPolicy=keepSource with combined online+offline migration.
+
+        STP Requirement: Namespace-level cleanup policy (P0)
+
+        Preconditions:
+            - Running VM (online migration) with source PVC/DataVolume
+            - Stopped VM (offline migration) with source PVC/DataVolume
+
+        Steps:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with namespace-level retentionPolicy=keepSource
+            2. Wait for migration to complete successfully for both VMs
+            3. Verify both VMs are using new PVCs/DataVolumes
+            4. Check if source PVCs/DataVolumes exist for both VMs
+
+        Expected:
+            - Source PVCs/DataVolumes are kept for both VMs
+        """
+
+    @pytest.mark.polarion("CNV-TODO")
+    def test_spec_level_retention_policy_delete_source_combined_mode(self):
+        """
+        Test plan-level retentionPolicy=deleteSource with combined online+offline migration.
+
+        STP Requirement: Plan-level cleanup policy (P0)
+
+        Preconditions:
+            - Running VM (online migration) with source PVC/DataVolume
+            - Stopped VM (offline migration) with source PVC/DataVolume
+
+        Steps:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=deleteSource
+            2. Wait for migration to complete successfully for both VMs
+            3. Verify both VMs are using new PVCs/DataVolumes
+            4. Check if source PVCs/DataVolumes exist for both VMs
+
+        Expected:
+            - Source PVCs/DataVolumes are deleted for both VMs
+        """
+
+    @pytest.mark.polarion("CNV-TODO")
+    def test_spec_level_retention_policy_keep_source_combined_mode(self):
+        """
+        Test plan-level retentionPolicy=keepSource with combined online+offline migration.
+
+        STP Requirement: Plan-level cleanup policy (P0)
+
+        Preconditions:
+            - Running VM (online migration) with source PVC/DataVolume
+            - Stopped VM (offline migration) with source PVC/DataVolume
+
+        Steps:
+            1. Create MultiNamespaceVirtualMachineStorageMigrationPlan with plan-level retentionPolicy=keepSource
+            2. Wait for migration to complete successfully for both VMs
+            3. Verify both VMs are using new PVCs/DataVolumes
+            4. Check if source PVCs/DataVolumes exist for both VMs
+
+        Expected:
+            - Source PVCs/DataVolumes are kept for both VMs
+        """
+
+
 class TestStorageMigrationCombinedRetentionPolicy:
     """
     Test combination of retentionPolicy for MultiNamespaceVirtualMachineStorageMigrationPlan.

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -15,8 +15,6 @@ STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob
 
 import pytest
 
-__test__ = False
-
 
 class TestStorageMigrationRetentionPolicy:
     """

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -68,9 +68,11 @@ class TestStorageMigrationRetentionPolicy:
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
             4. Check if source PVC/DataVolume exists
+            5. Verify MultiNamespaceVirtualMachineStorageMigrationPlan still exists
 
         Expected:
             - Source PVC/DataVolume is deleted
+            - MultiNamespaceVirtualMachineStorageMigrationPlan remains available after cleanup
         """
 
     @pytest.mark.polarion("CNV-16299")
@@ -88,9 +90,11 @@ class TestStorageMigrationRetentionPolicy:
             2. Wait for migration to complete successfully
             3. Verify VM is using new PVC/DataVolume
             4. Check if source PVC/DataVolume exists
+            5. Verify MultiNamespaceVirtualMachineStorageMigrationPlan still exists
 
         Expected:
             - Source PVC/DataVolume is deleted
+            - MultiNamespaceVirtualMachineStorageMigrationPlan remains available after cleanup
         """
 
     @pytest.mark.polarion("CNV-16301")
@@ -149,7 +153,7 @@ class TestStorageMigrationRetentionPolicyCombinedMode:
       - Stopped VM (offline migration) with source PVC/DataVolume
     """
 
-    @pytest.mark.polarion("CNV-TODO")
+    @pytest.mark.polarion("CNV-16558")
     def test_retention_policy_default_behavior_combined_mode(self):
         """
         Test that default behavior is keepSource with combined online+offline migration.
@@ -170,7 +174,7 @@ class TestStorageMigrationRetentionPolicyCombinedMode:
             - Source PVCs/DataVolumes are kept for both VMs (default keepSource behavior)
         """
 
-    @pytest.mark.polarion("CNV-TODO")
+    @pytest.mark.polarion("CNV-16559")
     def test_namespace_level_retention_policy_delete_source_combined_mode(self):
         """
         Test namespace-level retentionPolicy=deleteSource with combined online+offline migration.
@@ -186,12 +190,14 @@ class TestStorageMigrationRetentionPolicyCombinedMode:
             2. Wait for migration to complete successfully for both VMs
             3. Verify both VMs are using new PVCs/DataVolumes
             4. Check if source PVCs/DataVolumes exist for both VMs
+            5. Verify MultiNamespaceVirtualMachineStorageMigrationPlan still exists
 
         Expected:
             - Source PVCs/DataVolumes are deleted for both VMs
+            - MultiNamespaceVirtualMachineStorageMigrationPlan remains available after cleanup
         """
 
-    @pytest.mark.polarion("CNV-TODO")
+    @pytest.mark.polarion("CNV-16560")
     def test_namespace_level_retention_policy_keep_source_combined_mode(self):
         """
         Test namespace-level retentionPolicy=keepSource with combined online+offline migration.
@@ -212,7 +218,7 @@ class TestStorageMigrationRetentionPolicyCombinedMode:
             - Source PVCs/DataVolumes are kept for both VMs
         """
 
-    @pytest.mark.polarion("CNV-TODO")
+    @pytest.mark.polarion("CNV-16561")
     def test_spec_level_retention_policy_delete_source_combined_mode(self):
         """
         Test plan-level retentionPolicy=deleteSource with combined online+offline migration.
@@ -228,12 +234,14 @@ class TestStorageMigrationRetentionPolicyCombinedMode:
             2. Wait for migration to complete successfully for both VMs
             3. Verify both VMs are using new PVCs/DataVolumes
             4. Check if source PVCs/DataVolumes exist for both VMs
+            5. Verify MultiNamespaceVirtualMachineStorageMigrationPlan still exists
 
         Expected:
             - Source PVCs/DataVolumes are deleted for both VMs
+            - MultiNamespaceVirtualMachineStorageMigrationPlan remains available after cleanup
         """
 
-    @pytest.mark.polarion("CNV-TODO")
+    @pytest.mark.polarion("CNV-16562")
     def test_spec_level_retention_policy_keep_source_combined_mode(self):
         """
         Test plan-level retentionPolicy=keepSource with combined online+offline migration.
@@ -289,10 +297,12 @@ class TestStorageMigrationCombinedRetentionPolicy:
             2. Wait for all migrations to complete successfully
             3. Verify both VMs are using new PVCs
             4. Check if source PVCs exist in both namespaces
+            5. Verify MultiNamespaceVirtualMachineStorageMigrationPlan still exists
 
         Expected:
             - Source PVCs in namespace with namespace-level deleteSource policy are deleted
             - Source PVCs in namespace without namespace-level policy are kept (plan-level keepSource)
+            - MultiNamespaceVirtualMachineStorageMigrationPlan remains available after cleanup
         """
 
     @pytest.mark.polarion("CNV-16306")
@@ -311,10 +321,12 @@ class TestStorageMigrationCombinedRetentionPolicy:
             2. Wait for all migrations to complete successfully
             3. Verify both VMs are using new PVCs
             4. Check if source PVCs exist in both namespaces
+            5. Verify MultiNamespaceVirtualMachineStorageMigrationPlan still exists
 
         Expected:
             - Source PVCs in namespace with namespace-level keepSource policy are kept (namespace overrides plan)
             - Source PVCs in namespace without namespace-level policy are deleted (plan-level deleteSource)
+            - MultiNamespaceVirtualMachineStorageMigrationPlan remains available after cleanup
         """
 
     @pytest.mark.polarion("CNV-16307")
@@ -333,9 +345,11 @@ class TestStorageMigrationCombinedRetentionPolicy:
             2. Wait for all migrations to complete successfully
             3. Verify both VMs are using new PVCs
             4. Check if source PVCs exist in both namespaces
+            5. Verify MultiNamespaceVirtualMachineStorageMigrationPlan still exists
 
         Expected:
             - All source PVCs are deleted
+            - MultiNamespaceVirtualMachineStorageMigrationPlan remains available after cleanup
         """
 
     @pytest.mark.polarion("CNV-16308")

--- a/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
+++ b/tests/storage/storage_migration/test_storage_class_migration_cleanup.py
@@ -31,6 +31,8 @@ class TestStorageMigrationRetentionPolicy:
       - VM with source PVC/DataVolume
     """
 
+    __test__ = False
+
     @pytest.mark.polarion("CNV-16297")
     def test_retention_policy_default_behavior(self):
         """
@@ -150,6 +152,8 @@ class TestStorageMigrationRetentionPolicyCombinedMode:
       - Running VM (online migration) with source PVC/DataVolume
       - Stopped VM (offline migration) with source PVC/DataVolume
     """
+
+    __test__ = False
 
     @pytest.mark.polarion("CNV-16558")
     def test_retention_policy_default_behavior_combined_mode(self):
@@ -279,6 +283,8 @@ class TestStorageMigrationCombinedRetentionPolicy:
 
     """
 
+    __test__ = False
+
     @pytest.mark.polarion("CNV-16305")
     def test_namespace_delete_overrides_plan_keep(self):
         """
@@ -382,6 +388,8 @@ class TestStorageMigrationFailureRetentionPolicy:
     Preconditions:
       - VM with source PVC/DataVolume
     """
+
+    __test__ = False
 
     @pytest.mark.polarion("CNV-16309")
     def test_failed_migration_with_delete_source_policy(self):


### PR DESCRIPTION
##### What this PR does / why we need it:
Introduce STD for storage migration cleanup feature which allows the system to optionally decommission migration plans and legacy PVCs upon successful completion.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-81264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added documentation-only coverage for source retention behavior during virtual machine storage migrations.
  * Documented default, namespace-level, and plan-level retention policies, including precedence and matching configurations.
  * Covered combined online and offline migration modes and source resource retention after successful migrations.
  * Documented source resource retention after failed migrations, regardless of the configured policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->