### PR TITLE
fix(ci): fall back to org membership check for fork PRs

### DIFF
--- a/.github/workflows/check-pr-approval.yml
+++ b/.github/workflows/check-pr-approval.yml
@@ -5,10 +5,18 @@
 # for org members. This workflow fetches the value via the REST API (pulls.get),
 # which always returns the correct association.
 #
+# Caveat: GITHUB_TOKEN is repo-scoped and cannot check org membership.
+# pulls.get returns CONTRIBUTOR (not MEMBER) for org members who submit
+# PRs from forks. When the association is not in the trusted list AND
+# the PR is a fork, we fall back to an explicit org membership check
+# using ORG_READ_TOKEN (a fine-grained PAT with Organization: Members read).
+#
 # Usage:
 #   jobs:
 #     check-approval:
 #       uses: ./.github/workflows/check-pr-approval.yml
+#       secrets:
+#         ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
 #
 #     my-job:
 #       needs: [check-approval]
@@ -23,6 +31,10 @@ on:
         description: JSON array of trusted author associations that skip approval
         type: string
         default: '["COLLABORATOR", "MEMBER", "OWNER"]'
+    secrets:
+      ORG_READ_TOKEN:
+        description: Fine-grained PAT with Organization Members read permission for org membership checks
+        required: false
     outputs:
       needs_approval:
         description: Whether the PR needs environment approval (true/false)
@@ -42,6 +54,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           TRUSTED_ASSOCIATIONS: ${{ inputs.trusted_associations }}
+          ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -65,7 +78,34 @@ jobs:
 
               // head.repo is null when the fork has been deleted after the PR was opened
               const isFork = !data.head.repo || data.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
-              const isTrusted = trusted.includes(data.author_association);
+              let isTrusted = trusted.includes(data.author_association);
+
+              // GITHUB_TOKEN is repo-scoped, so pulls.get returns CONTRIBUTOR
+              // instead of MEMBER for org members who submit from forks.
+              // Fall back to an explicit org membership check.
+              if (!isTrusted && isFork) {
+                const orgToken = process.env.ORG_READ_TOKEN;
+                if (orgToken) {
+                  try {
+                    const orgOctokit = getOctokit(orgToken);
+                    await orgOctokit.rest.orgs.checkMembershipForUser({
+                      org: context.repo.owner,
+                      username: data.user.login,
+                    });
+                    isTrusted = true;
+                    core.info(`Org membership confirmed for ${data.user.login}`);
+                  } catch (err) {
+                    if (err.status === 404 || err.status === 302) {
+                      core.info(`User ${data.user.login} is not an org member (status=${err.status})`);
+                    } else {
+                      core.warning(`Org membership check failed for ${data.user.login}: ${err.message} (status=${err.status})`);
+                    }
+                  }
+                } else {
+                  core.warning('ORG_READ_TOKEN not configured — cannot verify org membership for fork PRs');
+                }
+              }
+
               const needsApproval = isFork && !isTrusted;
 
               core.info(`author=${data.user.login} association=${data.author_association} fork=${isFork} trusted=${isTrusted} needs_approval=${needsApproval}`);

--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       pull-requests: read
     uses: ./.github/workflows/check-pr-approval.yml
+    secrets:
+      ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
 
   build-and-push-staging:
     needs: [check-approval]

--- a/.github/workflows/net-utils-promote.yml
+++ b/.github/workflows/net-utils-promote.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       pull-requests: read
     uses: ./.github/workflows/check-pr-approval.yml
+    secrets:
+      ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
     with:
       trusted_associations: '["COLLABORATOR", "MEMBER", "OWNER", "CONTRIBUTOR"]'
 

--- a/.github/workflows/utilities-unit-tests.yml
+++ b/.github/workflows/utilities-unit-tests.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       pull-requests: read
     uses: ./.github/workflows/check-pr-approval.yml
+    secrets:
+      ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
 
   utilities-unit-tests:
     name: Run Utilities Unit Tests


### PR DESCRIPTION
##### What this PR does / why we need it:
When org members (e.g. `jpeimer` in #5443) open PRs from forks, GitHub Actions requires manual approval to run CI — even though they're org members.

**Root cause:** `GITHUB_TOKEN` is repo-scoped. The `pulls.get` API returns `author_association: "CONTRIBUTOR"` instead of `"MEMBER"` for org members submitting from forks, because the token can't see org membership. The workflow only trusts `COLLABORATOR`, `MEMBER`, `OWNER` — so `CONTRIBUTOR` triggers the approval gate.

**Fix:** Add a fallback org membership check using `ORG_READ_TOKEN` (a fine-grained PAT with Organization: Members read permission). When a fork PR author isn't in the trusted list, `orgs.checkMembershipForUser()` is called to verify org membership directly.

Key design decisions:
- `ORG_READ_TOKEN` is optional (`required: false`) — if not configured, the workflow logs a warning and falls back to requiring approval (fail-closed)
- Separate Octokit client via `getOctokit(orgToken)` — the PAT scope is isolated
- Error logging — 404/302 logged at info (expected), unexpected errors at warning (debuggable)
- Least privilege — callers pass only `ORG_READ_TOKEN`, not `secrets: inherit`

##### Which issue(s) this PR fixes:
Fixes false approval gates on fork PRs from org members (observed on #5443)

##### Special notes for reviewer:
- Requires `ORG_READ_TOKEN` repo/org secret (fine-grained PAT with Organization: Members → Read only) — already configured
- `getOctokit` is the correct v9 API for creating additional Octokit clients in `actions/github-script@v9` ([docs](https://github.com/actions/github-script#creating-additional-clients-with-getoctokit))
- `net-utils-promote.yml` already trusts `CONTRIBUTOR` so the org check is effectively skipped there by design

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR approval checks for forked pull requests by more reliably recognizing organization members.
  * Added support for an optional token to verify membership when standard PR metadata is incomplete or repository-scoped.
  * If verification cannot be completed, the workflow safely keeps the PR in a “needs approval” state.

* **Chores**
  * Updated related workflow calls to pass the new optional secret through approval checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->