### PR TITLE
fix(ci): allow checkout@v7 fork PR checkout with environment gate

### DIFF
--- a/.github/workflows/utilities-unit-tests.yml
+++ b/.github/workflows/utilities-unit-tests.yml
@@ -15,6 +15,8 @@ jobs:
     name: Run Utilities Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Org members run automatically; outside contributors need maintainer approval
+    environment: ${{ (github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && '' || 'external-pr-tests' }}
     permissions:
       contents: read
       pull-requests: read
@@ -27,6 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0


### PR DESCRIPTION
##### What this PR does / why we need it:
`actions/checkout@v7` (bumped in #5289) blocks fork PR checkouts in `pull_request_target` workflows by default to prevent "pwn request" attacks. This broke the `utilities-unit-tests` workflow for all fork PRs (e.g. #5355).

**Fix:** Add `allow-unsafe-pr-checkout: true` with an environment-based gate:
- **Org members** (`COLLABORATOR`/`MEMBER`/`OWNER`) → run automatically (no environment)
- **Outside contributors** → require maintainer approval via the `external-pr-tests` environment

**Note:** The `external-pr-tests` environment must be created in repo Settings → Environments with "Required reviewers" enabled for the gate to work. Without it, outside contributor PRs will fail with "environment not found".

##### Which issue(s) this PR fixes:
Fixes the `Run Utilities Unit Tests` check failure on fork PRs after checkout@v7 upgrade.

##### Special notes for reviewer:
- The repo already has "Require approval for all external contributors" at the Actions level, so `allow-unsafe-pr-checkout: true` alone would be safe. The environment gate adds a second layer of defense.
- `v6` had the same behavior (checked out fork code silently) — `v7` just made it explicit.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved how pull request tests are scheduled for internal vs. external contributions.
  * Updated test checkout settings to better support pull request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->