### PR TITLE
docs: update AGENTS.md — fix bugs, add missing sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,16 +51,12 @@ Before writing ANY new code:
 
 ### Utility Module Placement
 
-When adding functions to `utilities/`, place them in the correct module. See
-[Code Organization](docs/CODE_ORGANIZATION.md) for constants import rules and the fixtures package layout.
+When adding functions to `utilities/`, place them in the module that matches the domain.
+Each module is named after its domain (e.g., `network.py` for networking, `storage.py` for storage).
 
-- **`utilities/cluster.py`** — cluster-wide operations (oc commands, node operations, cluster state)
-- **`utilities/infra.py`** — infrastructure helpers (SSH, networking infrastructure, pod operations)
-- **`utilities/virt.py`** — VM lifecycle, VMI operations, migration helpers
-- **`utilities/storage.py`** — storage operations (PVC, DataVolume, StorageClass)
-- **`utilities/constants/<submodule>.py`** — shared constants; import from the submodule, not the package root (except `Images`)
-
-**NEVER** add functions to the wrong utility module — match the domain.
+- Browse `utilities/` for existing modules before creating a new one
+- If no matching module exists, create one named after the domain
+- **NEVER** add functions to the wrong utility module — match the domain
 
 ### Acceptable Defensive Checks (Exceptions Only)
 
@@ -99,9 +95,10 @@ New feature tests MUST follow the STD-first workflow:
 ### Test Requirements
 
 - **All new tests MUST have markers** - check pytest.ini for available markers, NEVER commit unmarked tests
-  - **Tier marker semantics**: tier1 = operator/infrastructure tests, tier2 = customer use case tests, tier3 = complex/hardware/platform-specific/time-consuming tests. Assign the correct tier based on what the test validates, not its complexity.
-  - **`tier2` is implicit** — added automatically to all tests that don't have an exclusion marker. Do NOT add `@pytest.mark.tier2` explicitly.
+  - **Tier marker semantics**: tier2 = customer use case tests (default), tier3 = complex/hardware/platform-specific/time-consuming tests. Assign the correct tier based on what the test validates, not its complexity.
+  - **`tier2` is implicit** — added automatically to all tests that don't have an exclusion marker (see `EXCLUDE_MARKER_FROM_TIER2_MARKER` in `conftest.py` for the full list). Do NOT add `@pytest.mark.tier2` explicitly.
   - **Team markers are implicit** — `network`, `storage`, `virt`, `iuo`, `observability`, `infrastructure`, `data_protection`, and `chaos` are added automatically based on the test's directory location. Do NOT add them explicitly.
+  - **`gating` marker** — marks tier2 tests that are part of the gating job. Apply when a test should block release promotion.
 - **Each test verifies ONE aspect only** - single purpose, easy to understand
 - **Tests MUST be independent** - use `pytest-dependency` ONLY when test B requires side effects from test A (e.g., cluster-wide configuration).
   For resource dependencies, use shared fixtures instead. **When using `@pytest.mark.dependency`, a comment explaining WHY the dependency exists is REQUIRED.**
@@ -145,6 +142,8 @@ When reviewing quarantine PRs, verify the **quarantine mechanism matches the fai
 - `@pytest.mark.xfail` quarantine is **unconditional** — requires a manual de-quarantine PR to remove
 
 **Review signal:** If the quarantine reason describes a **confirmed** product behavior that is broken (e.g., "feature X is not functioning in Y"), it is a product bug — use `@pytest.mark.jira`. If the root cause is unclear, under investigation, or relates to test/automation/environment issues (e.g., "test times out due to framework issue", "intermittent failure under investigation"), use `@pytest.mark.xfail` quarantine.
+
+- **`quarantined` marker is auto-added** — tests with `@pytest.mark.xfail(reason=f"{QUARANTINED}: ...", run=False)` automatically receive the `quarantined` marker at collection time. Do NOT add `@pytest.mark.quarantined` explicitly.
 
 ### Fixture Guidelines (CRITICAL)
 
@@ -216,8 +215,37 @@ When reviewing quarantine PRs, verify the **quarantine mechanism matches the fai
 - **Tests belong under the feature they test** - do NOT create standalone directories for cross-cutting concerns. If a test measures VM downtime during migration over a specific network type, it belongs under that network type's directory (e.g., `tests/network/l2_bridge/`), not a separate top-level directory.
 - **Test file naming REQUIRED** - ALWAYS use `test_<functionality>.py` format
 - **Local helpers location** - place helper utils in `<feature_dir>/utils.py`
