### PR TITLE
[Storage] Increase libguestfs pod timeout

### DIFF
--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -1,3 +1,9 @@
+"""
+Test virtctl guestfs command with specific user.
+
+Jira: https://redhat.atlassian.net/browse/CNV-7487 # <skip-jira-utils-check>
+"""
+
 from subprocess import check_output
 
 import pexpect
@@ -5,7 +11,7 @@ import pytest
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
-from utilities.constants import TIMEOUT_1MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
+from utilities.constants import TIMEOUT_1MIN, TIMEOUT_10MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
 from utilities.infra import login_with_user_password
 from utilities.storage import create_dv, get_dv_size_from_datasource
 
@@ -23,10 +29,11 @@ def virtctl_libguestfs_by_user(
         {fs_group_flag}"
     )
     libguestfs_pod = Pod(
+        client=unprivileged_client,
         name=f"libguestfs-tools-{dv_created_by_specific_user.name}",
         namespace=dv_created_by_specific_user.namespace,
     )
-    libguestfs_pod.wait_for_status(status=Pod.Status.RUNNING, timeout=TIMEOUT_1MIN)
+    libguestfs_pod.wait_for_status(status=Pod.Status.RUNNING, timeout=TIMEOUT_10MIN)
     guestfs_proc.send("\n\n")
     guestfs_proc.expect(r"\$", timeout=TIMEOUT_1MIN)
     yield guestfs_proc


### PR DESCRIPTION
##### What this PR does / why we need it:
Increase the timeout from TIMEOUT_1MIN (60s) to TIMEOUT_10MIN (600s) to match the product's own 500-second timeout for the libguestfs pod to reach Running state. The product code at [pkg/virtctl/guestfs/guestfs.go](https://github.com/kubevirt/kubevirt/blob/759a3049c9d1fad35bdb06205207aec277f6b112/pkg/virtctl/guestfs/guestfs.go#L67) defines timeout = 500 * time.Second for this same operation.

##### Which issue(s) this PR fixes:
Test failures on different lanes.

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
CNV-62312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of pod readiness checks by increasing the wait timeout when using `libguestfs-tools-*` in the `virtctl_libguestfs_by_user` fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->