### PR TITLE
Remove CNV-86102 xfail workaround for virt-platform-autopilot priority class

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -283,11 +283,6 @@ def jira_76659_open():
     return is_jira_open(jira_id="CNV-76659")
 
 
-@pytest.fixture(scope="session")
-def jira_86102_open():
-    return is_jira_open(jira_id="CNV-86102")
-
-
 @pytest.fixture()
 def expected_value(request, is_s390x_cluster):
     expected = request.param.copy()

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -11,7 +11,6 @@ from utilities.constants import (
     HCO_OPERATOR,
     HCO_WEBHOOK,
     HPP_POOL,
-    VIRT_PLATFORM_AUTOPILOT,
 )
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
@@ -71,12 +70,9 @@ def test_request_param(deployment_by_name, cpu_min_value):
 def test_cnv_deployment_priority_class_name(
     cnv_deployment_by_name,
     xfail_if_jira_76659_open_and_migration_controller_deployment,
-    jira_86102_open,
 ):
     if cnv_deployment_by_name.name.startswith(HPP_POOL):
         pytest.xfail("HPP pool deployment doesn't have priority class name")
-    elif cnv_deployment_by_name.name == VIRT_PLATFORM_AUTOPILOT and jira_86102_open:
-        pytest.xfail(f"{VIRT_PLATFORM_AUTOPILOT} deployment has no priority class name due to CNV-86102 bug")
     elif not cnv_deployment_by_name.instance.spec.template.spec.priorityClassName:
         pytest.fail(
             f"For cnv deployment {cnv_deployment_by_name.name}, spec.template.spec.priorityClassName has not been set."

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -15,7 +15,6 @@ from utilities.constants import (
     HOSTPATH_PROVISIONER_CSI,
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
-    VIRT_PLATFORM_AUTOPILOT,
 )
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
@@ -52,12 +51,9 @@ def test_no_new_cnv_pods_added(cnv_pods, cnv_jobs):
 def test_pods_priority_class_value(
     cnv_pods_by_type,
     xfail_if_jira_76659_open_and_migration_controller_pod,
-    jira_86102_open,
 ):
     if any(pod.name.startswith((HPP_POOL, HOSTPATH_PROVISIONER_CSI)) for pod in cnv_pods_by_type):
         pytest.xfail("HPP pods don't have priority class name")
-    if any(pod.name.startswith(VIRT_PLATFORM_AUTOPILOT) for pod in cnv_pods_by_type) and jira_86102_open:
-        pytest.xfail(f"{VIRT_PLATFORM_AUTOPILOT} pod has no priority class name due to CNV-86102 bug")
     validate_cnv_pods_priority_class_name_exists(pod_list=cnv_pods_by_type)
     validate_priority_class_value(pod_list=cnv_pods_by_type)
 


### PR DESCRIPTION
##### What this PR does / why we need it:

[CNV-86102](https://redhat.atlassian.net/browse/CNV-86102) reported that `virt-platform-autopilot` deployment didn't have a priority class set. The bug is now resolved (ON_QA), so we remove the `xfail` workarounds that were skipping priority class validation for this component.

**Changes:**
- Remove `jira_86102_open` session fixture from `tests/install_upgrade_operators/conftest.py`
- Remove xfail guard for `virt-platform-autopilot` in `test_cnv_deployment_priority_class_name`
- Remove xfail guard for `virt-platform-autopilot` in `test_pods_priority_class_value`
- Clean up unused `VIRT_PLATFORM_AUTOPILOT` imports

Tests will now properly validate that `virt-platform-autopilot` has a priority class set.

##### Which issue(s) this PR fixes:

CNV-86102

##### Special notes for reviewer:

##### jira-ticket:

CNV-86102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed test fixture and references related to a resolved issue.
  * Simplified deployment and pod validation tests by removing associated platform-specific checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->