-- **Local fixtures location** - place in `<feature_dir>/conftest.py` for feature-local fixtures, or `tests/fixtures/<team>/` for shared fixtures (see [Code Organization](docs/CODE_ORGANIZATION.md#fixtures-testsfixtures-and-conftestpy))
+- **Local fixtures location** - place in `<feature_dir>/conftest.py`
 - **Move to shared location** - move to `utilities/` or `tests/conftest.py` ONLY when used by different team directories
+
+### Scripts Directory
+
+Internal tooling and automation scripts live in `scripts/`. Each tool has its own subdirectory with an entry point, utilities, and tests. Scripts are NOT part of the test suite — they are standalone CLI tools for CI/CD integration and reporting.
+
+### Constants Module Placement
+
+Project constants live in `utilities/constants/` as domain-specific modules.
+Each module groups constants by domain (e.g., `cluster.py`, `virt.py`, `storage.py`).
+
+- Place new constants in the module matching their domain
+- If no matching module exists, create one with a module docstring describing its scope and listing what does NOT belong (with a pointer to the correct module)
+- The `__init__.py` re-exports all names for backward compatibility — new code should import directly from the submodule (e.g., `from utilities.constants.virt import X`)
+
+### conftest.py Architecture
+
+**Root `conftest.py`** (project root):
+- Contains pytest hooks (`pytest_collection_modifyitems`, `pytest_runtest_makereport`, etc.) and global configuration
+- **Do NOT add new hooks or complex logic directly** — extract into pytest plugins (registered via `pyproject.toml` entry points)
+- **No fixtures** — root conftest is for hooks and plugin registration only
+
+**`tests/conftest.py`**:
+- Contains shared test fixtures used across multiple team directories
+- **New shared fixtures should go in `tests/fixtures/`** as domain-specific modules (e.g., `tests/fixtures/network/`) and be imported via `tests/conftest.py`
+- **Fixture-only** — no helper functions, no utility code (place those in `utilities/`)
+
+**Feature-level `conftest.py`** (e.g., `tests/network/l2_bridge/conftest.py`):
+- Contains fixtures specific to that feature directory
+- Move to `tests/conftest.py` or `tests/fixtures/` only when used across team directories
 
 ### Internal API Stability
 
@@ -243,7 +271,7 @@ This is a test suite - internal APIs have NO backward compatibility requirements
 
 ## Essential Commands
 
-### Before commiting Verification (MANDATORY)
+### Before Committing Verification (MANDATORY)
 
 Before committing, these checks MUST pass:
 
@@ -264,8 +292,11 @@ uv run tox -e utilities-unittests
 ## Related Documentation
 
 - [`docs/CODE_ORGANIZATION.md`](docs/CODE_ORGANIZATION.md) — Constants, utilities, and fixtures layout and import rules
-- [`docs/QUARANTINE_GUIDELINES.md`](QUARANTINE_GUIDELINES.md) — Test quarantine and de-quarantine procedures
-- [`docs/SOFTWARE_TEST_DESCRIPTION.md`](SOFTWARE_TEST_DESCRIPTION.md) — STD docstring format and requirements
+- [`docs/QUARANTINE_GUIDELINES.md`](docs/QUARANTINE_GUIDELINES.md) — Test quarantine and de-quarantine procedures
+- [`docs/SOFTWARE_TEST_DESCRIPTION.md`](docs/SOFTWARE_TEST_DESCRIPTION.md) — STD docstring format and requirements
 - [`docs/CODING_AND_STYLE_GUIDE.md`](docs/CODING_AND_STYLE_GUIDE.md) — Detailed coding and style conventions
 - [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) — Contribution guidelines
 - [`tests/network/README.md`](tests/network/README.md) — Network domain knowledge: terminology, naming conventions and functionality.
+- [`docs/AI_CONTRIBUTION_POLICY.md`](docs/AI_CONTRIBUTION_POLICY.md) — AI contribution disclosure requirements
+- [`docs/MAINTAINER_GUIDELINES.md`](docs/MAINTAINER_GUIDELINES.md) — Maintainer/approver progression guidelines
+- [`docs/ARCHITECTURE_SUPPORT.md`](docs/ARCHITECTURE_SUPPORT.md) — Multi-architecture support documentation


### PR DESCRIPTION
##### What this PR does / why we need it:

Audited AGENTS.md and found 3 bugs and 7 missing sections. This PR fixes all of them:

**Bug fixes:**
- Fix broken links to `QUARANTINE_GUIDELINES.md` and `SOFTWARE_TEST_DESCRIPTION.md` (pointed to root instead of `docs/`)
- Remove nonexistent `tier1` from tier marker semantics (not in `pytest.ini`, never used)
- Fix typo: "commiting" → "committing"

**New/updated sections:**
- Generalize utility module placement — no explicit module list, just domain-match rule
- Document `gating` marker and add reference to tier2 exclusion markers in `conftest.py`
- Document `quarantined` marker auto-add behavior (from PR #5244)
- Add Scripts Directory section (`scripts/` placement guidance)
- Add Constants Module Placement section (`utilities/constants/` submodule imports)
- Add conftest.py Architecture section (root vs `tests/` vs feature-level)
- Add missing Related Documentation links (AI policy, maintainer guidelines, arch support)

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Pure documentation — no code changes.

##### jira-ticket:

Co-authored-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contribution guidance for placing new helper functions by matching them to the right domain area.
  * Updated test marker guidance, including clearer release-blocking test labeling and quarantine marker behavior.
  * Added guidance for organizing scripts, shared constants, and test setup structure.
  * Expanded related documentation links and fixed a heading typo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->