### PR TITLE
virt: extend post-migration SSH wait and log connectivity duration

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -45,7 +45,7 @@ from paramiko import ProxyCommandFailure
 from pyhelper_utils.shell import run_command, run_ssh_commands
 from pytest_testconfig import config as py_config
 from rrmngmnt import Host, ssh, user
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler, TimeoutWatch
 
 import utilities.cpu
 import utilities.data_utils
@@ -1669,6 +1669,7 @@ def wait_for_ssh_connectivity(
     vm: VirtualMachineForTests, timeout: int = TIMEOUT_2MIN, tcp_timeout: int = TIMEOUT_1MIN
 ) -> None:
     LOGGER.info(f"Wait for {vm.name} SSH connectivity.")
+    timeout_watch = TimeoutWatch(timeout=timeout)
 
     for sample in TimeoutSampler(
         wait_timeout=timeout,
@@ -1678,6 +1679,10 @@ def wait_for_ssh_connectivity(
         tcp_timeout=tcp_timeout,
     ):
         if sample:
+            LOGGER.info(
+                f"SSH connectivity to {vm.name} established after "
+                f"{timeout - timeout_watch.remaining_time():.1f}s."
+            )
             return
 
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1924,6 +1924,7 @@ def migrate_vm_and_verify(
     timeout: int = TIMEOUT_12MIN,
     wait_for_interfaces: bool = True,
     check_ssh_connectivity: bool = False,
+    ssh_timeout: int = TIMEOUT_3MIN,
     wait_for_migration_success: bool = True,
 ) -> VirtualMachineInstanceMigration | None:
     """Migrate VM and verify migration success.
@@ -1936,6 +1937,7 @@ def migrate_vm_and_verify(
         timeout (int, default=12 minutes): Maximum time to wait for the migration to finish.
         wait_for_interfaces (bool, default=True): Wait for VM network interfaces after migration completes.
         check_ssh_connectivity (bool, default=False): Verify SSH connectivity to the VM after migration completes.
+        ssh_timeout (int, default=3 minutes): Maximum time to wait for SSH connectivity after migration completes.
         wait_for_migration_success (bool, default=True):
             True = Full teardown will be applied.
             False = No teardown (responsibility on the programmer), and no
@@ -1963,6 +1965,7 @@ def migrate_vm_and_verify(
         node_before=node_before,
         wait_for_interfaces=wait_for_interfaces,
         check_ssh_connectivity=check_ssh_connectivity,
+        ssh_timeout=ssh_timeout,
     )
     return None
 
@@ -2031,6 +2034,7 @@ def verify_vm_migrated(
     node_before,
     wait_for_interfaces=True,
     check_ssh_connectivity=False,
+    ssh_timeout: int = TIMEOUT_3MIN,
 ):
     vmi_name = vm.vmi.name
     vmi_node_name = vm.vmi.node.name
@@ -2044,7 +2048,7 @@ def verify_vm_migrated(
             wait_for_vm_interfaces(vmi=vm.vmi)
 
         if check_ssh_connectivity:
-            wait_for_ssh_connectivity(vm=vm)
+            wait_for_ssh_connectivity(vm=vm, timeout=ssh_timeout)
     except TimeoutExpiredError:
         collect_vnc_screenshot_for_vms(vm=vm)
         raise

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1680,8 +1680,7 @@ def wait_for_ssh_connectivity(
     ):
         if sample:
             LOGGER.info(
-                f"SSH connectivity to {vm.name} established after "
-                f"{timeout - timeout_watch.remaining_time():.1f}s."
+                f"SSH connectivity to {vm.name} established after {timeout - timeout_watch.remaining_time():.1f}s."
             )
             return
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Extend post-migration SSH wait from 2 to 3 minutes for intermittent ssh flakes and log SSH connect duration on success for CI triage.
with this fix, we don't change default timeout of wait_for_ssh_connectivity but making it tunable for post migration cases.callers of migrate_vm_and_verify can make a choice now. 

##### Which issue(s) this PR fixes:
 SSH comes up quickly on some clusters and slowly on others, so we need real data to set a safe timeout. Logging the success duration gives us that  data and we can calibrate ssh_timeout from actual CI runs instead of guessing, understand why results vary across clusters under similar load and reduce flakiness.
Now we have this data : SSH connectivity to rhel10-hotplug-instance-type-vm-1782904035-2483807 established after 20.6s.
##### Special notes for reviewer:

##### jira-ticket:
failure in CI lanes seen rarely


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM migration verification by allowing SSH connectivity checks to use a configurable timeout.
  * Added timing visibility when SSH becomes available, helping diagnose longer connection waits during migration checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->