### PR TITLE
Handle non-UTF-8 pod logs in must-gather log comparison

### DIFF
--- a/tests/install_upgrade_operators/must_gather/utils.py
+++ b/tests/install_upgrade_operators/must_gather/utils.py
@@ -237,7 +237,14 @@ def check_logs(cnv_must_gather, running_hco_containers, namespace, label_selecto
             # Skip comparison of empty/large files. Large files could be ratated, and hence not equal.
             if log_size > 10000 or log_size == 0:
                 continue
-            pod_log = pod.log(previous=is_previous, container=container_name, timestamps=True)
+            try:
+                pod_log = pod.log(previous=is_previous, container=container_name, timestamps=True)
+            except UnicodeDecodeError:
+                LOGGER.warning(
+                    f"Skipping log comparison for {pod.name}/{container_name} "
+                    f"(previous={is_previous}): pod log contains non-UTF-8 data"
+                )
+                continue
             log_file = pod_logfile(
                 pod_name=pod.name,
                 container_name=container_name,


### PR DESCRIPTION
##### What this PR does / why we need it:
Pod logs can contain non-UTF-8 binary data (e.g. when nginx logs a raw TLS ClientHello sent to a plaintext HTTP port). The Kubernetes Python client's pod.log() fails with UnicodeDecodeError on such data.

Skip the log comparison for pods with non-decodable logs since the content cannot be retrieved as text for comparison.

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:
Failures in test_kubevirt_logs_collected in dual stream lane for iuo-ocs and rhcos10 iuo-ocs
##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-91551
https://redhat.atlassian.net/browse/CNV-91552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log collection during upgrade checks by safely handling non-UTF-8 pod logs.
  * When unreadable log content is encountered, the affected pod/container is skipped and a warning is recorded instead of failing the comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->