### PR TITLE
CherryPicked: [cnv-4.21] [Storage][4.22] Remove artifactory usage from disk preallocation tests

### DIFF
--- a/tests/storage/disk_preallocation/conftest.py
+++ b/tests/storage/disk_preallocation/conftest.py
@@ -1,0 +1,90 @@
+import pytest
+from ocp_resources.cdi import CDI
+
+from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
+from tests.storage.disk_preallocation.utils import wait_for_cdi_preallocation_enabled
+from utilities.constants import REGISTRY_STR, Images
+from utilities.hco import (
+    ResourceEditorValidateHCOReconcile,
+    hco_cr_jsonpatch_annotations_dict,
+)
+from utilities.storage import create_dv
+
+
+@pytest.fixture(scope="module")
+def cdi_preallocation_enabled(hyperconverged_resource_scope_module, cdi_config):
+    preallocation_value = True
+    with ResourceEditorValidateHCOReconcile(
+        patches={
+            hyperconverged_resource_scope_module: hco_cr_jsonpatch_annotations_dict(
+                component="cdi",
+                path="preallocation",
+                value=preallocation_value,
+            )
+        },
+        list_resource_reconcile=[CDI],
+    ):
+        wait_for_cdi_preallocation_enabled(cdi_config=cdi_config, expected_value=preallocation_value)
+        yield
+
+
+@pytest.fixture()
+def registry_dv_with_preallocation(namespace, storage_class_name_scope_function):
+    with create_dv(
+        dv_name=f"cnv-5512-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        source=REGISTRY_STR,
+        url=QUAY_FEDORA_CONTAINER_IMAGE,
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=storage_class_name_scope_function,
+        client=namespace.client,
+        preallocation=True,
+    ) as dv:
+        dv.wait_for_dv_success()
+        yield dv
+
+
+@pytest.fixture(scope="module")
+def registry_dv_no_preallocation_spec(namespace, storage_class_name_scope_module):
+    with create_dv(
+        dv_name=f"cnv-5513-{storage_class_name_scope_module}",
+        namespace=namespace.name,
+        source=REGISTRY_STR,
+        url=QUAY_FEDORA_CONTAINER_IMAGE,
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=storage_class_name_scope_module,
+        client=namespace.client,
+    ) as dv:
+        dv.wait_for_dv_success()
+        yield dv
+
+
+@pytest.fixture()
+def registry_dv_with_preallocation_false(namespace, storage_class_name_scope_function):
+    with create_dv(
+        dv_name=f"cnv-5741-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        source=REGISTRY_STR,
+        url=QUAY_FEDORA_CONTAINER_IMAGE,
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=storage_class_name_scope_function,
+        client=namespace.client,
+        preallocation=False,
+    ) as dv:
+        dv.wait_for_dv_success()
+        yield dv
+
+
+@pytest.fixture()
+def blank_dv_with_preallocation(namespace, storage_class_name_scope_function):
+    with create_dv(
+        dv_name=f"cnv-5737-{storage_class_name_scope_function}",
+        namespace=namespace.name,
+        source="blank",
+        size="100Mi",
+        storage_class=storage_class_name_scope_function,
+        client=namespace.client,
+        preallocation=True,
+    ) as dv:
+        dv.wait_for_dv_success()
+        yield dv

