### PR TITLE
[4.20] feat: auto-add quarantined marker for xfail-quarantined tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -557,6 +557,7 @@ def pytest_collection_modifyitems(session, config, items):
     3. Adds the tier2 marker for tests without an exclusion marker.
     4. Marks tests by team.
     5. Filters upgrade tests based on the --upgrade option.
+    6. Auto-adds the quarantined marker for xfail-quarantined tests.
 
     Args:
         session (pytest.Session): The pytest session object.
@@ -588,6 +589,14 @@ def pytest_collection_modifyitems(session, config, items):
 
         # All tests are verified on X86_64 platforms, adding `x86_64` to all tests
         item.add_marker(marker=X86_64)
+
+        # Auto-add quarantined marker for xfail tests with QUARANTINED reason
+        for marker in item.iter_markers(name="xfail"):
+            reason = marker.kwargs.get("reason", "")
+            run = marker.kwargs.get("run", True)
+            if QUARANTINED in reason and not run:
+                item.add_marker(marker="quarantined")
+                break
     #  Collect only 'upgrade_custom' tests when running pytest with --upgrade_custom
     keep, discard = filter_upgrade_tests(items=items, config=config)
     items[:] = keep

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ markers =
     early: Run fixtures early
     redhat_internal_dependency: Tests which have a dependency on an RedHat internal resource
     conformance: Run on standard cluster configuration
+    quarantined: Tests quarantined via xfail with QUARANTINED reason and run=False
 
     # Data collection markers
     skip_must_gather_collection: skip must gather collection on failures


### PR DESCRIPTION
##### What this PR does / why we need it:
Cherry-pick of upstream PR #5244 to cnv-4.20.

Detects xfail markers with QUARANTINED in the reason and run=False during collection, and auto-adds a quarantined marker.

##### Which issue(s) this PR fixes:
Cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/5244

##### Special notes for reviewer:

##### jira-ticket:

Assisted-by: Claude (claude-opus-4-6) <noreply@anthropic.com>