### PR TITLE
fix: rename /retest smoke trigger to /rerun-smoke

### DIFF
--- a/.github/workflows/retest-smoke.yml
+++ b/.github/workflows/retest-smoke.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   retest-smoke:
     if: >-
-      startsWith(github.event.comment.body, '/retest smoke')
+      startsWith(github.event.comment.body, '/rerun-smoke')
       && github.event.issue.pull_request
       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### What this PR does / why we need it:
Renames the smoke retest trigger command from `/retest smoke` to `/rerun-smoke`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

Assisted-by: Claude <noreply@anthropic.com>