### PR TITLE
feat(tox): add 4.23 target versions to verify-bugs-are-open-gh

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,8 +93,9 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     python-utility-scripts
+# TODO: Update target-versions when we branch 4.23 and 5.0
 commands =
-    pyutils-jira --cloud --url https://redhat.atlassian.net --target-versions "vfuture,5.0.0,5.0.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
+    pyutils-jira --cloud --url https://redhat.atlassian.net --target-versions "vfuture,4.23.0,4.23.z,5.0.0,5.0.z" --resolved-statuses "verified,release pending,closed" --issue-pattern "([A-Z]+-[0-9]+)" --version-string-not-targeted-jiras "vfuture" --verbose
 
 #Unused code
 [testenv:unused-code]


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds 4.23.0 and 4.23.z to `--target-versions` in `[testenv:verify-bugs-are-open-gh]` so Jira bugs targeting 4.23 are also verified. Includes a TODO reminder to update when we branch 4.23 and 5.0.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing configuration to support additional target versions during the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->