### PR TITLE
fix(iuo): de-quarantine disableMDevConfiguration feature gate test

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -12,6 +12,7 @@ WORKLOADUPDATEMETHODS = "workloadUpdateMethods"
 KEY_PATH_SEPARATOR = "->"
 TEMPLATE_VALIDATOR = "templateValidator"
 DEVELOPER_CONFIGURATION = "developerConfiguration"
+MEDIATED_DEVICES_CONFIGURATION = "mediatedDevicesConfiguration"
 # featuregates:
 DEPLOY_KUBE_SECONDARY_DNS = "deployKubeSecondaryDNS"
 ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT = "enableMultiArchBootImageImport"

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -2,16 +2,12 @@ import pytest
 from ocp_resources.kubevirt import KubeVirt
 
 from tests.install_upgrade_operators.constants import (
-    DEVELOPER_CONFIGURATION,
     DISABLE_MDEV_CONFIGURATION,
     FEATUREGATES,
     FG_ENABLED,
+    MEDIATED_DEVICES_CONFIGURATION,
 )
-from utilities.constants.cluster import VALUE_STR
-from utilities.constants.pytest import QUARANTINED
 from utilities.hco import ResourceEditorValidateHCOReconcile
-
-FEATUREGATE_NAME_KEY_STR = "featuregate_name"
 
 pytestmark = [pytest.mark.s390x, pytest.mark.skip_must_gather_collection]
 
@@ -29,20 +25,11 @@ def updated_fg_hco(
         yield
 
 
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: HCO feature gate being replaced with different spec; Tracked in CNV-79304",
-    run=False,
-)
 @pytest.mark.parametrize(
-    ("updated_fg_hco", "kubevirt_featuregate_name", "hco_featuregate"),
+    "updated_fg_hco",
     [
         pytest.param(
             {"featuregate": {DISABLE_MDEV_CONFIGURATION: FG_ENABLED}},
-            "DisableMDEVConfiguration",
-            {
-                FEATUREGATE_NAME_KEY_STR: DISABLE_MDEV_CONFIGURATION,
-                VALUE_STR: FG_ENABLED,
-            },
             marks=pytest.mark.polarion("CNV-10091"),
             id="test_enable_fg_disable_mdev_config_hco",
         ),
@@ -53,16 +40,12 @@ def test_enable_fg_hco(
     updated_fg_hco,
     hco_spec,
     kubevirt_resource,
-    kubevirt_featuregate_name,
-    hco_featuregate,
 ):
-    actual_value = hco_spec[FEATUREGATES][hco_featuregate[FEATUREGATE_NAME_KEY_STR]]
-    expected_value = hco_featuregate[VALUE_STR]
-    assert actual_value == expected_value, (
-        f"Current HCO featuregate {VALUE_STR}: {actual_value}, expected: {expected_value}"
+    assert hco_spec[FEATUREGATES][DISABLE_MDEV_CONFIGURATION] is True, (
+        f"HCO featureGates.{DISABLE_MDEV_CONFIGURATION} is not True: {hco_spec[FEATUREGATES]}"
     )
 
-    enabled_featuregates = kubevirt_resource.instance.spec["configuration"][DEVELOPER_CONFIGURATION][FEATUREGATES]
-    assert kubevirt_featuregate_name in enabled_featuregates, (
-        f"Current Kubevirt featuregate {VALUE_STR}: {enabled_featuregates}, expected: {expected_value}"
+    kubevirt_mdev_enabled = kubevirt_resource.instance.spec["configuration"][MEDIATED_DEVICES_CONFIGURATION]["enabled"]
+    assert kubevirt_mdev_enabled is False, (
+        f"KubeVirt {MEDIATED_DEVICES_CONFIGURATION}.enabled: {kubevirt_mdev_enabled}, expected: False"
     )


### PR DESCRIPTION
##### What this PR does / why we need it:

De-quarantines `test_enable_fg_hco` (Polarion CNV-10091) and updates its assertions to match the current HCO behavior.

HCO's `disableMDevConfiguration` feature gate no longer propagates `DisableMDEVConfiguration` to KubeVirt's `developerConfiguration.featureGates` list. Instead, HCO now syncs it to `mediatedDevicesConfiguration.enabled = false` (inverted boolean) in the KubeVirt CR.

**Changes:**
- Remove `@pytest.mark.xfail` quarantine decorator
- Remove unused imports and constants (`DEVELOPER_CONFIGURATION`, `VALUE_STR`, `QUARANTINED`, `FEATUREGATE_NAME_KEY_STR`)
- Simplify parametrize (remove extra params `kubevirt_featuregate_name` and `hco_featuregate`)
- Add `MEDIATED_DEVICES_CONFIGURATION` constant
- New assertions verify:
  1. HCO `featureGates.disableMDevConfiguration == True`
  2. KubeVirt `mediatedDevicesConfiguration.enabled == False`

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Should be backported to cnv-4.22 too. 

##### jira-ticket:
https://issues.redhat.com/browse/CNV-79304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated upgrade/install test coverage to reflect the current feature-gate behavior.
  * Added validation for mediated device configuration being disabled when the related feature gate is enabled.
  * Simplified test parameter handling for clearer assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->