### PR TITLE
fix(ci): use REST API for author_association in pull_request_target workflows

### DIFF
--- a/.github/workflows/check-pr-approval.yml
+++ b/.github/workflows/check-pr-approval.yml
@@ -1,0 +1,76 @@
+# Reusable workflow to check if a PR requires approval.
+#
+# The webhook payload field (github.event.pull_request.author_association) is
+# unreliable under pull_request_target events — it can be absent or stale even
+# for org members. This workflow fetches the value via the REST API (pulls.get),
+# which always returns the correct association.
+#
+# Usage:
+#   jobs:
+#     check-approval:
+#       uses: ./.github/workflows/check-pr-approval.yml
+#
+#     my-job:
+#       needs: [check-approval]
+#       environment: ${{ needs.check-approval.outputs.needs_approval == 'true' && 'external-pr-tests' || '' }}
+
+name: Check PR Approval
+
+on:
+  workflow_call:
+    inputs:
+      trusted_associations:
+        description: JSON array of trusted author associations that skip approval
+        type: string
+        default: '["COLLABORATOR", "MEMBER", "OWNER"]'
+    outputs:
+      needs_approval:
+        description: Whether the PR needs environment approval (true/false)
+        value: ${{ jobs.check.outputs.needs_approval }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: read
+    outputs:
+      needs_approval: ${{ steps.check.outputs.needs_approval }}
+    steps:
+      - name: Fetch author association via REST API
+        id: check
+        uses: actions/github-script@v9
+        env:
+          TRUSTED_ASSOCIATIONS: ${{ inputs.trusted_associations }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.warning(`No pull_request in event payload (event: ${context.eventName}) — called from a non-PR trigger?`);
+              core.setOutput('needs_approval', 'true');
+              return;
+            }
+
+            try {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+
+              const trusted = JSON.parse(process.env.TRUSTED_ASSOCIATIONS);
+              if (!Array.isArray(trusted)) {
+                throw new Error('trusted_associations input must be a JSON array');
+              }
+
+              // head.repo is null when the fork has been deleted after the PR was opened
+              const isFork = !data.head.repo || data.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
+              const isTrusted = trusted.includes(data.author_association);
+              const needsApproval = isFork && !isTrusted;
+
+              core.info(`author=${data.user.login} association=${data.author_association} fork=${isFork} trusted=${isTrusted} needs_approval=${needsApproval}`);
+              core.setOutput('needs_approval', String(needsApproval));
+            } catch (error) {
+              core.warning(`Failed to fetch PR author association: ${error.message}`);
+              core.setOutput('needs_approval', 'true');
+            }

--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -8,14 +8,23 @@ on:
       - 'containers/utility/Dockerfile'
 
 jobs:
+  check-approval:
+    # Fetch author_association via REST API; webhook payload is unreliable
+    # for pull_request_target events.
+    permissions:
+      pull-requests: read
+    uses: ./.github/workflows/check-pr-approval.yml
+
   build-and-push-staging:
+    needs: [check-approval]
+    if: "!cancelled() && (needs.check-approval.result == 'success' || needs.check-approval.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
 
     # Org members run automatically; outside contributors need maintainer approval
-    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
+    environment: ${{ needs.check-approval.outputs.needs_approval == 'true' && 'external-pr-tests' || '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7

--- a/.github/workflows/net-utils-promote.yml
+++ b/.github/workflows/net-utils-promote.yml
@@ -10,16 +10,28 @@ on:
       - 'containers/utility/Dockerfile'
 
 jobs:
+  check-approval:
+    # Fetch author_association via REST API; webhook payload is unreliable
+    # for pull_request_target events.
+    # Intentionally skipped when PR is not merged — promote-to-latest depends
+    # on this and will also be skipped.
+    if: github.event.pull_request.merged == true
+    permissions:
+      pull-requests: read
+    uses: ./.github/workflows/check-pr-approval.yml
+    with:
+      trusted_associations: '["COLLABORATOR", "MEMBER", "OWNER", "CONTRIBUTOR"]'
+
   promote-to-latest:
+    needs: [check-approval]
+    # This workflow only triggers on merged PRs; check-pr-approval fails closed
+    # (needs_approval='true' on error), so promotion requires an explicitly trusted author.
+    if: needs.check-approval.outputs.needs_approval == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
 
-    # safe to use pull_request_target because we only run this for trusted collaborators
-    if: |
-      contains(fromJson('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association) &&
-      github.event.pull_request.merged == true
     steps:
       - name: Install skopeo
         run: |

--- a/.github/workflows/utilities-unit-tests.yml
+++ b/.github/workflows/utilities-unit-tests.yml
@@ -11,12 +11,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-approval:
+    # Fetch author_association via REST API; webhook payload is unreliable
+    # for pull_request_target events.
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: read
+    uses: ./.github/workflows/check-pr-approval.yml
+
   utilities-unit-tests:
     name: Run Utilities Unit Tests
+    needs: [check-approval]
+    if: "!cancelled() && (needs.check-approval.result == 'success' || needs.check-approval.result == 'skipped')"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Org members run automatically; outside contributors need maintainer approval
-    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
+    environment: ${{ needs.check-approval.outputs.needs_approval == 'true' && 'external-pr-tests' || '' }}
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
##### What this PR does / why we need it:

The webhook payload field `github.event.pull_request.author_association` is unreliable under `pull_request_target` events — it can be absent or stale even for org members, causing false environment gate triggers that require manual maintainer approval for trusted contributors (e.g., [this run](https://github.com/RedHatQE/openshift-virtualization-tests/actions/runs/28328227349/job/83921788865?pr=5355) waited ~3 hours for approval despite the author being an org MEMBER).

This PR replaces inline `author_association` checks with a reusable workflow (`check-pr-author.yml`) that fetches the value via the REST API (`pulls.get`), which always returns the correct association.

**Changes:**
- **New:** `.github/workflows/check-pr-author.yml` — reusable workflow with configurable `trusted_associations` input, fail-closed error handling, and deleted-fork null guard
- **Updated:** `utilities-unit-tests.yml` — uses reusable workflow for environment gate
- **Updated:** `net-utils-builder-staging.yml` — uses reusable workflow for environment gate
- **Updated:** `net-utils-promote.yml` — uses reusable workflow with `CONTRIBUTOR` in trusted list (preserving original behavior)

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

The root cause is a known GitHub platform issue where `pull_request_target` webhook payloads deliver stale/empty `author_association` values. NVIDIA hit the same bug and fixed it the same way ([OpenShell#444](https://github.com/NVIDIA/OpenShell/commit/85a3d83)). The REST API `pulls.get` endpoint reliably returns the correct value.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared PR-approval check to gate staging, promotion, and unit test workflows.
  * External pull requests can now be routed to a dedicated approval-dependent test environment when needed.

* **Bug Fixes**
  * Improved forked/untrusted pull request handling by centralizing approval determination in one reusable workflow.
  * Reduced incorrect runs by replacing complex approval conditions with consistent gating across workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->