### PR TITLE
feat: s390x and arm64 fedora image publish

### DIFF
--- a/.github/component-builder-config.json
+++ b/.github/component-builder-config.json
@@ -1,0 +1,27 @@
+{
+  "fedora_version": "43",
+  "fedora_image_base": "Fedora-Cloud-Base-Generic-43-1.6",
+  "fedora_checksum_base": "Fedora-Cloud-43-1.6",
+  "matrix": {
+    "include": [
+      {
+        "arch": "amd64",
+        "url_arch": "x86_64",
+        "qemu_package": "qemu-system-x86",
+        "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
+      },
+      {
+        "arch": "arm64",
+        "url_arch": "aarch64",
+        "qemu_package": "qemu-system-aarch64",
+        "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
+      },
+      {
+        "arch": "s390x",
+        "url_arch": "s390x",
+        "qemu_package": "qemu-system-s390x",
+        "fedora_url": "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images"
+      }
+    ]
+  }
+}

--- a/.github/workflows/component-builder-prepare.yml
+++ b/.github/workflows/component-builder-prepare.yml
@@ -1,0 +1,45 @@
+name: "Component Builder Prepare"
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "JSON matrix consumed by build jobs via fromJson()"
+        value: ${{ jobs.prepare.outputs.matrix }}
+      fedora_version:
+        description: "Fedora version string (e.g. '43')"
+        value: ${{ jobs.prepare.outputs.fedora_version }}
+      fedora_image_base:
+        description: "Base name of the Fedora cloud image"
+        value: ${{ jobs.prepare.outputs.fedora_image_base }}
+      fedora_checksum_base:
+        description: "Base name of the Fedora checksum file"
+        value: ${{ jobs.prepare.outputs.fedora_checksum_base }}
+      architectures:
+        description: "Space-separated list of architectures (e.g. 'amd64 arm64 s390x')"
+        value: ${{ jobs.prepare.outputs.architectures }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.component-builder-config.outputs.matrix }}
+      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
+      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ steps.component-builder-config.outputs.fedora_checksum_base }}
+      architectures: ${{ steps.component-builder-config.outputs.architectures }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Read component builder config
+        id: component-builder-config
+        run: |
+          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_checksum_base=$(jq -r '.fedora_checksum_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "architectures=$(jq -r '[.matrix.include[].arch] | join(" ")' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -14,37 +14,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Single source of truth for the architecture list.
-  # Both build-images (matrix) and create-manifest (ARCHITECTURES) derive
-  # their values from this job's outputs so they can never drift.
   prepare:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      # JSON object consumed by build-images via fromJson(), e.g.
-      # {"include":[{"arch":"amd64","url_arch":"x86_64",...}, ...]}
-      matrix: ${{ steps.component-builder-config.outputs.matrix }}
-      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
-      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
-      fedora_checksum_base: ${{ steps.component-builder-config.outputs.fedora_checksum_base }}
-      # Space-separated string consumed by create-manifest, e.g.
-      # "amd64 arm64 s390x"
-      architectures: ${{ steps.component-builder-config.outputs.architectures }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Read component builder config
-        id: component-builder-config
-        run: |
-          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_checksum_base=$(jq -r '.fedora_checksum_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "architectures=$(jq -r '[.matrix.include[].arch] | join(" ")' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+    uses: ./.github/workflows/component-builder-prepare.yml
 
   build-images:
     runs-on: ubuntu-latest
@@ -158,7 +129,7 @@ jobs:
         env:
           QUAY_USER: ${{ secrets.QUAY_USER }}
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
 
       - name: Create and push manifest
         env:
@@ -173,4 +144,4 @@ jobs:
           done
           # Create and push the multi-arch manifest
           podman manifest create "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
-          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2
+          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=oci

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -10,12 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       FEDORA_VERSION: 43
-      CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -35,6 +33,8 @@ jobs:
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
         run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        env:
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -54,11 +54,14 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+          CPU_ARCH: amd64
         run: ./build.sh
       - name: Logging to quay.io
         run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
       - name: Tag & Push image to staging
         env:
+          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
           remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -2,7 +2,6 @@ name: "Component Builder Publish"
 permissions:
   contents: read
 env:
-  FEDORA_VERSION: 43
   REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
@@ -25,44 +24,27 @@ jobs:
     outputs:
       # JSON object consumed by build-images via fromJson(), e.g.
       # {"include":[{"arch":"amd64","url_arch":"x86_64",...}, ...]}
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.component-builder-config.outputs.matrix }}
+      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
+      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ steps.component-builder-config.outputs.fedora_checksum_base }}
       # Space-separated string consumed by create-manifest, e.g.
       # "amd64 arm64 s390x"
