### PR TITLE
refactor(storage): migrate utilities.constants imports to submodules

### DIFF
--- a/tests/data_protection/oadp/conftest.py
+++ b/tests/data_protection/oadp/conftest.py
@@ -14,18 +14,12 @@ from utilities.artifactory import (
     get_artifactory_secret,
     get_test_artifact_server_url,
 )
-from utilities.constants import (
-    BACKUP_STORAGE_LOCATION,
-    CONTAINER_DISK_IMAGE_PATH_STR,
-    FILE_NAME_FOR_BACKUP,
-    OS_FLAVOR_RHEL,
-    OS_FLAVOR_WIN_CONTAINER_DISK,
-    TEXT_TO_TEST,
-    TIMEOUT_8MIN,
-    TIMEOUT_15MIN,
-    U1_LARGE,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_RHEL, OS_FLAVOR_WIN_CONTAINER_DISK
+from utilities.constants.instance_types import U1_LARGE
+from utilities.constants.oadp import BACKUP_STORAGE_LOCATION, FILE_NAME_FOR_BACKUP, TEXT_TO_TEST
+from utilities.constants.os_matrix import CONTAINER_DISK_IMAGE_PATH_STR
+from utilities.constants.timeouts import TIMEOUT_8MIN, TIMEOUT_15MIN
 from utilities.infra import create_ns
 from utilities.oadp import (
     VeleroBackup,

--- a/tests/data_protection/oadp/test_velero.py
+++ b/tests/data_protection/oadp/test_velero.py
@@ -2,13 +2,9 @@ import pytest
 from ocp_resources.datavolume import DataVolume
 
 from tests.data_protection.oadp.utils import FILE_PATH_FOR_WINDOWS_BACKUP, wait_for_restored_dv
-from utilities.constants import (
-    FILE_NAME_FOR_BACKUP,
-    TEXT_TO_TEST,
-    TIMEOUT_10SEC,
-    TIMEOUT_15MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.oadp import FILE_NAME_FOR_BACKUP, TEXT_TO_TEST
+from utilities.constants.timeouts import TIMEOUT_10SEC, TIMEOUT_15MIN
 from utilities.oadp import check_file_in_running_vm
 from utilities.storage import verify_file_in_windows_vm
 from utilities.virt import wait_for_running_vm

--- a/tests/data_protection/oadp/utils.py
+++ b/tests/data_protection/oadp/utils.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 
-from utilities.constants import (
-    TIMEOUT_10SEC,
-    TIMEOUT_15SEC,
-)
+from utilities.constants.timeouts import TIMEOUT_10SEC, TIMEOUT_15SEC
 
 FILE_PATH_FOR_WINDOWS_BACKUP = "C:/oadp_file_before_backup.txt"
 

--- a/tests/storage/cdi_clone/conftest.py
+++ b/tests/storage/cdi_clone/conftest.py
@@ -2,7 +2,8 @@ import pytest
 from ocp_resources.datavolume import DataVolume
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
-from utilities.constants import REGISTRY_STR, Images
+from utilities.constants import Images
+from utilities.constants.storage import REGISTRY_STR
 from utilities.storage import create_dv, data_volume
 
 

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -11,13 +11,9 @@ from tests.storage.utils import (
     assert_use_populator,
     create_windows_vm_validate_guest_agent_info,
 )
-from utilities.constants import (
-    OS_FLAVOR_FEDORA,
-    OS_FLAVOR_WINDOWS,
-    TIMEOUT_1MIN,
-    TIMEOUT_40MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_WINDOWS
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_40MIN
 from utilities.storage import (
     check_disk_count_in_vm,
     create_dv,

--- a/tests/storage/cdi_config/test_cdi_config.py
+++ b/tests/storage/cdi_config/test_cdi_config.py
@@ -6,7 +6,7 @@ from ocp_resources.route import Route
 from timeout_sampler import TimeoutSampler
 
 from tests.storage.utils import LOGGER
-from utilities.constants import CDI_UPLOADPROXY
+from utilities.constants.components import CDI_UPLOADPROXY
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 pytestmark = pytest.mark.post_upgrade

--- a/tests/storage/cdi_import/conftest.py
+++ b/tests/storage/cdi_import/conftest.py
@@ -18,13 +18,11 @@ from tests.storage.utils import (
     create_pod_for_pvc,
     get_file_url,
 )
-from utilities.constants import (
-    LINUX_BRIDGE,
-    OS_FLAVOR_FEDORA,
-    REGISTRY_STR,
-    TIMEOUT_1MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.networking import LINUX_BRIDGE
+from utilities.constants.storage import REGISTRY_STR
+from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.infra import NON_EXIST_URL
 from utilities.network import network_device, network_nad
 from utilities.storage import create_dv, sc_volume_binding_mode_is_wffc

--- a/tests/storage/cdi_import/test_import_http.py
+++ b/tests/storage/cdi_import/test_import_http.py
@@ -23,13 +23,9 @@ from tests.storage.utils import (
     get_file_url,
     wait_for_dv_condition_message,
 )
-from utilities.constants import (
-    QUARANTINED,
-    TIMEOUT_1MIN,
-    TIMEOUT_2MIN,
-    TIMEOUT_5MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.pytest import QUARANTINED
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_2MIN, TIMEOUT_5MIN
 from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.storage import (
     ErrorMsg,

--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -8,7 +8,10 @@ from ocp_resources.resource import Resource
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
 from tests.storage.utils import wait_for_dv_condition_message
-from utilities.constants import OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_5MIN, Images
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.storage import REGISTRY_STR
+from utilities.constants.timeouts import TIMEOUT_5MIN
 from utilities.storage import ErrorMsg, check_disk_count_in_vm, create_dv, create_vm_from_dv
 from utilities.virt import running_vm
 

--- a/tests/storage/cdi_import/utils.py
+++ b/tests/storage/cdi_import/utils.py
@@ -9,7 +9,7 @@ from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.storage.utils import get_importer_pod
-from utilities.constants import TIMEOUT_1MIN, TIMEOUT_5SEC, TIMEOUT_20SEC
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5SEC, TIMEOUT_20SEC
 
 if TYPE_CHECKING:
     from ocp_resources.persistent_volume_claim import PersistentVolumeClaim

--- a/tests/storage/cdi_upload/conftest.py
+++ b/tests/storage/cdi_upload/conftest.py
@@ -11,7 +11,8 @@ from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
 from libs.net.ip import random_ipv4_address
 from libs.net.udn import create_udn_namespace
-from utilities.constants import TIMEOUT_1MIN, TIMEOUT_2MIN, Images
+from utilities.constants import Images
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_2MIN
 from utilities.storage import check_upload_virtctl_result, create_dv, get_downloaded_artifact, virtctl_upload_dv
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -18,13 +18,9 @@ from timeout_sampler import TimeoutSampler
 
 import tests.storage.utils as storage_utils
 import utilities.storage
-from utilities.constants import (
-    CDI_UPLOADPROXY,
-    TIMEOUT_1MIN,
-    TIMEOUT_3MIN,
-    TIMEOUT_5MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.components import CDI_UPLOADPROXY
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_3MIN, TIMEOUT_5MIN
 from utilities.storage import create_vm_from_dv, get_downloaded_artifact
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -15,7 +15,10 @@ from pytest_testconfig import config as py_config
 from libs.net.cluster import is_ipv6_single_stack_cluster
 from tests.storage.cdi_upload.utils import get_storage_profile_minimum_supported_pvc_size
 from tests.storage.utils import assert_use_populator, create_windows_vm_validate_guest_agent_info
-from utilities.constants import CDI_UPLOADPROXY, QUARANTINED, TIMEOUT_1MIN, Images
+from utilities.constants import Images
+from utilities.constants.components import CDI_UPLOADPROXY
+from utilities.constants.pytest import QUARANTINED
+from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.storage import (
     ErrorMsg,
     check_upload_virtctl_result,

--- a/tests/storage/checkups/conftest.py
+++ b/tests/storage/checkups/conftest.py
@@ -24,14 +24,9 @@ from tests.storage.checkups.constants import (
 )
 from tests.storage.checkups.utils import update_storage_profile
 from tests.utils import create_cirros_vm, get_image_from_csv
-from utilities.constants import (
-    BIND_IMMEDIATE_ANNOTATION,
-    OUTDATED,
-    TIMEOUT_10MIN,
-    VALUE_STR,
-    WILDCARD_CRON_EXPRESSION,
-    StorageClassNames,
-)
+from utilities.constants.cluster import VALUE_STR
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, OUTDATED, WILDCARD_CRON_EXPRESSION, StorageClassNames
+from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.exceptions import StorageCheckupConditionTimeoutExpiredError
 from utilities.infra import create_ns, get_pods
 from utilities.storage import update_default_sc

--- a/tests/storage/checkups/constants.py
+++ b/tests/storage/checkups/constants.py
@@ -1,6 +1,6 @@
 from ocp_resources.resource import Resource
 
-from utilities.constants import CREATE_STR, DELETE_STR, GET_STR, UPDATE_STR
+from utilities.constants.cluster import CREATE_STR, DELETE_STR, GET_STR, UPDATE_STR
 
 ACCESS_MODES = "accessModes"
 NON_EXISTENT_STR = "nonexistent"

--- a/tests/storage/checkups/test_checkups.py
+++ b/tests/storage/checkups/test_checkups.py
@@ -5,7 +5,7 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.job import Job
 
 from tests.storage.checkups.utils import assert_results_in_configmap
-from utilities.constants import QUARANTINED
+from utilities.constants.pytest import QUARANTINED
 
 MSG_MIGRATION_FAIL = "cannot migrate VMI"
 MSG_MIGRATION_SUCCESS = "migration completed"

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -43,20 +43,13 @@ from tests.storage.utils import (
 )
 from tests.utils import create_cirros_vm
 from utilities.artifactory import get_artifactory_config_map, get_artifactory_secret
-from utilities.constants import (
-    CDI_OPERATOR,
-    CDI_UPLOADPROXY,
-    CNV_TEST_SERVICE_ACCOUNT,
-    OS_FLAVOR_FEDORA,
-    OS_FLAVOR_RHEL,
-    RHEL10_PREFERENCE,
-    SECURITY_CONTEXT,
-    TIMEOUT_1MIN,
-    TIMEOUT_5SEC,
-    TIMEOUT_30MIN,
-    U1_SMALL,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.cluster import CNV_TEST_SERVICE_ACCOUNT
+from utilities.constants.components import CDI_OPERATOR, CDI_UPLOADPROXY
+from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_RHEL
+from utilities.constants.instance_types import RHEL10_PREFERENCE, U1_SMALL
+from utilities.constants.networking import SECURITY_CONTEXT
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5SEC, TIMEOUT_30MIN
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     hco_cr_jsonpatch_annotations_dict,

--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -1,4 +1,5 @@
-from utilities.constants import Images, StorageClassNames
+from utilities.constants import Images
+from utilities.constants.storage import StorageClassNames
 from utilities.storage import HppCsiStorageClass
 
 CIRROS_QCOW2_IMG = f"{Images.Cirros.DIR}/{Images.Cirros.QCOW2_IMG}"

--- a/tests/storage/cross_cluster_live_migration/conftest.py
+++ b/tests/storage/cross_cluster_live_migration/conftest.py
@@ -41,18 +41,12 @@ from utilities.artifactory import (
     get_artifactory_secret,
     get_test_artifact_server_url,
 )
-from utilities.constants import (
-    CONTAINER_DISK_IMAGE_PATH_STR,
-    OS_FLAVOR_RHEL,
-    OS_FLAVOR_WIN_CONTAINER_DISK,
-    RHEL10_PREFERENCE,
-    RHEL10_STR,
-    TIMEOUT_1MIN,
-    TIMEOUT_30SEC,
-    U1_LARGE,
-    U1_SMALL,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.components import RHEL10_STR
+from utilities.constants.images import OS_FLAVOR_RHEL, OS_FLAVOR_WIN_CONTAINER_DISK
+from utilities.constants.instance_types import RHEL10_PREFERENCE, U1_LARGE, U1_SMALL
+from utilities.constants.os_matrix import CONTAINER_DISK_IMAGE_PATH_STR
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_30SEC
 from utilities.infra import create_ns, get_hyperconverged_resource
 from utilities.storage import (
     data_volume_template_with_source_ref_dict,

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -20,7 +20,7 @@ from tests.storage.cross_cluster_live_migration.utils import (
     wait_for_vms_to_be_stopped,
 )
 from tests.storage.utils import check_file_in_vm
-from utilities.constants import TIMEOUT_10MIN, TIMEOUT_50MIN
+from utilities.constants.timeouts import TIMEOUT_10MIN, TIMEOUT_50MIN
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient

--- a/tests/storage/cross_cluster_live_migration/utils.py
+++ b/tests/storage/cross_cluster_live_migration/utils.py
@@ -9,7 +9,8 @@ from ocp_resources.network_attachment_definition import NetworkAttachmentDefinit
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from utilities import console
-from utilities.constants import TIMEOUT_3MIN, TIMEOUT_5SEC, VIRT_HANDLER
+from utilities.constants.components import VIRT_HANDLER
+from utilities.constants.timeouts import TIMEOUT_3MIN, TIMEOUT_5SEC
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import get_daemonset_by_name
 from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify, wait_for_virt_handler_pods_network_updated

--- a/tests/storage/data_import_cron/conftest.py
+++ b/tests/storage/data_import_cron/conftest.py
@@ -8,7 +8,10 @@ from ocp_resources.resource import Resource
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
 from tests.storage.utils import create_role_binding
-from utilities.constants import BIND_IMMEDIATE_ANNOTATION, OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_10MIN, Images
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, REGISTRY_STR
+from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.infra import create_ns
 from utilities.storage import create_dv, data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, running_vm

--- a/tests/storage/general/conftest.py
+++ b/tests/storage/general/conftest.py
@@ -11,7 +11,12 @@ from pytest_testconfig import config as py_config
 
 from tests.storage.cdi_import.utils import get_importer_pod_node, wait_dv_and_get_importer
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
-from utilities.constants import AMD_64, OS_FLAVOR_FEDORA, REGISTRY_STR, TIMEOUT_5MIN, TIMEOUT_12MIN, U1_SMALL, Images
+from utilities.constants import Images
+from utilities.constants.architecture import AMD_64
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.instance_types import U1_SMALL
+from utilities.constants.storage import REGISTRY_STR
+from utilities.constants.timeouts import TIMEOUT_5MIN, TIMEOUT_12MIN
 from utilities.storage import create_dv, data_volume_template_with_source_ref_dict, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm
 

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -8,7 +8,9 @@ import pytest
 
 from tests.storage.cdi_import.utils import wait_for_pvc_recreate
 from utilities import console
-from utilities.constants import OS_FLAVOR_FEDORA, TIMEOUT_1MIN, Images
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.infra import get_node_selector_dict
 from utilities.storage import create_dummy_first_consumer_pod, create_vm_from_dv, sc_volume_binding_mode_is_wffc
 

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -11,7 +11,9 @@ from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.volume_snapshot import VolumeSnapshot
 
 from tests.os_params import RHEL_LATEST_LABELS
-from utilities.constants import DATA_IMPORT_CRON_ENABLE, RHEL9_STR, TIMEOUT_3MIN
+from utilities.constants.components import RHEL9_STR
+from utilities.constants.hco import DATA_IMPORT_CRON_ENABLE
+from utilities.constants.timeouts import TIMEOUT_3MIN
 from utilities.hco import (
     disable_common_boot_image_import_hco_spec,
     update_hco_templates_spec,

--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -7,7 +7,8 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST
-from utilities.constants import PVC, TIMEOUT_20MIN
+from utilities.constants.storage import PVC
+from utilities.constants.timeouts import TIMEOUT_20MIN
 from utilities.storage import ErrorMsg, create_dv, get_dv_size_from_datasource
 
 pytestmark = pytest.mark.post_upgrade

--- a/tests/storage/hpp/conftest.py
+++ b/tests/storage/hpp/conftest.py
@@ -13,7 +13,7 @@ from tests.storage.hpp.utils import (
     wait_for_desired_hpp_pods_running,
 )
 from tests.utils import create_cirros_vm
-from utilities.constants import TIMEOUT_5MIN
+from utilities.constants.timeouts import TIMEOUT_5MIN
 from utilities.hco import add_labels_to_nodes
 from utilities.infra import (
     get_node_selector_dict,

--- a/tests/storage/hpp/test_hostpath.py
+++ b/tests/storage/hpp/test_hostpath.py
@@ -20,12 +20,8 @@ from ocp_resources.service import Service
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.service_monitor import ServiceMonitor
 
-from utilities.constants import (
-    HOSTPATH_PROVISIONER_OPERATOR,
-    HPP_POOL,
-    TIMEOUT_1MIN,
-    TIMEOUT_5MIN,
-)
+from utilities.constants.components import HOSTPATH_PROVISIONER_OPERATOR, HPP_POOL
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN
 from utilities.infra import get_pod_by_name_prefix
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/storage/hpp/test_hpp_node_placement.py
+++ b/tests/storage/hpp/test_hpp_node_placement.py
@@ -14,7 +14,7 @@ from tests.storage.hpp.utils import (
     VM_NAME,
     edit_hpp_with_node_selector,
 )
-from utilities.constants import NODE_STR
+from utilities.constants.aaq import NODE_STR
 from utilities.storage import check_disk_count_in_vm
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/storage/hpp/utils.py
+++ b/tests/storage/hpp/utils.py
@@ -14,14 +14,9 @@ from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from utilities.artifactory import get_http_image_url
-from utilities.constants import (
-    HOSTPATH_PROVISIONER_CSI,
-    HOSTPATH_PROVISIONER_OPERATOR,
-    HPP_POOL,
-    TIMEOUT_1MIN,
-    TIMEOUT_2MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.components import HOSTPATH_PROVISIONER_CSI, HOSTPATH_PROVISIONER_OPERATOR, HPP_POOL
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_2MIN
 from utilities.infra import (
     ExecCommandOnPod,
     get_resources_by_name_prefix,

--- a/tests/storage/memory_dump/conftest.py
+++ b/tests/storage/memory_dump/conftest.py
@@ -7,7 +7,8 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 
 from tests.storage.memory_dump.utils import wait_for_memory_dump_status_completed
-from utilities.constants import TIMEOUT_2MIN, Images
+from utilities.constants import Images
+from utilities.constants.timeouts import TIMEOUT_2MIN
 from utilities.storage import PodWithPVC, get_containers_for_pods_with_pvc, virtctl_memory_dump
 from utilities.virt import running_vm, vm_instance_from_template
 

--- a/tests/storage/memory_dump/utils.py
+++ b/tests/storage/memory_dump/utils.py
@@ -1,7 +1,7 @@
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import retry
 
-from utilities.constants import TIMEOUT_2MIN, TIMEOUT_5SEC
+from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_5SEC
 from utilities.virt import VirtualMachineForTests
 
 

--- a/tests/storage/online_resize/conftest.py
+++ b/tests/storage/online_resize/conftest.py
@@ -12,7 +12,9 @@ from tests.storage.online_resize.utils import (
     expand_pvc,
     wait_for_resize,
 )
-from utilities.constants import OS_FLAVOR_RHEL, Images, StorageClassNames
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_RHEL
+from utilities.constants.storage import StorageClassNames
 from utilities.storage import create_dv, is_snapshot_supported_by_sc
 from utilities.virt import VirtualMachineForTests, running_vm
 

--- a/tests/storage/online_resize/test_online_resize.py
+++ b/tests/storage/online_resize/test_online_resize.py
@@ -19,7 +19,7 @@ from tests.storage.online_resize.utils import (
     vm_restore,
     wait_for_resize,
 )
-from utilities.constants import TIMEOUT_1MIN, TIMEOUT_4MIN, TIMEOUT_5SEC
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_4MIN, TIMEOUT_5SEC
 from utilities.storage import add_dv_to_vm, create_dv, vm_snapshot
 from utilities.virt import migrate_vm_and_verify, running_vm
 

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -11,7 +11,7 @@ from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import TIMEOUT_2MIN, TIMEOUT_4MIN, TIMEOUT_5SEC
+from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_4MIN, TIMEOUT_5SEC
 from utilities.storage import create_dv
 from utilities.virt import running_vm
 

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -30,7 +30,10 @@ from tests.storage.utils import (
     create_role_binding,
     set_permissions,
 )
-from utilities.constants import OS_FLAVOR_FEDORA, PVC, UNPRIVILEGED_USER, Images
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.pytest import UNPRIVILEGED_USER
+from utilities.constants.storage import PVC
 from utilities.infra import create_ns
 from utilities.storage import create_dv, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -22,7 +22,8 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VERBS_SRC,
 )
 from tests.storage.restricted_namespace_cloning.utils import create_dv_negative, verify_snapshot_used_namespace_transfer
-from utilities.constants import OS_FLAVOR_FEDORA, Images
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA
 from utilities.storage import create_vm_from_dv
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning_vms.py
@@ -28,7 +28,9 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VM_FOR_TEST,
 )
 from tests.storage.restricted_namespace_cloning.utils import verify_snapshot_used_namespace_transfer
-from utilities.constants import OS_FLAVOR_FEDORA, QUARANTINED, Images
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.pytest import QUARANTINED
 from utilities.storage import ErrorMsg
 from utilities.virt import VirtualMachineForTests
 

--- a/tests/storage/restricted_namespace_cloning/utils.py
+++ b/tests/storage/restricted_namespace_cloning/utils.py
@@ -7,7 +7,7 @@ from ocp_resources.datavolume import DataVolume
 
 from tests.storage.restricted_namespace_cloning.constants import TARGET_DV
 from tests.storage.utils import assert_pvc_snapshot_clone_annotation
-from utilities.constants import PVC
+from utilities.constants.storage import PVC
 from utilities.storage import (
     ErrorMsg,
     create_dv,

--- a/tests/storage/snapshots/conftest.py
+++ b/tests/storage/snapshots/conftest.py
@@ -19,7 +19,8 @@ from tests.storage.utils import (
     create_windows_directory,
     set_permissions,
 )
-from utilities.constants import TIMEOUT_2MIN, TIMEOUT_5SEC, TIMEOUT_10MIN, UNPRIVILEGED_USER
+from utilities.constants.pytest import UNPRIVILEGED_USER
+from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_5SEC, TIMEOUT_10MIN
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/storage/snapshots/test_snapshots.py
+++ b/tests/storage/snapshots/test_snapshots.py
@@ -23,7 +23,8 @@ from tests.storage.snapshots.utils import (
     start_windows_vm_after_restore,
 )
 from tests.storage.utils import assert_windows_directory_existence
-from utilities.constants import LS_COMMAND, TIMEOUT_1MIN, TIMEOUT_10SEC
+from utilities.constants.cluster import LS_COMMAND
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_10SEC
 from utilities.storage import run_command_on_vm_and_check_output
 from utilities.virt import restart_vm_wait_for_running_vm, running_vm
 

--- a/tests/storage/snapshots/utils.py
+++ b/tests/storage/snapshots/utils.py
@@ -3,7 +3,7 @@ from kubernetes.client.rest import ApiException
 from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
 
 from tests.storage.snapshots.constants import ERROR_MSG_USER_CANNOT_CREATE_VM_SNAPSHOTS
-from utilities.constants import TIMEOUT_10MIN
+from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.virt import running_vm
 
 

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -25,15 +25,10 @@ from tests.storage.storage_migration.utils import (
 )
 from tests.storage.utils import create_windows_directory, get_storage_class_for_storage_migration
 from utilities.artifactory import get_http_image_url
-from utilities.constants import (
-    OS_FLAVOR_FEDORA,
-    OS_FLAVOR_RHEL,
-    OS_FLAVOR_WINDOWS,
-    TIMEOUT_2MIN,
-    TIMEOUT_5SEC,
-    U1_SMALL,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_RHEL, OS_FLAVOR_WINDOWS
+from utilities.constants.instance_types import U1_SMALL
+from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_5SEC
 from utilities.infra import create_ns
 from utilities.storage import (
     create_dv,

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -18,7 +18,7 @@ from tests.storage.storage_migration.utils import (
     verify_vm_storage_class_updated,
     verify_vms_boot_time_after_storage_migration,
 )
-from utilities.constants import TIMEOUT_60MIN
+from utilities.constants.timeouts import TIMEOUT_60MIN
 from utilities.storage import verify_file_in_windows_vm
 from utilities.virt import migrate_vm_and_verify
 

--- a/tests/storage/storage_migration/utils.py
+++ b/tests/storage/storage_migration/utils.py
@@ -11,7 +11,7 @@ from tests.storage.storage_migration.constants import (
     MOUNT_HOTPLUGGED_DEVICE_PATH,
 )
 from tests.storage.utils import check_file_in_vm
-from utilities.constants import TIMEOUT_2MIN, TIMEOUT_5SEC, TIMEOUT_10MIN, TIMEOUT_10SEC
+from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_5SEC, TIMEOUT_10MIN, TIMEOUT_10SEC
 from utilities.exceptions import StorageMigrationError
 from utilities.virt import VirtualMachineForTests, get_vm_boot_time
 

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -16,15 +16,10 @@ from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
-from utilities.constants import (
-    CDI_SECRETS,
-    QUARANTINED,
-    TIMEOUT_1MIN,
-    TIMEOUT_3MIN,
-    TIMEOUT_5SEC,
-    TIMEOUT_10MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.pytest import QUARANTINED
+from utilities.constants.storage import CDI_SECRETS
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_3MIN, TIMEOUT_5SEC, TIMEOUT_10MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import (
     check_upload_virtctl_result,

--- a/tests/storage/test_cdi_resources.py
+++ b/tests/storage/test_cdi_resources.py
@@ -18,18 +18,17 @@ from ocp_resources.service_account import ServiceAccount
 
 from tests.storage.utils import import_image_to_dv, upload_image_to_dv
 from utilities.artifactory import get_test_artifact_server_url
-from utilities.constants import (
-    CDI_APISERVER,
+from utilities.constants import Images
+from utilities.constants.components import CDI_APISERVER, CDI_OPERATOR
+from utilities.constants.storage import (
     CDI_CONFIGMAPS,
     CDI_LABEL,
-    CDI_OPERATOR,
     CDI_SECRETS,
     CDI_UPLOAD,
     CDI_UPLOAD_TMP_PVC,
     SOURCE_POD,
-    TIMEOUT_10MIN,
-    Images,
 )
+from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.storage import (
     create_dv,
     data_volume,

--- a/tests/storage/test_data_import_cron.py
+++ b/tests/storage/test_data_import_cron.py
@@ -15,15 +15,9 @@ from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.volume_snapshot import VolumeSnapshot
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import (
-    BIND_IMMEDIATE_ANNOTATION,
-    OUTDATED,
-    TIMEOUT_1MIN,
-    TIMEOUT_3MIN,
-    TIMEOUT_5SEC,
-    WILDCARD_CRON_EXPRESSION,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, OUTDATED, WILDCARD_CRON_EXPRESSION
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_3MIN, TIMEOUT_5SEC
 from utilities.storage import (
     wait_for_succeeded_dv,
     wait_for_volume_snapshot_ready_to_use,

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -15,7 +15,8 @@ from ocp_resources.storage_profile import StorageProfile
 
 from tests.storage.utils import assert_disk_bus
 from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
-from utilities.constants import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS, Images
+from utilities.constants import Images
+from utilities.constants.storage import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.jira import is_jira_open
 from utilities.storage import (

--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -11,7 +11,8 @@ import pytest
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
-from utilities.constants import TIMEOUT_1MIN, TIMEOUT_10MIN, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
+from utilities.constants.pytest import UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_10MIN
 from utilities.infra import login_with_user_password
 from utilities.storage import create_dv, get_dv_size_from_datasource
 

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -9,12 +9,9 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
-from utilities.constants import (
-    OS_FLAVOR_RHEL,
-    TIMEOUT_2MIN,
-    TIMEOUT_30SEC,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.images import OS_FLAVOR_RHEL
+from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_30SEC
 from utilities.storage import (
     add_dv_to_vm,
     check_disk_count_in_vm,

--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -10,7 +10,7 @@ from tests.storage.upgrade.utils import (
     create_snapshot_for_upgrade,
     create_vm_for_snapshot_upgrade_tests,
 )
-from utilities.constants import HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
+from utilities.constants.storage import HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import create_dv, virtctl_volume
 from utilities.virt import (

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -15,7 +15,9 @@ from tests.upgrade_params import (
     SNAPSHOT_RESTORE_CREATE_AFTER_UPGRADE,
     STORAGE_NODE_ID_PREFIX,
 )
-from utilities.constants import DEPENDENCY_SCOPE_SESSION, HOTPLUG_DISK_VIRTIO_BUS, LS_COMMAND
+from utilities.constants.cluster import LS_COMMAND
+from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
+from utilities.constants.storage import HOTPLUG_DISK_VIRTIO_BUS
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -32,16 +32,10 @@ from utilities.artifactory import (
     get_artifactory_secret,
     get_http_image_url,
 )
-from utilities.constants import (
-    CDI_UPLOADPROXY,
-    LS_COMMAND,
-    TIMEOUT_2MIN,
-    TIMEOUT_5MIN,
-    TIMEOUT_5SEC,
-    TIMEOUT_20SEC,
-    TIMEOUT_30MIN,
-    Images,
-)
+from utilities.constants import Images
+from utilities.constants.cluster import LS_COMMAND
+from utilities.constants.components import CDI_UPLOADPROXY
+from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_5MIN, TIMEOUT_5SEC, TIMEOUT_20SEC, TIMEOUT_30MIN
 from utilities.exceptions import DataVolumeConditionMessageNotFoundError
 from utilities.infra import (
     get_pod_by_name_prefix,

--- a/tests/storage/vm_export/conftest.py
+++ b/tests/storage/vm_export/conftest.py
@@ -20,7 +20,9 @@ from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
 
 from tests.storage.constants import TEST_FILE_CONTENT, TEST_FILE_NAME
 from tests.storage.vm_export.utils import create_blank_dv_by_specific_user, get_manifest_from_vmexport, get_manifest_url
-from utilities.constants import OS_FLAVOR_RHEL, U1_SMALL, UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
+from utilities.constants.images import OS_FLAVOR_RHEL
+from utilities.constants.instance_types import U1_SMALL
+from utilities.constants.pytest import UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
 from utilities.infra import create_ns, login_with_user_password
 from utilities.storage import data_volume_template_with_source_ref_dict, write_file_via_ssh
 from utilities.virt import VirtualMachineForTests, running_vm

--- a/tests/storage/vm_export/utils.py
+++ b/tests/storage/vm_export/utils.py
@@ -15,7 +15,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 from pyhelper_utils.shell import run_command
 from pytest_testconfig import config as py_config
 
-from utilities.constants import TIMEOUT_1MIN
+from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.storage import create_dv
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
##### What this PR does / why we need it:
Replace `from utilities.constants import X` with direct submodule imports across all 57 files in tests/storage/ and tests/data_protection/.

`from utilities.constants import Images` is intentionally kept as-is — Images is computed dynamically in __init__.py until the circular import in utilities/architecture.py is resolved.

Generated-by: Claude Sonnet 4.6

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
This is a next PR in a series.
https://redhat.atlassian.net/browse/CNV-80952 and a follow up of https://github.com/RedHatQE/openshift-virtualization-tests/pull/5188

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-89565


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated many test modules to use more specific constant imports, improving consistency and maintainability across storage and data-protection test suites.
  * Standardized timeouts, image, storage, and environment-related references through clearer module paths.

* **Chores**
  * No changes to test behavior, fixtures, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->