### PR TITLE
refactor(vm): consolidate VM start sequences into run_vm

### DIFF
--- a/libs/vm/oper.py
+++ b/libs/vm/oper.py
@@ -2,9 +2,29 @@ import logging
 
 from kubernetes.client import ApiException
 
+from libs.net.vmspec import wait_for_ifaces_status
 from libs.vm.vm import BaseVirtualMachine
 
 LOGGER = logging.getLogger(__name__)
+
+
+def run_vm(
+    vm: BaseVirtualMachine,
+    ip_addresses_by_spec_net_name: dict[str, list[str]],
+) -> BaseVirtualMachine:
+    """Start a VM, wait for agent connection, and verify interface IP addresses.
+
+    Args:
+        vm: The virtual machine to start.
+        ip_addresses_by_spec_net_name: Mapping of spec network name to expected IP addresses.
+
+    Returns:
+        The same VM, running with all interfaces reporting expected IPs.
+    """
+    vm.start(wait=True)
+    vm.wait_for_agent_connected()
+    wait_for_ifaces_status(vm=vm, ip_addresses_by_spec_net_name=ip_addresses_by_spec_net_name)
+    return vm
 
 
 def run_vms(vms: tuple[BaseVirtualMachine, ...]) -> tuple[BaseVirtualMachine, ...]:

--- a/tests/network/l2_bridge/bandwidth/conftest.py
+++ b/tests/network/l2_bridge/bandwidth/conftest.py
@@ -15,7 +15,7 @@ from libs.net.netattachdef import (
     NetConfig,
     NetworkAttachmentDefinition,
 )
-from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.oper import run_vm
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.l2_bridge.bandwidth.lib_helpers import (
     BANDWIDTH_RATE_BPS,
@@ -74,9 +74,7 @@ def server_vm(
         secondary_iface_name=BANDWIDTH_SECONDARY_IFACE_NAME,
         secondary_iface_addresses=addresses,
     ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        wait_for_ifaces_status(
+        run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
                 BANDWIDTH_SECONDARY_IFACE_NAME: [
@@ -106,9 +104,7 @@ def client_vm(
         secondary_iface_name=BANDWIDTH_SECONDARY_IFACE_NAME,
         secondary_iface_addresses=addresses,
     ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        wait_for_ifaces_status(
+        run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
                 BANDWIDTH_SECONDARY_IFACE_NAME: [

--- a/tests/network/l2_bridge/nad_ref_change/conftest.py
+++ b/tests/network/l2_bridge/nad_ref_change/conftest.py
@@ -6,7 +6,7 @@ from ocp_resources.namespace import Namespace
 
 from libs.net.ip import random_cidr_addresses_by_family
 from libs.net.netattachdef import NetworkAttachmentDefinition
-from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.oper import run_vm
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.l2_bridge.libl2bridge import LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2
 from tests.network.l2_bridge.nad_ref_change.lib_helpers import (
@@ -36,9 +36,7 @@ def ref_vm(
         iface_names=[LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2],
         runcmd=ARP_ISOLATION_SYSCTL_CMD,
     ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        wait_for_ifaces_status(
+        run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
                 LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],
@@ -65,9 +63,7 @@ def under_test_vm_two_ifaces(
         iface_names=[LINUX_BRIDGE_IFACE_NAME_1, LINUX_BRIDGE_IFACE_NAME_2],
         runcmd=ARP_ISOLATION_SYSCTL_CMD,
     ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        wait_for_ifaces_status(
+        run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
                 LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],
@@ -101,9 +97,7 @@ def non_migratable_under_test_vm(
         iface_names=[LINUX_BRIDGE_IFACE_NAME_1],
         runcmd=ARP_ISOLATION_SYSCTL_CMD,
     ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        wait_for_ifaces_status(
+        run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
                 LINUX_BRIDGE_IFACE_NAME_1: [addr.split("/")[0] for addr in iface_a_ips],

--- a/tests/network/localnet/nad_ref_change/conftest.py
+++ b/tests/network/localnet/nad_ref_change/conftest.py
@@ -6,7 +6,8 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 
 from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
-from libs.net.vmspec import lookup_iface_status, wait_for_ifaces_status
+from libs.net.vmspec import lookup_iface_status
+from libs.vm.oper import run_vm
 from libs.vm.spec import Interface, Multus, Network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cloudinit
@@ -73,9 +74,7 @@ def ref_vm_localnet(
         ),
         runcmd=ARP_ISOLATION_SYSCTL_CMD,
     ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        wait_for_ifaces_status(
+        run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
                 IFACE_A_NAME: [addr.split("/")[0] for addr in iface_a_ips],
@@ -102,9 +101,7 @@ def under_test_vm_localnet(
             ethernets={GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_a_ips)},
         ),
     ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        wait_for_ifaces_status(
+        run_vm(
             vm=vm,
             ip_addresses_by_spec_net_name={
                 IFACE_A_NAME: [addr.split("/")[0] for addr in iface_a_ips],


### PR DESCRIPTION
##### What this PR does / why we need it:
Add `run_vm` helper to `libs/vm/oper.py` that consolidates the repeated
`start → wait_for_agent_connected → wait_for_ifaces_status` sequence
into a single call. The caller passes expected IP addresses — the helper handles the lifecycle.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-92295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared VM startup helper that brings up a VM, waits for guest connectivity, and confirms network interfaces receive the expected IPs.

* **Refactor**
  * Updated several network test setups to use the new helper, simplifying VM initialization and reducing repeated readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->