### PR TITLE
net, tests, hot-plug: W/A guest-agent deadlock after hot plug

### DIFF
--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -1,4 +1,6 @@
 import contextlib
+import ipaddress
+import json
 import logging
 import re
 import time
@@ -6,11 +8,14 @@ from ipaddress import ip_interface
 from typing import Final
 
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.resource import ResourceField
 from ocp_resources.resource import ResourceEditor
+from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import (
+    IpNotFound,
     VMInterfaceStatusNotFoundError,
     lookup_iface_status,
     lookup_iface_status_ip,
@@ -34,13 +39,14 @@ from utilities.constants import (
     TIMEOUT_5SEC,
 )
 from utilities.infra import get_pod_by_name_prefix
+from utilities.jira import is_jira_open
 from utilities.network import (
     cloud_init_network_data,
     compose_cloud_init_data_dict,
     network_device,
     ping,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body, prepare_cloud_init_user_data
+from utilities.virt import VirtualMachineForTests, fedora_vm_body, prepare_cloud_init_user_data, vm_console_run_commands
 
 LOGGER = logging.getLogger(__name__)
 
@@ -144,12 +150,19 @@ def hot_plug_interface(
 
     update_hot_plug_config_in_vm(vm=vm, interfaces=interfaces, networks=networks)
 
-    return lookup_iface_status(
-        vm=vm,
-        iface_name=hot_plugged_interface_name,
-        predicate=lambda interface: "guest-agent" in interface["infoSource"],
-        timeout=TIMEOUT_2MIN,
-    )
+    try:
+        return lookup_iface_status(
+            vm=vm,
+            iface_name=hot_plugged_interface_name,
+            predicate=lambda interface: "guest-agent" in interface["infoSource"],
+            timeout=TIMEOUT_2MIN,
+        )
+    except VMInterfaceStatusNotFoundError:
+        if is_jira_open(jira_id="CNV-77961"):
+            fallback_iface = _iface_console_fallback(vm=vm, interface_name=hot_plugged_interface_name)
+            if fallback_iface:
+                return fallback_iface
+        raise
 
 
 def hot_unplug_interface(vm, hot_plugged_interface_name):
@@ -222,7 +235,17 @@ def set_secondary_static_ip_address(
     # Verify the IP address was set successfully.
     # The function fails on timeout if the interface or its address are not found,
     # so there's no need to check its return code.
-    hot_plugged_interface_ip = lookup_iface_status_ip(vm=vm, iface_name=vmi_interface, ip_family=4)
+    try:
+        hot_plugged_interface_ip = lookup_iface_status_ip(vm=vm, iface_name=vmi_interface, ip_family=4)
+    except IpNotFound:
+        if is_jira_open(jira_id="CNV-77961"):
+            hot_plugged_interface_ip = _read_guest_ipv4(vm=vm, interface_name=guest_vm_interface)
+            LOGGER.warning(
+                f"CNV-77961: Verified IP {hot_plugged_interface_ip} on {guest_vm_interface} via console "
+                f"(guest-agent not reporting on VM {vm.name})."
+            )
+        else:
+            raise
     LOGGER.info(f"{vm.name}/{vmi_interface} set with IP address {hot_plugged_interface_ip}")
 
 
@@ -253,9 +276,86 @@ def hot_plug_interface_and_set_address(
 def get_guest_vm_interface_name_by_vmi_interface_name(vm, vm_interface_name):
     vmi_interfaces = vm.vmi.interfaces
     for interface in vmi_interfaces:
-        if interface["name"] == vm_interface_name:
+        if interface["name"] == vm_interface_name and interface.get("interfaceName"):
             return interface["interfaceName"]
+
+    if is_jira_open(jira_id="CNV-77961"):
+        fallback = _iface_console_fallback(vm=vm, interface_name=vm_interface_name)
+        if fallback:
+            return fallback.interfaceName
     raise VMInterfaceStatusNotFoundError(f"Interface {vm_interface_name} not found in VM {vm.name} status")
+
+
+def _iface_console_fallback(vm: VirtualMachine, interface_name: str) -> ResourceField | None:
+    """Look up a hot-plugged interface via console when guest-agent is dead (CNV-77961).
+
+    Args:
+        vm: The virtual machine to query.
+        interface_name: The spec-level interface name.
+
+    Returns:
+        A ResourceField with interface data gathered from the guest, or None.
+    """
+    # VMI spec interfaces are set by virt-controller seconds after the hot-plug request;
+    # by the time we get here, lookup_iface_status has already waited 2 min for guest-agent.
+    vmi_iface = _lookup_vmi_interface(vmi=vm.vmi, interface_name=interface_name)
+    if not vmi_iface:
+        return None
+    LOGGER.warning(
+        f"CNV-77961: Guest agent did not report interface {interface_name} on VM {vm.name}, "
+        f"falling back to console lookup by MAC {vmi_iface['macAddress']}."
+    )
+    fallback = _lookup_guest_interface_by_mac(vm=vm, expected_mac=vmi_iface["macAddress"], iface_name=interface_name)
+    LOGGER.info(f"Console fallback found interface {fallback.interfaceName} for {interface_name} on VM {vm.name}.")
+    return fallback
+
+
+def _lookup_guest_interface_by_mac(
+    vm: VirtualMachine,
+    expected_mac: str,
+    iface_name: str,
+) -> ResourceField:
+    """Find an interface inside the VM guest OS by its MAC address.
+
+    Used as a fallback when guest-agent fails to report the interface (CNV-77961).
+
+    Args:
+        vm: The virtual machine to query.
+        expected_mac: The MAC address to search for.
+        iface_name: The spec-level interface name to set on the returned object.
+
+    Returns:
+        A ResourceField with name and interfaceName fields.
+
+    Raises:
+        VMInterfaceStatusNotFoundError: If no interface with the expected MAC is found.
+    """
+    cmd = "ip -j addr show"
+    output = vm_console_run_commands(vm=vm, commands=[cmd], timeout=30)
+    guest_interfaces = json.loads(output[cmd][1])
+    visible_ifaces = [{"ifname": iface.get("ifname"), "address": iface.get("address")} for iface in guest_interfaces]
+    LOGGER.info(f"CNV-77961: looking for MAC {expected_mac} in guest {vm.name}, visible interfaces: {visible_ifaces}")
+    for guest_iface in guest_interfaces:
+        if guest_iface.get("address", "").lower() == expected_mac.lower():
+            return ResourceField(
+                params={
+                    "name": iface_name,
+                    "interfaceName": guest_iface["ifname"],
+                }
+            )
+
+    raise VMInterfaceStatusNotFoundError(f"No interface with MAC {expected_mac} found inside VM {vm.name}")
+
+
+def _read_guest_ipv4(vm: VirtualMachine, interface_name: str) -> ipaddress.IPv4Address:
+    cmd = f"ip -j -4 addr show {interface_name}"
+    output = vm_console_run_commands(vm=vm, commands=[cmd], timeout=30)
+    iface_info = json.loads(output[cmd][1])
+    if iface_info and "addr_info" in iface_info[0]:
+        for addr in iface_info[0]["addr_info"]:
+            if addr["family"] == "inet":
+                return ipaddress.IPv4Address(address=addr["local"])
+    raise IpNotFound(f"No IPv4 address found on {interface_name} in VM {vm.name}")
 
 
 @contextlib.contextmanager

--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -207,8 +207,10 @@ def create_bridge_interface_for_hot_plug(
         yield br
 
 
-def set_secondary_static_ip_address(vm, ipv4_address, vmi_interface):
-    guest_vm_interface = get_guest_vm_interface_name_by_vmi_interface_name(
+def set_secondary_static_ip_address(
+    vm: VirtualMachineForTests, ipv4_address: str, vmi_interface: str, guest_device_name: str | None = None
+) -> None:
+    guest_vm_interface = guest_device_name or get_guest_vm_interface_name_by_vmi_interface_name(
         vm=vm,
         vm_interface_name=vmi_interface,
     )
@@ -242,6 +244,7 @@ def hot_plug_interface_and_set_address(
         vm=vm,
         ipv4_address=ipv4_address,
         vmi_interface=iface.name,
+        guest_device_name=iface.interfaceName,
     )
 
     return iface

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -110,6 +110,7 @@ def hot_plugged_interface_with_address(running_vm_for_nic_hot_plug, index_number
         vm=running_vm_for_nic_hot_plug,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
         vmi_interface=hot_plugged_interface.name,
+        guest_device_name=hot_plugged_interface.interfaceName,
     )
 
 
@@ -151,6 +152,7 @@ def hot_plugged_second_interface_with_address(
         vm=running_vm_with_secondary_and_hot_plugged_interfaces,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
         vmi_interface=hot_plugged_interface_on_vm_created_with_secondary_interface.name,
+        guest_device_name=hot_plugged_interface_on_vm_created_with_secondary_interface.interfaceName,
     )
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
CNV-77961 causes guest-agent to deadlock after hot-plugging an interface on VMs that start with only a primary (masquerade) interface. When this happens, lookup_iface_status() never sees the new interface in VMI status, and tests fail.

This PR adds a console-based fallback: when guest-agent fails to report the hot-plugged interface, we look it up directly inside the VM via `ip -j addr show`, matching by MAC address. Three call sites are covered:

1. `hot_plug_interface()` - falls back to console when VMI status times out
2. `set_secondary_static_ip_address()` - verifies IP via console when guest-agent doesn't report it
3. `get_guest_vm_interface_name_by_vmi_interface_name()` - resolves interface name via console

All fallback paths are guarded by `is_jira_open("CNV-77961")` and will be removed once the bug is fixed.

The first commit avoids a redundant VMI lookup by passing `guest_device_name` through from `hot_plug_interface()` to `set_secondary_static_ip_address()`.

##### Which issue(s) this PR fixes:
CNV-77961

##### Special notes for reviewer:
I wasn't able to reproduce the bug in our evs - I ran it dozens of time on both tlv2 env (bm02-tlv2) and rdu2 env (bm04-cnvqe-rdu2) and the bug didn't show. For this reason, I did the verification in two directions:
  - Natural run (no forced failures) - all hot-plug tests pass, confirming nothing was broken by the changes.
  - Forced W/A run - guest-agent was killed (`systemctl mask --now qemu-guest-agent`) before hot-plug to guarantee the W/A path fires. After the W/A completed, the agent was restored (`systemctl unmask` + `start`) so subsequent test steps that depend on guest-agent could proceed normally. All three fallback paths were verified this way.
Our plan is to get this W/A merged as is and follow the logs to see it in action when the bug appears. If we'll see an issue with the implementation - we will revert this immediately.


Example for the W/A path in action (by forcing it using https://github.com/RedHatQE/openshift-virtualization-tests/pull/5467):
  test_connectivity_of_hot_plugged_jumbo_interface — PASSED (forced W/A, all 3 paths exercised)

1. VM created, agent killed (forced W/A)
  2. Hot-plug bridge interface → agent timeout (2 min) → W/A path 1 kicked in
     - Console found eth1 by MAC 02:24:15:4d:78:3d ✓
  3. IP set (172.16.241.3/24) → agent didn't report it → W/A path 2 kicked in
     - Console verified IP on eth1 ✓
  4. Utility VM hot-plugged normally (agent alive)
  5. Jumbo ping (MTU 9000): 3/3 packets, 0% loss ✓

Actual test logs:
`2026-07-02T10:18:53.052667+00:00 timeout_sampler INFO Waiting for 300 seconds [0:05:00], retry every 10 seconds. (Function: utilities.console.connect Args: (<utilities.console.Console object at 0x7fb33673f9b0>,))
2026-07-02T10:18:53.053362+00:00 timeout_sampler INFO Waiting for 300 seconds [0:05:00], retry every 5 seconds. (Function: pexpect.pty_spawn.spawn  Kwargs: {'command': 'virtctl console jumbo-hot-plug-test-vm-1782987280-6881244 -n l2-bridge-test-bridge-nic-hot-plug', 'timeout': 30, 'encoding': 'utf-8'})
2026-07-02T13:18:53.052230 tests.network.l2_bridge.libl2bridge WARNING CNV-77961: Guest agent did not report interface hot-plug-jumbo-iface on VM jumbo-hot-plug-test-vm-1782987280-6881244, falling back to console lookup by MAC 02:24:15:4d:78:3d.
2026-07-02T13:18:53.053109 utilities.console INFO Connect to jumbo-hot-plug-test-vm-1782987280-6881244 console
...
2026-07-02T13:18:54.276254 utilities.virt INFO Execute ip -j addr show on jumbo-hot-plug-test-vm-1782987280-6881244
2026-07-02T10:18:55.980250+00:00 timeout_sampler INFO Waiting for 300 seconds [0:05:00], retry every 10 seconds. (Function: utilities.console.connect Args: (<utilities.console.Console object at 0x7fb33673fce0>,))
2026-07-02T10:18:55.981499+00:00 timeout_sampler INFO Waiting for 300 seconds [0:05:00], retry every 5 seconds. (Function: pexpect.pty_spawn.spawn  Kwargs: {'command': 'virtctl console jumbo-hot-plug-test-vm-1782987280-6881244 -n l2-bridge-test-bridge-nic-hot-plug', 'timeout': 30, 'encoding': 'utf-8'})
2026-07-02T13:18:55.978475 tests.network.l2_bridge.libl2bridge INFO CNV-77961: looking for MAC 02:24:15:4d:78:3d in guest jumbo-hot-plug-test-vm-1782987280-6881244, visible interfaces: [{'ifname': 'lo', 'address': '00:00:00:00:00:00'}, {'ifname': 'eth0', 'address': '02:24:15:4d:78:3c'}, {'ifname': 'eth1', 'address': '02:24:15:4d:78:3d'}]
2026-07-02T13:18:55.978900 tests.network.l2_bridge.libl2bridge INFO Console fallback found interface eth1 for hot-plug-jumbo-iface on VM jumbo-hot-plug-test-vm-1782987280-6881244.
...
2026-07-02T13:21:00.556203 utilities.console INFO jumbo-hot-plug-test-vm-1782987280-6881244: Got prompt \$ 
2026-07-02T13:21:00.557031 utilities.virt INFO Execute ip -j -4 addr show eth1 on jumbo-hot-plug-test-vm-1782987280-6881244
2026-07-02T13:21:02.298828 tests.network.l2_bridge.libl2bridge WARNING CNV-77961: Verified IP 172.16.241.3 on eth1 via console (guest-agent not reporting on VM jumbo-hot-plug-test-vm-1782987280-6881244).
2026-07-02T13:21:02.299476 tests.network.l2_bridge.libl2bridge INFO jumbo-hot-plug-test-vm-1782987280-6881244/hot-plug-jumbo-iface set with IP address 172.16.241.3
2026-07-02T13:21:02.300469 conftest INFO Executing function fixture: hot_plugged_jumbo_interface_in_utility_vm
...
PASSED2026-07-02T13:22:44.884117 utilities.network INFO ping returned PING 172.16.241.4 (172.16.241.4) 8972(9000) bytes of data.
`

 ##### jira-ticket:
https://issues.redhat.com/browse/CNV-77961