### PR TITLE
Remove CNV-81829 runbook bug marker

### DIFF
--- a/tests/observability/runbook_url/conftest.py
+++ b/tests/observability/runbook_url/conftest.py
@@ -6,12 +6,10 @@ from ocp_resources.prometheus_rule import PrometheusRule
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants.components import KUBEMACPOOL_PROMETHEUS_RULE
 from utilities.constants.timeouts import (
     TIMEOUT_10SEC,
     TIMEOUT_30SEC,
 )
-from utilities.jira import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,8 +24,6 @@ def cnv_alerts_runbook_urls_from_prometheus_rule(cnv_prometheus_rules_matrix__fu
     rule_name = cnv_prometheus_rules_matrix__function__
     if rule_name == "prometheus-hpp-rules" and not hpp_cr_installed:
         pytest.xfail(f"Rule {rule_name} should not be present if HPP CR is not installed")
-    if rule_name == KUBEMACPOOL_PROMETHEUS_RULE and is_jira_open(jira_id="CNV-81829"):
-        pytest.xfail(f"{KUBEMACPOOL_PROMETHEUS_RULE} missing runbook URLs: CNV-81829")
 
     cnv_prometheus_rule_by_name = PrometheusRule(
         namespace=py_config["hco_namespace"],


### PR DESCRIPTION
##### What this PR does / why we need it:
The link for the runbook in kubemacpool prometheus rule fixed and now we can see the DS link, removing the Remove CNV-81829 runbook bug marker since the bug is fixed
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated observability runbook URL test setup to rely on fewer special-case helpers.
  * Removed an outdated expected-failure condition from one check, so the test now reflects the current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->