### PR TITLE
Revert "CherryPicked: [cnv-4.19] CherryPicked: [4.21] Fix _sc_name_for_storage_api"

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1009,9 +1009,8 @@ class VirtualMachineForTests(VirtualMachine):
                 sc_name = self.vm_preference.instance.spec.get("volumes", {}).get("preferredStorageClassName")
                 if sc_name:
                     return sc_name
-            default_sc = get_default_storage_class(client=self.client).name
-            LOGGER.info(f"Using default storage class: {default_sc} for access mode field")
-            return default_sc
+            else:
+                return get_default_storage_class().name
 
         api_name = "pvc" if self.data_volume_template and self.data_volume_template["spec"].get("pvc") else "storage"
         return (


### PR DESCRIPTION
Reverts RedHatQE/openshift-virtualization-tests#5438

breaks gating lanes `failed on setup with "TypeError: get_default_storage_class() got an unexpected keyword argument 'client'"`