### PR TITLE
feat(gha): mandatory test verification via PR description and check runs

### DIFF
--- a/.github/TEST_VERIFICATION.md
+++ b/.github/TEST_VERIFICATION.md
@@ -1,0 +1,46 @@
+# Test verification (draft UX)
+
+Authors prove what they ran **only in the PR description**. No slash commands and no verification comments.
+
+## Flow
+
+1. Add **`verified`** label or comment **`/test-plan`** → CodeRabbit posts a test plan.
+2. Automation appends **Test verification** to the PR description and sets **`test-verification`** to *Action required*.
+3. Author edits the PR description: checks each box and fills **ran** / **ci** / **skip** / **na** with evidence.
+4. On save → **`test-verification`** turns green or red (errors in the Checks tab).
+5. New code push removes the section and resets the check (clean rebase preserved).
+
+## Dispositions
+
+| Value | Meaning |
+|-------|---------|
+| **ran** | You executed this (command/cluster) |
+| **ci** | Jenkins or GitHub Actions ran it (URL) |
+| **skip** | You disagree with this plan item — explain why (min 30 chars) |
+| **na** | Not applicable — explain why (min 30 chars) |
+
+If a reviewer wants changes, the author **edits the PR description** again (e.g. change `skip` → `ran` with evidence) and saves.
+
+## Example PR description
+
+```markdown
+<!-- test-verification-start -->
+### Test verification (required for merge)
+_Test plan: [view plan](...) · Tree: `a1b2c3d`_
+
+- [x] **1.** `tests/network/sriov/test_memory_hotplug.py` — **ran:** uv run pytest ... on cluster dev-sriov-01
+- [x] **2.** `Run smoke tests` — **skip:** Change limited to SR-IOV dir; smoke targets storage only per plan
+<!-- test-verification-end -->
+```
+
+## Checks panel
+
+| Scenario | `test-verification` |
+|----------|---------------------|
+| Section empty / incomplete | Action required or Failure |
+| All items valid | Success |
+| Includes skip/na with valid reasons | Success (disputes listed in check output for reviewers) |
+
+## Merge
+
+Requires **`verified`** + **`test-verification`** success + reviews/CI.

--- a/.github/workflows/request-coderabbit-test-instructions.yml
+++ b/.github/workflows/request-coderabbit-test-instructions.yml
@@ -1,6 +1,6 @@
-# description: Add comment for CodeRabbit to add test instructions. An inline informational test-plan comment will be added.
+# description: Request CodeRabbit test execution plan. A regular PR comment with checkboxes will be posted.
 
-name: Request CodeRabbit tests instructions
+name: Request CodeRabbit test execution plan
 
 on:
   pull_request_target:
@@ -11,6 +11,10 @@ on:
 permissions:
   pull-requests: write
   contents: read
+
+concurrency:
+  group: coderabbit-test-plan-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   comment-on-commit:
@@ -26,6 +30,7 @@ jobs:
         !endsWith(github.event.comment.user.login, '[bot]')
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Check team membership
@@ -47,14 +52,8 @@ jobs:
             <details>
               <summary>Test execution plan request details</summary>
 
-              CRITICAL: You MUST post an inline review comment on the first changed line of the first file.
-              The inline comment should contain the full Test Execution Plan (smoke decision, gating decision, and specific affected tests).
-              Do NOT submit a blocking review event (REQUEST_CHANGES/APPROVE).
-              Post a single inline PR comment on Files Changed (non-blocking COMMENT flow).
-
               As an expert software testing engineer, analyze all modified files in this PR and create a targeted test execution plan.
-              You will post an inline review comment with the test execution plan on the first changed file.
-              If you fail to run or post a comment, retry.
+              Post the test execution plan as your reply to this comment. Do NOT use inline review comments, API calls, or shell scripts to post — just include the plan directly in your response text.
 
               **Analysis Requirements:**
 
@@ -108,13 +107,14 @@ jobs:
               **Output rules:**
               Do NOT include analysis step numbers (1-8) in your visible output.
 
-              **Your deliverable:**
-              Your inline informational comment will be based on the following requirements:
+              **Your deliverable — use this EXACT format (including HTML comment markers and checkbox):**
 
+              <!-- test-execution-plan-start -->
               **Test Execution Plan**
 
               - **Run smoke tests: True / False** — If True, state the dependency path (test → fixture → changed symbol). True ONLY with a verified path.
               - **Run gating tests: True / False** — If True, state the dependency path. True if any gating-marked test is in the affected set.
