### PR TITLE
CherryPicked: [cnv-4.22] Enable disableMDevConfiguration feature gate

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -1,3 +1,5 @@
+from utilities.constants import DISABLE_MDEV_CONFIGURATION
+
 SECTION_TITLE = "section_title"
 FILE_SUFFIX = "file_suffix"
 HCO_CR_CERT_CONFIG_CA_KEY = "ca"
@@ -12,7 +14,6 @@ TEMPLATE_VALIDATOR = "templateValidator"
 DEVELOPER_CONFIGURATION = "developerConfiguration"
 # featuregates:
 DEPLOY_KUBE_SECONDARY_DNS = "deployKubeSecondaryDNS"
-DISABLE_MDEV_CONFIGURATION = "disableMDevConfiguration"
 ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT = "enableMultiArchBootImageImport"
 PERSISTENT_RESERVATION = "persistentReservation"
 FG_DISABLED = False

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -8,7 +8,6 @@ from ocp_resources.daemonset import DaemonSet
 from ocp_resources.deployment import Deployment
 from ocp_resources.infrastructure import Infrastructure
 from ocp_resources.performance_profile import PerformanceProfile
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.utils import (
     verify_cpumanager_workers,
@@ -17,17 +16,9 @@ from tests.utils import (
 )
 from tests.virt.node.gpu.constants import (
     GPU_CARDS_MAP,
-    GPU_WORKLOAD_CONFIG_LABEL,
-    MDEV_NAME_STR,
     NVIDIA_SANDBOX_VALIDATOR_DS,
     NVIDIA_VGPU_DEVICE_MANAGER_DS,
     NVIDIA_VGPU_MANAGER_DS,
-    VGPU_CONFIG_LABEL,
-)
-from tests.virt.node.gpu.utils import (
-    apply_node_labels,
-    toggle_vgpu_deploy_labels,
-    wait_for_ds_ready,
 )
 from tests.virt.utils import (
     get_allocatable_memory_per_node,
@@ -41,12 +32,10 @@ from tests.virt.utils import (
 from utilities.constants import (
     AMD,
     INTEL,
-    TIMEOUT_1MIN,
-    TIMEOUT_5SEC,
     NamespacesNames,
 )
 from utilities.exceptions import ResourceValueError, UnsupportedGPUDeviceError
-from utilities.infra import ExecCommandOnPod, get_nodes_with_label, get_resources_by_name_prefix, label_nodes
+from utilities.infra import get_nodes_with_label, get_resources_by_name_prefix
 from utilities.pytest_utils import exit_pytest_execution
 from utilities.virt import get_nodes_gpu_info, vm_instance_from_template
 
@@ -237,19 +226,6 @@ def hco_cr_with_mdev_permitted_hostdevices_scope_session(hyperconverged_resource
 
 
 @pytest.fixture(scope="session")
-def gpu_nodes_labeled_with_vgpu_config(nodes_with_supported_gpus, supported_gpu_device):
-    yield from label_nodes(
-        nodes=nodes_with_supported_gpus,
-        labels={VGPU_CONFIG_LABEL: supported_gpu_device[MDEV_NAME_STR].split()[-1]},
-    )
-
-
-@pytest.fixture(scope="session")
-def gpu_nodes_labeled_with_vm_vgpu(nodes_with_supported_gpus, gpu_nodes_labeled_with_vgpu_config):
-    yield from label_nodes(nodes=nodes_with_supported_gpus, labels={GPU_WORKLOAD_CONFIG_LABEL: "vm-vgpu"})
-
-
-@pytest.fixture(scope="session")
 def nvidia_vgpu_manager_ds(admin_client):
     return get_resources_by_name_prefix(
         prefix=NVIDIA_VGPU_MANAGER_DS,
@@ -274,60 +250,6 @@ def nvidia_vgpu_device_manager_ds(admin_client):
         namespace=NamespacesNames.NVIDIA_GPU_OPERATOR,
         name=NVIDIA_VGPU_DEVICE_MANAGER_DS,
     )
-
-
-@pytest.fixture(scope="session")
-def vgpu_ready_nodes(
-    gpu_nodes,
-    nodes_with_supported_gpus,
-    gpu_nodes_labeled_with_vm_vgpu,
-    nvidia_vgpu_manager_ds,
-    nvidia_sandbox_validator_ds,
-    nvidia_vgpu_device_manager_ds,
-):
-    wait_for_ds_ready(ds=nvidia_vgpu_manager_ds, expected=len(nodes_with_supported_gpus))
-    toggle_vgpu_deploy_labels(
-        gpu_nodes=gpu_nodes,
-        nodes_with_supported_gpus=nodes_with_supported_gpus,
-        sandbox_validator_ds=nvidia_sandbox_validator_ds,
-        vgpu_device_manager_ds=nvidia_vgpu_device_manager_ds,
-    )
-    yield gpu_nodes_labeled_with_vm_vgpu
-    apply_node_labels(nodes=nodes_with_supported_gpus, labels={"nvidia.com/vgpu.config.state": None})
-
-
-@pytest.fixture(scope="session")
-def non_existent_mdev_bus_nodes(workers_utility_pods, vgpu_ready_nodes):
-    """
-    Check if the mdev_bus needed for vGPU is available.
-
-    On the Worker Node on which GPU Device exists, check if the
-    mdev_bus needed for vGPU is available.
-    If it's not available, this means the nvidia-vgpu-manager-daemonset
-    Pod might not be in running state in the nvidia-gpu-operator namespace.
-    """
-    desired_bus = "mdev_bus"
-    non_existent_mdev_bus_nodes = []
-    for node in vgpu_ready_nodes:
-        pod_exec = ExecCommandOnPod(utility_pods=workers_utility_pods, node=node)
-        try:
-            for sample in TimeoutSampler(
-                wait_timeout=TIMEOUT_1MIN,
-                sleep=TIMEOUT_5SEC,
-                func=pod_exec.exec,
-                command=f"ls /sys/class | grep {desired_bus} || true",
-            ):
-                if sample:
-                    return
-        except TimeoutExpiredError:
-            non_existent_mdev_bus_nodes.append(node.name)
-    if non_existent_mdev_bus_nodes:
-        pytest.fail(
-            reason=(
-                f"On these nodes: {non_existent_mdev_bus_nodes} {desired_bus} is not available."
-                "Ensure that in 'nvidia-gpu-operator' namespace nvidia-vgpu-manager-daemonset Pod is Running."
-            )
-        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/virt/node/gpu/utils.py
+++ b/tests/virt/node/gpu/utils.py
@@ -1,9 +1,11 @@
 import logging
 import shlex
+from contextlib import contextmanager
 
+import pytest
 from ocp_resources.resource import ResourceEditor
 from pyhelper_utils.shell import run_ssh_commands
-from timeout_sampler import TimeoutSampler
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.virt.node.gpu.constants import (
     SANDBOX_VALIDATOR_DEPLOY_LABEL,
@@ -13,10 +15,12 @@ from tests.virt.node.gpu.constants import (
 from tests.virt.utils import fetch_gpu_device_name_from_vm_instance, verify_gpu_device_exists_in_vm
 from utilities.constants import (
     TCP_TIMEOUT_30SEC,
+    TIMEOUT_1MIN,
     TIMEOUT_2MIN,
     TIMEOUT_3MIN,
     TIMEOUT_5SEC,
 )
+from utilities.infra import ExecCommandOnPod
 from utilities.virt import restart_vm_wait_for_running_vm, running_vm
 
 LOGGER = logging.getLogger(__name__)
@@ -111,3 +115,76 @@ def toggle_vgpu_deploy_labels(gpu_nodes, nodes_with_supported_gpus, sandbox_vali
         apply_node_labels(nodes=nodes_with_supported_gpus, labels={VGPU_DEVICE_MANAGER_DEPLOY_LABEL: "true"})
     wait_for_ds_ready(ds=sandbox_validator_ds, expected=len(gpu_nodes))
     wait_for_ds_ready(ds=vgpu_device_manager_ds, expected=len(nodes_with_supported_gpus))
+
+
+@contextmanager
+def vgpu_node_labels_applied(
+    gpu_nodes,
+    nodes_with_supported_gpus,
+    labeled_nodes,
+    sandbox_validator_ds,
+    vgpu_device_manager_ds,
+):
+    """Cycle vGPU deploy labels and clear vgpu.config.state on teardown.
+
+    Args:
+        gpu_nodes: All GPU nodes.
+        nodes_with_supported_gpus: vGPU-supported nodes.
+        labeled_nodes: Nodes returned to the caller after setup completes.
+        sandbox_validator_ds: nvidia-sandbox-validator DaemonSet object.
+        vgpu_device_manager_ds: nvidia-vgpu-device-manager DaemonSet object.
+
+    Yields:
+        The labeled vGPU nodes after deploy-label cycling completes.
+    """
+    try:
+        toggle_vgpu_deploy_labels(
+            gpu_nodes=gpu_nodes,
+            nodes_with_supported_gpus=nodes_with_supported_gpus,
+            sandbox_validator_ds=sandbox_validator_ds,
+            vgpu_device_manager_ds=vgpu_device_manager_ds,
+        )
+        yield labeled_nodes
+    finally:
+        apply_node_labels(nodes=labeled_nodes, labels={"nvidia.com/vgpu.config.state": None})
+
+
+def wait_for_nvidia_vgpu_manager(nvidia_vgpu_manager_ds, nodes_with_supported_gpus):
+    """Wait until nvidia-vgpu-manager DaemonSet is ready on all vGPU nodes.
+
+    Args:
+        nvidia_vgpu_manager_ds: nvidia-vgpu-manager DaemonSet object.
+        nodes_with_supported_gpus: vGPU-supported nodes.
+    """
+    wait_for_ds_ready(ds=nvidia_vgpu_manager_ds, expected=len(nodes_with_supported_gpus))
+
+
+def verify_mdev_bus_available(workers_utility_pods, vgpu_nodes):
+    """Verify mdev_bus is available on all vGPU nodes.
+
+    Args:
+        workers_utility_pods: Utility pods for executing commands on nodes.
+        vgpu_nodes: List of vGPU-ready nodes to check.
+    """
+    desired_bus = "mdev_bus"
+    nodes_without_mdev_bus = []
+    for node in vgpu_nodes:
+        pod_exec = ExecCommandOnPod(utility_pods=workers_utility_pods, node=node)
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=TIMEOUT_1MIN,
+                sleep=TIMEOUT_5SEC,
+                func=pod_exec.exec,
+                command=f"ls /sys/class | grep {desired_bus} || true",
+            ):
+                if sample:
+                    break
+        except TimeoutExpiredError:
+            nodes_without_mdev_bus.append(node.name)
+    if nodes_without_mdev_bus:
+        pytest.fail(
+            reason=(
+                f"On these nodes: {nodes_without_mdev_bus} mdev_bus is not available. "
+                "Ensure that in 'nvidia-gpu-operator' namespace nvidia-vgpu-manager-daemonset Pod is Running."
+            )
+        )

--- a/tests/virt/node/gpu/vgpu/conftest.py
+++ b/tests/virt/node/gpu/vgpu/conftest.py
@@ -8,14 +8,21 @@ import pytest
 from ocp_resources.kubevirt import KubeVirt
 
 from tests.virt.node.gpu.constants import (
+    GPU_WORKLOAD_CONFIG_LABEL,
     MDEV_GRID_NAME_STR,
     MDEV_NAME_STR,
     VGPU_CONFIG_LABEL,
     VGPU_DEVICE_NAME_STR,
     VGPU_GRID_NAME_STR,
 )
-from tests.virt.node.gpu.utils import wait_for_ds_ready
+from tests.virt.node.gpu.utils import (
+    verify_mdev_bus_available,
+    vgpu_node_labels_applied,
+    wait_for_ds_ready,
+    wait_for_nvidia_vgpu_manager,
+)
 from tests.virt.utils import patch_hco_cr_with_mdev_permitted_hostdevices
+from utilities.constants import DISABLE_MDEV_CONFIGURATION, FEATURE_GATES
 from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.infra import label_nodes
 
@@ -76,3 +83,76 @@ def hco_cr_with_node_specific_mdev_permitted_hostdevices(
         wait_for_reconcile_post_update=True,
     ):
         yield
+
+
+@pytest.fixture(scope="package")
+def hco_with_disable_mdev_configuration(hyperconverged_resource_scope_session):
+    """
+    Enable disableMDevConfiguration feature gate in HCO.
+
+    This fixture must run before any vGPU node labeling to ensure CNV
+    does not configure mediated devices (vGPU configuration is handled
+    by NVIDIA GPU Operator).
+    """
+    with ResourceEditorValidateHCOReconcile(
+        patches={hyperconverged_resource_scope_session: {"spec": {FEATURE_GATES: {DISABLE_MDEV_CONFIGURATION: True}}}},
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+
+
+@pytest.fixture(scope="package")
+def gpu_nodes_labeled_with_vgpu_config(
+    hco_with_disable_mdev_configuration,
+    nodes_with_supported_gpus,
+    supported_gpu_device,
+):
+    yield from label_nodes(
+        nodes=nodes_with_supported_gpus,
+        labels={VGPU_CONFIG_LABEL: supported_gpu_device[MDEV_NAME_STR].split()[-1]},
+    )
+
+
+@pytest.fixture(scope="package")
+def gpu_nodes_labeled_with_vm_vgpu(nodes_with_supported_gpus, gpu_nodes_labeled_with_vgpu_config):
+    yield from label_nodes(nodes=nodes_with_supported_gpus, labels={GPU_WORKLOAD_CONFIG_LABEL: "vm-vgpu"})
+
+
+@pytest.fixture(scope="package")
+def nvidia_vgpu_manager_ready(
+    nvidia_vgpu_manager_ds,
+    gpu_nodes_labeled_with_vm_vgpu,
+):
+    """Wait until nvidia-vgpu-manager DaemonSet is ready on all vGPU nodes."""
+    wait_for_nvidia_vgpu_manager(
+        nvidia_vgpu_manager_ds=nvidia_vgpu_manager_ds,
+        nodes_with_supported_gpus=gpu_nodes_labeled_with_vm_vgpu,
+    )
+    yield nvidia_vgpu_manager_ds
+
+
+@pytest.fixture(scope="package")
+def vgpu_ready_nodes(
+    gpu_nodes,
+    nodes_with_supported_gpus,
+    gpu_nodes_labeled_with_vm_vgpu,
+    nvidia_vgpu_manager_ready,
+    nvidia_sandbox_validator_ds,
+    nvidia_vgpu_device_manager_ds,
+):
+    with vgpu_node_labels_applied(
+        gpu_nodes=gpu_nodes,
+        nodes_with_supported_gpus=nodes_with_supported_gpus,
+        labeled_nodes=gpu_nodes_labeled_with_vm_vgpu,
+        sandbox_validator_ds=nvidia_sandbox_validator_ds,
+        vgpu_device_manager_ds=nvidia_vgpu_device_manager_ds,
+    ) as nodes:
+        yield nodes
+
+
+@pytest.fixture(scope="package")
+def non_existent_mdev_bus_nodes(workers_utility_pods, vgpu_ready_nodes):
+    """Verify mdev_bus is available on all vGPU nodes."""
+    verify_mdev_bus_available(workers_utility_pods=workers_utility_pods, vgpu_nodes=vgpu_ready_nodes)
+    yield vgpu_ready_nodes

--- a/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
@@ -20,6 +20,7 @@ from tests.virt.node.gpu.utils import (
 )
 from tests.virt.utils import (
     build_node_affinity_dict,
+    get_data_volume_template_dict_with_default_storage_class,
     get_num_gpu_devices_in_rhel_vm,
     running_sleep_in_linux,
     verify_gpu_device_exists_in_vm,
@@ -48,7 +49,7 @@ TESTS_CLASS_NAME = "TestVGPURHELGPUSSpec"
 def gpu_vmb(
     unprivileged_client,
     namespace,
-    golden_image_data_volume_template_for_test_scope_class,
+    golden_image_data_source_for_test_scope_class,
     supported_gpu_device,
     gpu_vma,
 ):
@@ -60,7 +61,9 @@ def gpu_vmb(
         namespace=namespace.name,
         client=unprivileged_client,
         labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
-        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class,
+        ),
         vm_affinity=gpu_vma.vm_affinity,
         gpu_name=supported_gpu_device[VGPU_DEVICE_NAME_STR],
     ) as vm:
@@ -73,7 +76,7 @@ def node_mdevtype_gpu_vm(
     request,
     unprivileged_client,
     namespace,
-    golden_image_data_volume_template_for_test_scope_class,
+    golden_image_data_source_for_test_scope_class,
     nodes_with_supported_gpus,
     supported_gpu_device,
 ):
@@ -88,7 +91,9 @@ def node_mdevtype_gpu_vm(
         request=request,
         namespace=namespace,
         unprivileged_client=unprivileged_client,
-        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class,
+        ),
         vm_affinity=build_node_affinity_dict(values=[[*nodes_with_supported_gpus][1].name]),
         gpu_name=supported_gpu_device[VGPU_GRID_NAME_STR],
     ) as vm:

--- a/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
@@ -14,6 +14,7 @@ from tests.virt.node.gpu.utils import (
     restart_and_check_gpu_exists,
 )
 from tests.virt.utils import (
+    get_data_volume_template_dict_with_default_storage_class,
     get_gpu_device_name_from_windows_vm,
     validate_pause_unpause_windows_vm,
     verify_gpu_device_exists_in_vm,
@@ -42,7 +43,7 @@ TESTS_CLASS_NAME = "TestVGPUWindowsGPUSSpec"
 def gpu_vmc(
     unprivileged_client,
     namespace,
-    golden_image_data_volume_template_for_test_scope_class,
+    golden_image_data_source_for_test_scope_class,
     supported_gpu_device,
     gpu_vma,
 ):
@@ -54,7 +55,9 @@ def gpu_vmc(
         namespace=namespace.name,
         client=unprivileged_client,
         labels=Template.generate_template_labels(**WINDOWS_10_TEMPLATE_LABELS),
-        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class,
+        ),
         node_selector=gpu_vma.node_selector,
         gpu_name=supported_gpu_device[VGPU_DEVICE_NAME_STR],
         cloned_dv_size=DV_SIZE,

--- a/tests/virt/upgrade_custom/vgpu/conftest.py
+++ b/tests/virt/upgrade_custom/vgpu/conftest.py
@@ -1,15 +1,26 @@
 import pytest
 from ocp_resources.data_source import DataSource
+from ocp_resources.kubevirt import KubeVirt
 from pytest_testconfig import config as py_config
 
 from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, RHEL_LATEST_OS
 from tests.virt.node.gpu.constants import (
+    GPU_WORKLOAD_CONFIG_LABEL,
+    MDEV_NAME_STR,
+    VGPU_CONFIG_LABEL,
     VGPU_DEVICE_NAME_STR,
+)
+from tests.virt.node.gpu.utils import (
+    verify_mdev_bus_available,
+    vgpu_node_labels_applied,
+    wait_for_nvidia_vgpu_manager,
 )
 from tests.virt.upgrade.utils import vm_from_template
 from tests.virt.utils import build_node_affinity_dict, verify_gpu_device_exists_on_node
 from utilities.artifactory import get_test_artifact_server_url
-from utilities.constants import ES_NONE, TIMEOUT_30MIN
+from utilities.constants import DISABLE_MDEV_CONFIGURATION, ES_NONE, FEATURE_GATES, TIMEOUT_30MIN
+from utilities.hco import ResourceEditorValidateHCOReconcile
+from utilities.infra import label_nodes
 from utilities.storage import (
     create_dv,
     generate_data_source_dict,
@@ -74,3 +85,81 @@ def rhel_vm_for_upgrade_session_scope(
         eviction_strategy=ES_NONE,
     ) as vm:
         yield vm
+
+
+@pytest.fixture(scope="session")
+def hco_with_disable_mdev_configuration_session_scope(hyperconverged_resource_scope_session):
+    """
+    Enable disableMDevConfiguration feature gate in HCO.
+
+    This fixture must run before any vGPU node labeling to ensure CNV
+    does not configure mediated devices (vGPU configuration is handled
+    by NVIDIA GPU Operator).
+    """
+    with ResourceEditorValidateHCOReconcile(
+        patches={hyperconverged_resource_scope_session: {"spec": {FEATURE_GATES: {DISABLE_MDEV_CONFIGURATION: True}}}},
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+
+
+@pytest.fixture(scope="session")
+def gpu_nodes_labeled_with_vgpu_config_session_scope(
+    hco_with_disable_mdev_configuration_session_scope,
+    nodes_with_supported_gpus,
+    supported_gpu_device,
+):
+    yield from label_nodes(
+        nodes=nodes_with_supported_gpus,
+        labels={VGPU_CONFIG_LABEL: supported_gpu_device[MDEV_NAME_STR].split()[-1]},
+    )
+
+
+@pytest.fixture(scope="session")
+def gpu_nodes_labeled_with_vm_vgpu_session_scope(
+    nodes_with_supported_gpus, gpu_nodes_labeled_with_vgpu_config_session_scope
+):
+    yield from label_nodes(nodes=nodes_with_supported_gpus, labels={GPU_WORKLOAD_CONFIG_LABEL: "vm-vgpu"})
+
+
+@pytest.fixture(scope="session")
+def nvidia_vgpu_manager_ready_session_scope(
+    nvidia_vgpu_manager_ds,
+    gpu_nodes_labeled_with_vm_vgpu_session_scope,
+):
+    """Wait until nvidia-vgpu-manager DaemonSet is ready on all vGPU nodes."""
+    wait_for_nvidia_vgpu_manager(
+        nvidia_vgpu_manager_ds=nvidia_vgpu_manager_ds,
+        nodes_with_supported_gpus=gpu_nodes_labeled_with_vm_vgpu_session_scope,
+    )
+    yield nvidia_vgpu_manager_ds
+
+
+@pytest.fixture(scope="session")
+def vgpu_ready_nodes_session_scope(
+    gpu_nodes,
+    nodes_with_supported_gpus,
+    gpu_nodes_labeled_with_vm_vgpu_session_scope,
+    nvidia_vgpu_manager_ready_session_scope,
+    nvidia_sandbox_validator_ds,
+    nvidia_vgpu_device_manager_ds,
+):
+    with vgpu_node_labels_applied(
+        gpu_nodes=gpu_nodes,
+        nodes_with_supported_gpus=nodes_with_supported_gpus,
+        labeled_nodes=gpu_nodes_labeled_with_vm_vgpu_session_scope,
+        sandbox_validator_ds=nvidia_sandbox_validator_ds,
+        vgpu_device_manager_ds=nvidia_vgpu_device_manager_ds,
+    ) as nodes:
+        yield nodes
+
+
+@pytest.fixture(scope="session")
+def non_existent_mdev_bus_nodes_session_scope(workers_utility_pods, vgpu_ready_nodes_session_scope):
+    """Verify mdev_bus is available on all vGPU nodes."""
+    verify_mdev_bus_available(
+        workers_utility_pods=workers_utility_pods,
+        vgpu_nodes=vgpu_ready_nodes_session_scope,
+    )
+    yield vgpu_ready_nodes_session_scope

--- a/tests/virt/upgrade_custom/vgpu/test_vgpu_vm_upgrade.py
+++ b/tests/virt/upgrade_custom/vgpu/test_vgpu_vm_upgrade.py
@@ -20,7 +20,7 @@ pytestmark = [
     pytest.mark.ocp_upgrade,
     pytest.mark.special_infra,
     pytest.mark.usefixtures(
-        "non_existent_mdev_bus_nodes",
+        "non_existent_mdev_bus_nodes_session_scope",
         "hco_cr_with_mdev_permitted_hostdevices_scope_session",
         "vgpu_on_nodes",
     ),

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -406,6 +406,7 @@ DEPENDENCY_SCOPE_SESSION = "session"
 
 # hco spec
 ENABLE_COMMON_BOOT_IMAGE_IMPORT = "enableCommonBootImageImport"
+DISABLE_MDEV_CONFIGURATION = "disableMDevConfiguration"
 
 # Common templates constants
 DATA_SOURCE_NAME = "DATA_SOURCE_NAME"


### PR DESCRIPTION
 (#4959)
Add hco_with_disable_mdev_configuration fixture that enables the disableMDevConfiguration feature gate in HCO before any vGPU node labeling occurs. This ensures CNV does not configure mediated devices, as vGPU configuration is handled by NVIDIA GPU Operator. Changes:
- Add DISABLE_MDEV_CONFIGURATION constant to utilities/constants.py
- Create hco_with_disable_mdev_configuration session-scoped fixture
- Give each second vGPU test VM its own root disk instead of sharing the class-scoped data volume template, which caused XFS corruption and guest agent failures when VMs landed on different nodes.

##### What this PR does / why we need it:
This PR fixes vGPU test setup for clusters where NVIDIA GPU Operator owns vGPU configuration.

Feature gate: Adds a hco_with_disable_mdev_configuration fixture that enables disableMDevConfiguration in HCO before any vGPU node labeling. Without this, CNV auto-configures mediated devices and conflicts with GPU Operator’s vGPU setup.

Separate root disks: Second-VM fixtures (gpu_vmb, node_mdevtype_gpu_vm, gpu_vmc) now build a unique data volume template per VM instead of reusing the class-scoped template. The shared template gave both VMs the same RWX PVC name; when they landed on different nodes, vm2 hit XFS corruption and never reached AgentConnected=True (e.g. TestNodeMDEVTypeVGPURHELGPUSSpec).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->