### PR TITLE
Update VIRT_ALERTS_LIST with new and missing virt component alerts

### DIFF
--- a/tests/observability/constants.py
+++ b/tests/observability/constants.py
@@ -4,24 +4,35 @@ BAD_HTTPGET_PATH = "/metrics-fake"
 SSP_COMMON_TEMPLATES_MODIFICATION_REVERTED = "SSPCommonTemplatesModificationReverted"
 KUBEVIRT_VMI_NUMBER_OF_OUTDATED = "kubevirt_vmi_number_of_outdated"
 VIRT_ALERTS_LIST = [
+    # virt-operator
     "VirtOperatorDown",
     "NoReadyVirtOperator",
-    "LowVirtOperatorCount",
-    "VirtAPIDown",
-    "LowVirtOperatorCount",
-    "VirtHandlerDaemonSetRolloutFailing",
     "LowReadyVirtOperatorsCount",
+    "LowVirtOperatorCount",
     "NoLeadingVirtOperator",
     "VirtOperatorRESTErrorsBurst",
     "VirtOperatorRESTErrorsHigh",
+    # virt-api
+    "VirtAPIDown",
+    "NoReadyVirtAPI",
+    "LowReadyVirtAPICount",
+    "LowVirtAPICount",
     "VirtApiRESTErrorsBurst",
     "VirtApiRESTErrorsHigh",
-    "LowReadyVirtControllersCount",
+    # virt-controller
+    "VirtControllerDown",
     "NoReadyVirtController",
-    "VirtControllerRESTErrorsHigh",
+    "LowReadyVirtControllersCount",
+    "LowVirtControllersCount",
     "VirtControllerRESTErrorsBurst",
-    "VirtHandlerRESTErrorsHigh",
+    "VirtControllerRESTErrorsHigh",
+    # virt-handler
+    "VirtHandlerDown",
+    "NoReadyVirtHandler",
+    "LowReadyVirtHandlerCount",
+    "VirtHandlerDaemonSetRolloutFailing",
     "VirtHandlerRESTErrorsBurst",
+    "VirtHandlerRESTErrorsHigh",
 ]
 SSP_ALERTS_LIST = [
     "SSPDown",


### PR DESCRIPTION
##### What this PR does / why we need it:
Add 5 new alerts from CNV-71204 (VirtHandlerDown, LowReadyVirtAPICount, NoReadyVirtAPI, LowReadyVirtHandlerCount, NoReadyVirtHandler) and 3 alerts that were previously missing (VirtControllerDown, LowVirtAPICount, LowVirtControllersCount). Remove duplicate LowVirtOperatorCount entry and organize list by component.

jira-ticket: CNV-71204

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-91215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated observability alert coverage to include a broader set of alerts across multiple components.
  * Reorganized alert listings into clearer groups and added missing readiness-related alert entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->