-      architectures: ${{ steps.set-matrix.outputs.architectures }}
+      architectures: ${{ steps.component-builder-config.outputs.architectures }}
     steps:
-      - name: Set architecture matrix and list
-        id: set-matrix
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Read component builder config
+        id: component-builder-config
         run: |
-          matrix=$(cat <<'EOF'
-          {
-            "include": [
-              {
-                "arch": "amd64",
-                "url_arch": "x86_64",
-                "qemu_package": "qemu-system-x86",
-                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
-              },
-              {
-                "arch": "arm64",
-                "url_arch": "aarch64",
-                "qemu_package": "qemu-system-aarch64",
-                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
-              },
-              {
-                "arch": "s390x",
-                "url_arch": "s390x",
-                "qemu_package": "qemu-system-s390x",
-                "fedora_url": "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images"
-              }
-            ]
-          }
-          EOF
-          )
-          # Compact to a single line for the output
-          echo "matrix=$(echo "${matrix}" | jq -c .)" >> "${GITHUB_OUTPUT}"
-          # Derive the space-separated arch list directly from the same JSON
-          archs=$(echo "${matrix}" | jq -r '[.include[].arch] | join(" ")')
-          echo "architectures=${archs}" >> "${GITHUB_OUTPUT}"
+          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_checksum_base=$(jq -r '.fedora_checksum_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "architectures=$(jq -r '[.matrix.include[].arch] | join(" ")' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
 
   build-images:
     runs-on: ubuntu-latest
@@ -72,7 +54,9 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
-      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
+      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
+      FEDORA_CHECKSUM_BASE: ${{ needs.prepare.outputs.fedora_checksum_base }}
       CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -83,10 +67,12 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies for VM build
+        env:
+          QEMU_PACKAGE: ${{ matrix.qemu_package }}
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            ${{ matrix.qemu_package }} \
+            "$QEMU_PACKAGE" \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
@@ -97,9 +83,28 @@ jobs:
 
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
+        env:
+          FEDORA_URL: ${{ matrix.fedora_url }}
+          URL_ARCH: ${{ matrix.url_arch }}
+        run: |
+          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          wget -q "${FEDORA_URL}/${fedora_image}"
+          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
+          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
+
+      - name: Verify Fedora image checksum
+        working-directory: ./containers/fedora
         run: |
           FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
-          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+          # Extract the SHA256 line for the exact artifact and verify it.
+          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
+          # sha256sum expects: <digest>  <filename>
+          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
+            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
+            | sha256sum --check --status \
+            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
+          echo "Checksum verified for ${FEDORA_IMAGE}"
+          rm CHECKSUM
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2
@@ -127,7 +132,7 @@ jobs:
         env:
           QUAY_USER: ${{ secrets.QUAY_USER }}
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
 
       - name: Tag & Push image to staging
         env:
@@ -157,7 +162,7 @@ jobs:
 
       - name: Create and push manifest
         env:
-          FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
+          FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
           REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
         run: |
           remote_tag="${FEDORA_VERSION}-dev"
@@ -167,5 +172,5 @@ jobs:
             ARCH_IMAGES="${ARCH_IMAGES} ${REMOTE_REPOSITORY}:${FEDORA_VERSION}-${arch}"
           done
           # Create and push the multi-arch manifest
-          podman manifest create --log-level=debug "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
+          podman manifest create "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
           podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -1,4 +1,9 @@
 name: "Component Builder Publish"
+permissions:
+  contents: read
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
     paths:
@@ -10,31 +15,92 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora:
+  # Single source of truth for the architecture list.
+  # Both build-images (matrix) and create-manifest (ARCHITECTURES) derive
+  # their values from this job's outputs so they can never drift.
+  prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      # JSON object consumed by build-images via fromJson(), e.g.
+      # {"include":[{"arch":"amd64","url_arch":"x86_64",...}, ...]}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      # Space-separated string consumed by create-manifest, e.g.
+      # "amd64 arm64 s390x"
+      architectures: ${{ steps.set-matrix.outputs.architectures }}
+    steps:
+      - name: Set architecture matrix and list
+        id: set-matrix
+        run: |
+          matrix=$(cat <<'EOF'
+          {
+            "include": [
+              {
+                "arch": "amd64",
+                "url_arch": "x86_64",
+                "qemu_package": "qemu-system-x86",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
+              },
+              {
+                "arch": "arm64",
+                "url_arch": "aarch64",
+                "qemu_package": "qemu-system-aarch64",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
+              },
+              {
+                "arch": "s390x",
+                "url_arch": "s390x",
+                "qemu_package": "qemu-system-s390x",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images"
+              }
+            ]
+          }
+          EOF
+          )
+          # Compact to a single line for the output
+          echo "matrix=$(echo "${matrix}" | jq -c .)" >> "${GITHUB_OUTPUT}"
+          # Derive the space-separated arch list directly from the same JSON
+          archs=$(echo "${matrix}" | jq -r '[.include[].arch] | join(" ")')
+          echo "architectures=${archs}" >> "${GITHUB_OUTPUT}"
+
+  build-images:
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      contents: read
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
-      FEDORA_VERSION: 43
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
-        env:
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -54,20 +120,52 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-          CPU_ARCH: amd64
+          FEDORA_IMAGE: "${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2"
         run: ./build.sh
+
       - name: Logging to quay.io
-        run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+
       - name: Tag & Push image to staging
         env:
-          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-          remote_tag: "${{ env.FEDORA_VERSION }}-dev"
+          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
         run: |
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman push "${remote_repository}":"${arch_tag}"
-          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag}"
-          podman manifest push "${remote_repository}":"${remote_tag}" --all --format=v2s2
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman push "${REMOTE_REPOSITORY}":"${arch_tag}"
+
+  create-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - prepare
+      - build-images
+    env:
+      # Derived from prepare job output — stays in sync with the matrix automatically
+      ARCHITECTURES: ${{ needs.prepare.outputs.architectures }}
+    steps:
+      - name: Logging to quay.io
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+
+      - name: Create and push manifest
+        env:
+          FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
+          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
+        run: |
+          remote_tag="${FEDORA_VERSION}-dev"
+          # Build the list of arch-specific image references
+          ARCH_IMAGES=""
+          for arch in ${ARCHITECTURES}; do
+            ARCH_IMAGES="${ARCH_IMAGES} ${REMOTE_REPOSITORY}:${FEDORA_VERSION}-${arch}"
+          done
+          # Create and push the multi-arch manifest
+          podman manifest create --log-level=debug "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
+          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -51,12 +51,12 @@ jobs:
         run: |
           mkdir -p artifacts
           podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image.tar"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-container-image
