### PR TITLE
refactor(iuo): migrate iuo and observability imports to submodules

### DIFF
--- a/tests/install_upgrade_operators/cert_renewal/conftest.py
+++ b/tests/install_upgrade_operators/cert_renewal/conftest.py
@@ -19,7 +19,10 @@ from tests.install_upgrade_operators.constants import (
     HCO_CR_CERT_CONFIG_KEY,
     HCO_CR_CERT_CONFIG_SERVER_KEY,
 )
-from utilities.constants import TIMEOUT_1MIN, TIMEOUT_11MIN
+from utilities.constants.timeouts import (
+    TIMEOUT_1MIN,
+    TIMEOUT_11MIN,
+)
 from utilities.hco import ResourceEditorValidateHCOReconcile, wait_for_hco_conditions
 from utilities.jira import is_jira_open
 

--- a/tests/install_upgrade_operators/cert_renewal/constants.py
+++ b/tests/install_upgrade_operators/cert_renewal/constants.py
@@ -1,4 +1,4 @@
-from utilities.constants import VIRT_TEMPLATE_VALIDATOR
+from utilities.constants.components import VIRT_TEMPLATE_VALIDATOR
 
 VIRT_TEMPLATE_VALIDATOR_CERTS = f"{VIRT_TEMPLATE_VALIDATOR}-certs"
 SSP_OPERATOR_SERVICE_CERT = "ssp-operator-service-cert"

--- a/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
+++ b/tests/install_upgrade_operators/cert_renewal/test_cert_renewal.py
@@ -10,7 +10,7 @@ from tests.install_upgrade_operators.constants import (
     HCO_CR_CERT_CONFIG_DURATION_KEY,
     HCO_CR_CERT_CONFIG_RENEW_BEFORE_KEY,
 )
-from utilities.constants import QUARANTINED
+from utilities.constants.pytest import QUARANTINED
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]
 

--- a/tests/install_upgrade_operators/cert_renewal/utils.py
+++ b/tests/install_upgrade_operators/cert_renewal/utils.py
@@ -17,7 +17,11 @@ from tests.install_upgrade_operators.cert_renewal.constants import (
     VIRT_TEMPLATE_VALIDATOR_CERTS,
 )
 from tests.install_upgrade_operators.constants import KUBEMACPOOL_SERVICE
