### PR TITLE
fix(ci): add checkout@v7 allow-unsafe-pr-checkout to auto-retest workflow

### DIFF
--- a/.github/workflows/auto-retest-needs-rebase.yml
+++ b/.github/workflows/auto-retest-needs-rebase.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Get merged PR changed files
         id: merged-files


### PR DESCRIPTION
##### What this PR does / why we need it:

`auto-retest-needs-rebase.yml` was missed in #5368. Adds `allow-unsafe-pr-checkout: true` and `persist-credentials: false` to the checkout step, matching the other `pull_request_target` workflows.

##### Which issue(s) this PR fixes:

Follow-up to #5368

##### Special notes for reviewer:

##### jira-ticket:

Signed-off-by: rnetser <rnetser@redhat.com>
Assisted-by: Claude <noreply@anthropic.com>