### PR TITLE
[4.22] Remove CNV-88765 runbook bug marker

### DIFF
--- a/tests/observability/runbook_url/conftest.py
+++ b/tests/observability/runbook_url/conftest.py
@@ -6,8 +6,7 @@ from ocp_resources.prometheus_rule import PrometheusRule
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import KUBEMACPOOL_PROMETHEUS_RULE, TIMEOUT_10SEC, TIMEOUT_30SEC
-from utilities.jira import is_jira_open
+from utilities.constants import TIMEOUT_10SEC, TIMEOUT_30SEC
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,9 +21,6 @@ def cnv_alerts_runbook_urls_from_prometheus_rule(cnv_prometheus_rules_matrix__fu
     rule_name = cnv_prometheus_rules_matrix__function__
     if rule_name == "prometheus-hpp-rules" and not hpp_cr_installed:
         pytest.xfail(f"Rule {rule_name} should not be present if HPP CR is not installed")
-    if rule_name == KUBEMACPOOL_PROMETHEUS_RULE and is_jira_open(jira_id="CNV-88765"):
-        pytest.xfail(f"{KUBEMACPOOL_PROMETHEUS_RULE} missing runbook URLs: CNV-88765")
-
     cnv_prometheus_rule_by_name = PrometheusRule(
         namespace=py_config["hco_namespace"],
         name=rule_name,


### PR DESCRIPTION
##### What this PR does / why we need it:
The link for the runbook in kubemacpool prometheus rule fixed and now we can see the DS link, removing the CNV-88765 since the bug is fixed.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-88765


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observability test coverage by removing an outdated skip condition, so runbook URL checks now run consistently for all applicable alert rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->