-from utilities.constants import TIMEOUT_2MIN, TIMEOUT_10MIN, TIMEOUT_20SEC
+from utilities.constants.timeouts import (
+    TIMEOUT_2MIN,
+    TIMEOUT_10MIN,
+    TIMEOUT_20SEC,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -27,7 +27,11 @@ from tests.install_upgrade_operators.utils import (
     get_resource_by_name,
     get_resource_from_module_name,
 )
-from utilities.constants import HOSTPATH_PROVISIONER_CSI, HPP_POOL, MULTIARCH
+from utilities.constants.architecture import MULTIARCH
+from utilities.constants.components import (
+    HOSTPATH_PROVISIONER_CSI,
+    HPP_POOL,
+)
 from utilities.hco import ResourceEditorValidateHCOReconcile, get_hco_version
 from utilities.infra import (
     get_daemonset_by_name,

--- a/tests/install_upgrade_operators/console_cli_download/conftest.py
+++ b/tests/install_upgrade_operators/console_cli_download/conftest.py
@@ -6,7 +6,7 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.route import Route
 
 from tests.install_upgrade_operators.console_cli_download.utils import validate_custom_cli_downloads_urls_updated
-from utilities.constants import (
+from utilities.constants.components import (
     HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD,
     VIRTCTL_CLI_DOWNLOADS,
 )

--- a/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
+++ b/tests/install_upgrade_operators/console_cli_download/test_disconnected_virtctl.py
@@ -4,7 +4,7 @@ import re
 import pytest
 from pyhelper_utils.shell import run_command
 
-from utilities.constants import AMD_64
+from utilities.constants.architecture import AMD_64
 from utilities.infra import get_machine_platform
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.gating, pytest.mark.s390x, pytest.mark.conformance]

--- a/tests/install_upgrade_operators/console_cli_download/utils.py
+++ b/tests/install_upgrade_operators/console_cli_download/utils.py
@@ -3,7 +3,11 @@ import logging
 from kubernetes.dynamic import DynamicClient
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import TIMEOUT_1MIN, TIMEOUT_5SEC, VIRTCTL_CLI_DOWNLOADS
+from utilities.constants.components import VIRTCTL_CLI_DOWNLOADS
+from utilities.constants.timeouts import (
+    TIMEOUT_1MIN,
+    TIMEOUT_5SEC,
+)
 from utilities.infra import get_console_spec_links
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
+++ b/tests/install_upgrade_operators/crds_cluster_readers_role/test_crds_cluster_readers_role.py
@@ -8,7 +8,11 @@ from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.resource import Resource
 from timeout_sampler import retry
 
-from utilities.constants import BASE_EXCEPTIONS_DICT, TIMEOUT_3MIN, TIMEOUT_10SEC
+from utilities.constants.cluster import BASE_EXCEPTIONS_DICT
+from utilities.constants.timeouts import (
+    TIMEOUT_3MIN,
+    TIMEOUT_10SEC,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/crypto_policy/conftest.py
+++ b/tests/install_upgrade_operators/crypto_policy/conftest.py
@@ -40,15 +40,15 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
     get_services_pqc_status,
     update_apiserver_crypto_policy,
 )
-from utilities.constants import (
+from utilities.constants.components import (
     CDI_KUBEVIRT_HYPERCONVERGED,
     CLUSTER,
     KUBEVIRT_HCO_NAME,
     MIGCONTROLLER_KUBEVIRT_HYPERCONVERGED,
     SSP_KUBEVIRT_HYPERCONVERGED,
-    TIMEOUT_60MIN,
-    TLS_SECURITY_PROFILE,
 )
+from utilities.constants.hco import TLS_SECURITY_PROFILE
+from utilities.constants.timeouts import TIMEOUT_60MIN
 from utilities.exceptions import MissingResourceException
 from utilities.hco import enabled_aaq_in_hco, update_hco_annotations, wait_for_hco_conditions
 from utilities.infra import ExecCommandOnPod

--- a/tests/install_upgrade_operators/crypto_policy/constants.py
+++ b/tests/install_upgrade_operators/crypto_policy/constants.py
@@ -9,7 +9,10 @@ from ocp_resources.network_addons_config import NetworkAddonsConfig
 from ocp_resources.ssp import SSP
 
 from tests.install_upgrade_operators.constants import KEY_PATH_SEPARATOR
-from utilities.constants import TLS_CUSTOM_POLICY, TLS_OLD_POLICY
+from utilities.constants.hco import (
+    TLS_CUSTOM_POLICY,
+    TLS_OLD_POLICY,
+)
 
 MANAGED_CRS_LIST = [KubeVirt, CDI, NetworkAddonsConfig, SSP]
 MANAGED_CRS_LIST_WITH_AAQ = [*MANAGED_CRS_LIST, AAQ]

--- a/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_crypto_policy_default.py
@@ -24,13 +24,13 @@ from tests.install_upgrade_operators.crypto_policy.constants import (
 from tests.install_upgrade_operators.crypto_policy.utils import (
     assert_tls_version_connection,
 )
-from utilities.constants import (
+from utilities.constants.components import (
     CDI_KUBEVIRT_HYPERCONVERGED,
     CLUSTER,
     KUBEVIRT_HCO_NAME,
     SSP_KUBEVIRT_HYPERCONVERGED,
-    TLS_SECURITY_PROFILE,
 )
+from utilities.constants.hco import TLS_SECURITY_PROFILE
 
 LOGGER = logging.getLogger(__name__)
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
@@ -12,7 +12,7 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
     assert_crypto_policy_propagated_to_components,
     set_hco_crypto_policy,
 )
-from utilities.constants import TLS_SECURITY_PROFILE
+from utilities.constants.hco import TLS_SECURITY_PROFILE
 
 LOGGER = logging.getLogger(__name__)
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.s390x]

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -8,7 +8,10 @@ from tests.install_upgrade_operators.crypto_policy.constants import (
     MANAGED_CRS_LIST,
     TLS_CUSTOM_PROFILE,
 )
-from utilities.constants import TLS_CUSTOM_POLICY, TLS_SECURITY_PROFILE
+from utilities.constants.hco import (
+    TLS_CUSTOM_POLICY,
+    TLS_SECURITY_PROFILE,
+)
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
@@ -12,7 +12,10 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
     set_hco_crypto_policy,
     update_apiserver_crypto_policy,
 )
-from utilities.constants import TIMEOUT_2MIN, TIMEOUT_10SEC
+from utilities.constants.timeouts import (
+    TIMEOUT_2MIN,
+    TIMEOUT_10SEC,
+)
 
 LOGGER = logging.getLogger(__name__)
 pytestmark = pytest.mark.tier3

--- a/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
@@ -8,7 +8,7 @@ import logging
 
 import pytest
 
-from utilities.constants import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
+from utilities.constants.components import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
 
 LOGGER = logging.getLogger(__name__)
 pytestmark = pytest.mark.post_upgrade

--- a/tests/install_upgrade_operators/crypto_policy/test_tls_profile_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_tls_profile_propagation.py
@@ -13,7 +13,7 @@ from tests.install_upgrade_operators.crypto_policy.constants import (
     TLS_VERSION_1_3,
 )
 from tests.install_upgrade_operators.crypto_policy.utils import check_service_accepts_tls_version
-from utilities.constants import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
+from utilities.constants.components import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
 
 LOGGER = logging.getLogger(__name__)
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.tier3]

--- a/tests/install_upgrade_operators/crypto_policy/test_update_api_server.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_api_server.py
@@ -14,7 +14,10 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
     assert_tls_ciphers_blocked,
     assert_tls_version_connection,
 )
