### PR TITLE
fix: add OCS virtualization SC to AWS global_config for gating

### DIFF
--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -2,9 +2,9 @@ from typing import Any
 
 import pytest_testconfig
 from ocp_resources.datavolume import DataVolume
+from utilities.constants.storage import StorageClassNames
 
 from utilities.constants import Images
-from utilities.constants.storage import StorageClassNames
 
 global config
 global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")

--- a/tests/global_config_aws.py
+++ b/tests/global_config_aws.py
@@ -3,7 +3,8 @@ from typing import Any
 import pytest_testconfig
 from ocp_resources.datavolume import DataVolume
 
-from utilities.constants import Images, StorageClassNames
+from utilities.constants import Images
+from utilities.constants.storage import StorageClassNames
 
 global config
 global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")
@@ -11,6 +12,15 @@ global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", 
 Images.Windows.DEFAULT_DV_SIZE = "75Gi"
 
 storage_class_matrix = [
+    {
+        StorageClassNames.CEPH_RBD_VIRTUALIZATION: {
+            "volume_mode": DataVolume.VolumeMode.BLOCK,
+            "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
+        }
+    },
     {
         StorageClassNames.PORTWORX_CSI_DB_SHARED: {
             "volume_mode": DataVolume.VolumeMode.FILE,
@@ -27,7 +37,6 @@ storage_class_matrix = [
             "snapshot": True,
             "online_resize": True,
             "wffc": False,
-            "default": True,
         }
     },
     {
@@ -37,15 +46,16 @@ storage_class_matrix = [
             "snapshot": True,
             "online_resize": True,
             "wffc": True,
+            "default": True,
         }
     },
 ]
 
-storage_class_for_storage_migration_a = StorageClassNames.IO2_CSI
-storage_class_for_storage_migration_b = StorageClassNames.IO2_CSI
+storage_class_a = StorageClassNames.IO2_CSI
+storage_class_b = StorageClassNames.IO2_CSI
 
 for _dir in dir():
-    if not config:  # noqa: F821
+    if not config:
         config: dict[str, Any] = {}
     val = locals()[_dir]
     if type(val) not in [bool, list, dict, str]:
@@ -54,4 +64,4 @@ for _dir in dir():
     if _dir in ["encoding", "py_file"]:
         continue
 
-    config[_dir] = locals()[_dir]  # noqa: F821
+    config[_dir] = locals()[_dir]


### PR DESCRIPTION
## Summary

- Add `ocs-storagecluster-ceph-rbd-virtualization` (`CEPH_RBD_VIRTUALIZATION`) to `tests/global_config_aws.py` on the `cnv-4.19` branch
- Backport of openshift-virtualization-tests #3309 for OCS-based AWS gating clusters

## Problem

After [contra/cnv MR !8802](https://gitlab.cee.redhat.com/contra/cnv/-/merge_requests/8802) migrated tier0 gating to AWS IPI, Cluster Health Check fails pytest collection:

```
ValueError: storage_class_matrix is missing in config file
```

Health check runs with `--tc-file=tests/global_config_aws.py --storage-class-matrix=ocs-storagecluster-ceph-rbd-virtualization`, but `cnv-4.19` AWS config only had Portworx/Trident/IO2 entries.

**Example:** [verify-cnv-4.19.z-build #697](https://jenkins-csb-cnvqe-main.dno.corp.redhat.com/job/verify-cnv-4.19.z-build/697/) — deploy AWS OK, health check exit 2 (44 collection errors).

**Not** caused by `set-default-storage-class` (skipped for 4.19 verify jobs).

## Jira

- [CNV-91960](https://redhat.atlassian.net/browse/CNV-91960)
- Relates to [VMEDO-464](https://redhat.atlassian.net/browse/VMEDO-464)

## Test plan

- [ ] Merge to `cnv-4.19` and publish `openshift-virtualization-tests:cnv-4.19` image
- [ ] Re-run `verify-cnv-4.19.z-build` on AWS — Cluster Health Check should collect tests (exit 0)
- [ ] Cherry-pick same change to `cnv-4.20` before/at 4.99 AWS migration


Made with [Cursor](https://cursor.com)