### PR TITLE
net, localnet: fix import

### DIFF
--- a/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 
+from libs.net import nodenetworkconfigurationpolicy as libnncp
 from libs.net.ip import random_cidr_addresses_by_family
 from libs.net.traffic_generator import TcpServer, VMTcpClient, active_tcp_connections
 from libs.net.vmspec import wait_for_ifaces_status
@@ -15,7 +16,6 @@ from libs.vm.spec import Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cloudinit
 from tests.network.libs import cluster_user_defined_network as libcudn
-from tests.network.libs import nodenetworkconfigurationpolicy as libnncp
 from tests.network.libs.cloudinit import EthernetDevice
 from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
 from tests.network.localnet.liblocalnet import (


### PR DESCRIPTION

##### What this PR does / why we need it:
Refactoring PR was merged before localnet changes, causing import issue in main when running localnet tests + pre-commit error + tox error

`ImportError: cannot import name 'nodenetworkconfigurationpolicy' from 'tests.network.libs' (/home/azhivovk/repos/openshift-virtualization-tests/tests/network/libs/__init__.py)`

##### Which issue(s) this PR fixes:
Fix import in localnet

##### Special notes for reviewer: -

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring of test infrastructure imports to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->