-from utilities.constants import TLS_CUSTOM_POLICY, TLS_OLD_POLICY
+from utilities.constants.hco import (
+    TLS_CUSTOM_POLICY,
+    TLS_OLD_POLICY,
+)
 
 pytestmark = pytest.mark.tier3
 

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -20,13 +20,15 @@ from tests.install_upgrade_operators.crypto_policy.constants import (
 from tests.install_upgrade_operators.crypto_policy.utils import (
     get_resources_crypto_policy_dict,
 )
-from utilities.constants import (
+from utilities.constants.hco import (
     DEFAULT_HCO_CONDITIONS,
-    TIMEOUT_5MIN,
-    TIMEOUT_10SEC,
     TLS_CUSTOM_POLICY,
     TLS_OLD_POLICY,
     TLS_SECURITY_PROFILE,
+)
+from utilities.constants.timeouts import (
+    TIMEOUT_5MIN,
+    TIMEOUT_10SEC,
 )
 from utilities.hco import (
     is_hco_tainted,

--- a/tests/install_upgrade_operators/crypto_policy/utils.py
+++ b/tests/install_upgrade_operators/crypto_policy/utils.py
@@ -30,11 +30,11 @@ from tests.install_upgrade_operators.utils import (
     get_resource_by_name,
     get_resource_key_value,
 )
-from utilities.constants import (
-    CLUSTER,
+from utilities.constants.components import CLUSTER
+from utilities.constants.hco import TLS_SECURITY_PROFILE
+from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
     TIMEOUT_60MIN,
-    TLS_SECURITY_PROFILE,
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile, wait_for_hco_conditions
 from utilities.infra import ExecCommandOnPod

--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -8,7 +8,7 @@ from pytest_testconfig import config as py_config
 from tests.install_upgrade_operators.csv.csv_permissions_audit.utils import (
     get_csv_permissions,
 )
-from utilities.constants import (
+from utilities.constants.components import (
     AAQ_OPERATOR,
     CDI_OPERATOR,
     CLUSTER_NETWORK_ADDONS_OPERATOR,

--- a/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
+++ b/tests/install_upgrade_operators/daemonset/test_daemonset_params.py
@@ -1,6 +1,9 @@
 import pytest
 
-from utilities.constants import ALL_CNV_DAEMONSETS, HOSTPATH_PROVISIONER_CSI
+from utilities.constants.components import (
+    ALL_CNV_DAEMONSETS,
+    HOSTPATH_PROVISIONER_CSI,
+)
 from utilities.infra import get_daemonsets
 
 pytestmark = [

--- a/tests/install_upgrade_operators/deployment/conftest.py
+++ b/tests/install_upgrade_operators/deployment/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 
-from utilities.constants import HPP_POOL, KUBEVIRT_MIGRATION_CONTROLLER
+from utilities.constants.components import (
+    HPP_POOL,
+    KUBEVIRT_MIGRATION_CONTROLLER,
+)
 from utilities.infra import get_deployment_by_name, get_deployments
 
 

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -6,7 +6,7 @@ from tests.install_upgrade_operators.deployment.utils import (
     validate_liveness_probe_fields,
     validate_request_fields,
 )
-from utilities.constants import (
+from utilities.constants.components import (
     ALL_CNV_DEPLOYMENTS,
     HCO_OPERATOR,
     HCO_WEBHOOK,

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -14,7 +14,7 @@ from tests.install_upgrade_operators.constants import (
     RESOURCE_TYPE_STR,
 )
 from tests.install_upgrade_operators.utils import get_resource_key_value
-from utilities.constants import (
+from utilities.constants.components import (
     CDI_KUBEVIRT_HYPERCONVERGED,
     KUBEVIRT_KUBEVIRT_HYPERCONVERGED,
 )

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -7,7 +7,8 @@ from tests.install_upgrade_operators.constants import (
     FEATUREGATES,
     FG_ENABLED,
 )
-from utilities.constants import QUARANTINED, VALUE_STR
+from utilities.constants.cluster import VALUE_STR
+from utilities.constants.pytest import QUARANTINED
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 FEATUREGATE_NAME_KEY_STR = "featuregate_name"

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -10,9 +10,9 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     get_random_minutes_hours_fields_from_data_import_schedule,
     get_templates_by_type_from_hco_status,
 )
-from utilities.constants import (
+from utilities.constants.components import HCO_OPERATOR
+from utilities.constants.hco import (
     COMMON_TEMPLATES_KEY_NAME,
-    HCO_OPERATOR,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
 )
 from utilities.ssp import get_ssp_resource

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -14,7 +14,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     COMMON_TEMPLATE,
     get_templates_by_type_from_hco_status,
 )
-from utilities.constants import (
+from utilities.constants.timeouts import (
     TIMEOUT_3MIN,
     TIMEOUT_10MIN,
 )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_defaults.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from utilities.constants import SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME
+from utilities.constants.hco import SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME
 
 pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x, pytest.mark.conformance]
 

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_enable_common_boot_image_import.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from utilities.constants import (
+from utilities.constants.hco import (
     COMMON_TEMPLATES_KEY_NAME,
     ENABLE_COMMON_BOOT_IMAGE_IMPORT,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -14,12 +14,12 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     get_modifed_common_template_names,
     get_template_dict_by_name,
 )
-from utilities.constants import (
+from utilities.constants.hco import (
     DATA_IMPORT_CRON_ENABLE,
-    QUARANTINED,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
-    WILDCARD_CRON_EXPRESSION,
 )
+from utilities.constants.pytest import QUARANTINED
+from utilities.constants.storage import WILDCARD_CRON_EXPRESSION
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 pytestmark = [pytest.mark.gating, pytest.mark.arm64, pytest.mark.s390x]

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_negative_config.py
@@ -15,7 +15,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     CUSTOM_CRON_TEMPLATE,
     get_template_dict_by_name,
 )
-from utilities.constants import (
+from utilities.constants.hco import (
     DATA_IMPORT_CRON_ENABLE,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
 )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_non_defaults.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utilities.constants import (
+from utilities.constants.hco import (
     COMMON_TEMPLATES_KEY_NAME,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
 )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_update_hco_cr.py
@@ -10,7 +10,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     get_template_dict_by_name,
     get_templates_by_type_from_hco_status,
 )
-from utilities.constants import QUARANTINED
+from utilities.constants.pytest import QUARANTINED
 from utilities.hco import (
     update_hco_templates_spec,
     wait_for_auto_boot_config_stabilization,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -6,9 +6,9 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.data_import_cron import DataImportCron
 
 from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME
-from utilities.constants import (
+from utilities.constants.hco import SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME
+from utilities.constants.storage import (
     OUTDATED,
-    SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
     WILDCARD_CRON_EXPRESSION,
 )
 

--- a/tests/install_upgrade_operators/json_patch/utils.py
+++ b/tests/install_upgrade_operators/json_patch/utils.py
@@ -4,7 +4,10 @@ from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.install_upgrade_operators.json_patch.constants import DISABLE_TLS, PATH_CDI
-from utilities.constants import TIMEOUT_5MIN, TIMEOUT_30SEC
+from utilities.constants.timeouts import (
+    TIMEOUT_5MIN,
+    TIMEOUT_30SEC,
+)
 from utilities.hco import HCO_JSONPATCH_ANNOTATION_COMPONENT_DICT
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/install_upgrade_operators/launcher_updates/constants.py
+++ b/tests/install_upgrade_operators/launcher_updates/constants.py
@@ -1,7 +1,7 @@
 import copy
 
 from tests.install_upgrade_operators.constants import WORKLOAD_UPDATE_STRATEGY_KEY_NAME, WORKLOADUPDATEMETHODS
-from utilities.constants import LIVE_MIGRATE
+from utilities.constants.virt import LIVE_MIGRATE
 
 DEFAULT_BATCH_EVICTION_INTERVAL = "1m0s"
 DEFAULT_BATCH_EVICTION_SIZE = 10

--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -21,7 +21,8 @@ from tests.install_upgrade_operators.must_gather.utils import (
     get_must_gather_dir,
 )
 from tests.utils import create_vms
-from utilities.constants import LINUX_BRIDGE, TIMEOUT_40MIN
+from utilities.constants.networking import LINUX_BRIDGE
+from utilities.constants.timeouts import TIMEOUT_40MIN
 from utilities.exceptions import MissingResourceException
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import (

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -27,16 +27,18 @@ from tests.install_upgrade_operators.must_gather.utils import (
     compare_resource_contents,
     compare_webhook_svc_contents,
 )
-from utilities.constants import (
-    ALL_CNV_CRDS,
+from utilities.constants.components import (
     BRIDGE_MARKER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
     KUBE_CNI_LINUX_BRIDGE_PLUGIN,
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
-    KUBEMACPOOL_MAC_RANGE_CONFIG,
-    VM_CRD,
-    NamespacesNames,
 )
+from utilities.constants.hco import (
+    ALL_CNV_CRDS,
+    VM_CRD,
+)
+from utilities.constants.namespaces import NamespacesNames
+from utilities.constants.networking import KUBEMACPOOL_MAC_RANGE_CONFIG
 from utilities.must_gather import get_must_gather_output_file
 
 pytestmark = [

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_images.py
@@ -7,7 +7,7 @@ from tests.install_upgrade_operators.must_gather.utils import (
     VALIDATE_UID_NAME,
     check_list_of_resources,
 )
-from utilities.constants import NamespacesNames
+from utilities.constants.namespaces import NamespacesNames
 
 pytestmark = [
     pytest.mark.sno,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -31,7 +31,8 @@ from tests.install_upgrade_operators.must_gather.utils import (
     validate_no_empty_files_collected_must_gather_vm,
 )
 from tests.os_params import FEDORA_LATEST
-from utilities.constants import ARM_64, COUNT_FIVE
+from utilities.constants.architecture import ARM_64
+from utilities.constants.cluster import COUNT_FIVE
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.skip_must_gather_collection, pytest.mark.arm64, pytest.mark.s390x]
 

--- a/tests/install_upgrade_operators/must_gather/utils.py
+++ b/tests/install_upgrade_operators/must_gather/utils.py
@@ -13,7 +13,8 @@ from ocp_resources.resource import Resource
 from ocp_resources.service import Service
 
 from tests.install_upgrade_operators.relationship_labels.constants import PART_OF_LABEL_KEY
-from utilities.constants import HCO_PART_OF_LABEL_VALUE, NamespacesNames
+from utilities.constants.components import HCO_PART_OF_LABEL_VALUE
+from utilities.constants.namespaces import NamespacesNames
 from utilities.data_collector import get_data_collector_base_directory
 from utilities.exceptions import ResourceMismatch
 

--- a/tests/install_upgrade_operators/node_component/conftest.py
+++ b/tests/install_upgrade_operators/node_component/conftest.py
@@ -10,22 +10,24 @@ from tests.install_upgrade_operators.node_component.utils import (
     wait_for_pod_node_selector_clean_up,
 )
 from tests.install_upgrade_operators.utils import get_network_addon_config
-from utilities.constants import (
+from utilities.constants.components import (
     BRIDGE_MARKER,
     CDI_APISERVER,
     CDI_DEPLOYMENT,
     CDI_UPLOADPROXY,
-    HCO_SUBSCRIPTION,
     HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD,
-    IMAGE_CRON_STR,
     KUBE_CNI_LINUX_BRIDGE_PLUGIN,
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
-    TIMEOUT_5MIN,
     VIRT_API,
     VIRT_CONTROLLER,
     VIRT_HANDLER,
     VIRT_TEMPLATE_VALIDATOR,
 )
+from utilities.constants.hco import (
+    HCO_SUBSCRIPTION,
+    IMAGE_CRON_STR,
+)
+from utilities.constants.timeouts import TIMEOUT_5MIN
 from utilities.hco import add_labels_to_nodes, apply_np_changes, wait_for_hco_conditions
 from utilities.infra import (
     get_daemonset_by_name,

--- a/tests/install_upgrade_operators/node_component/utils.py
+++ b/tests/install_upgrade_operators/node_component/utils.py
@@ -7,7 +7,11 @@ from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import (
+from utilities.constants.cluster import (
+    NODE_ROLE_KUBERNETES_IO,
+    WORKER_NODE_LABEL_KEY,
+)
+from utilities.constants.components import (
     BRIDGE_MARKER,
     CDI_APISERVER,
     CDI_DEPLOYMENT,
@@ -17,27 +21,27 @@ from utilities.constants import (
     HCO_OPERATOR,
     HCO_WEBHOOK,
     HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD,
-    IMAGE_CRON_STR,
     KUBE_CNI_LINUX_BRIDGE_PLUGIN,
     KUBEMACPOOL_CERT_MANAGER,
     KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
     KUBEVIRT_APISERVER_PROXY,
     KUBEVIRT_CONSOLE_PLUGIN,
     KUBEVIRT_IPAM_CONTROLLER_MANAGER,
-    NODE_ROLE_KUBERNETES_IO,
     SSP_OPERATOR,
-    TIMEOUT_4MIN,
-    TIMEOUT_5MIN,
-    TIMEOUT_5SEC,
-    TIMEOUT_10MIN,
-    TIMEOUT_30SEC,
     VIRT_API,
     VIRT_CONTROLLER,
     VIRT_EXPORTPROXY,
     VIRT_HANDLER,
     VIRT_OPERATOR,
     VIRT_TEMPLATE_VALIDATOR,
-    WORKER_NODE_LABEL_KEY,
+)
+from utilities.constants.hco import IMAGE_CRON_STR
+from utilities.constants.timeouts import (
+    TIMEOUT_4MIN,
+    TIMEOUT_5MIN,
+    TIMEOUT_5SEC,
+    TIMEOUT_10MIN,
+    TIMEOUT_30SEC,
 )
 from utilities.hco import wait_for_hco_post_update_stable_state
 

--- a/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
+++ b/tests/install_upgrade_operators/pod_security/test_pod_security_audit_log.py
@@ -3,7 +3,10 @@ from collections import defaultdict
 
 import pytest
 
-from utilities.constants import BRIDGE_MARKER, CLUSTER_NETWORK_ADDONS_OPERATOR
+from utilities.constants.components import (
+    BRIDGE_MARKER,
+    CLUSTER_NETWORK_ADDONS_OPERATOR,
+)
 from utilities.infra import get_node_audit_log_line_dict
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -10,7 +10,7 @@ from tests.install_upgrade_operators.pod_validation.utils import (
     validate_cnv_pods_resource_request,
     validate_priority_class_value,
 )
-from utilities.constants import (
+from utilities.constants.components import (
     ALL_CNV_PODS,
     HOSTPATH_PROVISIONER_CSI,
     HPP_POOL,

--- a/tests/install_upgrade_operators/product_install/conftest.py
+++ b/tests/install_upgrade_operators/product_install/conftest.py
@@ -14,17 +14,21 @@ from timeout_sampler import TimeoutSampler
 from tests.install_upgrade_operators.product_install.constants import (
     HCO_NOT_INSTALLED_ALERT,
 )
-from utilities.constants import (
-    CRITICAL_STR,
-    HCO_CATALOG_SOURCE,
+from utilities.constants.components import HCO_CATALOG_SOURCE
+from utilities.constants.hco import (
     HCO_SUBSCRIPTION,
+    PRODUCTION_CATALOG_SOURCE,
+)
+from utilities.constants.monitoring import (
+    CRITICAL_STR,
     INFO_STR,
     PENDING_STR,
-    PRODUCTION_CATALOG_SOURCE,
+)
+from utilities.constants.storage import StorageClassNames
+from utilities.constants.timeouts import (
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_10MIN,
-    StorageClassNames,
 )
 from utilities.infra import (
     create_ns,

--- a/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
+++ b/tests/install_upgrade_operators/product_install/test_install_openshift_virtualization.py
@@ -8,11 +8,11 @@ from tests.install_upgrade_operators.product_install.constants import (
 from tests.install_upgrade_operators.product_install.utils import (
     validate_hpp_installation,
 )
-from utilities.constants import (
+from utilities.constants.monitoring import (
     KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS,
     PENDING_STR,
-    TIMEOUT_10MIN,
 )
+from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.hco import wait_for_hco_conditions
 from utilities.infra import wait_for_pods_running
 from utilities.monitoring import (

--- a/tests/install_upgrade_operators/product_install/utils.py
+++ b/tests/install_upgrade_operators/product_install/utils.py
@@ -4,9 +4,11 @@ from ocp_resources.deployment import Deployment
 from ocp_utilities.operators import TIMEOUT_5MIN
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import (
+from utilities.constants.components import (
     HOSTPATH_PROVISIONER,
     HOSTPATH_PROVISIONER_OPERATOR,
+)
+from utilities.constants.timeouts import (
     TIMEOUT_5SEC,
     TIMEOUT_15MIN,
 )

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
@@ -9,7 +9,9 @@ from ocp_resources.virtual_machine import VirtualMachine
 from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.product_uninstall.constants import BLOCK_REMOVAL_TEST_NODE_ID
-from utilities.constants import CDI_SECRETS, DEFAULT_HCO_CONDITIONS, TIMEOUT_10MIN
+from utilities.constants.hco import DEFAULT_HCO_CONDITIONS
+from utilities.constants.storage import CDI_SECRETS
+from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     get_hco_version,

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
@@ -5,7 +5,10 @@ from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler
 
-from utilities.constants import TIMEOUT_3MIN, TIMEOUT_4MIN
+from utilities.constants.timeouts import (
+    TIMEOUT_3MIN,
+    TIMEOUT_4MIN,
+)
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_namespace.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_namespace.py
@@ -5,7 +5,7 @@ import pytest
 from kubernetes.client.rest import ApiException
 
 from tests.install_upgrade_operators.product_uninstall.constants import BLOCK_REMOVAL_TEST_NODE_ID
-from utilities.constants import TIMEOUT_10MIN
+from utilities.constants.timeouts import TIMEOUT_10MIN
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -38,11 +38,11 @@ from tests.install_upgrade_operators.utils import (
     wait_for_operator_condition,
 )
 from tests.upgrade_params import EUS
-from utilities.constants import (
-    HCO_CATALOG_SOURCE,
+from utilities.constants.components import HCO_CATALOG_SOURCE
+from utilities.constants.namespaces import NamespacesNames
+from utilities.constants.timeouts import (
     TIMEOUT_10MIN,
     TIMEOUT_180MIN,
-    NamespacesNames,
 )
 from utilities.data_collector import (
     get_data_collector_base_directory,

--- a/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
+++ b/tests/install_upgrade_operators/product_upgrade/test_upgrade_iuo.py
@@ -11,7 +11,7 @@ from tests.upgrade_params import (
     IUO_CNV_ALERT_ORDERING_NODE_ID,
     IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
 )
-from utilities.constants import DEPENDENCY_SCOPE_SESSION
+from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/product_upgrade/utils.py
+++ b/tests/install_upgrade_operators/product_upgrade/utils.py
@@ -29,11 +29,15 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from tests.install_upgrade_operators.constants import WORKLOAD_UPDATE_STRATEGY_KEY_NAME, WORKLOADUPDATEMETHODS
 from tests.install_upgrade_operators.utils import wait_for_install_plan
 from tests.upgrade_params import EUS
-from utilities.constants import (
+from utilities.constants.cluster import (
     BASE_EXCEPTIONS_DICT,
-    FIRING_STATE,
-    HCO_CATALOG_SOURCE,
-    IMAGE_CRON_STR,
+    TSC_FREQUENCY,
+)
+from utilities.constants.components import HCO_CATALOG_SOURCE
+from utilities.constants.hco import IMAGE_CRON_STR
+from utilities.constants.monitoring import FIRING_STATE
+from utilities.constants.namespaces import NamespacesNames
+from utilities.constants.timeouts import (
     TIMEOUT_5SEC,
     TIMEOUT_10MIN,
     TIMEOUT_10SEC,
@@ -41,8 +45,6 @@ from utilities.constants import (
     TIMEOUT_30MIN,
     TIMEOUT_30SEC,
     TIMEOUT_180MIN,
-    TSC_FREQUENCY,
-    NamespacesNames,
 )
 from utilities.data_collector import write_to_file
 from utilities.hco import ResourceEditorValidateHCOReconcile, wait_for_hco_conditions, wait_for_hco_version

--- a/tests/install_upgrade_operators/relationship_labels/constants.py
+++ b/tests/install_upgrade_operators/relationship_labels/constants.py
@@ -1,6 +1,7 @@
 from ocp_resources.resource import Resource
 
-from utilities.constants import (
+from utilities.constants.cluster import VERSION_LABEL_KEY
+from utilities.constants.components import (
     AAQ_OPERATOR,
     BRIDGE_MARKER,
     CDI_APISERVER,
@@ -54,7 +55,6 @@ from utilities.constants import (
     SSP_KUBEVIRT_HYPERCONVERGED,
     SSP_OPERATOR,
     UPLOAD_BOOT_SOURCE,
-    VERSION_LABEL_KEY,
     VIRT_API,
     VIRT_CONTROLLER,
     VIRT_EXPORTPROXY,

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -12,7 +12,7 @@ from tests.install_upgrade_operators.relationship_labels.constants import (
 from tests.install_upgrade_operators.relationship_labels.utils import (
     verify_component_labels_by_resource,
 )
-from utilities.constants import VERSION_LABEL_KEY
+from utilities.constants.cluster import VERSION_LABEL_KEY
 
 pytestmark = [
     pytest.mark.post_upgrade,

--- a/tests/install_upgrade_operators/relationship_labels/utils.py
+++ b/tests/install_upgrade_operators/relationship_labels/utils.py
@@ -6,7 +6,11 @@ from tests.install_upgrade_operators.relationship_labels.constants import (
     KUBEVIRT_APISERVER_PROXY,
     VIRITO_WIN_STORAGE,
 )
-from utilities.constants import POD_STR, ROLEBINDING_STR, VIRTIO_WIN
+from utilities.constants.components import (
+    POD_STR,
+    ROLEBINDING_STR,
+    VIRTIO_WIN,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -5,7 +5,10 @@ Test to verify all HCO deployments have 'openshift.io/required-scc' annotation.
 import pytest
 from ocp_resources.deployment import Deployment
 
-from utilities.constants import ALL_CNV_DEPLOYMENTS, HPP_POOL
+from utilities.constants.components import (
+    ALL_CNV_DEPLOYMENTS,
+    HPP_POOL,
+)
 
 REQUIRED_SCC_ANNOTATION = "openshift.io/required-scc"
 REQUIRED_SCC_VALUE = "restricted-v2"

--- a/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_pods_scc.py
@@ -6,13 +6,13 @@ import logging
 
 import pytest
 
-from utilities.constants import (
+from utilities.constants.components import (
     BRIDGE_MARKER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
     HOSTPATH_PROVISIONER,
     HOSTPATH_PROVISIONER_CSI,
-    LINUX_BRIDGE,
 )
+from utilities.constants.networking import LINUX_BRIDGE
 
 pytestmark = [
     pytest.mark.post_upgrade,

--- a/tests/install_upgrade_operators/single_node_tests/test_sno_deployment_params.py
+++ b/tests/install_upgrade_operators/single_node_tests/test_sno_deployment_params.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utilities.constants import VIRT_OPERATOR
+from utilities.constants.components import VIRT_OPERATOR
 
 pytestmark = pytest.mark.sno
 

--- a/tests/install_upgrade_operators/strict_reconciliation/conftest.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/conftest.py
@@ -16,7 +16,8 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
     wait_for_resource_version_update,
 )
 from tests.utils import wait_for_cr_labels_change
-from utilities.constants import TIMEOUT_1MIN, VERSION_LABEL_KEY
+from utilities.constants.cluster import VERSION_LABEL_KEY
+from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_cr_nondefault_fields.py
@@ -24,11 +24,11 @@ from tests.install_upgrade_operators.strict_reconciliation.constants import (
 from tests.install_upgrade_operators.strict_reconciliation.utils import (
     compare_expected_with_cr,
 )
-from utilities.constants import (
+from utilities.constants.components import (
     CDI_KUBEVIRT_HYPERCONVERGED,
     KUBEVIRT_HCO_NAME,
-    RESOURCE_REQUIREMENTS_KEY_HCO_CR,
 )
+from utilities.constants.hco import RESOURCE_REQUIREMENTS_KEY_HCO_CR
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -2,7 +2,8 @@ import pytest
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.virtual_machine import VirtualMachine
 
-from utilities.constants import ARM_64, HCO_DEFAULT_CPU_MODEL_KEY
+from utilities.constants.architecture import ARM_64
+from utilities.constants.hco import HCO_DEFAULT_CPU_MODEL_KEY
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_optional_fgs_suite.py
@@ -6,7 +6,7 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
     validate_featuregates_not_in_cdi_cr,
     wait_for_fg_update,
 )
-from utilities.constants import FEATURE_GATES
+from utilities.constants.hco import FEATURE_GATES
 from utilities.hco import get_hco_spec, wait_for_hco_conditions
 from utilities.virt import (
     get_kubevirt_hyperconverged_spec,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -3,7 +3,7 @@ import pytest
 from tests.install_upgrade_operators.strict_reconciliation.utils import (
     validate_related_objects,
 )
-from utilities.constants import ALL_HCO_RELATED_OBJECTS
+from utilities.constants.components import ALL_HCO_RELATED_OBJECTS
 
 pytestmark = [
     pytest.mark.post_upgrade,

--- a/tests/install_upgrade_operators/strict_reconciliation/utils.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/utils.py
@@ -20,7 +20,10 @@ from tests.install_upgrade_operators.utils import (
     get_function_name,
     get_network_addon_config,
 )
-from utilities.constants import TIMEOUT_3MIN, TIMEOUT_5SEC
+from utilities.constants.timeouts import (
+    TIMEOUT_3MIN,
+    TIMEOUT_5SEC,
+)
 from utilities.hco import get_hco_spec
 from utilities.infra import get_hyperconverged_resource
 from utilities.storage import get_hyperconverged_cdi

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -25,9 +25,11 @@ from tests.install_upgrade_operators.constants import (
     KONFLUX_PIPELINE,
     RH_IDMS_SOURCE,
 )
-from utilities.constants import (
+from utilities.constants.hco import (
     HCO_SUBSCRIPTION,
     PRODUCTION_CATALOG_SOURCE,
+)
+from utilities.constants.timeouts import (
     TIMEOUT_1MIN,
     TIMEOUT_5SEC,
     TIMEOUT_10SEC,

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -39,31 +39,37 @@ from tests.observability.metrics.utils import (
 from tests.observability.utils import validate_metrics_value
 from tests.utils import create_vms, start_stress_on_vm
 from utilities import console
-from utilities.constants import (
-    IPV4_STR,
+from utilities.constants import Images
+from utilities.constants.components import (
+    SSP_OPERATOR,
+    VIRT_TEMPLATE_VALIDATOR,
+)
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.instance_types import U1_SMALL
+from utilities.constants.monitoring import (
     KUBEVIRT_VMI_MEMORY_PGMAJFAULT_TOTAL,
     KUBEVIRT_VMI_MEMORY_PGMINFAULT_TOTAL,
     KUBEVIRT_VMI_MEMORY_SWAP_IN_TRAFFIC_BYTES,
     KUBEVIRT_VMI_MEMORY_SWAP_OUT_TRAFFIC_BYTES,
     KUBEVIRT_VMI_MEMORY_UNUSED_BYTES,
     KUBEVIRT_VMI_MEMORY_USABLE_BYTES,
-    MIGRATION_POLICY_VM_LABEL,
-    ONE_CPU_CORE,
-    ONE_CPU_THREAD,
-    OS_FLAVOR_FEDORA,
-    SSP_OPERATOR,
-    STRESS_CPU_MEM_IO_COMMAND,
+)
+from utilities.constants.networking import IPV4_STR
+from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
     TIMEOUT_5MIN,
     TIMEOUT_15SEC,
+)
+from utilities.constants.virt import (
+    MIGRATION_POLICY_VM_LABEL,
+    ONE_CPU_CORE,
+    ONE_CPU_THREAD,
+    STRESS_CPU_MEM_IO_COMMAND,
     TWO_CPU_CORES,
     TWO_CPU_SOCKETS,
     TWO_CPU_THREADS,
-    U1_SMALL,
-    VIRT_TEMPLATE_VALIDATOR,
-    Images,
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile, enabled_aaq_in_hco
 from utilities.infra import (

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -10,9 +10,7 @@ from tests.observability.metrics.utils import (
     compare_kubevirt_vmi_info_metric_with_vm_info,
 )
 from tests.observability.utils import validate_metrics_value
-from utilities.constants import (
-    KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS,
-)
+from utilities.constants.monitoring import KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 

--- a/tests/observability/metrics/test_prometheus_service_monitor.py
+++ b/tests/observability/metrics/test_prometheus_service_monitor.py
@@ -1,7 +1,7 @@
 import pytest
 from ocp_resources.service_monitor import ServiceMonitor
 
-from utilities.constants import VIRT_OPERATOR
+from utilities.constants.components import VIRT_OPERATOR
 
 
 @pytest.fixture()

--- a/tests/observability/metrics/test_recording_rules.py
+++ b/tests/observability/metrics/test_recording_rules.py
@@ -1,7 +1,11 @@
 import pytest
 from ocp_resources.resource import Resource
 
-from utilities.constants import VIRT_CONTROLLER, VIRT_HANDLER, VIRT_OPERATOR
+from utilities.constants.components import (
+    VIRT_CONTROLLER,
+    VIRT_HANDLER,
+    VIRT_OPERATOR,
+)
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 

--- a/tests/observability/metrics/test_ssp_metrics.py
+++ b/tests/observability/metrics/test_ssp_metrics.py
@@ -8,7 +8,7 @@ from tests.observability.metrics.utils import (
     validate_metric_value_within_range,
 )
 from tests.observability.utils import validate_metrics_value
-from utilities.constants import (
+from utilities.constants.components import (
     SSP_OPERATOR,
     VIRT_TEMPLATE_VALIDATOR,
 )

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -28,15 +28,17 @@ from tests.observability.metrics.utils import (
     validate_vnic_info,
 )
 from tests.observability.utils import validate_metrics_value
-from utilities.constants import (
+from utilities.constants.pytest import QUARANTINED
+from utilities.constants.storage import (
     CAPACITY,
-    MIGRATION_POLICY_VM_LABEL,
-    QUARANTINED,
+    USED,
+)
+from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_30SEC,
-    USED,
 )
+from utilities.constants.virt import MIGRATION_POLICY_VM_LABEL
 from utilities.infra import get_node_selector_dict
 from utilities.monitoring import get_metrics_value
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -34,11 +34,16 @@ from utilities.artifactory import (
     get_artifactory_secret,
     get_test_artifact_server_url,
 )
-from utilities.constants import (
+from utilities.constants import Images
+from utilities.constants.aaq import NODE_STR
+from utilities.constants.components import VIRT_HANDLER
+from utilities.constants.images import OS_FLAVOR_WINDOWS
+from utilities.constants.storage import (
     CAPACITY,
-    NODE_STR,
-    OS_FLAVOR_WINDOWS,
     REGISTRY_STR,
+    USED,
+)
+from utilities.constants.timeouts import (
     TIMEOUT_1MIN,
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
@@ -50,9 +55,6 @@ from utilities.constants import (
     TIMEOUT_20SEC,
     TIMEOUT_30SEC,
     TIMEOUT_40MIN,
-    USED,
-    VIRT_HANDLER,
-    Images,
 )
 from utilities.monitoring import get_metrics_value
 from utilities.virt import VirtualMachineForTests, running_vm

--- a/tests/observability/runbook_url/conftest.py
+++ b/tests/observability/runbook_url/conftest.py
@@ -6,7 +6,11 @@ from ocp_resources.prometheus_rule import PrometheusRule
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import KUBEMACPOOL_PROMETHEUS_RULE, TIMEOUT_10SEC, TIMEOUT_30SEC
+from utilities.constants.components import KUBEMACPOOL_PROMETHEUS_RULE
+from utilities.constants.timeouts import (
+    TIMEOUT_10SEC,
+    TIMEOUT_30SEC,
+)
 from utilities.jira import is_jira_open
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/observability/runbook_url/test_runbook_url.py
+++ b/tests/observability/runbook_url/test_runbook_url.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from utilities.constants import CNV_PROMETHEUS_RULES
+from utilities.constants.components import CNV_PROMETHEUS_RULES
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/observability/upgrade/conftest.py
+++ b/tests/observability/upgrade/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
-from utilities.constants import ES_NONE
+from utilities.constants.virt import ES_NONE
 from utilities.infra import create_ns, get_node_selector_dict
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 

--- a/tests/observability/upgrade/test_upgrade_observability.py
+++ b/tests/observability/upgrade/test_upgrade_observability.py
@@ -3,7 +3,7 @@ import pytest
 from tests.observability.constants import KUBEVIRT_VMI_NUMBER_OF_OUTDATED
 from tests.observability.utils import validate_metrics_value
 from tests.upgrade_params import IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID
-from utilities.constants import DEPENDENCY_SCOPE_SESSION
+from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
 
 
 @pytest.mark.cnv_upgrade

--- a/tests/observability/utils.py
+++ b/tests/observability/utils.py
@@ -5,7 +5,7 @@ from ocp_utilities.monitoring import Prometheus
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.observability.constants import SSP_COMMON_TEMPLATES_MODIFICATION_REVERTED
-from utilities.constants import (
+from utilities.constants.timeouts import (
     TIMEOUT_4MIN,
     TIMEOUT_15SEC,
 )


### PR DESCRIPTION
##### What this PR does / why we need it:
Replace `from utilities.constants import` with direct submodule imports in tests/install_upgrade_operators/ and tests/observability/. Images remains on the package shim in two observability files until the compat layer is removed.

Generated-by: Claude Sonnet 4.6

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
This is a next PR in a series.
https://redhat.atlassian.net/browse/CNV-80952 and a follow up of https://github.com/RedHatQE/openshift-virtualization-tests/pull/5188

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-89563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test suite to reference constants from more specific submodules (e.g., timeouts, components, architecture, cluster, monitoring), replacing broader shared imports.
  * This improves consistency and readability across tests without changing test logic or expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->