### PR TITLE
net, tests, stuntime: Wait for VMI affinity reconciliation before migration

### DIFF
--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -10,6 +10,7 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 from pytest_testconfig import config as py_config
+from timeout_sampler import retry
 
 from libs.net.vmspec import VMInterfaceSpecNotFoundError
 from libs.vm.spec import (
@@ -33,6 +34,10 @@ from utilities.virt import get_oc_image_info, vm_console_run_commands
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
+
+
+class VMControllerGenerationNotProcessedError(Exception):
+    """Raised if VM controller fails to process the current generation within the timeout."""
 
 
 class BaseVirtualMachine(VirtualMachine):
@@ -151,6 +156,7 @@ class BaseVirtualMachine(VirtualMachine):
 
         Serializes without dict_factory so that None-valued fields (e.g. podAffinity: None)
         are preserved as null in the merge patch, ensuring the old affinity type is removed.
+        Waits until the VM controller has processed the updated generation before returning.
 
         Args:
             affinity: Affinity object to set, or None to clear.
@@ -159,6 +165,23 @@ class BaseVirtualMachine(VirtualMachine):
         template_affinity = asdict(obj=affinity) if affinity else None
         patches = {self: {"spec": {"template": {"spec": {"affinity": template_affinity}}}}}
         ResourceEditor(patches=patches).update()
+        self._wait_for_vm_controller_processed_generation()
+
+    @retry(
+        wait_timeout=10,
+        sleep=1,
+        exceptions_dict={VMControllerGenerationNotProcessedError: []},
+    )
+    def _wait_for_vm_controller_processed_generation(self) -> bool:
+        """Wait until the VM controller has processed the current VM generation."""
+        generation = self.instance.metadata.generation
+        desired_generation = self.instance.status.desiredGeneration
+        if generation != desired_generation:
+            raise VMControllerGenerationNotProcessedError(
+                f"VM {self.name} generation not processed by controller: "
+                f"generation={generation}, desiredGeneration={desired_generation}"
+            )
+        return True
 
     @property
     def template_spec(self) -> VMISpec:

--- a/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
@@ -189,7 +189,6 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
-        stuntime_server_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=CLIENT_VM_LABEL))
         migrate_vm_and_verify(vm=stuntime_server_vm, client=admin_client)
         measured_stuntime = measure_stuntime(active_ping=l2_bridge_active_ping)
         assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (

--- a/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/l2_bridge/migration_stuntime/test_migration_stuntime.py
@@ -19,7 +19,12 @@ STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob
 import pytest
 
 from libs.vm.affinity import new_pod_affinity, new_pod_anti_affinity
-from tests.network.libs.stuntime import CLIENT_VM_LABEL, SERVER_VM_LABEL, STUNTIME_THRESHOLD_SECONDS, measure_stuntime
+from tests.network.libs.stuntime import (
+    CLIENT_VM_LABEL,
+    SERVER_VM_LABEL,
+    STUNTIME_THRESHOLD_SECONDS,
+    measure_stuntime,
+)
 from utilities.virt import migrate_vm_and_verify
 
 pytestmark = [pytest.mark.tier3]

--- a/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
+++ b/tests/network/localnet/migration_stuntime/test_migration_stuntime.py
@@ -190,7 +190,6 @@ class TestMigrationStuntime:
         Expected:
             - Measured stuntime does not exceed the global threshold.
         """
-        localnet_stuntime_server_vm.set_template_affinity(affinity=new_pod_anti_affinity(label=CLIENT_VM_LABEL))
         migrate_vm_and_verify(vm=localnet_stuntime_server_vm, client=admin_client)
         measured_stuntime = measure_stuntime(active_ping=active_ping)
         assert measured_stuntime <= STUNTIME_THRESHOLD_SECONDS, (


### PR DESCRIPTION
##### What this PR does / why we need it:
When a VM template affinity is updated and migration is triggered immediately after, virt-controller and the VMIM controller race: the VMIM controller may read the VMI before the VM controller has reconciled the template change, creating the migration target pod with stale affinity rules. The VM ends up on the wrong node.

This PR adds `wait_for_vmi_affinity()` to `BaseVirtualMachine`, which polls the VMI until its affinity matches the VM template — ensuring the VM controller has reconciled before migration is triggered. All stuntime tests (L2 bridge + localnet) now call it after `set_template_affinity`.

Additionally, temporary post-migration affinity assertions are added (gated behind `is_jira_open("CNV-90576")`) to detect the race if it still occurs despite the wait. These assertions will be removed once CNV-90576 is resolved.

The first commit removes a redundant `set_template_affinity` call from `test_server_migrates_between_non_client_nodes` — the preceding test already sets the same affinity and `@pytest.mark.incremental` preserves it.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VM template affinity updates by confirming they are fully applied before continuing.
  - Added clearer error reporting when affinity changes are not processed in time.
  - Improved migration handling to ensure VM affinity settings are synchronized before and after migrations.
  - Corrected affinity behavior for migrations between non-client nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->