### PR TITLE
feat: Add vm templates STD

### DIFF
--- a/tests/infrastructure/vm_template/test_vm_template_admission.py
+++ b/tests/infrastructure/vm_template/test_vm_template_admission.py
@@ -1,0 +1,61 @@
+"""
+VM Template Admission Behavior Tests
+
+Tests for VirtualMachineTemplate admission behavior: validate that templates whose
+defaulted parameters always produce an invalid VM are rejected by the admission
+webhook, and that templates who use the same fields as common instance types resolve
+to a valid VM definition are accepted.
+
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-infra/virtual-machine-template.md
+
+Markers:
+    - tier2
+"""
+
+import pytest
+
+__test__ = False
+
+
+class TestVMTemplateAdmission:
+    """
+    Tests for VirtualMachineTemplate admission behavior under defaulted parameters.
+
+    Preconditions:
+        - OpenShift Virtualization cluster with common instance types deployed
+    """
+
+    @pytest.mark.polarion("CNV-16314")
+    def test_valid_template_with_defaulted_parameters_accepted(self):
+        """
+        Test that a VirtualMachineTemplate whose default parameter values resolve to a
+        valid VM definition is accepted by the cluster.
+
+        The template uses default values that mirror the fields of a common instance type,
+        ensuring the rendered VM definition is structurally valid.
+
+        Steps:
+            1. Submit a VirtualMachineTemplate whose parameters all have defaults modeled
+               after a common instance type, producing a complete and valid VM definition
+
+        Expected:
+            - VirtualMachineTemplate is created successfully
+
+        Markers:
+            - smoke
+        """
+
+    @pytest.mark.polarion("CNV-16315")
+    def test_invalid_by_default_template_rejected(self):
+        """
+        [NEGATIVE] Test that a VirtualMachineTemplate whose default parameter values would
+        always produce an invalid VM definition is rejected by the admission webhook.
+
+        Steps:
+            1. Submit a VirtualMachineTemplate resource whose defaulted parameters produce
+               an invalid VM definition
+
+        Expected:
+            - VirtualMachineTemplate creation is rejected with an admission error indicating
+              the template would always produce an invalid VM
+        """

--- a/tests/infrastructure/vm_template/test_vm_template_capability.py
+++ b/tests/infrastructure/vm_template/test_vm_template_capability.py
@@ -1,0 +1,132 @@
+"""
+VM Template Capability Disable and Reenable Tests
+
+Tests for the Template capability feature gate: validate that disabling the capability
+blocks new template workflows while preserving existing objects, and that re-enabling
+the capability restores expected template workflows.
+
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-infra/virtual-machine-template.md
+
+Markers:
+    - tier2
+    - post_upgrade
+"""
+
+import pytest
+
+__test__ = False
+
+
+@pytest.mark.incremental
+class TestVMTemplateCapability:
+    """
+    Tests for VirtualMachineTemplate capability disable and reenable behavior.
+
+    The tests run in order: the disable phase first, then the reenable phase.
+    Each phase depends on the cluster state left by previous tests in the class.
+
+    Preconditions:
+        - OpenShift Virtualization cluster with the Template capability enabled
+    """
+
+    @pytest.mark.polarion("CNV-16316")
+    def test_new_template_creation_blocked_after_capability_disabled(self):
+        """
+        [NEGATIVE] Test that creating a new VirtualMachineTemplate is blocked after the
+        Template capability is disabled.
+
+        Preconditions:
+            - OpenShift Virtualization cluster with the Template capability enabled
+
+        Steps:
+            1. Disable the Template capability on the cluster
+            2. Attempt to create a new VirtualMachineTemplate resource
+
+        Expected:
+            - VirtualMachineTemplate creation is rejected
+        """
+
+    @pytest.mark.polarion("CNV-16317")
+    def test_new_template_request_blocked_after_capability_disabled(self):
+        """
+        [NEGATIVE] Test that creating a new VirtualMachineTemplateRequest is blocked
+        while the Template capability is disabled.
+
+        Preconditions:
+            - Template capability is disabled on the cluster
+
+        Steps:
+            1. Attempt to create a new VirtualMachineTemplateRequest resource
+
+        Expected:
+            - VirtualMachineTemplateRequest creation is rejected
+        """
+
+    @pytest.mark.polarion("CNV-16318")
+    def test_existing_templates_preserved_after_capability_disabled(self):
+        """
+        Test that existing VirtualMachineTemplate resources remain present on the cluster
+        after the Template capability is disabled.
+
+        Preconditions:
+            - Template capability is disabled on the cluster
+            - A VirtualMachineTemplate existed on the cluster before the capability was disabled
+
+        Steps:
+            1. List VirtualMachineTemplate resources on the cluster
+
+        Expected:
+            - The pre-existing VirtualMachineTemplate is still present
+        """
+
+    @pytest.mark.polarion("CNV-16319")
+    def test_existing_template_requests_preserved_after_capability_disabled(self):
+        """
+        Test that existing VirtualMachineTemplateRequest resources remain present on the
+        cluster after the Template capability is disabled.
+
+        Preconditions:
+            - Template capability is disabled on the cluster
+            - A VirtualMachineTemplateRequest existed on the cluster before the capability
+              was disabled
+
+        Steps:
+            1. List VirtualMachineTemplateRequest resources on the cluster
+
+        Expected:
+            - The pre-existing VirtualMachineTemplateRequest is still present
+        """
+
+    @pytest.mark.polarion("CNV-16320")
+    def test_new_template_creation_succeeds_after_capability_reenabled(self):
+        """
+        Test that creating a new VirtualMachineTemplate succeeds after the Template
+        capability is re-enabled following a disable.
+
+        Preconditions:
+            - Template capability was previously disabled and is now re-enabled
+
+        Steps:
+            1. Create a new VirtualMachineTemplate resource
+
+        Expected:
+            - VirtualMachineTemplate is created successfully
+        """
+
+    @pytest.mark.polarion("CNV-16321")
+    def test_vm_creation_from_template_succeeds_after_capability_reenabled(self):
+        """
+        Test that creating a VM from a template succeeds after the Template capability
+        is re-enabled following a disable.
+
+        Preconditions:
+            - Template capability is re-enabled on the cluster
+            - A VirtualMachineTemplate exists on the cluster
+
+        Steps:
+            1. Create a VirtualMachineTemplateRequest referencing the existing template
+
+        Expected:
+            - VirtualMachineTemplateRequest is accepted and a new VM is created from the
+              template
+        """


### PR DESCRIPTION
##### What this PR does / why we need it:
Add STD for testing Kubevirt virtual machine templates.

##### Which issue(s) this PR fixes:
 - Admission behavior: verifies that templates whose defaulted parameters always produce a valid VM definition are accepted, while templates that would always produce an invalid VM are rejected by the admission webhook.
 - Capability feature gate: verifies that disabling the Template capability blocks new template and template-request creation while preserving existing objects, and that re-enabling it restores full template workflows.

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-86112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for VirtualMachineTemplate admission, verifying acceptance when defaulted parameters resolve to valid VM definitions, and rejection when they resolve to invalid definitions.
  * Added coverage for Template capability gating, ensuring new template creation and template-based requests are blocked when disabled and restored when re-enabled.
  * Strengthened validation for VM creation from existing template-based requests across capability state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->