+
               - **Affected tests to run** _(required when utilities/, libs/, or shared conftest changes — list concrete paths even when smoke is False)_
 
               Use these formats:
@@ -149,6 +149,11 @@ jobs:
               Expected: session starts normally
               ```
 
+              <!-- test-execution-plan-end -->
+
+              Authors record what they ran in the **Test verification** section of the PR description
+              (added automatically after you post this plan). Do not add acknowledgment checkboxes here.
+
               **Guidelines:**
 
               - Include tests affected directly OR via fixture setup/teardown, `yield from` cleanup, or transitive utility call chains (caller calls modified helper)
@@ -168,21 +173,15 @@ jobs:
 
               **CRITICAL WORKFLOW COMPLETION RULES:**
 
-              When responding to this test execution plan request, you MUST follow these rules EXACTLY:
+              1. **YOUR ONLY DELIVERABLE**: Reply to this comment with the test execution plan using the exact format above
+              2. **THEN STOP IMMEDIATELY** — no follow-up comments
+              3. You MUST include the `<!-- test-execution-plan-start -->` and `<!-- test-execution-plan-end -->` HTML markers
+              4. Do NOT post inline review comments — reply as a regular PR comment only
 
-              1. **YOUR ONLY DELIVERABLE**: Post one non-blocking inline comment containing the test execution plan on the first changed line
-              2. **THEN STOP IMMEDIATELY** - Do NOT generate any additional response
-              3. **FALLBACK ONLY**: If inline comment API calls fail after retrying, post as a regular PR comment
-              4. **SILENCE = SUCCESS**: After successfully submitting the review, your task is complete. No confirmation needed.
-
-              **ABSOLUTE PROHIBITIONS** (violating these creates empty/meaningless reviews):
-              - ❌ Do NOT post acknowledgment messages like "Test execution plan posted", "Review posted successfully", "I've successfully posted"
-              - ❌ Do NOT mention review IDs, URLs, or confirmation of posting in the PR thread
-              - ❌ Do NOT add any follow-up comments after submitting the review
-              - ❌ Do NOT reply to confirm task completion
-              - ❌ Do NOT explain what you did - just do it and stop
-
-              **Remember**: The pull request review is visible to users. Additional comments are redundant noise.
+              **ABSOLUTE PROHIBITIONS:**
+              - ❌ Do NOT post acknowledgment messages like "Test execution plan posted"
+              - ❌ Do NOT add any follow-up comments after the test plan
+              - ❌ Do NOT use shell scripts or API calls to post the plan — just include it in your reply text
 
               CRITICAL — Verification rules for smoke and gating decisions:
                 - For each True decision, you must have traced a concrete path: test file → fixture → utility function → modified symbol.

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -1,0 +1,407 @@
+# description: Mandatory test verification gate. When CodeRabbit posts a test plan,
+# append an editable verification section to the PR description. Authors fill evidence
+# per plan item; test-verification check blocks merge until complete. Resets on code push.
+
+name: Test verification
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [edited, synchronize]
+
+concurrency:
+  group: test-verification-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  checks: write
+
+jobs:
+  inject-verification-section:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      (
+        github.event.comment.user.login == 'coderabbitai[bot]' ||
+        github.event.comment.user.login == 'openshift-virtualization-qe-bot-3'
+      ) &&
+      contains(github.event.comment.body, '<!-- test-execution-plan-start -->')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Inject verification section and require action
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.BOT3_TOKEN }}
+          script: |
+            const comment = context.payload.comment;
+            const issue = context.payload.issue;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = issue.number;
+            const planUrl = comment.html_url;
+            const planBody = comment.body || '';
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const headSha = pr.head.sha;
+            let body = pr.body || '';
+
+            // Extract plan content between markers, fall back to full body
+            const planMarkerMatch = planBody.match(
+              /<!-- test-execution-plan-start -->([\s\S]*?)<!-- test-execution-plan-end -->/
+            );
+            const planContent = planMarkerMatch ? planMarkerMatch[1] : planBody;
+
+            // Build verification items from plan bullets and smoke/gating flags
+            const items = [];
+            const bulletRe = /^\s*-\s*`([^`]+)`/gm;
+            let match;
+            const examplePatterns = ['path/to/test_file.py'];
+            while ((match = bulletRe.exec(planContent)) !== null) {
+              const label = match[1];
+              if (!examplePatterns.some(pattern => label.includes(pattern))) {
+                items.push({ label });
+              }
+            }
+            if (/Run smoke tests:\s*True/i.test(planContent)) {
+              items.push({ label: 'Run smoke tests' });
+            }
+            if (/Run gating tests:\s*True/i.test(planContent)) {
+              items.push({ label: 'Run gating tests' });
+            }
+            if (!items.length) {
+              items.push({ label: 'Review the test execution plan and list what you ran' });
+            }
+
+            const itemLines = items.map((item, index) => {
+              const num = index + 1;
+              return `- [ ] **${num}.** \`${item.label}\` — **ran:** _fill command, Jenkins job, or CI link_`;
+            }).join('\n');
+
+            const verificationBlock = [
+              '<!-- test-verification-start -->',
+              '### Test verification (required for merge)',
+              `_Test plan: [view plan](${planUrl}) · Tree: \`${headSha.slice(0, 7)}\`_`,
+              '',
+              '**Edit this section** (you own the PR description). For each item, check the box and set exactly one:',
+              '- **ran:** command you executed (cluster/local)',
+              '- **ci:** Jenkins or GitHub Actions run URL',
+              '- **skip:** you disagree with this plan item — explain why (min 30 characters)',
+              '- **na:** not applicable with reason (min 30 characters)',
+              '',
+              itemLines,
+              '<!-- test-verification-end -->',
+            ].join('\n');
+
+            if (body.includes('<!-- test-verification-start -->')) {
+              body = body.replace(
+                /<!-- test-verification-start -->[\s\S]*?<!-- test-verification-end -->/,
+                verificationBlock
+              );
+            } else {
+              body = body.trimEnd() + `\n\n---\n${verificationBlock}\n`;
+            }
+
+            await github.rest.pulls.update({ owner, repo, pull_number: prNumber, body });
+
+            await github.rest.checks.create({
+              owner, repo,
+              name: 'test-verification',
+              head_sha: headSha,
+              status: 'completed',
+              conclusion: 'action_required',
+              output: {
+                title: 'Test verification required',
+                summary: 'Fill the **Test verification** section in the PR description, then save.',
+                text: [
+                  `Test plan: ${planUrl}`,
+                  '',
+                  'Each plan item needs ran/ci/skip/na with evidence.',
+                  'Merge is blocked until this check is green.',
+                ].join('\n'),
+              },
+            });
+
+  validate-verification:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'edited' &&
+      github.event.changes.body &&
+      !endsWith(github.event.sender.login, '[bot]') &&
+      github.event.sender.login != 'openshift-virtualization-qe-bot-3'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate verification section and update check
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.BOT3_TOKEN }}
+          script: |
+            const core = require('@actions/core');
+            const pr = context.payload.pull_request;
+            const sender = context.payload.sender;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = pr.number;
+            const headSha = pr.head.sha;
+            const body = pr.body || '';
+
+            if (!body.includes('<!-- test-verification-start -->')) {
+              const previousBody = context.payload.changes?.body?.from || '';
+              if (previousBody.includes('<!-- test-verification-start -->')) {
+                await github.rest.checks.create({
+                  owner, repo,
+                  name: 'test-verification',
+                  head_sha: headSha,
+                  status: 'completed',
+                  conclusion: 'action_required',
+                  output: {
+                    title: 'Test verification section removed',
+                    summary: 'The verification section was removed from the PR description. Restore it or wait for a new test plan.',
+                  },
+                });
+              }
+              return;
+            }
+
+            const sectionMatch = body.match(
+              /<!-- test-verification-start -->[\s\S]*?<!-- test-verification-end -->/
+            );
+            if (!sectionMatch) {
+              await github.rest.checks.create({
+                owner, repo,
+                name: 'test-verification',
+                head_sha: headSha,
+                status: 'completed',
+                conclusion: 'action_required',
+                output: {
+                  title: 'Test verification section corrupted',
+                  summary: 'The verification section markers are incomplete or malformed. Restore the section or wait for a new test plan.',
+                },
+              });
+              return;
+            }
+            const section = sectionMatch[0];
+
+            // Authorization: PR author or write/admin
+            const prAuthor = pr.user.login;
+            let isAllowed = sender.login === prAuthor;
+            if (!isAllowed) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner, repo, username: sender.login,
+                });
+                isAllowed = ['admin', 'write'].includes(data.permission);
+              } catch (error) {
+                core.warning(`Permission check failed: ${error.message}`);
+              }
+            }
+            if (!isAllowed) {
+              await github.rest.checks.create({
+                owner, repo,
+                name: 'test-verification',
+                head_sha: headSha,
+                status: 'completed',
+                conclusion: 'action_required',
+                output: {
+                  title: 'Verification edit rejected',
+                  summary: `@${sender.login} is not authorized to update the verification section. Only the PR author or users with write access can fill verification.`,
+                },
+              });
+              return;
+            }
+
+            const PLACEHOLDERS = new Set([
+              'n/a', 'na', 'none', 'not needed', 'tbd', 'tba', '-', '.',
+              'fill command, jenkins job, or ci link',
+              '_fill command, jenkins job, or ci link_',
+            ]);
+
+            function reasonOk(text) {
+              const t = text.trim();
+              if (t.length < 30) return false;
+              if (PLACEHOLDERS.has(t.toLowerCase())) return false;
+              return t.split(/\s+/).filter(Boolean).length >= 3;
+            }
+
+            const itemRe = /^-\s*\[([ xX])\]\s*\*\*(\d+)\.\*\*\s*`([^`]+)`\s*—\s*\*\*(ran|ci|skip|na):\*\*\s*(.*)$/gm;
+            const items = [];
+            let itemMatch;
+            while ((itemMatch = itemRe.exec(section)) !== null) {
+              items.push({
+                checked: itemMatch[1].toLowerCase() === 'x',
+                num: itemMatch[2],
+                label: itemMatch[3],
+                disposition: itemMatch[4].toLowerCase(),
+                evidence: itemMatch[5].trim(),
+              });
+            }
+
+            const errors = [];
+            if (!items.length) {
+              errors.push('No verification items found — use the template lines under Test verification.');
+            }
+
+            for (const item of items) {
+              if (!item.checked) {
+                errors.push(`Item ${item.num} (${item.label}): checkbox not checked.`);
+              }
+              if (item.disposition === 'ran' || item.disposition === 'ci') {
+                if (!item.evidence || item.evidence.length < 10 || PLACEHOLDERS.has(item.evidence.toLowerCase())) {
+                  errors.push(`Item ${item.num}: ${item.disposition} requires concrete evidence (command or URL).`);
+                }
+              } else if (item.disposition === 'skip' || item.disposition === 'na') {
+                if (!reasonOk(item.evidence)) {
+                  errors.push(`Item ${item.num}: ${item.disposition} requires a specific reason (min 30 chars, 3+ words).`);
+                }
+              } else {
+                // Unreachable with current regex (ran|ci|skip|na) — guard against future pattern changes
+                errors.push(`Item ${item.num}: use ran, ci, skip, or na.`);
+              }
+            }
+
+            if (errors.length) {
+              await github.rest.checks.create({
+                owner, repo,
+                name: 'test-verification',
+                head_sha: headSha,
+                status: 'completed',
+                conclusion: 'failure',
+                output: {
+                  title: 'Test verification incomplete',
+                  summary: `${errors.length} issue(s) — fix the PR description and save again.`,
+                  text: errors.map((e) => `- ${e}`).join('\n'),
+                },
+              });
+              return;
+            }
+
+            const summaryLines = items.map((item) =>
+              `${item.num}. ${item.label} → ${item.disposition}: ${item.evidence}`
+            );
+
+            const disputedItems = items.filter(
+              (item) => item.disposition === 'skip' || item.disposition === 'na'
+            );
+
+            const checkTitle = disputedItems.length
+              ? 'Test verification complete (includes disputed items)'
+              : 'Test verification complete';
+
+            const checkSummary = disputedItems.length
+              ? `Recorded by @${sender.login} for tree ${headSha.slice(0, 7)} — ${disputedItems.length} skip/na item(s); reviewers judge in code review`
+              : `Verified by @${sender.login} for tree ${headSha.slice(0, 7)}`;
+
+            await github.rest.checks.create({
+              owner, repo,
+              name: 'test-verification',
+              head_sha: headSha,
+              status: 'completed',
+              conclusion: 'success',
+              output: {
+                title: checkTitle,
+                summary: checkSummary,
+                text: summaryLines.join('\n'),
+              },
+            });
+
+  reset-on-push:
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Reset verification on code change
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.BOT3_TOKEN }}
+          script: |
+            const before = context.payload.before;
+            const after = context.payload.after;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+
+            let isCleanRebase = false;
+            if (before !== '0000000000000000000000000000000000000000') {
+              try {
+                const [beforeCommit, afterCommit] = await Promise.all([
+                  github.rest.git.getCommit({ owner, repo, commit_sha: before }),
+                  github.rest.git.getCommit({ owner, repo, commit_sha: after }),
+                ]);
+                isCleanRebase = beforeCommit.data.tree.sha === afterCommit.data.tree.sha;
+              } catch {
+                isCleanRebase = false;
+              }
+            }
+
+            if (isCleanRebase) {
+              console.log('Clean rebase — preserving prior verification state.');
+
+              // Look up the prior check conclusion on the old commit
+              const { data: checkRuns } = await github.rest.checks.listForRef({
+                owner, repo,
+                ref: before,
+                check_name: 'test-verification',
+                per_page: 1,
+              });
+
+              if (checkRuns.check_runs.length) {
+                const prior = checkRuns.check_runs[0];
+                await github.rest.checks.create({
+                  owner, repo,
+                  name: 'test-verification',
+                  head_sha: after,
+                  status: prior.status,
+                  conclusion: prior.conclusion,
+                  output: {
+                    title: `${prior.output?.title ?? 'Test verification'} (rebase)`,
+                    summary: prior.output?.summary || 'Preserved from previous commit.',
+                  },
+                });
+              } else {
+                await github.rest.checks.create({
+                  owner, repo,
+                  name: 'test-verification',
+                  head_sha: after,
+                  status: 'completed',
+                  conclusion: 'action_required',
+                  output: {
+                    title: 'Test verification state unknown',
+                    summary: 'No prior verification check found. Request a new test plan or fill the verification section.',
+                  },
+                });
+              }
+              return;
+            }
+
+            const { data: fullPr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            let body = fullPr.body || '';
+
+            if (body.includes('<!-- test-verification-start -->')) {
+              body = body.replace(
+                /(?:\n*---\n)?<!-- test-verification-start -->[\s\S]*?<!-- test-verification-end -->/,
+                ''
+              ).trimEnd();
+              await github.rest.pulls.update({ owner, repo, pull_number: prNumber, body });
+            }
+
+            await github.rest.checks.create({
+              owner, repo,
+              name: 'test-verification',
+              head_sha: after,
+              status: 'completed',
+              conclusion: 'action_required',
+              output: {
+                title: 'Test verification invalidated',
+                summary: 'Code changed — re-run tests and fill verification after a new plan is posted.',
+                text: 'Push removed the verification section. Add verified label or /test-plan to get a new plan.',
+              },
+            });


### PR DESCRIPTION
##### What this PR does / why we need it:

Replaces the label-based test-plan acknowledgment with a structured verification workflow:

1. **CodeRabbit posts a test plan** as a regular PR comment (with `<!-- test-execution-plan-start -->` markers) — fixes HTTP 403 on fork PRs
2. **GHA auto-injects a "Test verification" section** into the PR description with one item per plan bullet
3. **Author edits the PR description** — checks each box with disposition (`ran`/`ci`/`skip`/`na`) and evidence
4. **`test-verification` check run** gates merge — goes green when all items are valid, red on errors, action_required when unfilled
5. **Code push resets** the verification section and check (clean rebases preserved via tree SHA comparison)

**Key design decisions:**
- **Check runs, not labels** — avoids label proliferation; check run is visible in the merge checks panel
- **PR description, not comments** — authors own the description and can always edit it regardless of repo permissions
- **Dispositions with evidence** — `ran`/`ci` require concrete evidence (command or URL); `skip`/`na` require a 30+ char reason with 3+ words
- **Disputed items visible to reviewers** — skip/na items are listed in the check output for reviewers to judge during code review

**Files:**
- `test-verification.yml` (new) — 3-job workflow: inject section on plan comment, validate on PR edit, reset on push
- `request-coderabbit-test-instructions.yml` (modified) — regular comment format with HTML markers, concurrency, timeout
- `TEST_VERIFICATION.md` (new) — UX documentation for the verification flow

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

- Uses `pull_request_target` for write access to PR description and checks — bot comment triggers are filtered to CodeRabbit/bot only
- `BOT3_TOKEN` used for check run creation and PR body edits
- Clean rebase detection compares tree SHAs to avoid unnecessary reset

##### jira-ticket: