### PR TITLE
[4.22] feat: auto-add quarantined marker for xfail-quarantined tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -599,6 +599,7 @@ def pytest_collection_modifyitems(session, config, items):
     4. Adds the tier2 marker for tests without an exclusion marker.
     5. Filters upgrade tests based on the --upgrade option.
     6. Dynamically mark NMState-dependent tests.
+    7. Auto-adds the quarantined marker for xfail-quarantined tests.
 
     Args:
         session (pytest.Session): The pytest session object.
@@ -628,6 +629,14 @@ def pytest_collection_modifyitems(session, config, items):
 
         # Add tier2 marker for tests without an exclusion marker.
         add_tier2_marker(item=item)
+
+        # Auto-add quarantined marker for xfail tests with QUARANTINED reason
+        for marker in item.iter_markers(name="xfail"):
+            reason = marker.kwargs.get("reason", "")
+            run = marker.kwargs.get("run", True)
+            if QUARANTINED in reason and not run:
+                item.add_marker(marker="quarantined")
+                break
 
         # All tests are verified on amd64 platforms, adding `amd64` to all tests
         item.add_marker(marker=AMD_64)

--- a/docs/QUARANTINE_GUIDELINES.md
+++ b/docs/QUARANTINE_GUIDELINES.md
@@ -172,6 +172,22 @@ Understanding this distinction is critical:
 - `pytest_jira` - For conditional skipping when bugs are open
 - `pytest-repeat` - For stability verification (de-quarantine)
 
+**Selecting quarantined tests:**
+
+Tests marked with `@pytest.mark.xfail(reason=f"{QUARANTINED}: ...", run=False)` automatically
+receive a `quarantined` pytest marker during collection. This enables:
+
+```bash
+# Run only quarantined tests (e.g., to verify fixes)
+pytest -m quarantined
+
+# Exclude quarantined tests
+pytest -m "not quarantined"
+
+# Combine with other markers
+pytest -m "quarantined and storage"
+```
+
 ### Pull Request Requirements
 
 When submitting quarantine PR:

--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,7 @@ markers =
     early: Run fixtures early
     redhat_internal_dependency: Tests which have a dependency on an RedHat internal resource
     conformance: Run on standard cluster configuration
+    quarantined: Tests quarantined via xfail with QUARANTINED reason and run=False
 
     # Data collection markers
     skip_must_gather_collection: skip must gather collection on failures


### PR DESCRIPTION
##### What this PR does / why we need it:
Cherry-pick of upstream PR #5244 to cnv-4.22.

Detects xfail markers with QUARANTINED in the reason and run=False during collection, and auto-adds a quarantined marker.

##### Which issue(s) this PR fixes:
Cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/5244

##### Special notes for reviewer:

##### jira-ticket:

Assisted-by: Claude (claude-opus-4-6) <noreply@anthropic.com>