### PR TITLE
fix(ci): allow checkout@v7 fork PR checkout with environment gate

### DIFF
--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     # Org members run automatically; outside contributors need maintainer approval
-    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","CONTRIBUTOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7

--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -16,7 +16,6 @@ jobs:
 
     # Org members run automatically; outside contributors need maintainer approval
     environment: ${{ (github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
-    if: contains(fromJson('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -24,6 +23,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Set up QEMU for multi-arch builds
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -14,7 +14,8 @@ jobs:
       contents: read
       pull-requests: write
 
-    # safe to use pull_request_target because we only run this for trusted collaborators
+    # Org members run automatically; outside contributors need maintainer approval
+    environment: ${{ (github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     if: contains(fromJson('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     steps:
       - name: Check out repository
@@ -22,6 +23,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Set up QEMU for multi-arch builds
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
 
     # Org members run automatically; outside contributors need maintainer approval
-    environment: ${{ (github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","CONTRIBUTOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7

--- a/.github/workflows/utilities-unit-tests.yml
+++ b/.github/workflows/utilities-unit-tests.yml
@@ -15,6 +15,8 @@ jobs:
     name: Run Utilities Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Org members run automatically; outside contributors need maintainer approval
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     permissions:
       contents: read
       pull-requests: read
@@ -27,6 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/utilities-unit-tests.yml
+++ b/.github/workflows/utilities-unit-tests.yml
@@ -30,6 +30,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/validate-coderabbit-schema.yml
+++ b/.github/workflows/validate-coderabbit-schema.yml
@@ -14,6 +14,8 @@ jobs:
     name: Validate .coderabbit.yaml against schema
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Org members run automatically; outside contributors need maintainer approval
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     permissions:
       contents: read
       pull-requests: read
@@ -23,6 +25,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/validate-coderabbit-schema.yml
+++ b/.github/workflows/validate-coderabbit-schema.yml
@@ -14,8 +14,6 @@ jobs:
     name: Validate .coderabbit.yaml against schema
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Org members run automatically; outside contributors need maintainer approval
-    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/validate-coderabbit-schema.yml
+++ b/.github/workflows/validate-coderabbit-schema.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0


### PR DESCRIPTION
##### What this PR does / why we need it:
`actions/checkout@v7` blocks fork PR checkouts in `pull_request_target` workflows by default. This adds `allow-unsafe-pr-checkout: true` with an environment gate so that:
- Org members (COLLABORATOR/MEMBER/OWNER) run automatically
- Outside contributors require maintainer approval via the `external-pr-tests` environment

Without this fix, ALL fork PRs that touch `utilities/` fail the "Run Utilities Unit Tests" CI check (e.g. #4959).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The `external-pr-tests` environment is already configured in the repo with reviewer gates.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to mark `pull_request_target` runs from forked, non-trusted contributions with `external-pr-tests`, leaving trusted runs unchanged.
* **Security**
  * Adjusted pull request checkout behavior in CI to allow unsafe PR checkout while disabling credential persistence, strengthening safety controls for external CI executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->