### PR TITLE
net: Filter IPv4 on IPv6-only clusters

### DIFF
--- a/libs/net/cluster.py
+++ b/libs/net/cluster.py
@@ -8,6 +8,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 @cache
+def supported_cluster_ip_versions() -> set[int]:
+    """Return the set of IP versions (4, 6) supported by the cluster."""
+    return {version for version, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled}
+
+
+@cache
 def is_ipv6_single_stack_cluster() -> bool:
     ipv4_supported = ipv4_supported_cluster()
     ipv6_supported = ipv6_supported_cluster()

--- a/libs/net/ip.py
+++ b/libs/net/ip.py
@@ -3,7 +3,7 @@ import random
 from functools import cache
 from typing import Final
 
-from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster, supported_cluster_ip_versions
 
 _MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION: Final[int] = 16
 _MAX_NUM_OF_RANDOM_HEXTETS_PER_SESSION: Final[int] = 16
@@ -137,6 +137,20 @@ def filter_link_local_addresses(ip_addresses: list[str]) -> list[ipaddress.IPv4A
         List of IP address objects with link-local addresses removed.
     """
     return [ip for addr in ip_addresses if not (ip := ipaddress.ip_interface(address=addr).ip).is_link_local]
+
+
+def filter_cluster_unsupported_addresses(
+    ip_addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address],
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Filter out IP addresses whose family is not supported by the cluster.
+
+    Args:
+        ip_addresses: List of IP address objects to filter.
+
+    Returns:
+        List containing only addresses whose IP version is supported by the cluster.
+    """
+    return [ip for ip in ip_addresses if ip.version in supported_cluster_ip_versions()]
 
 
 def ip_header_size(ip: ipaddress.IPv4Address | ipaddress.IPv6Address | str) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
 import utilities.hco
-from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster, supported_cluster_ip_versions
 from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
 from libs.net.vmspec import lookup_iface_status
 from tests.utils import download_and_extract_tar
@@ -1695,9 +1695,7 @@ def running_vm_upgrade_a(
         eviction_strategy=ES_NONE,
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)
-        ip_families = [
-            family for family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
-        ]
+        ip_families = supported_cluster_ip_versions()
         lookup_iface_status(
             vm=vm,
             iface_name=upgrade_bridge_marker_nad.name,
@@ -1730,9 +1728,7 @@ def running_vm_upgrade_b(
         eviction_strategy=ES_NONE,
     ) as vm:
         running_vm(vm=vm, wait_for_cloud_init=True)
-        ip_families = [
-            family for family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
-        ]
+        ip_families = supported_cluster_ip_versions()
         lookup_iface_status(
             vm=vm,
             iface_name=upgrade_bridge_marker_nad.name,

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -5,8 +5,13 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 
 from libs.net import nodenetworkconfigurationpolicy as libnncp
-from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
-from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
+from libs.net.cluster import supported_cluster_ip_versions
+from libs.net.ip import (
+    filter_cluster_unsupported_addresses,
+    filter_link_local_addresses,
+    random_ipv4_address,
+    random_ipv6_address,
+)
 from libs.net.traffic_generator import TcpServer, VMTcpClient, active_tcp_connections
 from libs.net.vmspec import lookup_iface_status
 from libs.vm.oper import run_vms
@@ -210,15 +215,18 @@ def localnet_running_vms(
     vm_localnet_2: BaseVirtualMachine,
 ) -> tuple[BaseVirtualMachine, BaseVirtualMachine]:
     vm1, vm2 = run_vms(vms=(vm_localnet_1, vm_localnet_2))
-    ip_families = [
-        ip_family for ip_family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
-    ]
+    ip_families = supported_cluster_ip_versions()
     for vm in (vm1, vm2):
         lookup_iface_status(
             vm=vm,
             iface_name=LOCALNET_BR_EX_INTERFACE,
             predicate=lambda interface: (
-                len(filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))) == len(ip_families)
+                len(
+                    filter_cluster_unsupported_addresses(
+                        ip_addresses=filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))
+                    )
+                )
+                == len(ip_families)
             ),
         )
     return vm1, vm2
@@ -355,15 +363,18 @@ def ovs_bridge_localnet_running_vms(
     vm_ovs_bridge_localnet_2: BaseVirtualMachine,
 ) -> Generator[tuple[BaseVirtualMachine, BaseVirtualMachine]]:
     vm1, vm2 = run_vms(vms=(vm_ovs_bridge_localnet_1, vm_ovs_bridge_localnet_2))
