### PR TITLE
[4.20][Storage] Wait for interfaces while creating VM in Clone tests

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -60,7 +60,7 @@ def create_vm_from_clone_dv_template(
             storage_class=storage_class,
         ),
     ) as vm:
-        running_vm(vm=vm, wait_for_interfaces=False)
+        running_vm(vm=vm)
         check_disk_count_in_vm(vm=vm)
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove `wait_for_interfaces=False` from `running_vm()` in `create_vm_from_clone_dv_template`.

##### Which issue(s) this PR fixes:
This parameter was skipping the wait for guest agent and network interfaces before attempting SSH, which could cause intermittent SSH connection failures.
Without it, `running_vm()` defaults to waiting for interfaces before checking SSH connectivity, which is the correct order.

##### Special notes for reviewer:
Already fixed on `main` as part of PR #3678 

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE