### PR TITLE
storage: Rename data_volume_template_dict

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -18,7 +18,7 @@ from utilities.storage import (
     check_disk_count_in_vm,
     create_dv,
     create_vm_from_dv,
-    data_volume_template_dict,
+    data_volume_template_dict_with_pvc_source,
     get_dv_size_from_datasource,
     overhead_size_for_dv,
     sc_volume_binding_mode_is_wffc,
@@ -48,7 +48,7 @@ def create_vm_from_clone_dv_template(
         os_flavor=OS_FLAVOR_FEDORA,
         client=client,
         memory_guest=Images.Fedora.DEFAULT_MEMORY_SIZE,
-        data_volume_template=data_volume_template_dict(
+        data_volume_template=data_volume_template_dict_with_pvc_source(
             target_dv_name=dv_name,
             target_dv_namespace=namespace_name,
             source_dv=source_dv,

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -645,14 +645,14 @@ class PodWithPVC(Pod):
         )
 
 
-def data_volume_template_dict(
-    target_dv_name,
-    target_dv_namespace,
-    source_dv,
-    volume_mode=None,
-    size=None,
-    storage_class=None,
-):
+def data_volume_template_dict_with_pvc_source(
+    target_dv_name: str,
+    target_dv_namespace: str,
+    source_dv: DataVolume,
+    volume_mode: str | None = None,
+    size: str | None = None,
+    storage_class: str | None = None,
+) -> dict[str, Any]:
     source_dv_pvc_spec = source_dv.pvc.instance.spec
     dv = DataVolume(
         name=target_dv_name,


### PR DESCRIPTION
##### What this PR does / why we need it:
Rename `data_volume_template_dict` to `data_volume_template_dict_with_pvc_source` as [suggested by @jpeimer](https://github.com/RedHatQE/openshift-virtualization-tests/pull/5512#discussion_r3529471066)

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the storage helper used for clone-based virtual machine setup to a new, more explicitly typed variant.
  * Adjusted the related test wiring to use the updated helper when building clone templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->