### PR TITLE
[4.22] Block test_vmi_reports_ip_on_secondary_interface_without_vlan due to CNV-91976

### DIFF
--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -56,6 +56,7 @@ def test_connectivity_post_migration_between_localnet_vms(
                 assert is_tcp_connection(server=server, client=client)
 
 
+@pytest.mark.jira("CNV-91976", run=False)
 @pytest.mark.single_nic
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet")


### PR DESCRIPTION
Has to manually cherry-pick because the back-ported bug ticket has a different ID than the original bug.