### PR TITLE
net, IPv6: Adjust upgrade tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ from timeout_sampler import TimeoutSampler
 
 import utilities.hco
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
-from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
+from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
 from libs.net.vmspec import lookup_iface_status
 from tests.utils import download_and_extract_tar
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
@@ -1664,16 +1664,7 @@ def running_vm_upgrade_a(
 ):
     name = "vm-upgrade-a"
     cloud_init_data = cloud_init_network_data(
-        data={
-            "ethernets": {
-                "eth1": {
-                    "addresses": [
-                        f"{random_ipv4_address(net_seed=0, host_address=1)}/24",
-                        f"{random_ipv6_address(net_seed=0, host_address=1)}/64",
-                    ]
-                }
-            }
-        }
+        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=1)}}}
     )
     with VirtualMachineForTests(
         name=name,
@@ -1708,16 +1699,7 @@ def running_vm_upgrade_b(
 ):
     name = "vm-upgrade-b"
     cloud_init_data = cloud_init_network_data(
-        data={
-            "ethernets": {
-                "eth1": {
-                    "addresses": [
-                        f"{random_ipv4_address(net_seed=0, host_address=2)}/24",
-                        f"{random_ipv6_address(net_seed=0, host_address=2)}/64",
-                    ]
-                }
-            }
-        }
+        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=2)}}}
     )
     with VirtualMachineForTests(
         name=name,


### PR DESCRIPTION
##### What this PR does / why we need it:
IPv6 address is assigned regardless of cluster's network IP stack which leads to setup error in `test_linux_bridge_before_upgrade` when upgrade tests run on IPv4 single-stack cluster:

```
libs.net.vmspec.VMInterfaceStatusNotFoundError:
Network interface named upg-br-mark was not found in VM vm-upgrade-a-1782056057-1819053.
```

##### Which issue(s) this PR fixes:
This change includes IP address assignment according to cluster's network IP stack

##### Special notes for reviewer: -

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-90808
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined network address generation in test fixtures by consolidating IPv4 and IPv6 logic into a single unified helper function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->