### PR TITLE
feat: component builder publish s390x and arm64

### DIFF
--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -10,12 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       FEDORA_VERSION: 43
-      CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -35,6 +33,8 @@ jobs:
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
         run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        env:
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -54,11 +54,14 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+          CPU_ARCH: amd64
         run: ./build.sh
       - name: Logging to quay.io
         run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
       - name: Tag & Push image to staging
         env:
+          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
           remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -1,4 +1,9 @@
 name: "Component Builder Publish"
+permissions:
+  contents: read
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
     paths:
@@ -10,31 +15,92 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora:
+  # Single source of truth for the architecture list.
+  # Both build-images (matrix) and create-manifest (ARCHITECTURES) derive
+  # their values from this job's outputs so they can never drift.
+  prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      # JSON object consumed by build-images via fromJson(), e.g.
+      # {"include":[{"arch":"amd64","url_arch":"x86_64",...}, ...]}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      # Space-separated string consumed by create-manifest, e.g.
+      # "amd64 arm64 s390x"
+      architectures: ${{ steps.set-matrix.outputs.architectures }}
+    steps:
+      - name: Set architecture matrix and list
+        id: set-matrix
+        run: |
+          matrix=$(cat <<'EOF'
+          {
+            "include": [
+              {
+                "arch": "amd64",
+                "url_arch": "x86_64",
+                "qemu_package": "qemu-system-x86",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
+              },
+              {
+                "arch": "arm64",
+                "url_arch": "aarch64",
+                "qemu_package": "qemu-system-aarch64",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
+              },
+              {
+                "arch": "s390x",
+                "url_arch": "s390x",
+                "qemu_package": "qemu-system-s390x",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images"
+              }
+            ]
+          }
+          EOF
+          )
+          # Compact to a single line for the output
+          echo "matrix=$(echo "${matrix}" | jq -c .)" >> "${GITHUB_OUTPUT}"
+          # Derive the space-separated arch list directly from the same JSON
+          archs=$(echo "${matrix}" | jq -r '[.include[].arch] | join(" ")')
+          echo "architectures=${archs}" >> "${GITHUB_OUTPUT}"
+
+  build-images:
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      contents: read
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
-      FEDORA_VERSION: 43
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
-        env:
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -54,20 +120,52 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-          CPU_ARCH: amd64
+          FEDORA_IMAGE: "${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2"
         run: ./build.sh
+
       - name: Logging to quay.io
-        run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+
       - name: Tag & Push image to staging
         env:
-          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-          remote_tag: "${{ env.FEDORA_VERSION }}-dev"
+          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
         run: |
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman push "${remote_repository}":"${arch_tag}"
-          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag}"
-          podman manifest push "${remote_repository}":"${remote_tag}" --all --format=v2s2
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman push "${REMOTE_REPOSITORY}":"${arch_tag}"
+
+  create-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - prepare
+      - build-images
+    env:
+      # Derived from prepare job output — stays in sync with the matrix automatically
+      ARCHITECTURES: ${{ needs.prepare.outputs.architectures }}
+    steps:
+      - name: Logging to quay.io
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+
+      - name: Create and push manifest
+        env:
+          FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
+          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
+        run: |
+          remote_tag="${FEDORA_VERSION}-dev"
+          # Build the list of arch-specific image references
+          ARCH_IMAGES=""
+          for arch in ${ARCHITECTURES}; do
+            ARCH_IMAGES="${ARCH_IMAGES} ${REMOTE_REPOSITORY}:${FEDORA_VERSION}-${arch}"
+          done
+          # Create and push the multi-arch manifest
+          podman manifest create --log-level=debug "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
+          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -51,12 +51,12 @@ jobs:
         run: |
           mkdir -p artifacts
           podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image.tar"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-container-image
-          path: artifacts/fedora-image.tar
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
           retention-days: 5
           compression-level: 0

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -7,32 +7,60 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
+
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            url_arch: x86_64
+            qemu_package: qemu-system-x86
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images
+          - arch: arm64
+            url_arch: aarch64
+            qemu_package: qemu-system-aarch64
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images
+          - arch: s390x
+            url_arch: s390x
+            qemu_package: qemu-system-s390x
+            fedora_url: https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
-      FEDORA_VERSION: 43
-      CPU_ARCH: amd64
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
         with:
@@ -42,17 +70,19 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
           NO_SECRETS: "true"
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2
         run: ./build.sh
+
       - name: Save container image as tarball
         env:
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
         run: |
           mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          podman tag "${local_repository}":"${arch_tag}" "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
           echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
+
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Commit 1:
fix: architecture suffix for the fedora-container-image artifact

This change introduces a suffix to the built artifact to facilitate
multi-architecture image testing. Without this modification, a race
condition occurs when the jobs for s390x and x86_64 run in parallel.

Commit 2:
feat: build s390x and arm64 images in the component builder workflow

Uses a matrix approach in order to reduce code duplication.

After the job runs, the artifacts should be published.

Commit 3:
Refactor: preparation work for Fedora image multiarch publish

The build.sh script primarily utilizes environment variables. To
generate an image for a new architecture, these variables must be
adjusted. This change relocates the generic environment variables
to specific steps, facilitating the transition to multiarch building.

Commit 4:
feat: component Builder Publish s390x and arm64 enablement

This change enables the publication of the Fedora s390x and arm images,
alongside the amd64 image in a single manifest. To achieve this,
the following steps must be taken:

1. Install qemu-system-s390x.
2. Execute build.sh twice with different environment variables.

After completing these steps, both all the images should be added
to the manifest.


##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture image builds for `amd64`, `arm64`, and `s390x`.
  * Release artifacts are now generated and tagged per architecture, with a multi-architecture manifest published for simplified use.
* **Chores**
  * Standardized build and publish workflow settings for more consistent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->