-          path: artifacts/fedora-image.tar
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
           retention-days: 5
           compression-level: 0

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -11,29 +11,38 @@ permissions:
   contents: read
 
 env:
-  FEDORA_VERSION: 43
   REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.component-builder-config.outputs.matrix }}
+      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
+      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Read component builder config
+        id: component-builder-config
+        run: |
+          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+
   guest-fedora:
     runs-on: ubuntu-latest
+    needs: prepare
     strategy:
-      matrix:
-        include:
-          - arch: amd64
-            url_arch: x86_64
-            qemu_package: qemu-system-x86
-            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images
-          - arch: arm64
-            url_arch: aarch64
-            qemu_package: qemu-system-aarch64
-            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images
-          - arch: s390x
-            url_arch: s390x
-            qemu_package: qemu-system-s390x
-            fedora_url: https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
-      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
+      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
       CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -15,25 +15,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      matrix: ${{ steps.component-builder-config.outputs.matrix }}
-      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
-      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Read component builder config
-        id: component-builder-config
-        run: |
-          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+    uses: ./.github/workflows/component-builder-prepare.yml
 
   guest-fedora:
     runs-on: ubuntu-latest

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -7,32 +7,60 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
+
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            url_arch: x86_64
+            qemu_package: qemu-system-x86
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images
+          - arch: arm64
+            url_arch: aarch64
+            qemu_package: qemu-system-aarch64
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images
+          - arch: s390x
+            url_arch: s390x
+            qemu_package: qemu-system-s390x
+            fedora_url: https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
-      FEDORA_VERSION: 43
-      CPU_ARCH: amd64
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2
         with:
