### PR TITLE
[4.21] feat: auto-add quarantined marker for xfail-quarantined tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -578,6 +578,8 @@ def pytest_collection_modifyitems(session, config, items):
     3. Adds the tier2 marker for tests without an exclusion marker.
     4. Marks tests by team.
     5. Filters upgrade tests based on the --upgrade option.
+    6. Dynamically mark NMState-dependent tests.
+    7. Auto-adds the quarantined marker for xfail-quarantined tests.
 
     Args:
         session (pytest.Session): The pytest session object.
@@ -609,6 +611,15 @@ def pytest_collection_modifyitems(session, config, items):
 
         # All tests are verified on X86_64 platforms, adding `x86_64` to all tests
         item.add_marker(marker=X86_64)
+
+        # Auto-add quarantined marker for xfail tests with QUARANTINED reason
+        for marker in item.iter_markers(name="xfail"):
+            reason = marker.kwargs.get("reason", "")
+            run = marker.kwargs.get("run", True)
+            if QUARANTINED in reason and not run:
+                item.add_marker(marker="quarantined")
+                break
+
     #  Collect only 'upgrade_custom' tests when running pytest with --upgrade_custom
     keep, discard = filter_upgrade_tests(items=items, config=config)
     items[:] = keep

--- a/docs/QUARANTINE_GUIDELINES.md
+++ b/docs/QUARANTINE_GUIDELINES.md
@@ -165,6 +165,22 @@ Understanding this distinction is critical:
 | **Tracking**       | Blocker bug in Jira                     | Task with `xfail` marker                       |
 | **Fix Timeline**   | Current sprint                          | Based on priority                              |
 
+**Selecting quarantined tests:**
+
+Tests marked with `@pytest.mark.xfail(reason=f"{QUARANTINED}: ...", run=False)` automatically
+receive a `quarantined` pytest marker during collection. This enables:
+
+```bash
+# Run only quarantined tests (e.g., to verify fixes)
+pytest -m quarantined
+
+# Exclude quarantined tests
+pytest -m "not quarantined"
+
+# Combine with other markers
+pytest -m "quarantined and storage"
+```
+
 ### Implementation
 
 **Tools:**

--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ markers =
     early: Run fixtures early
     redhat_internal_dependency: Tests which have a dependency on an RedHat internal resource
     conformance: Run on standard cluster configuration
+    quarantined: Tests quarantined via xfail with QUARANTINED reason and run=False
 
     # Data collection markers
     skip_must_gather_collection: skip must gather collection on failures


### PR DESCRIPTION
##### What this PR does / why we need it:
Cherry-pick of upstream PR #5244 to cnv-4.21.

Detects xfail markers with QUARANTINED in the reason and run=False during collection, and auto-adds a quarantined marker.

##### Which issue(s) this PR fixes:
Cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/5244

##### Special notes for reviewer:

##### jira-ticket:


Assisted-by: Claude (claude-opus-4-6) <noreply@anthropic.com>
