### PR TITLE
feat: add retest-smoke workflow for /retest smoke PR comments

### DIFF
--- a/.github/workflows/retest-smoke.yml
+++ b/.github/workflows/retest-smoke.yml
@@ -1,0 +1,37 @@
+name: Retest Smoke
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: retest-smoke-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  retest-smoke:
+    if: >-
+      startsWith(github.event.comment.body, '/retest smoke')
+      && github.event.issue.pull_request
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add thumbs up reaction
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '+1'
+
+      - name: Add retest-smoke label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['retest-smoke']
+            });


### PR DESCRIPTION
##### What this PR does / why we need it:

Adds a GitHub Actions workflow that triggers on `/retest smoke` PR comments.

**Flow:**
1. Checks if the commenter is a member of the `cnvqe-bot` team
2. If **not authorized** → adds ❌ reaction and exits
3. If **authorized** → adds 👍 reaction and adds the `retest-smoke` label to the PR

**Actions used:**
- `tspascoal/get-user-teams-membership@v3` — team membership check
- `peter-evans/create-or-update-comment@v4` — reactions
- `actions/github-script@v7` — label management

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Requires `BOT3_TOKEN` secret with `org:read` scope for team membership checks.

##### jira-ticket:

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new “Retest Smoke” GitHub Actions workflow that can be triggered on pull requests by a `/retest smoke` comment.
  * The workflow runs with per-issue concurrency (auto-cancel in progress) and only proceeds after verifying the commenter is authorized, then updates reactions and applies the `retest-smoke` label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->