@@ -42,17 +70,19 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
           NO_SECRETS: "true"
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2
         run: ./build.sh
+
       - name: Save container image as tarball
         env:
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
         run: |
           mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          podman tag "${local_repository}":"${arch_tag}" "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
           echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
+
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -71,21 +71,58 @@ if [ $FEDORA_VERSION -gt 40 ]; then
    OS_VARIANT="fedora40"
 fi
 
+# Work on a copy of the base image so the original is never mutated.
+# This ensures cloud-init always runs fresh on repeated executions.
+WORK_IMAGE="${FEDORA_IMAGE%.qcow2}-work.qcow2"
+cp "${FEDORA_IMAGE}" "${WORK_IMAGE}"
+
+
+# Clean up any leftovers from a previous failed run
+rm -rf $BUILD_DIR
+if virsh domstate "${NAME}" &>/dev/null; then
+    echo "Found existing domain '${NAME}', removing it before proceeding..."
+    virsh destroy "${NAME}" 2>/dev/null || true
+    if [ "${CPU_ARCH}" = "arm64" ]; then
+        virsh undefine --nvram "${NAME}"
+    else
+        virsh undefine "${NAME}"
+    fi
+fi
+
 echo "Run the VM (ctrl+] to exit)"
 virt-install \
   --memory 2048 \
   --vcpus 2 \
   --arch $CPU_ARCH_CODE \
   --name $NAME \
-  --disk $FEDORA_IMAGE,device=disk \
+  --disk $WORK_IMAGE,device=disk \
   --disk $CLOUD_INIT_ISO,device=cdrom \
   --os-variant $OS_VARIANT \
   --virt-type $VIRT_TYPE \
   --graphics none \
   --network default \
   --noautoconsole \
-  --wait 30 \
   --import
+
+# Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
+# virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.
+echo "Waiting for VM to shut down after cloud-init completes..."
+WAIT_SECONDS=0
+PERIOD_SECONDS=60
+TIMEOUT_SECONDS=1800
+while true; do
+    DOMAIN_STATE=$(virsh domstate "${NAME}" 2>&1) || true
+    if [ "${DOMAIN_STATE}" = "shut off" ] || echo "${DOMAIN_STATE}" | grep -q "failed to get domain"; then
+        break
+    fi
+    if [ ${WAIT_SECONDS} -ge ${TIMEOUT_SECONDS} ]; then
+        echo "ERROR: VM did not shut down within ${TIMEOUT_SECONDS} seconds (last state: ${DOMAIN_STATE})"
+        exit 1
+    fi
+    sleep ${PERIOD_SECONDS}
+    WAIT_SECONDS=$((WAIT_SECONDS + PERIOD_SECONDS))
+done
+echo "VM shut down after ${WAIT_SECONDS} seconds"
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr
@@ -104,7 +141,7 @@ rm -f "${CLOUD_INIT_ISO}"
 
 mkdir $BUILD_DIR
 echo "Snapshot image"
-qemu-img convert -c -O qcow2 "${FEDORA_IMAGE}" "${BUILD_DIR}/${FEDORA_IMAGE}"
+qemu-img convert -c -O qcow2 "${WORK_IMAGE}" "${BUILD_DIR}/${FEDORA_IMAGE}"
 
 echo "Create Dockerfile"
 

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -89,6 +89,10 @@ if virsh domstate "${NAME}" &>/dev/null; then
     fi
 fi
 
+CONSOLE_LOG="/tmp/console-${NAME}.log"
+# Pre-create the log file with open permissions so the qemu process can write to it
+touch "${CONSOLE_LOG}"
+chmod 666 "${CONSOLE_LOG}"
 echo "Run the VM (ctrl+] to exit)"
 virt-install \
   --memory 2048 \
@@ -102,7 +106,13 @@ virt-install \
   --graphics none \
   --network default \
   --noautoconsole \
+  --serial file,path="${CONSOLE_LOG}" \
   --import
+
+# Stream the guest serial console log to stdout so CI logs show what is happening inside the VM.
+# tail -f works without a TTY and streams as lines are written by the guest.
+tail -f "${CONSOLE_LOG}" &
+CONSOLE_PID=$!
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
 # virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.
@@ -123,6 +133,9 @@ while true; do
     WAIT_SECONDS=$((WAIT_SECONDS + PERIOD_SECONDS))
 done
 echo "VM shut down after ${WAIT_SECONDS} seconds"
