### PR TITLE
[STORGE][GATING] Add retry for virtctl download to handle transient SSL errors

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -689,11 +689,21 @@ def download_and_extract_file_from_cluster(tmpdir, url):
     LOGGER.info(f"Downloading archive using: url={url}")
     urllib3.disable_warnings()  # TODO: remove this when we fix the SSL warning
     local_file_name = os.path.join(tmpdir, url.split("/")[-1])
-    with requests.get(url, verify=False, stream=True) as created_request:
-        created_request.raise_for_status()
-        with open(local_file_name, "wb") as file_downloaded:
-            for chunk in created_request.iter_content(chunk_size=8192):
-                file_downloaded.write(chunk)
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_2MIN,
+        sleep=TIMEOUT_10SEC,
+        func=requests.get,
+        exceptions_dict={requests.exceptions.SSLError: [], requests.exceptions.ConnectionError: []},
+        url=url,
+        verify=False,
+        stream=True,
+    ):
+        with sample:
+            sample.raise_for_status()
+            with open(local_file_name, "wb") as file_downloaded:
+                for chunk in sample.iter_content(chunk_size=8192):
+                    file_downloaded.write(chunk)
+        break
     LOGGER.info("Extract the downloaded archive.")
     if url.endswith(zip_file_extension):
         archive_file_object = zipfile.ZipFile(file=local_file_name)


### PR DESCRIPTION
##### What this PR does / why we need it:
The `virtctl` binary download from the cluster CLI route can fail with `SSLEOFError` during TLS handshake, causing all tests depending on the `virtctl_binary` fixture to fail in setup.

Wraps the download in `TimeoutSampler` to retry on `SSLError` and `ConnectionError` for up to 2 minutes (10s between attempts).

##### Which issue(s) this PR fixes:
Cherry-pick source for https://github.com/RedHatQE/cnv-tests/pull/3497

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-83631