-    ip_families = [
-        ip_family for ip_family, enabled in ((4, ipv4_supported_cluster()), (6, ipv6_supported_cluster())) if enabled
-    ]
+    ip_families = supported_cluster_ip_versions()
     for vm in (vm1, vm2):
         lookup_iface_status(
             vm=vm,
             iface_name=LOCALNET_OVS_BRIDGE_INTERFACE,
             predicate=lambda interface: (
-                len(filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))) == len(ip_families)
+                len(
+                    filter_cluster_unsupported_addresses(
+                        ip_addresses=filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))
+                    )
+                )
+                == len(ip_families)
             ),
         )
     yield vm1, vm2

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from libs.net.ip import filter_link_local_addresses, have_same_ip_families
+from libs.net.ip import filter_cluster_unsupported_addresses, filter_link_local_addresses, have_same_ip_families
 from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
 from libs.net.vmspec import lookup_iface_status
 from tests.network.localnet.liblocalnet import (
@@ -65,7 +65,6 @@ def test_connectivity_post_migration_between_localnet_vms(
                 assert is_tcp_connection(server=server, client=client)
 
 
-@pytest.mark.jira("CNV-90600", run=False)
 @pytest.mark.single_nic
 @pytest.mark.s390x
 @pytest.mark.usefixtures("nncp_localnet")
@@ -86,16 +85,20 @@ def test_vmi_reports_ip_on_secondary_interface_without_vlan(
         vm=vm,
         iface_name=LOCALNET_BR_EX_INTERFACE_NO_VLAN,
         predicate=lambda interface: have_same_ip_families(
-            actual_ips=filter_link_local_addresses(
-                ip_addresses=[str(ip_interface(addr).ip) for addr in interface["ipAddresses"]]
+            actual_ips=filter_cluster_unsupported_addresses(
+                ip_addresses=filter_link_local_addresses(
+                    ip_addresses=[str(ip_interface(addr).ip) for addr in interface["ipAddresses"]]
+                )
             ),
             expected_ips=expected_ips,
         ),
     )
-    reported_ips = filter_link_local_addresses(
-        ip_addresses=[str(ip_interface(addr).ip) for addr in iface_status.ipAddresses]
+    reported_ips = filter_cluster_unsupported_addresses(
+        ip_addresses=filter_link_local_addresses(
+            ip_addresses=[str(ip_interface(addr).ip) for addr in iface_status.ipAddresses]
+        )
     )
     assert set(reported_ips) == set(expected_ips), (
-        f"IP addresses mismatch for interface {LOCALNET_BR_EX_INTERFACE_NO_VLAN} on VM {vm.name},"
+        f"IP addresses mismatch for interface {LOCALNET_BR_EX_INTERFACE_NO_VLAN} on VM {vm.name}, "
         f"Reported: {reported_ips}, Expected: {expected_ips}"
     )


### PR DESCRIPTION
##### What this PR does / why we need it:
On IPv6-only clusters, VMIs may still report IPv4 addresses due to a cloud-init [limitation](https://github.com/canonical/cloud-init/issues/6685):
- If DHCPv4 is disabled with no static IPv4 provided, DHCPv4 is still left enabled by cloud-init.
- If DHCPv4 is disabled with a static IPv4 provided, DHCPv4 is kept disabled.


##### Which issue(s) this PR fixes:
This caused fixture predicates to wait indefinitely (count mismatch) and the IP visibility test to fail (extra IPv4 address in reported set).

This change includes extracting a new cached helper for repeated fetching of cluster IP support and addition of a new helper to strip cluster-unsupported addresses. Apply it in the localnet fixture predicates and in `test_vmi_reports_ip_on_secondary_interface_without_vlan`.

Filtering rather than blocking preserves test coverage on IPv6-only clusters. Blocking would skip the test entirely, losing the regression guard for CNV-38477. The cloud-init DHCPv4 behavior is a
known infrastructure limitation, not a product bug - filtering the extra IPv4 addresses out is the correct response

##### Special notes for reviewer: 
Targeted for backport to 4.22, the first release to support secondary networks on single-stack IPv6 clusters

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IP address validation to count and report only IPv4/IPv6 addresses supported by the cluster configuration.
  * Updated local network and bridge interface checks to ignore unsupported IP families when verifying VM interface IPs.
* **Tests**
  * Adjusted test fixtures and upgrade scenario validations to use the unified cluster-supported IP-family logic.
  * Removed a disabled test marker and refined expected IP-mismatch reporting formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->