### PR TITLE
[Storage] Add STD docstrings to CCLM tests

### DIFF
--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -59,6 +59,17 @@ pytestmark = [
 )
 @pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
 class TestCCLMSeveralVMs:
+    """
+    Tests for cross-cluster live migration of multiple VMs.
+
+    Preconditions:
+        - Two OpenShift clusters (source and target) with live migration network configured
+        - MTV installed on the target cluster with Provider, StorageMap, and NetworkMap configured
+        - Several running VMs on the source cluster, accessible via console
+        - Test file written to the source VMs before migration
+        - Boot IDs recorded for all source VMs before migration
+    """
+
     @pytest.mark.polarion("CNV-11995")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster")
     def test_migrate_vm_from_remote_to_local_cluster(
@@ -67,6 +78,15 @@ class TestCCLMSeveralVMs:
         vms_boot_id_before_cclm,
         mtv_migration,
     ):
+        """
+        Test that multiple VMs can be live migrated from the source cluster to the target cluster.
+
+        Steps:
+            1. Wait for the MTV migration to reach Succeeded condition
+
+        Expected:
+            - Migration succeeds for all VMs
+        """
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
             status=mtv_migration.Condition.Status.TRUE,
@@ -77,6 +97,19 @@ class TestCCLMSeveralVMs:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-11910")
     def test_verify_vms_not_rebooted_after_migration(self, local_vms_after_cclm_migration, vms_boot_id_before_cclm):
+        """
+        Test that VMs are not rebooted during cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Read boot ID from each migrated VM on the target cluster
+            2. Compare current boot IDs with boot IDs recorded before migration
+
+        Expected:
+            - Boot IDs are unchanged for all migrated VMs
+        """
         verify_vms_boot_id_after_cross_cluster_live_migration(
             local_vms=local_vms_after_cclm_migration, initial_boot_id=vms_boot_id_before_cclm
         )
@@ -84,6 +117,18 @@ class TestCCLMSeveralVMs:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-14332")
     def test_verify_file_persisted_after_migration(self, local_vms_after_cclm_migration):
+        """
+        Test that files written before migration are preserved after cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Read the test file from each migrated VM on the target cluster
+
+        Expected:
+            - File content on each migrated VM equals the content written before migration
+        """
         for vm in local_vms_after_cclm_migration:
             check_file_in_vm(
                 vm=vm,
@@ -96,6 +141,18 @@ class TestCCLMSeveralVMs:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-14333")
     def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        """
+        Test that source VMs on the source cluster are stopped after cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Check the status of each source VM on the source cluster
+
+        Expected:
+            - All source VMs are in "Stopped" state
+        """
         assert_vms_are_stopped(vms=vms_for_cclm)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
@@ -103,14 +160,45 @@ class TestCCLMSeveralVMs:
     def test_compute_live_migrate_vms_after_cclm(
         self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
     ):
+        """
+        Test that VMs can be compute live migrated within the target cluster after cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Trigger intra-cluster live migration for each migrated VM on the target cluster
+            2. Wait for each migration to complete
+
+        Expected:
+            - All migrated VMs are successfully live migrated within the target cluster
+        """
         verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14334")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        """
+        Test that source VMs on the source cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete each source VM on the source cluster
+
+        Expected:
+            - All source VMs are successfully deleted
+        """
         assert_vms_can_be_deleted(vms=vms_for_cclm)
 
     @pytest.mark.polarion("CNV-15237")
     def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
+        """
+        Test that migrated VMs on the target cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete each migrated VM on the target cluster
+
+        Expected:
+            - All migrated VMs are successfully deleted
+        """
         assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)
 
 
@@ -128,6 +216,15 @@ class TestCCLMSeveralVMs:
 )
 @pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class", "dv_wait_timeout")
 class TestCCLMWindowsWithVTPM:
+    """
+    Tests for cross-cluster live migration of a Windows VM with vTPM.
+
+    Preconditions:
+        - Two OpenShift clusters (source and target) with live migration network configured
+        - MTV installed on the target cluster with Provider, StorageMap, and NetworkMap configured
+        - Running Windows VM on the source cluster
+    """
+
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_WINDOWS_VM}::test_migrate_windows_vm_from_remote_to_local_cluster")
     @pytest.mark.polarion("CNV-11999")
     def test_migrate_windows_vm_from_remote_to_local_cluster(
@@ -135,6 +232,15 @@ class TestCCLMWindowsWithVTPM:
         booted_vms_for_cclm,
         mtv_migration,
     ):
+        """
+        Test that a Windows VM can be live migrated from the source cluster to the target cluster.
+
+        Steps:
+            1. Wait for the MTV migration to reach Succeeded condition
+
+        Expected:
+            - Migration succeeds for the Windows VM
+        """
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
             status=mtv_migration.Condition.Status.TRUE,
@@ -147,6 +253,18 @@ class TestCCLMWindowsWithVTPM:
     )
     @pytest.mark.polarion("CNV-14335")
     def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        """
+        Test that the source Windows VM on the source cluster is stopped after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Wait for the source VM on the source cluster to reach Stopped state
+
+        Expected:
+            - Source VM is in "Stopped" state
+        """
         wait_for_vms_to_be_stopped(vms=vms_for_cclm)
 
     @pytest.mark.dependency(
@@ -156,14 +274,45 @@ class TestCCLMWindowsWithVTPM:
     def test_compute_live_migrate_windows_vms_after_cclm(
         self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
     ):
+        """
+        Test that a Windows VM can be compute live migrated within the target cluster after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Trigger intra-cluster live migration for the migrated Windows VM on the target cluster
+            2. Wait for migration to complete
+
+        Expected:
+            - Migrated Windows VM is successfully live migrated within the target cluster
+        """
         verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14336")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        """
+        Test that the source Windows VM on the source cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the source VM on the source cluster
+
+        Expected:
+            - Source VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=vms_for_cclm)
 
     @pytest.mark.polarion("CNV-15236")
     def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
