### PR TITLE
storage: Add client to DataVolume creation in utilities/storage.py

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -657,6 +657,7 @@ def data_volume_template_dict(
     dv = DataVolume(
         name=target_dv_name,
         namespace=target_dv_namespace,
+        client=source_dv.client,
         source_dict=construct_datavolume_source_dict(
             source="pvc",
             source_pvc_name=source_dv.name,
@@ -675,6 +676,7 @@ def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
     dv = DataVolume(
         name=utilities.infra.unique_name(name=data_source.name),
         namespace=data_source.namespace,
+        client=data_source.client,
         size=get_dv_size_from_datasource(data_source=data_source),
         storage_class=storage_class,
         api_name="storage",


### PR DESCRIPTION
##### What this PR does / why we need it:
Add client to DataVolume in `data_volume_template_dict` and `data_volume_template_with_source_ref_dict`

##### Which issue(s) this PR fixes:
`FutureWarning` showing when running tests 

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-68519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DataVolume template creation so the Kubernetes client context is preserved when generating templates from existing storage sources.
  * This ensures templates are correctly bound to the intended dynamic client, improving reliability for flows that reference current storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->