### PR TITLE
fix(vhostmd): allign  ResourceProcessorLimit metric type with KubeVirt

### DIFF
--- a/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
+++ b/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
@@ -31,7 +31,7 @@ EXPECTED_METRICS = {
     ("VirtualizationVendor", "string", "host"),
     ("VirtProductInfo", "string", "host"),
     ("TotalCPUTime", "real64", "vm"),
-    ("ResourceProcessorLimit", "uint64", "vm"),
+    ("ResourceProcessorLimit", "int64", "vm"),
     ("PhysicalMemoryAllocatedToVirtualSystem", "uint64", "vm"),
     ("ResourceMemoryLimit", "uint64", "vm"),
     ("NumberOfPhysicalCPUs", "int64", "host"),


### PR DESCRIPTION
##### What this PR does / why we need it:
KubeVirt commit c7d5c82f26 removed NrVirtCpu from DomainStats because it was redundant. The scraper already loops over vmStats.Vcpu for TotalCPUTime, so it can count online vCPUs in the same pass instead of carrying a separate field from libvirt.onlineVcpus is int → XML type="int64"

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
seen in recent CI runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated metric validation to match the current metric type expected during virtual machine downward metrics checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->