+        """
+        Test that the migrated Windows VM on the target cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the migrated VM on the target cluster
+
+        Expected:
+            - Migrated VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)
 
 
@@ -184,6 +333,18 @@ class TestCCLMWindowsWithVTPM:
 )
 @pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
 class TestCCLMFromStorageAtoB:
+    """
+    Tests for cross-cluster live migration of a VM across different storage classes.
+
+    Preconditions:
+        - Two OpenShift clusters (source and target) with live migration network configured
+        - MTV installed on the target cluster with Provider, StorageMap, and NetworkMap configured
+        - Running VM on the source cluster, accessible via console
+        - Different storage classes used on source and target clusters
+        - Test file written to the source VM before migration
+        - Boot ID recorded for the source VM before migration
+    """
+
     @pytest.mark.polarion("CNV-15955")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster")
     def test_migrate_vm_from_remote_to_local_cluster(
@@ -192,6 +353,15 @@ class TestCCLMFromStorageAtoB:
         vms_boot_id_before_cclm,
         mtv_migration,
     ):
+        """
+        Test that a VM can be cross-cluster live migrated when source and target storage classes are different.
+
+        Steps:
+            1. Wait for the MTV migration to reach Succeeded condition
+
+        Expected:
+            - Migration succeeds for the VM
+        """
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
             status=mtv_migration.Condition.Status.TRUE,
@@ -204,6 +374,19 @@ class TestCCLMFromStorageAtoB:
     )
     @pytest.mark.polarion("CNV-15956")
     def test_verify_vms_not_rebooted_after_migration(self, local_vms_after_cclm_migration, vms_boot_id_before_cclm):
+        """
+        Test that VM is not rebooted during cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Read boot ID from the migrated VM on the target cluster
+            2. Compare current boot ID with boot ID recorded before migration
+
+        Expected:
+            - Boot ID is unchanged for the migrated VM
+        """
         verify_vms_boot_id_after_cross_cluster_live_migration(
             local_vms=local_vms_after_cclm_migration, initial_boot_id=vms_boot_id_before_cclm
         )
@@ -213,6 +396,18 @@ class TestCCLMFromStorageAtoB:
     )
     @pytest.mark.polarion("CNV-15957")
     def test_verify_file_persisted_after_migration(self, local_vms_after_cclm_migration):
+        """
+        Test that files written before migration are preserved after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Read the test file from the migrated VM on the target cluster
+
+        Expected:
+            - File content on the migrated VM equals the content written before migration
+        """
         for vm in local_vms_after_cclm_migration:
             check_file_in_vm(
                 vm=vm,
@@ -227,6 +422,18 @@ class TestCCLMFromStorageAtoB:
     )
     @pytest.mark.polarion("CNV-15958")
     def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        """
+        Test that source VM on the source cluster is stopped after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Check the status of the source VM on the source cluster
+
+        Expected:
+            - Source VM is in "Stopped" state
+        """
         assert_vms_are_stopped(vms=vms_for_cclm)
 
     @pytest.mark.dependency(
@@ -236,12 +443,43 @@ class TestCCLMFromStorageAtoB:
     def test_compute_live_migrate_vms_after_cclm(
         self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
     ):
+        """
+        Test that a VM can be compute live migrated within the target cluster after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Trigger intra-cluster live migration for the migrated VM on the target cluster
+            2. Wait for migration to complete
+
+        Expected:
+            - Migrated VM is successfully live migrated within the target cluster
+        """
         verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-15959")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        """
+        Test that source VM on the source cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the source VM on the source cluster
+
+        Expected:
+            - Source VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=vms_for_cclm)
 
     @pytest.mark.polarion("CNV-15960")
     def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
+        """
+        Test that migrated VM on the target cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the migrated VM on the target cluster
+
+        Expected:
+            - Migrated VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -1,7 +1,7 @@
 """
 Cross-cluster live migration tests.
 
-Jira epic: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
+Jira: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
 """
 
 from __future__ import annotations


### PR DESCRIPTION
##### What this PR does / why we need it:
- Add STD docstrings to CCLM tests
- Fix pre-merge check: rename `Jira epic:` → `Jira: `

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Assisted-by: Claude <noreply@anthropic.com>

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded migration test documentation with structured multi-line descriptions, including preconditions, steps, and expected results.
  * Added clearer coverage notes for multiple VM cross-cluster live migration scenarios, a Windows VM with vTPM, and migrations across different storage classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->