### PR TITLE
Remove CNV-82351 xfail from TLS compliance tests

### DIFF
--- a/tests/install_upgrade_operators/crypto_policy/conftest.py
+++ b/tests/install_upgrade_operators/crypto_policy/conftest.py
@@ -43,6 +43,7 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
 from utilities.constants.components import (
     CDI_KUBEVIRT_HYPERCONVERGED,
     CLUSTER,
+    HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD,
     KUBEVIRT_HCO_NAME,
     MIGCONTROLLER_KUBEVIRT_HYPERCONVERGED,
     SSP_KUBEVIRT_HYPERCONVERGED,
@@ -171,6 +172,7 @@ def cnv_services_with_template(enabled_template_feature_gate, hco_namespace, adm
         service
         for service in Service.get(namespace=hco_namespace.name, client=admin_client)
         if service.instance.spec.clusterIP not in (None, "", "None")
+        and service.name != HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
     ]
     assert services_list, f"No services found in {hco_namespace.name}"
     service_names = [svc.name for svc in services_list]

--- a/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
@@ -8,8 +8,6 @@ import logging
 
 import pytest
 
-from utilities.constants.components import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
-
 LOGGER = logging.getLogger(__name__)
 pytestmark = pytest.mark.post_upgrade
 
@@ -39,8 +37,6 @@ def test_cnv_services_pqc_key_exchange(subtests, fips_enabled_cluster, pqc_statu
     """
     for service_name, accepted in pqc_status_by_service.items():
         with subtests.test(msg=service_name):
-            if service_name == HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD:
-                pytest.xfail(f"CNV-82351: {service_name} — plaintext HTTP behind TLS route, TLS planned for 5.0")
             assert accepted is not None, f"Service {service_name} is unreachable"
             if fips_enabled_cluster:
                 runtime = services_tls_runtime.get(service_name, "go")

--- a/tests/install_upgrade_operators/crypto_policy/test_tls_profile_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_tls_profile_propagation.py
@@ -13,7 +13,6 @@ from tests.install_upgrade_operators.crypto_policy.constants import (
     TLS_VERSION_1_3,
 )
 from tests.install_upgrade_operators.crypto_policy.utils import check_service_accepts_tls_version
-from utilities.constants.components import HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD
 
 LOGGER = logging.getLogger(__name__)
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.tier3]
@@ -45,8 +44,6 @@ def test_modern_profile_propagates_to_cnv_services(
     for service in cnv_services_with_template:
         service_name = service.name
         with subtests.test(msg=service_name):
-            if service_name == HYPERCONVERGED_CLUSTER_CLI_DOWNLOAD:
-                pytest.xfail(f"CNV-82351: {service_name} — plaintext HTTP behind TLS route, TLS planned for 5.0")
             accepts_tls12 = check_service_accepts_tls_version(
                 utility_pods=workers_utility_pods,
                 node=worker_node1,


### PR DESCRIPTION
##### What this PR does / why we need it:
Per CNV-82351 resolution: hyperconverged-cluster-cli-download relies on a secured route for TLS, matching OCP CLI downloads server behavior. No plans to secure the service itself. The service is excluded from TLS testing at the fixture level instead of xfailing per subtest.

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-82351