--- a/tests/storage/disk_preallocation/test_disk_preallocation.py
+++ b/tests/storage/disk_preallocation/test_disk_preallocation.py
@@ -1,0 +1,66 @@
+import pytest
+
+from tests.storage.disk_preallocation.utils import (
+    assert_preallocation_annotation,
+    assert_preallocation_requested_annotation,
+)
+
+"""
+Test preallocation functionality for DataVolumes
+Jira: http://redhat.atlassian.net/browse/CNV-6008
+"""
+pytestmark = pytest.mark.post_upgrade
+
+
+@pytest.mark.polarion("CNV-5512")
+@pytest.mark.gating
+@pytest.mark.sno
+@pytest.mark.s390x
+def test_preallocation_dv(registry_dv_with_preallocation):
+    """
+    Test that preallocation of the kubevirt disk is enabled via an API in the DataVolume spec
+    """
+    pvc = registry_dv_with_preallocation.pvc
+    assert_preallocation_requested_annotation(pvc=pvc, status="true")
+    assert_preallocation_annotation(pvc=pvc, res="true")
+
+
+@pytest.mark.polarion("CNV-5513")
+@pytest.mark.sno
+@pytest.mark.usefixtures("cdi_preallocation_enabled")
+def test_preallocation_globally_dv_spec_without_preallocation(
+    registry_dv_no_preallocation_spec,
+):
+    """
+    Test that preallocation can be also turned on for all DataVolumes with the CDI CR entry.
+    When create a general DataVolume without preallocation on DataVolume's spec, CDI would look into CDI CR.
+    """
+    pvc = registry_dv_no_preallocation_spec.pvc
+    assert_preallocation_requested_annotation(pvc=pvc, status="true")
+
+
+@pytest.mark.polarion("CNV-5741")
+@pytest.mark.sno
+@pytest.mark.usefixtures("cdi_preallocation_enabled")
+def test_preallocation_globally_dv_spec_with_preallocation_false(
+    registry_dv_with_preallocation_false,
+):
+    """
+    When create a general DataVolume with preallocation set false on DataVolume's spec, preallocation will not be used.
+    It won't take CDI CR into account because it is explicit in the DV.
+    """
+    pvc = registry_dv_with_preallocation_false.pvc
+    assert_preallocation_requested_annotation(pvc=pvc, status="false")
+
+
+@pytest.mark.polarion("CNV-5737")
+@pytest.mark.gating
+@pytest.mark.sno
+@pytest.mark.s390x
+def test_preallocation_for_blank_dv(blank_dv_with_preallocation):
+    """
+    Test that preallocation for blank disk should be supported
+    """
+    pvc = blank_dv_with_preallocation.pvc
+    assert_preallocation_requested_annotation(pvc=pvc, status="true")
+    assert_preallocation_annotation(pvc=pvc, res="true")

--- a/tests/storage/disk_preallocation/utils.py
+++ b/tests/storage/disk_preallocation/utils.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ocp_resources.resource import NamespacedResource
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from utilities.constants import TIMEOUT_2MIN
+
+if TYPE_CHECKING:
+    from ocp_resources.cdi_config import CDIConfig
+    from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+
+LOGGER = logging.getLogger(__name__)
+
+
+def assert_preallocation_requested_annotation(pvc: PersistentVolumeClaim, status: str) -> None:
+    """Assert that PVC has the expected preallocation.requested annotation value.
+
+    Args:
+        pvc: PersistentVolumeClaim to check.
+        status: Expected annotation value (e.g. "true" or "false").
+    """
+    preallocation_requested_annotation = (
+        f"{NamespacedResource.ApiGroup.CDI_KUBEVIRT_IO}/storage.preallocation.requested"
+    )
+    assert pvc.instance.metadata.annotations.get(preallocation_requested_annotation) == status, (
+        f"'{preallocation_requested_annotation}' should be '{status}'"
+    )
+
+
+def assert_preallocation_annotation(pvc: PersistentVolumeClaim, res: str) -> None:
+    """Assert that PVC has the expected preallocation annotation value.
+
+    Args:
+        pvc: PersistentVolumeClaim to check.
+        res: Expected annotation value (e.g. "true" or "false").
+    """
+    preallocation_annotation = f"{NamespacedResource.ApiGroup.CDI_KUBEVIRT_IO}/storage.preallocation"
+    assert pvc.instance.metadata.annotations.get(preallocation_annotation) == res, (
+        f"'{preallocation_annotation}' should be '{res}'"
+    )
+
+
+def wait_for_cdi_preallocation_enabled(cdi_config: CDIConfig, expected_value: bool) -> None:
+    """Wait for CDIConfig status.preallocation to match the expected value.
+
+    Args:
+        cdi_config: CDIConfig resource to monitor.
+        expected_value: Expected preallocation status.
+
+    Raises:
+        TimeoutExpiredError: If preallocation status does not match within timeout.
+    """
+    preallocation_status = ""
+    try:
+        for preallocation_status in TimeoutSampler(
+            wait_timeout=TIMEOUT_2MIN,
+            sleep=1,
+            func=lambda: cdi_config.instance.status.preallocation,
+        ):
+            if preallocation_status == expected_value:
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(
+            f"CDIconfig status.preallocation is '{preallocation_status}', but expected to be '{expected_value}'"
+        )
+        raise


### PR DESCRIPTION
Cherry-pick from `cnv-4.22` branch, original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5359, PR owner: ema-aka-young