+# Stop the console tailer and clean up the log file
+kill "${CONSOLE_PID}" 2>/dev/null || true
+rm -f "${CONSOLE_LOG}"
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -30,14 +30,32 @@ case "$CPU_ARCH" in
     "amd64")
         CPU_ARCH_CODE="x86_64"
         VIRT_TYPE="kvm"
+        BOOT_OPTS=""
 	;;
     "arm64")
         CPU_ARCH_CODE="aarch64"
         VIRT_TYPE="qemu"
-	;;
+        # aarch64 requires UEFI and a writable per-VM NVRAM vars file.
+        # Without the vars file libvirt cannot configure ACPI on aarch64.
+        AARCH64_VARS="/tmp/aavmf-vars-${NAME}.fd"
+        for vars_path in \
+            "/usr/share/edk2/aarch64/vars-template-pflash.qcow2" \
+            "/usr/share/AAVMF/AAVMF_VARS.fd"; do
+            if [ -f "${vars_path}" ]; then
+                cp "${vars_path}" "${AARCH64_VARS}"
+                break
+            fi
+        done
+        if [ ! -f "${AARCH64_VARS}" ]; then
+            echo "ERROR: No aarch64 UEFI vars template found. Install qemu-efi-aarch64."
+            exit 1
+        fi
+        BOOT_OPTS="--boot uefi,nvram=${AARCH64_VARS}"
+ ;;
     "s390x")
         CPU_ARCH_CODE="s390x"
         VIRT_TYPE="qemu"
+        BOOT_OPTS=""
 	;;
     *)
         echo "Use the value amd64, s390x or arm64 for CPU_ARCH env variable"
@@ -94,6 +112,7 @@ CONSOLE_LOG="/tmp/console-${NAME}.log"
 touch "${CONSOLE_LOG}"
 chmod 666 "${CONSOLE_LOG}"
 echo "Run the VM (ctrl+] to exit)"
+# shellcheck disable=SC2086
 virt-install \
   --memory 2048 \
   --vcpus 2 \
@@ -107,6 +126,7 @@ virt-install \
   --network default \
   --noautoconsole \
   --serial file,path="${CONSOLE_LOG}" \
+  $BOOT_OPTS \
   --import
 
 # Stream the guest serial console log to stdout so CI logs show what is happening inside the VM.
@@ -133,9 +153,9 @@ while true; do
     WAIT_SECONDS=$((WAIT_SECONDS + PERIOD_SECONDS))
 done
 echo "VM shut down after ${WAIT_SECONDS} seconds"
-# Stop the console tailer and clean up the log file
+# Stop the console tailer and clean up temp files
 kill "${CONSOLE_PID}" 2>/dev/null || true
-rm -f "${CONSOLE_LOG}"
+rm -f "${CONSOLE_LOG}" "${AARCH64_VARS:-}"
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -31,7 +31,7 @@ case "$CPU_ARCH" in
         CPU_ARCH_CODE="x86_64"
         VIRT_TYPE="kvm"
         BOOT_OPTS=""
-	;;
+ ;;
     "arm64")
         CPU_ARCH_CODE="aarch64"
         VIRT_TYPE="qemu"
@@ -56,7 +56,7 @@ case "$CPU_ARCH" in
         CPU_ARCH_CODE="s390x"
         VIRT_TYPE="qemu"
         BOOT_OPTS=""
-	;;
+ ;;
     *)
         echo "Use the value amd64, s390x or arm64 for CPU_ARCH env variable"
         exit 1
@@ -94,6 +94,44 @@ fi
 WORK_IMAGE="${FEDORA_IMAGE%.qcow2}-work.qcow2"
 cp "${FEDORA_IMAGE}" "${WORK_IMAGE}"
 
