### PR TITLE
fix(network): wait for ovnkube-node rollout after enabling MNP

### DIFF
--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -23,10 +23,12 @@ from tests.network.flat_overlay.utils import (
     get_vm_connection_reply,
     get_vm_kubevirt_domain_label,
     is_port_number_available,
+    restart_ovnkube_node_daemonset,
     start_nc_response_on_vm,
 )
 from utilities.constants import DEFAULT_RESOURCE_CONDITIONS, FLAT_OVERLAY_STR
 from utilities.infra import create_ns, wait_for_consistent_resource_conditions
+from utilities.jira import is_jira_open
 from utilities.network import assert_ping_successful, network_nad
 from utilities.virt import migrate_vm_and_verify
 
@@ -63,6 +65,8 @@ def multi_network_policy_enabled(admin_client, network_operator):
             resource_name="network",
             expected_conditions=DEFAULT_RESOURCE_CONDITIONS,
         )
+        if is_jira_open(jira_id="OCPBUGS-92080"):
+            restart_ovnkube_node_daemonset()
         yield
     wait_for_consistent_resource_conditions(
         dynamic_client=admin_client,

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -2,6 +2,7 @@ import logging
 import shlex
 
 from ocp_resources.resource import Resource
+from pyhelper_utils.shell import run_command
 
 from libs.net.ip import random_ipv4_address
 from tests.network.flat_overlay.constants import (
@@ -18,6 +19,12 @@ from utilities.virt import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+def restart_ovnkube_node_daemonset() -> None:
+    """Restarts the ovnkube-node DaemonSet and waits for the rollout to complete."""
+    run_command(command=shlex.split("oc rollout restart daemonset/ovnkube-node -n openshift-ovn-kubernetes"))
+    run_command(command=shlex.split("oc rollout status daemonset/ovnkube-node -n openshift-ovn-kubernetes --timeout=10m"))
 
 
 def create_flat_overlay_vm(

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -24,7 +24,9 @@ LOGGER = logging.getLogger(__name__)
 def restart_ovnkube_node_daemonset() -> None:
     """Restarts the ovnkube-node DaemonSet and waits for the rollout to complete."""
     run_command(command=shlex.split("oc rollout restart daemonset/ovnkube-node -n openshift-ovn-kubernetes"))
-    run_command(command=shlex.split("oc rollout status daemonset/ovnkube-node -n openshift-ovn-kubernetes --timeout=10m"))
+    run_command(
+        command=shlex.split("oc rollout status daemonset/ovnkube-node -n openshift-ovn-kubernetes --timeout=10m")
+    )
 
 
 def create_flat_overlay_vm(


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a race condition where `MultiNetworkPolicy` enforcement is silently disabled on OVN-K overlay secondary networks.

**The problem:** The `multi_network_policy_enabled` fixture patches the Network operator with `useMultiNetworkPolicy: True` and waits for the `ClusterOperator "network"` to stabilize. However, CNO updates the `ovnkube-config` configmap but does **not** trigger a DaemonSet rollout (the config hash [only covers `008-script-lib.yaml`](https://github.com/openshift/cluster-network-operator/blob/release-4.22/pkg/network/ovn_kubernetes.go#L478-L480), not [`004-config.yaml`](https://github.com/openshift/cluster-network-operator/blob/release-4.22/bindata/network/ovn-kubernetes/self-hosted/004-config.yaml#L52-L53) where `enable-multi-networkpolicy` is rendered). OVN-K reads config once at startup and does not hot-reload, so the running pods have `EnableMultiNetworkPolicy=false` in memory.

**Reproduced and confirmed:** On a cluster-bot OCP 4.22 cluster with [debug logging added to `shouldWatchNamespaces()`](https://github.com/openshift/ovn-kubernetes/pull/3264), enabling `useMultiNetworkPolicy` causes the ClusterOperator to report stable immediately (within 1 second), but the OVN-K pods are never restarted. Creating a secondary L2 NAD produces:

```
shouldWatchNamespaces=false for network test-l2-net: IsDefault=false IsPrimary=false IsUDN=true MNPEnabled=false NetSegEnabled=true
Ignoring namespaces events for network: test-l2-net
```

**The fix:** Explicitly `oc rollout restart` the `ovnkube-node` DaemonSet after enabling the feature and wait for the rollout to complete before proceeding with the test.

## Which issue(s) this PR fixes

- [CNV-90807](https://redhat.atlassian.net/browse/CNV-90807): MultiNetworkPolicy not enforced on OVN-Kubernetes overlay secondary networks

## Special notes for reviewer

There is also a CNO-side issue: `004-config.yaml` should be included in the [`cmPaths` hash list](https://github.com/openshift/cluster-network-operator/blob/release-4.22/pkg/network/ovn_kubernetes.go#L478-L480) so that configmap changes trigger a DaemonSet rollout automatically. This PR works around it on the test side.

jira-ticket: CNV-90807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved flat overlay multi-network policy test setup by automatically restarting the `ovnkube-node` DaemonSet when the relevant gate is open.
  * Added rollout synchronization to wait for the DaemonSet restart to complete before continuing, improving test stability and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->