### PR TITLE
[STORGE][GATING]  Add retry for virtctl download to handle transient SSL errors

### DIFF
--- a/.github/workflows/utilities-unit-tests.yml
+++ b/.github/workflows/utilities-unit-tests.yml
@@ -1,7 +1,7 @@
 name: Utilities Unit Tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -25,7 +25,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Install uv

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -690,19 +690,22 @@ def download_and_extract_file_from_cluster(tmpdir, url):
     LOGGER.info(f"Downloading archive using: url={url}")
     urllib3.disable_warnings()  # TODO: remove this when we fix the SSL warning
     local_file_name = os.path.join(tmpdir, url.split("/")[-1])
+
+    def _download_file() -> bool:
+        with requests.get(url=url, verify=False, stream=True) as response:
+            response.raise_for_status()
+            with open(local_file_name, "wb") as file_downloaded:
+                file_downloaded.writelines(response.iter_content(chunk_size=8192))
+        return True
+
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_2MIN,
         sleep=TIMEOUT_10SEC,
-        func=requests.get,
+        func=_download_file,
         exceptions_dict={requests.exceptions.SSLError: [], requests.exceptions.ConnectionError: []},
-        url=url,
-        verify=False,
-        stream=True,
     ):
-        sample.raise_for_status()
-        with open(local_file_name, "wb") as file_downloaded:
-            file_downloaded.writelines(sample.iter_content(chunk_size=8192))
-        break
+        if sample:
+            break
     LOGGER.info("Extract the downloaded archive.")
     if url.endswith(zip_file_extension):
         archive_file_object = zipfile.ZipFile(file=local_file_name)

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -690,10 +690,19 @@ def download_and_extract_file_from_cluster(tmpdir, url):
     LOGGER.info(f"Downloading archive using: url={url}")
     urllib3.disable_warnings()  # TODO: remove this when we fix the SSL warning
     local_file_name = os.path.join(tmpdir, url.split("/")[-1])
-    with requests.get(url, verify=False, stream=True) as created_request:
-        created_request.raise_for_status()
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_2MIN,
+        sleep=TIMEOUT_10SEC,
+        func=requests.get,
+        exceptions_dict={requests.exceptions.SSLError: [], requests.exceptions.ConnectionError: []},
+        url=url,
+        verify=False,
+        stream=True,
+    ):
+        sample.raise_for_status()
         with open(local_file_name, "wb") as file_downloaded:
-            file_downloaded.writelines(created_request.iter_content(chunk_size=8192))
+            file_downloaded.writelines(sample.iter_content(chunk_size=8192))
+        break
     LOGGER.info("Extract the downloaded archive.")
     if url.endswith(zip_file_extension):
         archive_file_object = zipfile.ZipFile(file=local_file_name)


### PR DESCRIPTION
##### What this PR does / why we need it:
The `virtctl` binary download from the cluster CLI route can fail with `SSLEOFError` during TLS handshake, causing all tests depending on the `virtctl_binary` fixture to fail in setup.

Wraps the download in `TimeoutSampler` to retry on `SSLError` and `ConnectionError` for up to 2 minutes (10s between attempts).

##### Which issue(s) this PR fixes:
Cherry-pick source for https://github.com/RedHatQE/cnv-tests/pull/3497


##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-83631



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file downloads from cluster infrastructure by adding controlled retry handling for transient network and SSL issues, reducing interruptions during large transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->