+# On arm64 QEMU emulation (arm64, s390x) the real-root systemd device timeout
+# (DefaultDeviceTimeoutSec, 45s) can expire before virtio devices are
+# enumerated after pivot-root, causing local-fs.target to fail and breaking
+# cloud-init's dependency chain.
+#
+# Fedora uses BLS (Boot Loader Specification): the kernel cmdline lives in a
+# per-entry .conf file under /boot/loader/entries/ on the ext4 /boot partition
+# (vda2). grub.cfg only sets a kernelopts fallback and delegates to blscfg.
+# We must patch the options line in that .conf file directly.
+#
+# guestfish operations are pure host-side filesystem ops requiring no guest
+# code execution, so they work cross-architecture without KVM.
+if [ "${CPU_ARCH}" = "arm64" ]; then
+    BLS_ENTRY_TMP=$(mktemp)
+    # Mount the ext4 /boot partition (second partition) explicitly.
+    # guestfish -i mounts the btrfs root subvolume, which does not contain
+    # the BLS entries.
+    BLS_ENTRY=$(guestfish -a "${WORK_IMAGE}" \
+        run : \
+        mount /dev/sda2 / : \
+        ls /loader/entries \
+        | grep '\.conf$' | head -1)
+    if [ -z "${BLS_ENTRY}" ]; then
+        echo "ERROR: No BLS entry found in /boot/loader/entries/"
+        rm -f "${BLS_ENTRY_TMP}"
+        exit 1
+    fi
+    guestfish -a "${WORK_IMAGE}" \
+        run : \
+        mount /dev/sda2 / : \
+        download "/loader/entries/${BLS_ENTRY}" "${BLS_ENTRY_TMP}"
+    sed -i 's/^\(options .*\)/\1 systemd.default_device_timeout_sec=300/' "${BLS_ENTRY_TMP}"
+    guestfish -a "${WORK_IMAGE}" \
+        run : \
+        mount /dev/sda2 / : \
+        upload "${BLS_ENTRY_TMP}" "/loader/entries/${BLS_ENTRY}"
+    rm -f "${BLS_ENTRY_TMP}"
+fi
 
 # Clean up any leftovers from a previous failed run
 rm -rf $BUILD_DIR
@@ -139,7 +177,7 @@ CONSOLE_PID=$!
 echo "Waiting for VM to shut down after cloud-init completes..."
 WAIT_SECONDS=0
 PERIOD_SECONDS=60
-TIMEOUT_SECONDS=1800
+TIMEOUT_SECONDS=3600
 while true; do
     DOMAIN_STATE=$(virsh domstate "${NAME}" 2>&1) || true
     if [ "${DOMAIN_STATE}" = "shut off" ] || echo "${DOMAIN_STATE}" | grep -q "failed to get domain"; then


### PR DESCRIPTION
Commit 1:
fix: architecture suffix for the fedora-container-image artifact

This change introduces a suffix to the built artifact to facilitate
multi-architecture image testing. Without this modification, a race
condition occurs when the jobs for s390x and x86_64 run in parallel.

Commit 2:
feat: build s390x and arm64 images in the component builder workflow

Uses a matrix approach in order to reduce code duplication.

After the job runs, the artifacts should be published.

Commit 3:
Refactor: preparation work for Fedora image multiarch publish

The build.sh script primarily utilizes environment variables. To
generate an image for a new architecture, these variables must be
adjusted. This change relocates the generic environment variables
to specific steps, facilitating the transition to multiarch building.

Commit 4:
feat: component Builder Publish s390x and arm64 enablement

This change enables the publication of the Fedora s390x and arm images,
alongside the amd64 image in a single manifest. To achieve this,
the following steps must be taken:

1. Install qemu-system-s390x.
2. Execute build.sh twice with different environment variables.

After completing these steps, both all the images should be added
to the manifest.

Commit 5:
refactor: extract fedora image builder config into a shared file

Move hardcoded Fedora version, image base, and architecture
matrix out of both workflow files and into a single source of
truth.

Both component-builder and component-builder-publish now read
their matrix, and variables from its config file via a
dedicate 'prepare' job step.

Commit 6:
fix: support repeated executions in build.sh

- Replace --wait with a virsh domstate polling loop, since runcmd
  in user-data already triggers a shutdown.
- Work from a copy of the base image to keep it pristine, since
  virt-install mutates qcow2 images in-place.
- Add pre-flight domain cleanups.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Fedora 43 component image builds for `amd64`, `arm64`, and `s390x`, driven by a configurable build matrix.
  - Published architecture-specific container images and a consolidated multi-architecture `dev` image manifest.
  - Updated VM image preparation for ARM64, including UEFI boot support.

- **Bug Fixes**
  - Added checksum verification for downloaded Fedora base images.
  - Ensured base images are not modified during VM creation.
  - Improved robustness by handling existing VM domains and enforcing clearer startup/completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->