### PR TITLE
net, tests, hot-plug: Avoid redundant VMI interface lookup

### DIFF
--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -207,8 +207,10 @@ def create_bridge_interface_for_hot_plug(
         yield br
 
 
-def set_secondary_static_ip_address(vm, ipv4_address, vmi_interface):
-    guest_vm_interface = get_guest_vm_interface_name_by_vmi_interface_name(
+def set_secondary_static_ip_address(
+    vm: VirtualMachineForTests, ipv4_address: str, vmi_interface: str, guest_device_name: str | None = None
+) -> None:
+    guest_vm_interface = guest_device_name or get_guest_vm_interface_name_by_vmi_interface_name(
         vm=vm,
         vm_interface_name=vmi_interface,
     )
@@ -242,6 +244,7 @@ def hot_plug_interface_and_set_address(
         vm=vm,
         ipv4_address=ipv4_address,
         vmi_interface=iface.name,
+        guest_device_name=iface.interfaceName,
     )
 
     return iface

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -110,6 +110,7 @@ def hot_plugged_interface_with_address(running_vm_for_nic_hot_plug, index_number
         vm=running_vm_for_nic_hot_plug,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
         vmi_interface=hot_plugged_interface.name,
+        guest_device_name=hot_plugged_interface.interfaceName,
     )
 
 
@@ -151,6 +152,7 @@ def hot_plugged_second_interface_with_address(
         vm=running_vm_with_secondary_and_hot_plugged_interfaces,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
         vmi_interface=hot_plugged_interface_on_vm_created_with_secondary_interface.name,
+        guest_device_name=hot_plugged_interface_on_vm_created_with_secondary_interface.interfaceName,
     )
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
All callers of `set_secondary_static_ip_address()` already have the guest device name from the `hot_plug_interface()` return value, but the function re-queries VMI status to look it up again via `get_guest_vm_interface_name_by_vmi_interface_name()`.

Add an optional `guest_device_name` parameter so callers can pass the name they already have, skipping the redundant lookup. Callers without it still fall back to the VMI query.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static IP assignment for hot-plugged network interfaces by using the expected guest-side interface name when available.
  * Made IP configuration more reliable in environments where the guest device name differs from the default mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->