### PR TITLE
docs: add timeout mismatch pattern to AI classification guidance

### DIFF
--- a/JOB_INSIGHT_PROMPT.md
+++ b/JOB_INSIGHT_PROMPT.md
@@ -244,6 +244,19 @@ Pattern guidance:
   cleanup blocked by infrastructure is `INFRASTRUCTURE`
 - **Console access failure:** Wrong `pexpect` patterns or timeouts in test is
   `CODE ISSUE`; `virtctl console` unable to connect to a healthy VMI is `PRODUCT BUG`
+- **Timeout mismatch with product code:** When a test uses `TimeoutSampler` or
+  `wait_for_status` to wait for a product-initiated operation (e.g., pod creation by
+  `virtctl`, DataVolume import by CDI), compare the test's timeout against the
+  product's own internal timeout for the SAME operation. If the product allows a
+  significantly longer wait (e.g., product waits 500s but test waits 60s), the test
+  timeout is too aggressive — classify as `CODE ISSUE`, not `PRODUCT BUG`. The product
+  defines what is a reasonable wait time for its own operations. To verify: read the
+  product source code for the operation being tested and find its timeout constant.
+  Example: `virtctl guestfs` internally waits 500s for the libguestfs pod to reach
+  Running (`pkg/virtctl/guestfs/guestfs.go`), but a test that only waits 60s
+  (`TIMEOUT_1MIN`) for the same pod is a test timeout issue — the pod may need time
+  for image pull, scheduling, or volume attach, all within the product's expected
+  tolerance.
 
 ### Jira Search Keyword Guidance
 


### PR DESCRIPTION
## What

Adds a new pattern to the "Exception and Pattern Signals" section of `JOB_INSIGHT_PROMPT.md`:

**Timeout mismatch with product code** — When a test waits for a product-initiated operation (e.g., pod creation by `virtctl`, DataVolume import by CDI), the AI should compare the test's timeout against the product's own internal timeout for the same operation. If the product allows a significantly longer wait, the test timeout is too aggressive — classify as `CODE ISSUE`, not `PRODUCT BUG`.

## Why

We observed the same test (`test_virtctl_libguestfs_with_specific_user`) being classified as `PRODUCT BUG` in one build and `CODE ISSUE` in another, with identical error signatures. Root cause investigation revealed:

- The test uses `TIMEOUT_1MIN` (60s) to wait for the libguestfs pod to reach Running
- The product (`virtctl guestfs` in `kubevirt/pkg/virtctl/guestfs/guestfs.go`) uses `timeout = 500 * time.Second` (500s) for the same operation
- The pod sometimes takes >60s due to image pull on cold nodes, causing flaky failures
- The 8x gap between test timeout (60s) and product timeout (500s) is the root cause

Without this guidance, the AI has no rule to check product-side timeouts, leading to inconsistent classifications.

## Example

| Build | Classification | Correct? |
|-------|---------------|----------|
| #41 | PRODUCT BUG | ❌ |
| #39 | CODE ISSUE | ✅ |

Both had the same error: `TimeoutExpiredError: Timed Out: 60` waiting for the libguestfs pod. The correct classification is `CODE ISSUE` — the test timeout is too aggressive for the product's expected operation time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for properly identifying and classifying timeout-related test failures based on product expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->