### PR TITLE
Role aggregation (RBAC) enforcement tests implementation

### DIFF
--- a/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
+++ b/tests/after_cluster_deploy_sanity/test_after_cluster_deploy_sanity.py
@@ -205,4 +205,4 @@ def test_webhook_endpoints_health(admin_client, hco_namespace):
 @pytest.mark.cluster_health_check
 def test_vm_creation_capability(admin_client):
     """Test VM creation capability by performing a dry-run VM creation."""
-    check_vm_creation_capability(admin_client=admin_client, namespace="default")
+    check_vm_creation_capability(client=admin_client, namespace="default")

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -1,12 +1,79 @@
 from __future__ import annotations
 
-import pytest
+from collections.abc import Generator
+from typing import TYPE_CHECKING
 
-from tests.install_upgrade_operators.role_aggregation.utils import reenabled_aggregation_with_role_binding
+import pytest
+from ocp_resources.virtual_machine import VirtualMachine
+
+from tests.install_upgrade_operators.role_aggregation.utils import (
+    disabled_aggregation_with_role_binding,
+    reenabled_aggregation_with_role_binding,
+)
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from kubernetes.dynamic.resource import Resource
+    from ocp_resources.hyperconverged import HyperConverged
+    from ocp_resources.namespace import Namespace
 
 
 @pytest.fixture()
-def admin_reenabled_aggregation(admin_client, namespace, hyperconverged_resource_scope_class):
+def disabled_aggregation_with_role(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    hyperconverged_resource_scope_class: HyperConverged,
+) -> Generator[None]:
+    """RoleBinding → baseline access verified → Manual → labels removed → RBAC revoked."""
+    yield from disabled_aggregation_with_role_binding(
+        admin_client=admin_client,
+        unprivileged_client=unprivileged_client,
+        namespace_name=namespace.name,
+        hyperconverged_resource=hyperconverged_resource_scope_class,
+        role_name=request.param,
+    )
+
+
+@pytest.fixture()
+def vm_resource_for_unprivileged_client(unprivileged_client: DynamicClient) -> Resource:
+    """VirtualMachine API resource handle for the unprivileged client."""
+    return unprivileged_client.resources.get(api_version="kubevirt.io/v1", kind="VirtualMachine")
+
+
+@pytest.fixture()
+def dry_run_vm(unprivileged_client: DynamicClient, namespace: Namespace) -> VirtualMachine:
+    """Minimal VirtualMachine configured for server-side dry-run creation."""
+    return VirtualMachine(
+        name="rbac-dry-run-vm",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        body={
+            "spec": {
+                "running": False,
+                "template": {
+                    "spec": {
+                        "domain": {
+                            "devices": {},
+                            "resources": {
+                                "requests": {
+                                    "memory": "64Mi",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        dry_run=True,
+    )
+
+
+@pytest.fixture()
+def admin_reenabled_aggregation(
+    admin_client: DynamicClient, namespace: Namespace, hyperconverged_resource_scope_class: HyperConverged
+) -> Generator[None]:
     """Manual → admin RoleBinding → AggregateToDefault, with labels confirmed restored."""
     yield from reenabled_aggregation_with_role_binding(
         admin_client=admin_client,
@@ -17,7 +84,9 @@ def admin_reenabled_aggregation(admin_client, namespace, hyperconverged_resource
 
 
 @pytest.fixture()
-def edit_reenabled_aggregation(admin_client, namespace, hyperconverged_resource_scope_class):
+def edit_reenabled_aggregation(
+    admin_client: DynamicClient, namespace: Namespace, hyperconverged_resource_scope_class: HyperConverged
+) -> Generator[None]:
     """Manual → edit RoleBinding → AggregateToDefault, with labels confirmed restored."""
     yield from reenabled_aggregation_with_role_binding(
         admin_client=admin_client,
@@ -28,7 +97,9 @@ def edit_reenabled_aggregation(admin_client, namespace, hyperconverged_resource_
 
 
 @pytest.fixture()
-def view_reenabled_aggregation(admin_client, namespace, hyperconverged_resource_scope_class):
+def view_reenabled_aggregation(
+    admin_client: DynamicClient, namespace: Namespace, hyperconverged_resource_scope_class: HyperConverged
+) -> Generator[None]:
     """Manual → view RoleBinding → AggregateToDefault, with labels confirmed restored."""
     yield from reenabled_aggregation_with_role_binding(
         admin_client=admin_client,

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -1,8 +1,3 @@
-from __future__ import annotations
-
-from collections.abc import Generator
-from typing import TYPE_CHECKING
-
 import pytest
 from ocp_resources.virtual_machine import VirtualMachine
 
@@ -11,21 +6,15 @@ from tests.install_upgrade_operators.role_aggregation.utils import (
     reenabled_aggregation_with_role_binding,
 )
 
-if TYPE_CHECKING:
-    from kubernetes.dynamic import DynamicClient
-    from kubernetes.dynamic.resource import Resource
-    from ocp_resources.hyperconverged import HyperConverged
-    from ocp_resources.namespace import Namespace
-
 
 @pytest.fixture()
 def disabled_aggregation_with_role(
-    request: pytest.FixtureRequest,
-    admin_client: DynamicClient,
-    unprivileged_client: DynamicClient,
-    namespace: Namespace,
-    hyperconverged_resource_scope_class: HyperConverged,
-) -> Generator[None]:
+    request,
+    admin_client,
+    unprivileged_client,
+    namespace,
+    hyperconverged_resource_scope_class,
+):
     """RoleBinding → baseline access verified → Manual → labels removed → RBAC revoked."""
     yield from disabled_aggregation_with_role_binding(
         admin_client=admin_client,
@@ -37,13 +26,13 @@ def disabled_aggregation_with_role(
 
 
 @pytest.fixture()
-def vm_resource_for_unprivileged_client(unprivileged_client: DynamicClient) -> Resource:
+def vm_collection_resource_for_unprivileged_client(unprivileged_client):
     """VirtualMachine API resource handle for the unprivileged client."""
     return unprivileged_client.resources.get(api_version="kubevirt.io/v1", kind="VirtualMachine")
 
 
 @pytest.fixture()
-def dry_run_vm(unprivileged_client: DynamicClient, namespace: Namespace) -> VirtualMachine:
+def dry_run_vm(unprivileged_client, namespace):
     """Minimal VirtualMachine configured for server-side dry-run creation."""
     return VirtualMachine(
         name="rbac-dry-run-vm",
@@ -71,39 +60,11 @@ def dry_run_vm(unprivileged_client: DynamicClient, namespace: Namespace) -> Virt
 
 
 @pytest.fixture()
-def admin_reenabled_aggregation(
-    admin_client: DynamicClient, namespace: Namespace, hyperconverged_resource_scope_class: HyperConverged
-) -> Generator[None]:
-    """Manual → admin RoleBinding → AggregateToDefault, with labels confirmed restored."""
+def reenabled_aggregation_with_role(request, admin_client, namespace, hyperconverged_resource_scope_class):
+    """Manual → RoleBinding → AggregateToDefault, with labels confirmed restored."""
     yield from reenabled_aggregation_with_role_binding(
         admin_client=admin_client,
         namespace_name=namespace.name,
         hyperconverged_resource=hyperconverged_resource_scope_class,
-        role_name="admin",
-    )
-
-
-@pytest.fixture()
-def edit_reenabled_aggregation(
-    admin_client: DynamicClient, namespace: Namespace, hyperconverged_resource_scope_class: HyperConverged
-) -> Generator[None]:
-    """Manual → edit RoleBinding → AggregateToDefault, with labels confirmed restored."""
-    yield from reenabled_aggregation_with_role_binding(
-        admin_client=admin_client,
-        namespace_name=namespace.name,
-        hyperconverged_resource=hyperconverged_resource_scope_class,
-        role_name="edit",
-    )
-
-
-@pytest.fixture()
-def view_reenabled_aggregation(
-    admin_client: DynamicClient, namespace: Namespace, hyperconverged_resource_scope_class: HyperConverged
-) -> Generator[None]:
-    """Manual → view RoleBinding → AggregateToDefault, with labels confirmed restored."""
-    yield from reenabled_aggregation_with_role_binding(
-        admin_client=admin_client,
-        namespace_name=namespace.name,
-        hyperconverged_resource=hyperconverged_resource_scope_class,
-        role_name="view",
+        role_name=request.param,
     )

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.install_upgrade_operators.role_aggregation.utils import reenabled_aggregation_with_role_binding
+
+
+@pytest.fixture()
+def admin_reenabled_aggregation(admin_client, namespace, hyperconverged_resource_scope_class):
+    """Manual → admin RoleBinding → AggregateToDefault, with labels confirmed restored."""
+    yield from reenabled_aggregation_with_role_binding(
+        admin_client=admin_client,
+        namespace_name=namespace.name,
+        hyperconverged_resource=hyperconverged_resource_scope_class,
+        role_name="admin",
+    )
+
+
+@pytest.fixture()
+def edit_reenabled_aggregation(admin_client, namespace, hyperconverged_resource_scope_class):
+    """Manual → edit RoleBinding → AggregateToDefault, with labels confirmed restored."""
+    yield from reenabled_aggregation_with_role_binding(
+        admin_client=admin_client,
+        namespace_name=namespace.name,
+        hyperconverged_resource=hyperconverged_resource_scope_class,
+        role_name="edit",
+    )
+
+
+@pytest.fixture()
+def view_reenabled_aggregation(admin_client, namespace, hyperconverged_resource_scope_class):
+    """Manual → view RoleBinding → AggregateToDefault, with labels confirmed restored."""
+    yield from reenabled_aggregation_with_role_binding(
+        admin_client=admin_client,
+        namespace_name=namespace.name,
+        hyperconverged_resource=hyperconverged_resource_scope_class,
+        role_name="view",
+    )

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -27,7 +27,7 @@ def view_role_binding(admin_client, namespace):
     yield from unprivileged_role_binding(admin_client=admin_client, namespace_name=namespace.name, role_name="view")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def aggregation_disabled(admin_client, hyperconverged_resource_scope_class):
     """HCO with roleAggregationStrategy set to Manual and aggregation labels removed."""
     with ResourceEditorValidateHCOReconcile(
@@ -40,7 +40,7 @@ def aggregation_disabled(admin_client, hyperconverged_resource_scope_class):
         yield
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def aggregation_reenabled(admin_client, hyperconverged_resource_scope_class):
     """HCO with roleAggregationStrategy at AggregateToDefault and aggregation labels present."""
     current_strategy = hyperconverged_resource_scope_class.instance.spec.get(

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -3,7 +3,6 @@ from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.virtual_machine import VirtualMachine
 
 from tests.install_upgrade_operators.role_aggregation.utils import (
-    ensure_aggregation_enabled,
     unprivileged_role_binding,
     wait_for_aggregation_labels,
 )
@@ -28,7 +27,7 @@ def view_role_binding(admin_client, namespace):
     yield from unprivileged_role_binding(admin_client=admin_client, namespace_name=namespace.name, role_name="view")
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="function")
 def aggregation_disabled(admin_client, hyperconverged_resource_scope_class):
     """HCO with roleAggregationStrategy set to Manual and aggregation labels removed."""
     with ResourceEditorValidateHCOReconcile(
@@ -41,13 +40,16 @@ def aggregation_disabled(admin_client, hyperconverged_resource_scope_class):
         yield
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def aggregation_reenabled(admin_client, hyperconverged_resource_scope_class):
     """HCO with roleAggregationStrategy at AggregateToDefault and aggregation labels present."""
-    ensure_aggregation_enabled(
-        admin_client=admin_client,
-        hyperconverged_resource=hyperconverged_resource_scope_class,
+    current_strategy = hyperconverged_resource_scope_class.instance.spec.get(
+        "roleAggregationStrategy", "AggregateToDefault"
     )
+    assert current_strategy == "AggregateToDefault", (
+        f"roleAggregationStrategy is {current_strategy}, expected AggregateToDefault"
+    )
+    wait_for_aggregation_labels(admin_client=admin_client, should_be_present=True)
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -1,90 +1,52 @@
 import pytest
-from ocp_resources.role_binding import RoleBinding
+from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.virtual_machine import VirtualMachine
 
 from tests.install_upgrade_operators.role_aggregation.utils import (
-    disable_aggregation_and_wait,
     ensure_aggregation_enabled,
-    wait_for_vm_list_access,
+    unprivileged_role_binding,
+    wait_for_aggregation_labels,
 )
-from utilities.constants.pytest import UNPRIVILEGED_USER
+from utilities.hco import ResourceEditorValidateHCOReconcile
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def admin_role_binding(admin_client, namespace):
     """RoleBinding granting admin ClusterRole to the unprivileged user."""
-    with RoleBinding(
-        name="test-role-bind-admin",
-        namespace=namespace.name,
-        client=admin_client,
-        subjects_kind="User",
-        subjects_name=UNPRIVILEGED_USER,
-        subjects_namespace=namespace.name,
-        role_ref_kind="ClusterRole",
-        role_ref_name="admin",
-    ):
-        yield
+    yield from unprivileged_role_binding(admin_client=admin_client, namespace_name=namespace.name, role_name="admin")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def edit_role_binding(admin_client, namespace):
     """RoleBinding granting edit ClusterRole to the unprivileged user."""
-    with RoleBinding(
-        name="test-role-bind-edit",
-        namespace=namespace.name,
-        client=admin_client,
-        subjects_kind="User",
-        subjects_name=UNPRIVILEGED_USER,
-        subjects_namespace=namespace.name,
-        role_ref_kind="ClusterRole",
-        role_ref_name="edit",
-    ):
-        yield
+    yield from unprivileged_role_binding(admin_client=admin_client, namespace_name=namespace.name, role_name="edit")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def view_role_binding(admin_client, namespace):
     """RoleBinding granting view ClusterRole to the unprivileged user."""
-    with RoleBinding(
-        name="test-role-bind-view",
-        namespace=namespace.name,
-        client=admin_client,
-        subjects_kind="User",
-        subjects_name=UNPRIVILEGED_USER,
-        subjects_namespace=namespace.name,
-        role_ref_kind="ClusterRole",
-        role_ref_name="view",
+    yield from unprivileged_role_binding(admin_client=admin_client, namespace_name=namespace.name, role_name="view")
+
+
+@pytest.fixture(scope="class")
+def aggregation_disabled(admin_client, hyperconverged_resource_scope_class):
+    """HCO with roleAggregationStrategy set to Manual and aggregation labels removed."""
+    with ResourceEditorValidateHCOReconcile(
+        patches={hyperconverged_resource_scope_class: {"spec": {"roleAggregationStrategy": "Manual"}}},
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
+        admin_client=admin_client,
     ):
+        wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
         yield
 
 
 @pytest.fixture()
-def disabled_aggregation_state(
-    request,
-    admin_client,
-    unprivileged_client,
-    namespace,
-    hyperconverged_resource_scope_module,
-):
-    """Activate module-scoped RoleBinding, disable aggregation, wait for RBAC revocation."""
-    role_name = request.param
-    request.getfixturevalue(f"{role_name}_role_binding")
-    wait_for_vm_list_access(client=unprivileged_client, namespace_name=namespace.name)
-    yield from disable_aggregation_and_wait(
-        admin_client=admin_client,
-        unprivileged_client=unprivileged_client,
-        namespace_name=namespace.name,
-        hyperconverged_resource=hyperconverged_resource_scope_module,
-        role_name=role_name,
-    )
-
-
-@pytest.fixture()
-def reenabled_aggregation_state(admin_client, hyperconverged_resource_scope_module):
-    """Verify aggregation is AggregateToDefault, wait for labels to be present."""
+def aggregation_reenabled(admin_client, hyperconverged_resource_scope_class):
+    """HCO with roleAggregationStrategy at AggregateToDefault and aggregation labels present."""
     ensure_aggregation_enabled(
         admin_client=admin_client,
-        hyperconverged_resource=hyperconverged_resource_scope_module,
+        hyperconverged_resource=hyperconverged_resource_scope_class,
     )
 
 

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -55,32 +55,7 @@ def aggregation_reenabled(admin_client, hyperconverged_resource_scope_class):
 @pytest.fixture()
 def vm_collection_resource_for_unprivileged_client(unprivileged_client):
     """VirtualMachine API resource handle for the unprivileged client."""
-    return unprivileged_client.resources.get(api_version="kubevirt.io/v1", kind="VirtualMachine")
-
-
-@pytest.fixture()
-def dry_run_vm(unprivileged_client, namespace):
-    """Minimal VirtualMachine configured for server-side dry-run creation."""
-    return VirtualMachine(
-        name="rbac-dry-run-vm",
-        namespace=namespace.name,
-        client=unprivileged_client,
-        body={
-            "spec": {
-                "running": False,
-                "template": {
-                    "spec": {
-                        "domain": {
-                            "devices": {},
-                            "resources": {
-                                "requests": {
-                                    "memory": "64Mi",
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-        dry_run=True,
+    return unprivileged_client.resources.get(
+        api_version=f"{VirtualMachine.ApiGroup.KUBEVIRT_IO}/{VirtualMachine.ApiVersion.V1}",
+        kind=VirtualMachine.kind,
     )

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -1,27 +1,90 @@
 import pytest
+from ocp_resources.role_binding import RoleBinding
 from ocp_resources.virtual_machine import VirtualMachine
 
 from tests.install_upgrade_operators.role_aggregation.utils import (
-    disabled_aggregation_with_role_binding,
-    reenabled_aggregation_with_role_binding,
+    disable_aggregation_and_wait,
+    ensure_aggregation_enabled,
+    wait_for_vm_list_access,
 )
+from utilities.constants.pytest import UNPRIVILEGED_USER
+
+
+@pytest.fixture(scope="module")
+def admin_role_binding(admin_client, namespace):
+    """RoleBinding granting admin ClusterRole to the unprivileged user."""
+    with RoleBinding(
+        name="test-role-bind-admin",
+        namespace=namespace.name,
+        client=admin_client,
+        subjects_kind="User",
+        subjects_name=UNPRIVILEGED_USER,
+        subjects_namespace=namespace.name,
+        role_ref_kind="ClusterRole",
+        role_ref_name="admin",
+    ):
+        yield
+
+
+@pytest.fixture(scope="module")
+def edit_role_binding(admin_client, namespace):
+    """RoleBinding granting edit ClusterRole to the unprivileged user."""
+    with RoleBinding(
+        name="test-role-bind-edit",
+        namespace=namespace.name,
+        client=admin_client,
+        subjects_kind="User",
+        subjects_name=UNPRIVILEGED_USER,
+        subjects_namespace=namespace.name,
+        role_ref_kind="ClusterRole",
+        role_ref_name="edit",
+    ):
+        yield
+
+
+@pytest.fixture(scope="module")
+def view_role_binding(admin_client, namespace):
+    """RoleBinding granting view ClusterRole to the unprivileged user."""
+    with RoleBinding(
+        name="test-role-bind-view",
+        namespace=namespace.name,
+        client=admin_client,
+        subjects_kind="User",
+        subjects_name=UNPRIVILEGED_USER,
+        subjects_namespace=namespace.name,
+        role_ref_kind="ClusterRole",
+        role_ref_name="view",
+    ):
+        yield
 
 
 @pytest.fixture()
-def disabled_aggregation_with_role(
+def disabled_aggregation_state(
     request,
     admin_client,
     unprivileged_client,
     namespace,
-    hyperconverged_resource_scope_class,
+    hyperconverged_resource_scope_module,
 ):
-    """RoleBinding → baseline access verified → Manual → labels removed → RBAC revoked."""
-    yield from disabled_aggregation_with_role_binding(
+    """Activate module-scoped RoleBinding, disable aggregation, wait for RBAC revocation."""
+    role_name = request.param
+    request.getfixturevalue(f"{role_name}_role_binding")
+    wait_for_vm_list_access(client=unprivileged_client, namespace_name=namespace.name)
+    yield from disable_aggregation_and_wait(
         admin_client=admin_client,
         unprivileged_client=unprivileged_client,
         namespace_name=namespace.name,
-        hyperconverged_resource=hyperconverged_resource_scope_class,
-        role_name=request.param,
+        hyperconverged_resource=hyperconverged_resource_scope_module,
+        role_name=role_name,
+    )
+
+
+@pytest.fixture()
+def reenabled_aggregation_state(admin_client, hyperconverged_resource_scope_module):
+    """Verify aggregation is AggregateToDefault, wait for labels to be present."""
+    ensure_aggregation_enabled(
+        admin_client=admin_client,
+        hyperconverged_resource=hyperconverged_resource_scope_module,
     )
 
 
@@ -56,15 +119,4 @@ def dry_run_vm(unprivileged_client, namespace):
             },
         },
         dry_run=True,
-    )
-
-
-@pytest.fixture()
-def reenabled_aggregation_with_role(request, admin_client, namespace, hyperconverged_resource_scope_class):
-    """Manual → RoleBinding → AggregateToDefault, with labels confirmed restored."""
-    yield from reenabled_aggregation_with_role_binding(
-        admin_client=admin_client,
-        namespace_name=namespace.name,
-        hyperconverged_resource=hyperconverged_resource_scope_class,
-        role_name=request.param,
     )

--- a/tests/install_upgrade_operators/role_aggregation/conftest.py
+++ b/tests/install_upgrade_operators/role_aggregation/conftest.py
@@ -37,7 +37,7 @@ def aggregation_disabled(admin_client, hyperconverged_resource_scope_class):
         wait_for_reconcile_post_update=True,
         admin_client=admin_client,
     ):
-        wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
+        wait_for_aggregation_labels(admin_client=admin_client, should_be_present=False)
         yield
 
 

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -101,10 +101,7 @@ class TestRoleAggregationReenabledAccess:
         Expected:
             - Delete-collection operation succeeds
         """
-        result = vm_resource_for_unprivileged_client.delete(
-            namespace=namespace.name, label_selector="rbac-test=nonexistent"
-        )
-        assert result.kind == "VirtualMachineList", f"Expected VirtualMachineList response, got: {result.kind}"
+        vm_resource_for_unprivileged_client.delete(namespace=namespace.name, label_selector="rbac-test=nonexistent")
 
     @pytest.mark.polarion("CNV-16260")
     @pytest.mark.usefixtures("edit_reenabled_aggregation")
@@ -142,4 +139,3 @@ class TestRoleAggregationReenabledAccess:
             - VirtualMachine resources are listed successfully
         """
         list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name))
-        LOGGER.info("View user successfully listed VirtualMachines")

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -16,16 +16,7 @@ import logging
 
 import pytest
 from kubernetes.dynamic.exceptions import ForbiddenError
-from ocp_resources.cluster_role import ClusterRole
-from ocp_resources.kubevirt import KubeVirt
-from ocp_resources.role_binding import RoleBinding
 from ocp_resources.virtual_machine import VirtualMachine
-from timeout_sampler import TimeoutSampler
-
-from tests.install_upgrade_operators.role_aggregation.utils import vm_list_is_forbidden, wait_for_aggregation_labels
-from utilities.constants.pytest import UNPRIVILEGED_USER
-from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_30SEC
-from utilities.hco import ResourceEditorValidateHCOReconcile
 
 LOGGER = logging.getLogger(__name__)
 
@@ -43,15 +34,16 @@ class TestRoleAggregationDisabled:
     """
 
     @pytest.mark.parametrize(
-        "role",
+        "disabled_aggregation_with_role",
         [
             pytest.param("admin", marks=pytest.mark.polarion("CNV-16028")),
             pytest.param("edit", marks=pytest.mark.polarion("CNV-16262")),
             pytest.param("view", marks=pytest.mark.polarion("CNV-16263")),
         ],
+        indirect=True,
     )
     def test_vm_list_forbidden_when_aggregation_disabled(
-        self, role, admin_client, unprivileged_client, namespace, hyperconverged_resource_scope_class
+        self, disabled_aggregation_with_role, unprivileged_client, namespace
     ):
         """
         [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
@@ -73,46 +65,8 @@ class TestRoleAggregationDisabled:
         Expected:
             - Operation is rejected with a Forbidden error
         """
-        cluster_role = ClusterRole(name=role, client=admin_client, ensure_exists=True)
-        with RoleBinding(
-            name=f"test-role-bind-{role}",
-            namespace=namespace.name,
-            client=admin_client,
-            subjects_kind="User",
-            subjects_name=UNPRIVILEGED_USER,
-            subjects_namespace=namespace.name,
-            role_ref_kind=cluster_role.kind,
-            role_ref_name=cluster_role.name,
-        ):
-            LOGGER.info(f"Baseline: waiting for {role} role RBAC propagation before testing")
-            for sample in TimeoutSampler(
-                wait_timeout=TIMEOUT_30SEC,
-                sleep=2,
-                func=lambda: list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name)) is not None,
-                exceptions_dict={ForbiddenError: []},
-            ):
-                if sample:
-                    break
-
-            with ResourceEditorValidateHCOReconcile(
-                patches={hyperconverged_resource_scope_class: {"spec": {"roleAggregationStrategy": "Manual"}}},
-                list_resource_reconcile=[KubeVirt],
-                wait_for_reconcile_post_update=True,
-            ):
-                wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
-                LOGGER.info(f"Waiting for {role} role de-aggregation to propagate")
-                for sample in TimeoutSampler(
-                    wait_timeout=TIMEOUT_1MIN,
-                    sleep=2,
-                    func=vm_list_is_forbidden,
-                    client=unprivileged_client,
-                    namespace_name=namespace.name,
-                ):
-                    if sample:
-                        break
-                LOGGER.info(f"Asserting user with {role} role is forbidden from listing VMs")
-                with pytest.raises(ForbiddenError):
-                    list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name))
+        with pytest.raises(ForbiddenError):
+            list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name))
 
 
 class TestRoleAggregationReenabledAccess:
@@ -130,7 +84,9 @@ class TestRoleAggregationReenabledAccess:
 
     @pytest.mark.polarion("CNV-16029")
     @pytest.mark.usefixtures("admin_reenabled_aggregation")
-    def test_admin_can_delete_vm_collection_when_aggregation_reenabled(self, unprivileged_client, namespace):
+    def test_admin_can_delete_vm_collection_when_aggregation_reenabled(
+        self, vm_resource_for_unprivileged_client, namespace
+    ):
         """
         Test that an unprivileged user with the admin role can perform a delete-collection
         call on VirtualMachine resources when role aggregation is enabled.
@@ -145,13 +101,14 @@ class TestRoleAggregationReenabledAccess:
         Expected:
             - Delete-collection operation succeeds
         """
-        vm_resource = unprivileged_client.resources.get(api_version="kubevirt.io/v1", kind="VirtualMachine")
-        vm_resource.delete(namespace=namespace.name, label_selector="rbac-test=nonexistent")
-        LOGGER.info("Admin user successfully performed delete-collection on VirtualMachines")
+        result = vm_resource_for_unprivileged_client.delete(
+            namespace=namespace.name, label_selector="rbac-test=nonexistent"
+        )
+        assert result.kind == "VirtualMachineList", f"Expected VirtualMachineList response, got: {result.kind}"
 
     @pytest.mark.polarion("CNV-16260")
     @pytest.mark.usefixtures("edit_reenabled_aggregation")
-    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, unprivileged_client, namespace):
+    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, dry_run_vm):
         """
         Test that an unprivileged user with the edit role can create a VirtualMachine
         using a server-side dry-run when role aggregation is enabled.
@@ -166,31 +123,7 @@ class TestRoleAggregationReenabledAccess:
         Expected:
             - Dry-run create operation succeeds
         """
-        vm = VirtualMachine(
-            name="rbac-dry-run-vm",
-            namespace=namespace.name,
-            client=unprivileged_client,
-            body={
-                "spec": {
-                    "running": False,
-                    "template": {
-                        "spec": {
-                            "domain": {
-                                "devices": {},
-                                "resources": {
-                                    "requests": {
-                                        "memory": "64Mi",
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-            dry_run=True,
-        )
-        vm.create()
-        LOGGER.info("Edit user successfully performed dry-run VM creation")
+        dry_run_vm.create()
 
     @pytest.mark.polarion("CNV-16261")
     @pytest.mark.usefixtures("view_reenabled_aggregation")

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -12,9 +12,24 @@ Preconditions:
     - Namespace for RBAC testing
 """
 
-import pytest
+import logging
 
-__test__ = False
+import pytest
+from kubernetes.dynamic.exceptions import ForbiddenError
+from ocp_resources.cluster_role import ClusterRole
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.role_binding import RoleBinding
+from ocp_resources.virtual_machine import VirtualMachine
+from timeout_sampler import TimeoutSampler
+
+from tests.install_upgrade_operators.role_aggregation.utils import vm_list_is_forbidden, wait_for_aggregation_labels
+from utilities.constants.pytest import UNPRIVILEGED_USER
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_30SEC
+from utilities.hco import ResourceEditorValidateHCOReconcile
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
 class TestRoleAggregationDisabled:
@@ -22,7 +37,8 @@ class TestRoleAggregationDisabled:
     Tests for RBAC enforcement when role aggregation is disabled.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault" (role aggregation enabled)
+        - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault"
+          (role aggregation enabled)
         - RoleBinding granting the unprivileged user the parametrized ClusterRole in the namespace
     """
 
@@ -34,7 +50,9 @@ class TestRoleAggregationDisabled:
             pytest.param("view", marks=pytest.mark.polarion("CNV-16263")),
         ],
     )
-    def test_vm_list_forbidden_when_aggregation_disabled(self, role):
+    def test_vm_list_forbidden_when_aggregation_disabled(
+        self, role, admin_client, unprivileged_client, namespace, hyperconverged_resource_scope_class
+    ):
         """
         [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
         from listing virtualization resources when role aggregation is disabled.
@@ -46,7 +64,8 @@ class TestRoleAggregationDisabled:
             - User can list VirtualMachine resources in the namespace successfully
 
         Steps:
-            1. Set HyperConverged CR spec.roleAggregationStrategy to "Manual" (disable role aggregation)
+            1. Set HyperConverged CR spec.roleAggregationStrategy to "Manual"
+               (disable role aggregation)
             2. Wait for the aggregation labels to be removed from the kubevirt.io ClusterRoles
             3. Attempt to list VirtualMachine resources in the namespace using the unprivileged
                user's credentials
@@ -54,6 +73,46 @@ class TestRoleAggregationDisabled:
         Expected:
             - Operation is rejected with a Forbidden error
         """
+        cluster_role = ClusterRole(name=role, client=admin_client, ensure_exists=True)
+        with RoleBinding(
+            name=f"test-role-bind-{role}",
+            namespace=namespace.name,
+            client=admin_client,
+            subjects_kind="User",
+            subjects_name=UNPRIVILEGED_USER,
+            subjects_namespace=namespace.name,
+            role_ref_kind=cluster_role.kind,
+            role_ref_name=cluster_role.name,
+        ):
+            LOGGER.info(f"Baseline: waiting for {role} role RBAC propagation before testing")
+            for sample in TimeoutSampler(
+                wait_timeout=TIMEOUT_30SEC,
+                sleep=2,
+                func=lambda: list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name)) is not None,
+                exceptions_dict={ForbiddenError: []},
+            ):
+                if sample:
+                    break
+
+            with ResourceEditorValidateHCOReconcile(
+                patches={hyperconverged_resource_scope_class: {"spec": {"roleAggregationStrategy": "Manual"}}},
+                list_resource_reconcile=[KubeVirt],
+                wait_for_reconcile_post_update=True,
+            ):
+                wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
+                LOGGER.info(f"Waiting for {role} role de-aggregation to propagate")
+                for sample in TimeoutSampler(
+                    wait_timeout=TIMEOUT_1MIN,
+                    sleep=2,
+                    func=vm_list_is_forbidden,
+                    client=unprivileged_client,
+                    namespace_name=namespace.name,
+                ):
+                    if sample:
+                        break
+                LOGGER.info(f"Asserting user with {role} role is forbidden from listing VMs")
+                with pytest.raises(ForbiddenError):
+                    list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name))
 
 
 class TestRoleAggregationReenabledAccess:
@@ -61,14 +120,17 @@ class TestRoleAggregationReenabledAccess:
     Tests for role-specific access when role aggregation is re-enabled.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "Manual" (role aggregation disabled)
+        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+          (role aggregation disabled)
         - RoleBinding granting the unprivileged user the respective ClusterRole in the namespace
-        - HyperConverged CR spec.roleAggregationStrategy restored to "AggregateToDefault" (role aggregation re-enabled)
+        - HyperConverged CR spec.roleAggregationStrategy restored to "AggregateToDefault"
+          (role aggregation re-enabled)
         - Wait for the aggregation labels to be restored on the kubevirt.io ClusterRoles
     """
 
     @pytest.mark.polarion("CNV-16029")
-    def test_admin_can_delete_vm_collection_when_aggregation_reenabled(self):
+    @pytest.mark.usefixtures("admin_reenabled_aggregation")
+    def test_admin_can_delete_vm_collection_when_aggregation_reenabled(self, unprivileged_client, namespace):
         """
         Test that an unprivileged user with the admin role can perform a delete-collection
         call on VirtualMachine resources when role aggregation is enabled.
@@ -83,9 +145,13 @@ class TestRoleAggregationReenabledAccess:
         Expected:
             - Delete-collection operation succeeds
         """
+        vm_resource = unprivileged_client.resources.get(api_version="kubevirt.io/v1", kind="VirtualMachine")
+        vm_resource.delete(namespace=namespace.name, label_selector="rbac-test=nonexistent")
+        LOGGER.info("Admin user successfully performed delete-collection on VirtualMachines")
 
     @pytest.mark.polarion("CNV-16260")
-    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self):
+    @pytest.mark.usefixtures("edit_reenabled_aggregation")
+    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, unprivileged_client, namespace):
         """
         Test that an unprivileged user with the edit role can create a VirtualMachine
         using a server-side dry-run when role aggregation is enabled.
@@ -100,9 +166,35 @@ class TestRoleAggregationReenabledAccess:
         Expected:
             - Dry-run create operation succeeds
         """
+        vm = VirtualMachine(
+            name="rbac-dry-run-vm",
+            namespace=namespace.name,
+            client=unprivileged_client,
+            body={
+                "spec": {
+                    "running": False,
+                    "template": {
+                        "spec": {
+                            "domain": {
+                                "devices": {},
+                                "resources": {
+                                    "requests": {
+                                        "memory": "64Mi",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            dry_run=True,
+        )
+        vm.create()
+        LOGGER.info("Edit user successfully performed dry-run VM creation")
 
     @pytest.mark.polarion("CNV-16261")
-    def test_view_can_list_vms_when_aggregation_reenabled(self):
+    @pytest.mark.usefixtures("view_reenabled_aggregation")
+    def test_view_can_list_vms_when_aggregation_reenabled(self, unprivileged_client, namespace):
         """
         Test that an unprivileged user with the view role can list VirtualMachine
         resources when role aggregation is enabled.
@@ -116,3 +208,5 @@ class TestRoleAggregationReenabledAccess:
         Expected:
             - VirtualMachine resources are listed successfully
         """
+        list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name))
+        LOGGER.info("View user successfully listed VirtualMachines")

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -12,13 +12,9 @@ Preconditions:
     - Namespace for RBAC testing
 """
 
-import logging
-
 import pytest
 from kubernetes.dynamic.exceptions import ForbiddenError
 from ocp_resources.virtual_machine import VirtualMachine
-
-LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
@@ -79,13 +75,16 @@ class TestRoleAggregationReenabledAccess:
         - RoleBinding granting the unprivileged user the respective ClusterRole in the namespace
         - HyperConverged CR spec.roleAggregationStrategy restored to "AggregateToDefault"
           (role aggregation re-enabled)
-        - Wait for the aggregation labels to be restored on the kubevirt.io ClusterRoles
+        - Aggregation labels restored on kubevirt.io ClusterRoles
     """
 
-    @pytest.mark.polarion("CNV-16029")
-    @pytest.mark.usefixtures("admin_reenabled_aggregation")
+    @pytest.mark.parametrize(
+        "reenabled_aggregation_with_role",
+        [pytest.param("admin", marks=pytest.mark.polarion("CNV-16029"))],
+        indirect=True,
+    )
     def test_admin_can_delete_vm_collection_when_aggregation_reenabled(
-        self, vm_resource_for_unprivileged_client, namespace
+        self, reenabled_aggregation_with_role, vm_collection_resource_for_unprivileged_client, namespace
     ):
         """
         Test that an unprivileged user with the admin role can perform a delete-collection
@@ -101,11 +100,16 @@ class TestRoleAggregationReenabledAccess:
         Expected:
             - Delete-collection operation succeeds
         """
-        vm_resource_for_unprivileged_client.delete(namespace=namespace.name, label_selector="rbac-test=nonexistent")
+        vm_collection_resource_for_unprivileged_client.delete(
+            namespace=namespace.name, label_selector="rbac-test=nonexistent"
+        )
 
-    @pytest.mark.polarion("CNV-16260")
-    @pytest.mark.usefixtures("edit_reenabled_aggregation")
-    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, dry_run_vm):
+    @pytest.mark.parametrize(
+        "reenabled_aggregation_with_role",
+        [pytest.param("edit", marks=pytest.mark.polarion("CNV-16260"))],
+        indirect=True,
+    )
+    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, reenabled_aggregation_with_role, dry_run_vm):
         """
         Test that an unprivileged user with the edit role can create a VirtualMachine
         using a server-side dry-run when role aggregation is enabled.
@@ -122,9 +126,14 @@ class TestRoleAggregationReenabledAccess:
         """
         dry_run_vm.create()
 
-    @pytest.mark.polarion("CNV-16261")
-    @pytest.mark.usefixtures("view_reenabled_aggregation")
-    def test_view_can_list_vms_when_aggregation_reenabled(self, unprivileged_client, namespace):
+    @pytest.mark.parametrize(
+        "reenabled_aggregation_with_role",
+        [pytest.param("view", marks=pytest.mark.polarion("CNV-16261"))],
+        indirect=True,
+    )
+    def test_view_can_list_vms_when_aggregation_reenabled(
+        self, reenabled_aggregation_with_role, unprivileged_client, namespace
+    ):
         """
         Test that an unprivileged user with the view role can list VirtualMachine
         resources when role aggregation is enabled.

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -13,93 +13,56 @@ Preconditions:
 """
 
 import pytest
-from kubernetes.dynamic.exceptions import ForbiddenError
-from ocp_resources.virtual_machine import VirtualMachine
+
+from tests.install_upgrade_operators.role_aggregation.utils import wait_for_vm_list_permission
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
-class TestRoleAggregationDisabled:
+@pytest.mark.usefixtures("aggregation_disabled", "admin_role_binding")
+class TestRoleAggregationAdmin:
     """
-    Tests for RBAC enforcement when role aggregation is disabled.
+    Tests for admin role RBAC behavior across aggregation state changes.
+
+    The re-enabled test depends on the disabled test; if the disabled test
+    failed, the aggregation state may be inconsistent for the re-enabled flow.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "AggregateToDefault"
-          (role aggregation enabled)
-        - RoleBinding granting the unprivileged user the parametrized ClusterRole in the namespace
+        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+          (role aggregation disabled)
+        - RoleBinding granting the unprivileged user the admin ClusterRole
+          in the namespace, created while aggregation is disabled
     """
 
-    @pytest.mark.parametrize(
-        "disabled_aggregation_state",
-        [
-            pytest.param(
-                "admin",
-                marks=[pytest.mark.polarion("CNV-16028"), pytest.mark.dependency(name="test_disabled_admin")],
-            ),
-            pytest.param(
-                "edit",
-                marks=[pytest.mark.polarion("CNV-16262"), pytest.mark.dependency(name="test_disabled_edit")],
-            ),
-            pytest.param(
-                "view",
-                marks=[pytest.mark.polarion("CNV-16263"), pytest.mark.dependency(name="test_disabled_view")],
-            ),
-        ],
-        indirect=True,
-    )
-    def test_vm_list_forbidden_when_aggregation_disabled(
-        self, disabled_aggregation_state, unprivileged_client, namespace
-    ):
+    @pytest.mark.polarion("CNV-16028")
+    @pytest.mark.dependency(name="test_disabled_admin")
+    def test_admin_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
         """
-        [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
+        [NEGATIVE] Test that an unprivileged user with the admin role is forbidden
         from listing virtualization resources when role aggregation is disabled.
 
-        Parametrize:
-            - role: [admin, edit, view]
-
-        Preconditions:
-            - User can list VirtualMachine resources in the namespace successfully
-
         Steps:
-            1. Set HyperConverged CR spec.roleAggregationStrategy to "Manual"
-               (disable role aggregation)
-            2. Wait for the aggregation labels to be removed from the kubevirt.io ClusterRoles
-            3. Attempt to list VirtualMachine resources in the namespace using the unprivileged
-               user's credentials
+            1. Attempt to list VirtualMachine resources in the namespace using
+               the unprivileged user's credentials
 
         Expected:
             - Operation is rejected with a Forbidden error
         """
-        with pytest.raises(ForbiddenError):
-            list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name))
-
-
-class TestRoleAggregationReenabledAccess:
-    """
-    Tests for role-specific access when role aggregation is re-enabled.
-
-    Each test depends on the corresponding disabled test, which creates the
-    RoleBinding and restores the aggregation strategy.
-
-    Preconditions:
-        - RoleBinding granting the unprivileged user the respective ClusterRole in the namespace
-        - HyperConverged CR spec.roleAggregationStrategy is "AggregateToDefault"
-          (role aggregation enabled)
-        - Aggregation labels restored on kubevirt.io ClusterRoles
-    """
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=False)
 
     @pytest.mark.polarion("CNV-16029")
-    @pytest.mark.usefixtures("admin_role_binding", "reenabled_aggregation_state")
     @pytest.mark.dependency(depends=["test_disabled_admin"])
+    @pytest.mark.usefixtures("aggregation_reenabled")
     def test_admin_can_delete_vm_collection_when_aggregation_reenabled(
-        self, vm_collection_resource_for_unprivileged_client, namespace
+        self, unprivileged_client, vm_collection_resource_for_unprivileged_client, namespace
     ):
         """
         Test that an unprivileged user with the admin role can perform a delete-collection
-        call on VirtualMachine resources when role aggregation is enabled.
+        call on VirtualMachine resources when role aggregation is re-enabled.
 
         Preconditions:
-            - Unprivileged user with the admin ClusterRole bound in the namespace
+            - HyperConverged CR spec.roleAggregationStrategy restored to
+              "AggregateToDefault"
 
         Steps:
             1. Issue a raw DELETE request to the VirtualMachine collection API endpoint
@@ -112,16 +75,49 @@ class TestRoleAggregationReenabledAccess:
             namespace=namespace.name, label_selector="rbac-test=nonexistent"
         )
 
+
+@pytest.mark.usefixtures("aggregation_disabled", "edit_role_binding")
+class TestRoleAggregationEdit:
+    """
+    Tests for edit role RBAC behavior across aggregation state changes.
+
+    The re-enabled test depends on the disabled test; if the disabled test
+    failed, the aggregation state may be inconsistent for the re-enabled flow.
+
+    Preconditions:
+        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+          (role aggregation disabled)
+        - RoleBinding granting the unprivileged user the edit ClusterRole
+          in the namespace, created while aggregation is disabled
+    """
+
+    @pytest.mark.polarion("CNV-16262")
+    @pytest.mark.dependency(name="test_disabled_edit")
+    def test_edit_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
+        """
+        [NEGATIVE] Test that an unprivileged user with the edit role is forbidden
+        from listing virtualization resources when role aggregation is disabled.
+
+        Steps:
+            1. Attempt to list VirtualMachine resources in the namespace using
+               the unprivileged user's credentials
+
+        Expected:
+            - Operation is rejected with a Forbidden error
+        """
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=False)
+
     @pytest.mark.polarion("CNV-16260")
-    @pytest.mark.usefixtures("edit_role_binding", "reenabled_aggregation_state")
     @pytest.mark.dependency(depends=["test_disabled_edit"])
-    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, dry_run_vm):
+    @pytest.mark.usefixtures("aggregation_reenabled")
+    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, unprivileged_client, namespace, dry_run_vm):
         """
         Test that an unprivileged user with the edit role can create a VirtualMachine
-        using a server-side dry-run when role aggregation is enabled.
+        using a server-side dry-run when role aggregation is re-enabled.
 
         Preconditions:
-            - Unprivileged user with the edit ClusterRole bound in the namespace
+            - HyperConverged CR spec.roleAggregationStrategy restored to
+              "AggregateToDefault"
 
         Steps:
             1. Create a VirtualMachine using server-side dry-run with the unprivileged
@@ -132,21 +128,55 @@ class TestRoleAggregationReenabledAccess:
         """
         dry_run_vm.create()
 
+
+@pytest.mark.usefixtures("aggregation_disabled", "view_role_binding")
+class TestRoleAggregationView:
+    """
+    Tests for view role RBAC behavior across aggregation state changes.
+
+    The re-enabled test depends on the disabled test; if the disabled test
+    failed, the aggregation state may be inconsistent for the re-enabled flow.
+
+    Preconditions:
+        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+          (role aggregation disabled)
+        - RoleBinding granting the unprivileged user the view ClusterRole
+          in the namespace, created while aggregation is disabled
+    """
+
+    @pytest.mark.polarion("CNV-16263")
+    @pytest.mark.dependency(name="test_disabled_view")
+    def test_view_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
+        """
+        [NEGATIVE] Test that an unprivileged user with the view role is forbidden
+        from listing virtualization resources when role aggregation is disabled.
+
+        Steps:
+            1. Attempt to list VirtualMachine resources in the namespace using
+               the unprivileged user's credentials
+
+        Expected:
+            - Operation is rejected with a Forbidden error
+        """
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=False)
+
     @pytest.mark.polarion("CNV-16261")
-    @pytest.mark.usefixtures("view_role_binding", "reenabled_aggregation_state")
     @pytest.mark.dependency(depends=["test_disabled_view"])
+    @pytest.mark.usefixtures("aggregation_reenabled")
     def test_view_can_list_vms_when_aggregation_reenabled(self, unprivileged_client, namespace):
         """
         Test that an unprivileged user with the view role can list VirtualMachine
-        resources when role aggregation is enabled.
+        resources when role aggregation is re-enabled.
 
         Preconditions:
-            - Unprivileged user with the view ClusterRole bound in the namespace
+            - HyperConverged CR spec.roleAggregationStrategy restored to
+              "AggregateToDefault"
 
         Steps:
-            1. List VirtualMachine resources in the namespace using the unprivileged user's credentials
+            1. List VirtualMachine resources in the namespace using the unprivileged
+               user's credentials
 
         Expected:
             - VirtualMachine resources are listed successfully
         """
-        list(VirtualMachine.get(client=unprivileged_client, namespace=namespace.name))
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=True)

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -15,6 +15,7 @@ Preconditions:
 import pytest
 
 from tests.install_upgrade_operators.role_aggregation.utils import wait_for_vm_list_permission
+from utilities.sanity import check_vm_creation_capability
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
@@ -126,7 +127,7 @@ class TestRoleAggregationEdit:
     # Aggregation must be disabled before re-enabling to test the transition
     @pytest.mark.dependency(depends=["test_disabled_edit"])
     @pytest.mark.usefixtures("aggregation_reenabled")
-    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, unprivileged_client, namespace, dry_run_vm):
+    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, unprivileged_client, namespace):
         """
         Test that an unprivileged user with the edit role can create a VirtualMachine
         using a server-side dry-run when role aggregation is re-enabled.
@@ -144,7 +145,7 @@ class TestRoleAggregationEdit:
         Expected:
             - Dry-run create operation succeeds
         """
-        dry_run_vm.create()
+        check_vm_creation_capability(client=unprivileged_client, namespace=namespace.name)
 
 
 @pytest.mark.usefixtures("view_role_binding")

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -30,16 +30,25 @@ class TestRoleAggregationDisabled:
     """
 
     @pytest.mark.parametrize(
-        "disabled_aggregation_with_role",
+        "disabled_aggregation_state",
         [
-            pytest.param("admin", marks=pytest.mark.polarion("CNV-16028")),
-            pytest.param("edit", marks=pytest.mark.polarion("CNV-16262")),
-            pytest.param("view", marks=pytest.mark.polarion("CNV-16263")),
+            pytest.param(
+                "admin",
+                marks=[pytest.mark.polarion("CNV-16028"), pytest.mark.dependency(name="test_disabled_admin")],
+            ),
+            pytest.param(
+                "edit",
+                marks=[pytest.mark.polarion("CNV-16262"), pytest.mark.dependency(name="test_disabled_edit")],
+            ),
+            pytest.param(
+                "view",
+                marks=[pytest.mark.polarion("CNV-16263"), pytest.mark.dependency(name="test_disabled_view")],
+            ),
         ],
         indirect=True,
     )
     def test_vm_list_forbidden_when_aggregation_disabled(
-        self, disabled_aggregation_with_role, unprivileged_client, namespace
+        self, disabled_aggregation_state, unprivileged_client, namespace
     ):
         """
         [NEGATIVE] Test that an unprivileged user with a standard OpenShift role is forbidden
@@ -69,22 +78,21 @@ class TestRoleAggregationReenabledAccess:
     """
     Tests for role-specific access when role aggregation is re-enabled.
 
+    Each test depends on the corresponding disabled test, which creates the
+    RoleBinding and restores the aggregation strategy.
+
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
-          (role aggregation disabled)
         - RoleBinding granting the unprivileged user the respective ClusterRole in the namespace
-        - HyperConverged CR spec.roleAggregationStrategy restored to "AggregateToDefault"
-          (role aggregation re-enabled)
+        - HyperConverged CR spec.roleAggregationStrategy is "AggregateToDefault"
+          (role aggregation enabled)
         - Aggregation labels restored on kubevirt.io ClusterRoles
     """
 
-    @pytest.mark.parametrize(
-        "reenabled_aggregation_with_role",
-        [pytest.param("admin", marks=pytest.mark.polarion("CNV-16029"))],
-        indirect=True,
-    )
+    @pytest.mark.polarion("CNV-16029")
+    @pytest.mark.usefixtures("admin_role_binding", "reenabled_aggregation_state")
+    @pytest.mark.dependency(depends=["test_disabled_admin"])
     def test_admin_can_delete_vm_collection_when_aggregation_reenabled(
-        self, reenabled_aggregation_with_role, vm_collection_resource_for_unprivileged_client, namespace
+        self, vm_collection_resource_for_unprivileged_client, namespace
     ):
         """
         Test that an unprivileged user with the admin role can perform a delete-collection
@@ -104,12 +112,10 @@ class TestRoleAggregationReenabledAccess:
             namespace=namespace.name, label_selector="rbac-test=nonexistent"
         )
 
-    @pytest.mark.parametrize(
-        "reenabled_aggregation_with_role",
-        [pytest.param("edit", marks=pytest.mark.polarion("CNV-16260"))],
-        indirect=True,
-    )
-    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, reenabled_aggregation_with_role, dry_run_vm):
+    @pytest.mark.polarion("CNV-16260")
+    @pytest.mark.usefixtures("edit_role_binding", "reenabled_aggregation_state")
+    @pytest.mark.dependency(depends=["test_disabled_edit"])
+    def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, dry_run_vm):
         """
         Test that an unprivileged user with the edit role can create a VirtualMachine
         using a server-side dry-run when role aggregation is enabled.
@@ -126,14 +132,10 @@ class TestRoleAggregationReenabledAccess:
         """
         dry_run_vm.create()
 
-    @pytest.mark.parametrize(
-        "reenabled_aggregation_with_role",
-        [pytest.param("view", marks=pytest.mark.polarion("CNV-16261"))],
-        indirect=True,
-    )
-    def test_view_can_list_vms_when_aggregation_reenabled(
-        self, reenabled_aggregation_with_role, unprivileged_client, namespace
-    ):
+    @pytest.mark.polarion("CNV-16261")
+    @pytest.mark.usefixtures("view_role_binding", "reenabled_aggregation_state")
+    @pytest.mark.dependency(depends=["test_disabled_view"])
+    def test_view_can_list_vms_when_aggregation_reenabled(self, unprivileged_client, namespace):
         """
         Test that an unprivileged user with the view role can list VirtualMachine
         resources when role aggregation is enabled.

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -51,7 +51,7 @@ class TestRoleAggregationAdmin:
         Expected:
             - Operation is rejected with a Forbidden error
         """
-        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=False)
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, is_allowed=False)
 
     @pytest.mark.polarion("CNV-16029")
     @pytest.mark.dependency(depends=["test_disabled_admin"])
@@ -111,7 +111,7 @@ class TestRoleAggregationEdit:
         Expected:
             - Operation is rejected with a Forbidden error
         """
-        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=False)
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, is_allowed=False)
 
     @pytest.mark.polarion("CNV-16260")
     @pytest.mark.dependency(depends=["test_disabled_edit"])
@@ -167,7 +167,7 @@ class TestRoleAggregationView:
         Expected:
             - Operation is rejected with a Forbidden error
         """
-        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=False)
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, is_allowed=False)
 
     @pytest.mark.polarion("CNV-16261")
     @pytest.mark.dependency(depends=["test_disabled_view"])
@@ -188,4 +188,4 @@ class TestRoleAggregationView:
         Expected:
             - VirtualMachine resources are listed successfully
         """
-        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, allowed=True)
+        wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, is_allowed=True)

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -19,7 +19,7 @@ from tests.install_upgrade_operators.role_aggregation.utils import wait_for_vm_l
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.arm64]
 
 
-@pytest.mark.usefixtures("aggregation_disabled", "admin_role_binding")
+@pytest.mark.usefixtures("admin_role_binding")
 class TestRoleAggregationAdmin:
     """
     Tests for admin role RBAC behavior across aggregation state changes.
@@ -28,18 +28,21 @@ class TestRoleAggregationAdmin:
     failed, the aggregation state may be inconsistent for the re-enabled flow.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
-          (role aggregation disabled)
         - RoleBinding granting the unprivileged user the admin ClusterRole
-          in the namespace, created while aggregation is disabled
+          in the namespace
     """
 
     @pytest.mark.polarion("CNV-16028")
     @pytest.mark.dependency(name="test_disabled_admin")
+    @pytest.mark.usefixtures("aggregation_disabled")
     def test_admin_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
         """
         [NEGATIVE] Test that an unprivileged user with the admin role is forbidden
         from listing virtualization resources when role aggregation is disabled.
+
+        Preconditions:
+            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+              (role aggregation disabled)
 
         Steps:
             1. Attempt to list VirtualMachine resources in the namespace using
@@ -76,7 +79,7 @@ class TestRoleAggregationAdmin:
         )
 
 
-@pytest.mark.usefixtures("aggregation_disabled", "edit_role_binding")
+@pytest.mark.usefixtures("edit_role_binding")
 class TestRoleAggregationEdit:
     """
     Tests for edit role RBAC behavior across aggregation state changes.
@@ -85,18 +88,21 @@ class TestRoleAggregationEdit:
     failed, the aggregation state may be inconsistent for the re-enabled flow.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
-          (role aggregation disabled)
         - RoleBinding granting the unprivileged user the edit ClusterRole
-          in the namespace, created while aggregation is disabled
+          in the namespace
     """
 
     @pytest.mark.polarion("CNV-16262")
     @pytest.mark.dependency(name="test_disabled_edit")
+    @pytest.mark.usefixtures("aggregation_disabled")
     def test_edit_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
         """
         [NEGATIVE] Test that an unprivileged user with the edit role is forbidden
         from listing virtualization resources when role aggregation is disabled.
+
+        Preconditions:
+            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+              (role aggregation disabled)
 
         Steps:
             1. Attempt to list VirtualMachine resources in the namespace using
@@ -129,7 +135,7 @@ class TestRoleAggregationEdit:
         dry_run_vm.create()
 
 
-@pytest.mark.usefixtures("aggregation_disabled", "view_role_binding")
+@pytest.mark.usefixtures("view_role_binding")
 class TestRoleAggregationView:
     """
     Tests for view role RBAC behavior across aggregation state changes.
@@ -138,18 +144,21 @@ class TestRoleAggregationView:
     failed, the aggregation state may be inconsistent for the re-enabled flow.
 
     Preconditions:
-        - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
-          (role aggregation disabled)
         - RoleBinding granting the unprivileged user the view ClusterRole
-          in the namespace, created while aggregation is disabled
+          in the namespace
     """
 
     @pytest.mark.polarion("CNV-16263")
     @pytest.mark.dependency(name="test_disabled_view")
+    @pytest.mark.usefixtures("aggregation_disabled")
     def test_view_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
         """
         [NEGATIVE] Test that an unprivileged user with the view role is forbidden
         from listing virtualization resources when role aggregation is disabled.
+
+        Preconditions:
+            - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
+              (role aggregation disabled)
 
         Steps:
             1. Attempt to list VirtualMachine resources in the namespace using

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -33,6 +33,7 @@ class TestRoleAggregationAdmin:
     """
 
     @pytest.mark.polarion("CNV-16028")
+    # Re-enabled test requires the disabled test's side effects (aggregation state)
     @pytest.mark.dependency(name="test_disabled_admin")
     @pytest.mark.usefixtures("aggregation_disabled")
     def test_admin_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
@@ -41,6 +42,8 @@ class TestRoleAggregationAdmin:
         from listing virtualization resources when role aggregation is disabled.
 
         Preconditions:
+            - RoleBinding granting the unprivileged user the admin ClusterRole
+              in the namespace
             - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
               (role aggregation disabled)
 
@@ -54,6 +57,7 @@ class TestRoleAggregationAdmin:
         wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, is_allowed=False)
 
     @pytest.mark.polarion("CNV-16029")
+    # Aggregation must be disabled before re-enabling to test the transition
     @pytest.mark.dependency(depends=["test_disabled_admin"])
     @pytest.mark.usefixtures("aggregation_reenabled")
     def test_admin_can_delete_vm_collection_when_aggregation_reenabled(
@@ -64,6 +68,8 @@ class TestRoleAggregationAdmin:
         call on VirtualMachine resources when role aggregation is re-enabled.
 
         Preconditions:
+            - RoleBinding granting the unprivileged user the admin ClusterRole
+              in the namespace
             - HyperConverged CR spec.roleAggregationStrategy restored to
               "AggregateToDefault"
 
@@ -93,6 +99,7 @@ class TestRoleAggregationEdit:
     """
 
     @pytest.mark.polarion("CNV-16262")
+    # Re-enabled test requires the disabled test's side effects (aggregation state)
     @pytest.mark.dependency(name="test_disabled_edit")
     @pytest.mark.usefixtures("aggregation_disabled")
     def test_edit_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
@@ -101,6 +108,8 @@ class TestRoleAggregationEdit:
         from listing virtualization resources when role aggregation is disabled.
 
         Preconditions:
+            - RoleBinding granting the unprivileged user the edit ClusterRole
+              in the namespace
             - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
               (role aggregation disabled)
 
@@ -114,6 +123,7 @@ class TestRoleAggregationEdit:
         wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, is_allowed=False)
 
     @pytest.mark.polarion("CNV-16260")
+    # Aggregation must be disabled before re-enabling to test the transition
     @pytest.mark.dependency(depends=["test_disabled_edit"])
     @pytest.mark.usefixtures("aggregation_reenabled")
     def test_edit_can_create_vm_dry_run_when_aggregation_reenabled(self, unprivileged_client, namespace, dry_run_vm):
@@ -122,6 +132,8 @@ class TestRoleAggregationEdit:
         using a server-side dry-run when role aggregation is re-enabled.
 
         Preconditions:
+            - RoleBinding granting the unprivileged user the edit ClusterRole
+              in the namespace
             - HyperConverged CR spec.roleAggregationStrategy restored to
               "AggregateToDefault"
 
@@ -149,6 +161,7 @@ class TestRoleAggregationView:
     """
 
     @pytest.mark.polarion("CNV-16263")
+    # Re-enabled test requires the disabled test's side effects (aggregation state)
     @pytest.mark.dependency(name="test_disabled_view")
     @pytest.mark.usefixtures("aggregation_disabled")
     def test_view_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
@@ -157,6 +170,8 @@ class TestRoleAggregationView:
         from listing virtualization resources when role aggregation is disabled.
 
         Preconditions:
+            - RoleBinding granting the unprivileged user the view ClusterRole
+              in the namespace
             - HyperConverged CR spec.roleAggregationStrategy set to "Manual"
               (role aggregation disabled)
 
@@ -170,6 +185,7 @@ class TestRoleAggregationView:
         wait_for_vm_list_permission(client=unprivileged_client, namespace_name=namespace.name, is_allowed=False)
 
     @pytest.mark.polarion("CNV-16261")
+    # Aggregation must be disabled before re-enabling to test the transition
     @pytest.mark.dependency(depends=["test_disabled_view"])
     @pytest.mark.usefixtures("aggregation_reenabled")
     def test_view_can_list_vms_when_aggregation_reenabled(self, unprivileged_client, namespace):
@@ -178,6 +194,8 @@ class TestRoleAggregationView:
         resources when role aggregation is re-enabled.
 
         Preconditions:
+            - RoleBinding granting the unprivileged user the view ClusterRole
+              in the namespace
             - HyperConverged CR spec.roleAggregationStrategy restored to
               "AggregateToDefault"
 

--- a/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
+++ b/tests/install_upgrade_operators/role_aggregation/test_role_aggregation_rbac_enforcement.py
@@ -40,7 +40,7 @@ class TestRoleAggregationAdmin:
     def test_admin_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
         """
         [NEGATIVE] Test that an unprivileged user with the admin role is forbidden
-        from listing virtualization resources when role aggregation is disabled.
+        from listing virtual machines when role aggregation is disabled.
 
         Preconditions:
             - RoleBinding granting the unprivileged user the admin ClusterRole
@@ -106,7 +106,7 @@ class TestRoleAggregationEdit:
     def test_edit_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
         """
         [NEGATIVE] Test that an unprivileged user with the edit role is forbidden
-        from listing virtualization resources when role aggregation is disabled.
+        from listing virtual machines when role aggregation is disabled.
 
         Preconditions:
             - RoleBinding granting the unprivileged user the edit ClusterRole
@@ -168,7 +168,7 @@ class TestRoleAggregationView:
     def test_view_forbidden_when_aggregation_disabled(self, unprivileged_client, namespace):
         """
         [NEGATIVE] Test that an unprivileged user with the view role is forbidden
-        from listing virtualization resources when role aggregation is disabled.
+        from listing virtual machines when role aggregation is disabled.
 
         Preconditions:
             - RoleBinding granting the unprivileged user the view ClusterRole

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -12,7 +12,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler
 
 from utilities.constants.pytest import UNPRIVILEGED_USER
-from utilities.constants.timeouts import TIMEOUT_5MIN
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 if TYPE_CHECKING:
@@ -43,7 +43,7 @@ def aggregation_labels_match_expected_state(admin_client: DynamicClient, expecte
         labels = cluster_role.instance.metadata.labels or {}
         label_present = labels.get(label_key) == "true"
         if label_present != expected_present:
-            LOGGER.info(
+            LOGGER.warning(
                 f"Label {label_key} on {role_name}: present={label_present}, expected_present={expected_present}"
             )
             return False
@@ -86,6 +86,87 @@ def vm_list_is_forbidden(client: DynamicClient, namespace_name: str) -> bool:
         return False
     except ForbiddenError:
         return True
+
+
+def vm_list_is_accessible(client: DynamicClient, namespace_name: str) -> bool:
+    """Check if listing VirtualMachines succeeds without ForbiddenError.
+
+    Args:
+        client: DynamicClient to test access with.
+        namespace_name: Namespace to list VMs in.
+
+    Returns:
+        True if listing succeeds, False if ForbiddenError is raised.
+    """
+    return not vm_list_is_forbidden(client=client, namespace_name=namespace_name)
+
+
+def wait_for_vm_list_access(client: DynamicClient, namespace_name: str) -> None:
+    """Wait for an unprivileged user to be able to list VirtualMachines.
+
+    Args:
+        client: DynamicClient to test access with.
+        namespace_name: Namespace to list VMs in.
+    """
+    LOGGER.info("Waiting for VM list access to propagate")
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_1MIN,
+        sleep=2,
+        func=vm_list_is_accessible,
+        client=client,
+        namespace_name=namespace_name,
+    ):
+        if sample:
+            break
+
+
+def disabled_aggregation_with_role_binding(
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    namespace_name: str,
+    hyperconverged_resource: HyperConverged,
+    role_name: str,
+) -> Generator[None]:
+    """Create role binding, disable aggregation, wait for RBAC revocation.
+
+    Args:
+        admin_client: Admin DynamicClient for API access.
+        unprivileged_client: Unprivileged DynamicClient to verify access changes.
+        namespace_name: Namespace where the RoleBinding is created.
+        hyperconverged_resource: HyperConverged CR to patch.
+        role_name: ClusterRole name to bind (admin, edit, or view).
+    """
+    cluster_role = ClusterRole(name=role_name, client=admin_client, ensure_exists=True)
+    with RoleBinding(
+        name=f"test-role-bind-{role_name}",
+        namespace=namespace_name,
+        client=admin_client,
+        subjects_kind="User",
+        subjects_name=UNPRIVILEGED_USER,
+        subjects_namespace=namespace_name,
+        role_ref_kind=cluster_role.kind,
+        role_ref_name=cluster_role.name,
+    ):
+        wait_for_vm_list_access(client=unprivileged_client, namespace_name=namespace_name)
+
+        with ResourceEditorValidateHCOReconcile(
+            patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "Manual"}}},
+            list_resource_reconcile=[KubeVirt],
+            wait_for_reconcile_post_update=True,
+        ):
+            wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
+            LOGGER.info(f"Waiting for {role_name} role de-aggregation to propagate")
+            for sample in TimeoutSampler(
+                wait_timeout=TIMEOUT_1MIN,
+                sleep=2,
+                func=vm_list_is_forbidden,
+                client=unprivileged_client,
+                namespace_name=namespace_name,
+            ):
+                if sample:
+                    break
+            LOGGER.info(f"Aggregation disabled with {role_name} RoleBinding; user access revoked")
+            yield
 
 
 def reenabled_aggregation_with_role_binding(

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -88,19 +88,6 @@ def vm_list_is_forbidden(client: DynamicClient, namespace_name: str) -> bool:
         return True
 
 
-def vm_list_is_accessible(client: DynamicClient, namespace_name: str) -> bool:
-    """Check if listing VirtualMachines succeeds without ForbiddenError.
-
-    Args:
-        client: DynamicClient to test access with.
-        namespace_name: Namespace to list VMs in.
-
-    Returns:
-        True if listing succeeds, False if ForbiddenError is raised.
-    """
-    return not vm_list_is_forbidden(client=client, namespace_name=namespace_name)
-
-
 def wait_for_vm_list_access(client: DynamicClient, namespace_name: str) -> None:
     """Wait for an unprivileged user to be able to list VirtualMachines.
 
@@ -112,11 +99,11 @@ def wait_for_vm_list_access(client: DynamicClient, namespace_name: str) -> None:
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=2,
-        func=vm_list_is_accessible,
+        func=vm_list_is_forbidden,
         client=client,
         namespace_name=namespace_name,
     ):
-        if sample:
+        if not sample:
             break
 
 

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -123,7 +123,6 @@ def disabled_aggregation_with_role_binding(
         hyperconverged_resource: HyperConverged CR to patch.
         role_name: ClusterRole name to bind (admin, edit, or view).
     """
-    cluster_role = ClusterRole(name=role_name, client=admin_client, ensure_exists=True)
     with RoleBinding(
         name=f"test-role-bind-{role_name}",
         namespace=namespace_name,
@@ -131,8 +130,8 @@ def disabled_aggregation_with_role_binding(
         subjects_kind="User",
         subjects_name=UNPRIVILEGED_USER,
         subjects_namespace=namespace_name,
-        role_ref_kind=cluster_role.kind,
-        role_ref_name=cluster_role.name,
+        role_ref_kind="ClusterRole",
+        role_ref_name=role_name,
     ):
         wait_for_vm_list_access(client=unprivileged_client, namespace_name=namespace_name)
 
@@ -180,7 +179,6 @@ def reenabled_aggregation_with_role_binding(
     ):
         wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
         LOGGER.info(f"Creating RoleBinding for {role_name} role")
-        cluster_role = ClusterRole(name=role_name, client=admin_client, ensure_exists=True)
         with RoleBinding(
             name=f"test-role-bind-{role_name}",
             namespace=namespace_name,
@@ -188,8 +186,8 @@ def reenabled_aggregation_with_role_binding(
             subjects_kind="User",
             subjects_name=UNPRIVILEGED_USER,
             subjects_namespace=namespace_name,
-            role_ref_kind=cluster_role.kind,
-            role_ref_name=cluster_role.name,
+            role_ref_kind="ClusterRole",
+            role_ref_name=role_name,
         ):
             LOGGER.info("Restoring roleAggregationStrategy to AggregateToDefault")
             with ResourceEditorValidateHCOReconcile(

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+
+from kubernetes.dynamic.exceptions import ForbiddenError
+from ocp_resources.cluster_role import ClusterRole
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.role_binding import RoleBinding
+from ocp_resources.virtual_machine import VirtualMachine
+from timeout_sampler import TimeoutSampler
+
+from utilities.constants.pytest import UNPRIVILEGED_USER
+from utilities.constants.timeouts import TIMEOUT_5MIN
+from utilities.hco import ResourceEditorValidateHCOReconcile
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.hyperconverged import HyperConverged
+
+LOGGER = logging.getLogger(__name__)
+
+KUBEVIRT_AGGREGATION_ROLES: dict[str, str] = {
+    "kubevirt.io:admin": "rbac.authorization.k8s.io/aggregate-to-admin",
+    "kubevirt.io:edit": "rbac.authorization.k8s.io/aggregate-to-edit",
+    "kubevirt.io:view": "rbac.authorization.k8s.io/aggregate-to-view",
+}
+
+
+def aggregation_labels_match_expected_state(admin_client: DynamicClient, expected_present: bool) -> bool:
+    """Check if aggregation labels on kubevirt.io ClusterRoles match expected state.
+
+    Args:
+        admin_client: Admin DynamicClient for API access.
+        expected_present: True to check labels exist, False to check they are absent.
+
+    Returns:
+        True if all ClusterRoles match the expected label state.
+    """
+    for role_name, label_key in KUBEVIRT_AGGREGATION_ROLES.items():
+        cluster_role = ClusterRole(name=role_name, client=admin_client)
+        labels = cluster_role.instance.metadata.labels or {}
+        label_present = labels.get(label_key) == "true"
+        if label_present != expected_present:
+            LOGGER.info(
+                f"Label {label_key} on {role_name}: present={label_present}, expected_present={expected_present}"
+            )
+            return False
+    return True
+
+
+def wait_for_aggregation_labels(admin_client: DynamicClient, expected_present: bool) -> None:
+    """Wait for aggregation labels on kubevirt.io ClusterRoles to reach expected state.
+
+    Args:
+        admin_client: Admin DynamicClient for API access.
+        expected_present: True to wait for labels to appear, False to wait for removal.
+    """
+    state_description = "present" if expected_present else "absent"
+    LOGGER.info(f"Waiting for aggregation labels to be {state_description} on kubevirt.io ClusterRoles")
+    for sample in TimeoutSampler(
+        wait_timeout=TIMEOUT_5MIN,
+        sleep=10,
+        func=aggregation_labels_match_expected_state,
+        admin_client=admin_client,
+        expected_present=expected_present,
+    ):
+        if sample:
+            break
+    LOGGER.info(f"Aggregation labels are {state_description} on all kubevirt.io ClusterRoles")
+
+
+def vm_list_is_forbidden(client: DynamicClient, namespace_name: str) -> bool:
+    """Check if listing VirtualMachines raises ForbiddenError.
+
+    Args:
+        client: DynamicClient to test access with.
+        namespace_name: Namespace to list VMs in.
+
+    Returns:
+        True if ForbiddenError is raised, False if listing succeeds.
+    """
+    try:
+        list(VirtualMachine.get(client=client, namespace=namespace_name))
+        return False
+    except ForbiddenError:
+        return True
+
+
+def reenabled_aggregation_with_role_binding(
+    admin_client: DynamicClient,
+    namespace_name: str,
+    hyperconverged_resource: HyperConverged,
+    role_name: str,
+) -> Generator[None]:
+    """Disable aggregation, create role binding, re-enable aggregation, wait for labels.
+
+    Follows the precondition order: Manual → RoleBinding → AggregateToDefault → labels restored.
+
+    Args:
+        admin_client: Admin DynamicClient for API access.
+        namespace_name: Namespace where the RoleBinding is created.
+        hyperconverged_resource: HyperConverged CR to patch.
+        role_name: ClusterRole name to bind (admin, edit, or view).
+    """
+    LOGGER.info(f"Setting roleAggregationStrategy to Manual for {role_name} re-enable test")
+    with ResourceEditorValidateHCOReconcile(
+        patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "Manual"}}},
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
+    ):
+        wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
+        LOGGER.info(f"Creating RoleBinding for {role_name} role")
+        cluster_role = ClusterRole(name=role_name, client=admin_client, ensure_exists=True)
+        with RoleBinding(
+            name=f"test-role-bind-{role_name}",
+            namespace=namespace_name,
+            client=admin_client,
+            subjects_kind="User",
+            subjects_name=UNPRIVILEGED_USER,
+            subjects_namespace=namespace_name,
+            role_ref_kind=cluster_role.kind,
+            role_ref_name=cluster_role.name,
+        ):
+            LOGGER.info("Restoring roleAggregationStrategy to AggregateToDefault")
+            with ResourceEditorValidateHCOReconcile(
+                patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "AggregateToDefault"}}},
+                list_resource_reconcile=[KubeVirt],
+                wait_for_reconcile_post_update=True,
+            ):
+                wait_for_aggregation_labels(admin_client=admin_client, expected_present=True)
+                LOGGER.info(f"Role aggregation re-enabled with {role_name} RoleBinding; labels confirmed present")
+                yield

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -8,7 +8,7 @@ from kubernetes.dynamic.exceptions import ForbiddenError
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.virtual_machine import VirtualMachine
-from timeout_sampler import TimeoutSampler
+from timeout_sampler import TimeoutSampler, retry
 
 from utilities.constants.pytest import UNPRIVILEGED_USER
 from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN, TIMEOUT_5SEC, TIMEOUT_10SEC
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
 
 LOGGER = logging.getLogger(__name__)
-
-KUBEVIRT_AGGREGATION_LEVELS = ("admin", "edit", "view")
 
 
 def get_kubevirt_aggregation_roles(admin_client: DynamicClient) -> dict[str, str]:
@@ -33,8 +31,9 @@ def get_kubevirt_aggregation_roles(admin_client: DynamicClient) -> dict[str, str
     Returns:
         Dict mapping kubevirt.io role name to its aggregation label key.
     """
+    kubevirt_aggregation_levels = ("admin", "edit", "view")
     roles = {}
-    for level in KUBEVIRT_AGGREGATION_LEVELS:
+    for level in kubevirt_aggregation_levels:
         built_in_role = ClusterRole(name=level, client=admin_client)
         selectors = built_in_role.instance.aggregationRule.clusterRoleSelectors
         label_key, _ = next(iter(selectors[0].matchLabels))
@@ -53,7 +52,7 @@ def aggregation_labels_match_expected_state(
         aggregation_roles: Mapping of kubevirt.io role name to aggregation label key.
 
     Returns:
-        True if all ClusterRoles match the expected label state.
+        True if all ClusterRoles match the expected label state, False otherwise.
     """
     for role_name, label_key in aggregation_roles.items():
         labels = ClusterRole(name=role_name, client=admin_client).instance.metadata.labels or {}
@@ -88,42 +87,24 @@ def wait_for_aggregation_labels(admin_client: DynamicClient, should_be_present: 
     LOGGER.info(f"Aggregation labels match expected state: should_be_present={should_be_present}")
 
 
-def can_list_vms(client: DynamicClient, namespace_name: str) -> bool:
-    """Check if listing VirtualMachines succeeds.
-
-    Args:
-        client: DynamicClient to test access with.
-        namespace_name: Namespace to list VMs in.
-
-    Returns:
-        True if listing succeeds, False if ForbiddenError is raised.
-    """
-    try:
-        list(VirtualMachine.get(client=client, namespace=namespace_name))
-        return True
-    except ForbiddenError:
-        return False
-
-
-def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, is_allowed: bool) -> None:
+@retry(wait_timeout=TIMEOUT_1MIN, sleep=TIMEOUT_5SEC)
+def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, is_allowed: bool) -> bool:
     """Wait for VM list permission to reach the expected state.
 
     Args:
         client: DynamicClient to test access with.
         namespace_name: Namespace to list VMs in.
         is_allowed: True to wait for access, False to wait for forbidden.
+
+    Returns:
+        True when VM list access matches the expected state, False otherwise.
     """
-    LOGGER.info(f"Waiting for VM list access: allowed={is_allowed}")
-    for sample in TimeoutSampler(
-        wait_timeout=TIMEOUT_1MIN,
-        sleep=TIMEOUT_5SEC,
-        func=can_list_vms,
-        client=client,
-        namespace_name=namespace_name,
-    ):
-        if sample == is_allowed:
-            LOGGER.info(f"VM list access reached expected state: allowed={is_allowed}")
-            break
+    try:
+        list(VirtualMachine.get(client=client, namespace=namespace_name))
+        can_list = True
+    except ForbiddenError:
+        can_list = False
+    return can_list == is_allowed
 
 
 def unprivileged_role_binding(

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -11,12 +11,10 @@ from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler
 
 from utilities.constants.pytest import UNPRIVILEGED_USER
-from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN, TIMEOUT_5SEC
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN, TIMEOUT_5SEC, TIMEOUT_10SEC
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
-    from ocp_resources.hyperconverged import HyperConverged
-
 LOGGER = logging.getLogger(__name__)
 
 KUBEVIRT_AGGREGATION_LEVELS = ("admin", "edit", "view")
@@ -38,7 +36,7 @@ def get_kubevirt_aggregation_roles(admin_client: DynamicClient) -> dict[str, str
     for level in KUBEVIRT_AGGREGATION_LEVELS:
         built_in_role = ClusterRole(name=level, client=admin_client)
         selectors = built_in_role.instance.aggregationRule.clusterRoleSelectors
-        label_key = next(iter(selectors[0].matchLabels))
+        label_key, _ = next(iter(selectors[0].matchLabels))
         roles[f"kubevirt.io:{level}"] = label_key
     return roles
 
@@ -78,7 +76,7 @@ def wait_for_aggregation_labels(admin_client: DynamicClient, should_be_present: 
     LOGGER.info(f"Waiting for aggregation labels: should_be_present={should_be_present}")
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_5MIN,
-        sleep=10,
+        sleep=TIMEOUT_10SEC,
         func=aggregation_labels_match_expected_state,
         admin_client=admin_client,
         should_be_present=should_be_present,
@@ -153,17 +151,3 @@ def unprivileged_role_binding(
         role_ref_name=role_name,
     ):
         yield
-
-
-def ensure_aggregation_enabled(admin_client: DynamicClient, hyperconverged_resource: HyperConverged) -> None:
-    """Verify roleAggregationStrategy is AggregateToDefault and aggregation labels are present.
-
-    Args:
-        admin_client: Admin DynamicClient for API access.
-        hyperconverged_resource: HyperConverged CR to check and patch.
-    """
-    current_strategy = hyperconverged_resource.instance.spec.get("roleAggregationStrategy", "AggregateToDefault")
-    assert current_strategy == "AggregateToDefault", (
-        f"roleAggregationStrategy is {current_strategy}, expected AggregateToDefault"
-    )
-    wait_for_aggregation_labels(admin_client=admin_client, should_be_present=True)

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -7,9 +7,11 @@ from typing import TYPE_CHECKING
 from kubernetes.dynamic.exceptions import ForbiddenError
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.role_binding import RoleBinding
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler
 
+from utilities.constants.pytest import UNPRIVILEGED_USER
 from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
@@ -55,8 +57,7 @@ def wait_for_aggregation_labels(admin_client: DynamicClient, expected_present: b
         admin_client: Admin DynamicClient for API access.
         expected_present: True to wait for labels to appear, False to wait for removal.
     """
-    state_description = "present" if expected_present else "absent"
-    LOGGER.info(f"Waiting for aggregation labels to be {state_description} on kubevirt.io ClusterRoles")
+    LOGGER.info(f"Waiting for aggregation labels: expected_present={expected_present}")
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_5MIN,
         sleep=10,
@@ -66,81 +67,71 @@ def wait_for_aggregation_labels(admin_client: DynamicClient, expected_present: b
     ):
         if sample:
             break
-    LOGGER.info(f"Aggregation labels are {state_description} on all kubevirt.io ClusterRoles")
+    LOGGER.info(f"Aggregation labels match expected state: expected_present={expected_present}")
 
 
-def vm_list_is_forbidden(client: DynamicClient, namespace_name: str) -> bool:
-    """Check if listing VirtualMachines raises ForbiddenError.
+def can_list_vms(client: DynamicClient, namespace_name: str) -> bool:
+    """Check if listing VirtualMachines succeeds.
 
     Args:
         client: DynamicClient to test access with.
         namespace_name: Namespace to list VMs in.
 
     Returns:
-        True if ForbiddenError is raised, False if listing succeeds.
+        True if listing succeeds, False if ForbiddenError is raised.
     """
     try:
         list(VirtualMachine.get(client=client, namespace=namespace_name))
-        return False
-    except ForbiddenError:
         return True
+    except ForbiddenError:
+        return False
 
 
-def wait_for_vm_list_access(client: DynamicClient, namespace_name: str) -> None:
-    """Wait for an unprivileged user to be able to list VirtualMachines.
+def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, allowed: bool) -> None:
+    """Wait for VM list permission to reach the expected state.
 
     Args:
         client: DynamicClient to test access with.
         namespace_name: Namespace to list VMs in.
+        allowed: True to wait for access, False to wait for forbidden.
     """
-    LOGGER.info("Waiting for VM list access to propagate")
+    LOGGER.info(f"Waiting for VM list access: allowed={allowed}")
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=2,
-        func=vm_list_is_forbidden,
+        func=can_list_vms,
         client=client,
         namespace_name=namespace_name,
     ):
-        if not sample:
+        if sample == allowed:
             break
 
 
-def disable_aggregation_and_wait(
+def unprivileged_role_binding(
     admin_client: DynamicClient,
-    unprivileged_client: DynamicClient,
     namespace_name: str,
-    hyperconverged_resource: HyperConverged,
     role_name: str,
 ) -> Generator[None]:
-    """Set roleAggregationStrategy to Manual and wait for RBAC revocation.
+    """Create a RoleBinding granting a ClusterRole to the unprivileged user.
 
     Args:
         admin_client: Admin DynamicClient for API access.
-        unprivileged_client: Unprivileged DynamicClient to verify access changes.
-        namespace_name: Namespace to verify RBAC in.
-        hyperconverged_resource: HyperConverged CR to patch.
-        role_name: ClusterRole name for logging context.
+        namespace_name: Namespace where the RoleBinding is created.
+        role_name: ClusterRole name to bind (admin, edit, or view).
 
     Yields:
-        None when aggregation is disabled and RBAC revocation is confirmed.
+        None while the RoleBinding exists.
     """
-    with ResourceEditorValidateHCOReconcile(
-        patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "Manual"}}},
-        list_resource_reconcile=[KubeVirt],
-        wait_for_reconcile_post_update=True,
+    with RoleBinding(
+        name=f"test-role-bind-{role_name}",
+        namespace=namespace_name,
+        client=admin_client,
+        subjects_kind="User",
+        subjects_name=UNPRIVILEGED_USER,
+        subjects_namespace=namespace_name,
+        role_ref_kind="ClusterRole",
+        role_ref_name=role_name,
     ):
-        wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
-        LOGGER.info(f"Waiting for {role_name} role de-aggregation to propagate")
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_1MIN,
-            sleep=2,
-            func=vm_list_is_forbidden,
-            client=unprivileged_client,
-            namespace_name=namespace_name,
-        ):
-            if sample:
-                break
-        LOGGER.info(f"Aggregation disabled with {role_name} RoleBinding; user access revoked")
         yield
 
 
@@ -161,6 +152,7 @@ def ensure_aggregation_enabled(admin_client: DynamicClient, hyperconverged_resou
             patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "AggregateToDefault"}}},
             list_resource_reconcile=[KubeVirt],
             wait_for_reconcile_post_update=True,
+            admin_client=admin_client,
         )
         editor.update(backup_resources=False)
     wait_for_aggregation_labels(admin_client=admin_client, expected_present=True)

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -104,6 +104,7 @@ def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, allo
         namespace_name=namespace_name,
     ):
         if sample == allowed:
+            LOGGER.info(f"VM list access reached expected state: allowed={allowed}")
             break
 
 

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -104,15 +104,15 @@ def can_list_vms(client: DynamicClient, namespace_name: str) -> bool:
         return False
 
 
-def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, allowed: bool) -> None:
+def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, is_allowed: bool) -> None:
     """Wait for VM list permission to reach the expected state.
 
     Args:
         client: DynamicClient to test access with.
         namespace_name: Namespace to list VMs in.
-        allowed: True to wait for access, False to wait for forbidden.
+        is_allowed: True to wait for access, False to wait for forbidden.
     """
-    LOGGER.info(f"Waiting for VM list access: allowed={allowed}")
+    LOGGER.info(f"Waiting for VM list access: allowed={is_allowed}")
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
         sleep=TIMEOUT_5SEC,
@@ -120,8 +120,8 @@ def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, allo
         client=client,
         namespace_name=namespace_name,
     ):
-        if sample == allowed:
-            LOGGER.info(f"VM list access reached expected state: allowed={allowed}")
+        if sample == is_allowed:
+            LOGGER.info(f"VM list access reached expected state: allowed={is_allowed}")
             break
 
 

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -7,11 +7,9 @@ from typing import TYPE_CHECKING
 from kubernetes.dynamic.exceptions import ForbiddenError
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.kubevirt import KubeVirt
-from ocp_resources.role_binding import RoleBinding
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler
 
-from utilities.constants.pytest import UNPRIVILEGED_USER
 from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
@@ -107,94 +105,62 @@ def wait_for_vm_list_access(client: DynamicClient, namespace_name: str) -> None:
             break
 
 
-def disabled_aggregation_with_role_binding(
+def disable_aggregation_and_wait(
     admin_client: DynamicClient,
     unprivileged_client: DynamicClient,
     namespace_name: str,
     hyperconverged_resource: HyperConverged,
     role_name: str,
 ) -> Generator[None]:
-    """Create role binding, disable aggregation, wait for RBAC revocation.
+    """Set roleAggregationStrategy to Manual and wait for RBAC revocation.
 
     Args:
         admin_client: Admin DynamicClient for API access.
         unprivileged_client: Unprivileged DynamicClient to verify access changes.
-        namespace_name: Namespace where the RoleBinding is created.
+        namespace_name: Namespace to verify RBAC in.
         hyperconverged_resource: HyperConverged CR to patch.
-        role_name: ClusterRole name to bind (admin, edit, or view).
+        role_name: ClusterRole name for logging context.
+
+    Yields:
+        None when aggregation is disabled and RBAC revocation is confirmed.
     """
-    with RoleBinding(
-        name=f"test-role-bind-{role_name}",
-        namespace=namespace_name,
-        client=admin_client,
-        subjects_kind="User",
-        subjects_name=UNPRIVILEGED_USER,
-        subjects_namespace=namespace_name,
-        role_ref_kind="ClusterRole",
-        role_ref_name=role_name,
-    ):
-        wait_for_vm_list_access(client=unprivileged_client, namespace_name=namespace_name)
-
-        with ResourceEditorValidateHCOReconcile(
-            patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "Manual"}}},
-            list_resource_reconcile=[KubeVirt],
-            wait_for_reconcile_post_update=True,
-        ):
-            wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
-            LOGGER.info(f"Waiting for {role_name} role de-aggregation to propagate")
-            for sample in TimeoutSampler(
-                wait_timeout=TIMEOUT_1MIN,
-                sleep=2,
-                func=vm_list_is_forbidden,
-                client=unprivileged_client,
-                namespace_name=namespace_name,
-            ):
-                if sample:
-                    break
-            LOGGER.info(f"Aggregation disabled with {role_name} RoleBinding; user access revoked")
-            yield
-
-
-def reenabled_aggregation_with_role_binding(
-    admin_client: DynamicClient,
-    namespace_name: str,
-    hyperconverged_resource: HyperConverged,
-    role_name: str,
-) -> Generator[None]:
-    """Disable aggregation, create role binding, re-enable aggregation, wait for labels.
-
-    Follows the precondition order: Manual → RoleBinding → AggregateToDefault → labels restored.
-
-    Args:
-        admin_client: Admin DynamicClient for API access.
-        namespace_name: Namespace where the RoleBinding is created.
-        hyperconverged_resource: HyperConverged CR to patch.
-        role_name: ClusterRole name to bind (admin, edit, or view).
-    """
-    LOGGER.info(f"Setting roleAggregationStrategy to Manual for {role_name} re-enable test")
     with ResourceEditorValidateHCOReconcile(
         patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "Manual"}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,
     ):
         wait_for_aggregation_labels(admin_client=admin_client, expected_present=False)
-        LOGGER.info(f"Creating RoleBinding for {role_name} role")
-        with RoleBinding(
-            name=f"test-role-bind-{role_name}",
-            namespace=namespace_name,
-            client=admin_client,
-            subjects_kind="User",
-            subjects_name=UNPRIVILEGED_USER,
-            subjects_namespace=namespace_name,
-            role_ref_kind="ClusterRole",
-            role_ref_name=role_name,
+        LOGGER.info(f"Waiting for {role_name} role de-aggregation to propagate")
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_1MIN,
+            sleep=2,
+            func=vm_list_is_forbidden,
+            client=unprivileged_client,
+            namespace_name=namespace_name,
         ):
-            LOGGER.info("Restoring roleAggregationStrategy to AggregateToDefault")
-            with ResourceEditorValidateHCOReconcile(
-                patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "AggregateToDefault"}}},
-                list_resource_reconcile=[KubeVirt],
-                wait_for_reconcile_post_update=True,
-            ):
-                wait_for_aggregation_labels(admin_client=admin_client, expected_present=True)
-                LOGGER.info(f"Role aggregation re-enabled with {role_name} RoleBinding; labels confirmed present")
-                yield
+            if sample:
+                break
+        LOGGER.info(f"Aggregation disabled with {role_name} RoleBinding; user access revoked")
+        yield
+
+
+def ensure_aggregation_enabled(admin_client: DynamicClient, hyperconverged_resource: HyperConverged) -> None:
+    """Verify roleAggregationStrategy is AggregateToDefault and aggregation labels are present.
+
+    Checks the current strategy value and patches it if not AggregateToDefault,
+    then waits for aggregation labels to be present on all kubevirt.io ClusterRoles.
+
+    Args:
+        admin_client: Admin DynamicClient for API access.
+        hyperconverged_resource: HyperConverged CR to check and patch.
+    """
+    current_strategy = hyperconverged_resource.instance.spec.get("roleAggregationStrategy", "AggregateToDefault")
+    if current_strategy != "AggregateToDefault":
+        LOGGER.info(f"roleAggregationStrategy is {current_strategy}, setting to AggregateToDefault")
+        editor = ResourceEditorValidateHCOReconcile(
+            patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "AggregateToDefault"}}},
+            list_resource_reconcile=[KubeVirt],
+            wait_for_reconcile_post_update=True,
+        )
+        editor.update(backup_resources=False)
+    wait_for_aggregation_labels(admin_client=admin_client, expected_present=True)

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -15,6 +15,7 @@ from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN, TIMEOUT_5SE
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
+
 LOGGER = logging.getLogger(__name__)
 
 KUBEVIRT_AGGREGATION_LEVELS = ("admin", "edit", "view")

--- a/tests/install_upgrade_operators/role_aggregation/utils.py
+++ b/tests/install_upgrade_operators/role_aggregation/utils.py
@@ -6,14 +6,12 @@ from typing import TYPE_CHECKING
 
 from kubernetes.dynamic.exceptions import ForbiddenError
 from ocp_resources.cluster_role import ClusterRole
-from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.virtual_machine import VirtualMachine
 from timeout_sampler import TimeoutSampler
 
 from utilities.constants.pytest import UNPRIVILEGED_USER
-from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN
-from utilities.hco import ResourceEditorValidateHCOReconcile
+from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN, TIMEOUT_5SEC
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
@@ -21,53 +19,74 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-KUBEVIRT_AGGREGATION_ROLES: dict[str, str] = {
-    "kubevirt.io:admin": "rbac.authorization.k8s.io/aggregate-to-admin",
-    "kubevirt.io:edit": "rbac.authorization.k8s.io/aggregate-to-edit",
-    "kubevirt.io:view": "rbac.authorization.k8s.io/aggregate-to-view",
-}
+KUBEVIRT_AGGREGATION_LEVELS = ("admin", "edit", "view")
 
 
-def aggregation_labels_match_expected_state(admin_client: DynamicClient, expected_present: bool) -> bool:
+def get_kubevirt_aggregation_roles(admin_client: DynamicClient) -> dict[str, str]:
+    """Build mapping of kubevirt.io ClusterRole names to their aggregation label keys.
+
+    Reads the aggregationRule from the built-in admin/edit/view ClusterRoles
+    to discover the label key each role aggregates on.
+
+    Args:
+        admin_client: Admin DynamicClient for API access.
+
+    Returns:
+        Dict mapping kubevirt.io role name to its aggregation label key.
+    """
+    roles = {}
+    for level in KUBEVIRT_AGGREGATION_LEVELS:
+        built_in_role = ClusterRole(name=level, client=admin_client)
+        selectors = built_in_role.instance.aggregationRule.clusterRoleSelectors
+        label_key = next(iter(selectors[0].matchLabels))
+        roles[f"kubevirt.io:{level}"] = label_key
+    return roles
+
+
+def aggregation_labels_match_expected_state(
+    admin_client: DynamicClient, should_be_present: bool, aggregation_roles: dict[str, str]
+) -> bool:
     """Check if aggregation labels on kubevirt.io ClusterRoles match expected state.
 
     Args:
         admin_client: Admin DynamicClient for API access.
-        expected_present: True to check labels exist, False to check they are absent.
+        should_be_present: True to check labels exist, False to check they are absent.
+        aggregation_roles: Mapping of kubevirt.io role name to aggregation label key.
 
     Returns:
         True if all ClusterRoles match the expected label state.
     """
-    for role_name, label_key in KUBEVIRT_AGGREGATION_ROLES.items():
-        cluster_role = ClusterRole(name=role_name, client=admin_client)
-        labels = cluster_role.instance.metadata.labels or {}
-        label_present = labels.get(label_key) == "true"
-        if label_present != expected_present:
-            LOGGER.warning(
-                f"Label {label_key} on {role_name}: present={label_present}, expected_present={expected_present}"
-            )
+    for role_name, label_key in aggregation_roles.items():
+        labels = ClusterRole(name=role_name, client=admin_client).instance.metadata.labels or {}
+        label_found = labels.get(label_key) == "true"
+        if label_found != should_be_present:
+            state = "present" if label_found else "absent"
+            expected = "present" if should_be_present else "absent"
+            LOGGER.warning(f"Label {label_key} on {role_name} is {state}, expected {expected}")
             return False
     return True
 
 
-def wait_for_aggregation_labels(admin_client: DynamicClient, expected_present: bool) -> None:
+def wait_for_aggregation_labels(admin_client: DynamicClient, should_be_present: bool) -> None:
     """Wait for aggregation labels on kubevirt.io ClusterRoles to reach expected state.
 
     Args:
         admin_client: Admin DynamicClient for API access.
-        expected_present: True to wait for labels to appear, False to wait for removal.
+        should_be_present: True to wait for labels to appear, False to wait for removal.
     """
-    LOGGER.info(f"Waiting for aggregation labels: expected_present={expected_present}")
+    aggregation_roles = get_kubevirt_aggregation_roles(admin_client=admin_client)
+    LOGGER.info(f"Waiting for aggregation labels: should_be_present={should_be_present}")
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_5MIN,
         sleep=10,
         func=aggregation_labels_match_expected_state,
         admin_client=admin_client,
-        expected_present=expected_present,
+        should_be_present=should_be_present,
+        aggregation_roles=aggregation_roles,
     ):
         if sample:
             break
-    LOGGER.info(f"Aggregation labels match expected state: expected_present={expected_present}")
+    LOGGER.info(f"Aggregation labels match expected state: should_be_present={should_be_present}")
 
 
 def can_list_vms(client: DynamicClient, namespace_name: str) -> bool:
@@ -98,7 +117,7 @@ def wait_for_vm_list_permission(client: DynamicClient, namespace_name: str, allo
     LOGGER.info(f"Waiting for VM list access: allowed={allowed}")
     for sample in TimeoutSampler(
         wait_timeout=TIMEOUT_1MIN,
-        sleep=2,
+        sleep=TIMEOUT_5SEC,
         func=can_list_vms,
         client=client,
         namespace_name=namespace_name,
@@ -139,21 +158,12 @@ def unprivileged_role_binding(
 def ensure_aggregation_enabled(admin_client: DynamicClient, hyperconverged_resource: HyperConverged) -> None:
     """Verify roleAggregationStrategy is AggregateToDefault and aggregation labels are present.
 
-    Checks the current strategy value and patches it if not AggregateToDefault,
-    then waits for aggregation labels to be present on all kubevirt.io ClusterRoles.
-
     Args:
         admin_client: Admin DynamicClient for API access.
         hyperconverged_resource: HyperConverged CR to check and patch.
     """
     current_strategy = hyperconverged_resource.instance.spec.get("roleAggregationStrategy", "AggregateToDefault")
-    if current_strategy != "AggregateToDefault":
-        LOGGER.info(f"roleAggregationStrategy is {current_strategy}, setting to AggregateToDefault")
-        editor = ResourceEditorValidateHCOReconcile(
-            patches={hyperconverged_resource: {"spec": {"roleAggregationStrategy": "AggregateToDefault"}}},
-            list_resource_reconcile=[KubeVirt],
-            wait_for_reconcile_post_update=True,
-            admin_client=admin_client,
-        )
-        editor.update(backup_resources=False)
-    wait_for_aggregation_labels(admin_client=admin_client, expected_present=True)
+    assert current_strategy == "AggregateToDefault", (
+        f"roleAggregationStrategy is {current_strategy}, expected AggregateToDefault"
+    )
+    wait_for_aggregation_labels(admin_client=admin_client, should_be_present=True)

--- a/utilities/sanity.py
+++ b/utilities/sanity.py
@@ -146,13 +146,13 @@ def check_webhook_endpoints_health(admin_client: DynamicClient, namespace: Names
     LOGGER.info("All discovered webhook services have available endpoints")
 
 
-def check_vm_creation_capability(admin_client: DynamicClient, namespace: str) -> None:
+def check_vm_creation_capability(client: DynamicClient, namespace: str) -> None:
     """
     Verify VM creation capability by performing a dry-run VM creation.
 
     Args:
-        admin_client: Kubernetes dynamic client with admin privileges for cluster operations.
-        namespace: str
+        client: Kubernetes dynamic client for cluster operations.
+        namespace: Target namespace for the dry-run VM.
 
     Raises:
         ClusterSanityError: When dry-run VM creation fails.
@@ -163,7 +163,7 @@ def check_vm_creation_capability(admin_client: DynamicClient, namespace: str) ->
         vm = VirtualMachine(
             name="sanity-check-dry-run-vm",
             namespace=namespace,
-            client=admin_client,
+            client=client,
             body={
                 "spec": {
                     "running": False,
@@ -307,7 +307,7 @@ def cluster_sanity(
         else:
             LOGGER.info(f"Check webhook endpoints health. (To skip webhook check pass {skip_webhook_check} to pytest)")
             check_webhook_endpoints_health(admin_client=admin_client, namespace=hco_namespace)
-            check_vm_creation_capability(admin_client=admin_client, namespace="default")
+            check_vm_creation_capability(client=admin_client, namespace="default")
 
         # Wait for hco to be healthy
         wait_for_hco_conditions(

--- a/utilities/unittests/test_sanity.py
+++ b/utilities/unittests/test_sanity.py
@@ -1077,7 +1077,7 @@ class TestCheckVmCreationCapability:
         mock_admin_client = MagicMock()
 
         # Should not raise
-        check_vm_creation_capability(admin_client=mock_admin_client, namespace="openshift-cnv")
+        check_vm_creation_capability(client=mock_admin_client, namespace="openshift-cnv")
 
         mock_vm.create.assert_called_once()
 
@@ -1093,7 +1093,7 @@ class TestCheckVmCreationCapability:
         mock_admin_client = MagicMock()
 
         with pytest.raises(ClusterSanityError) as exc_info:
-            check_vm_creation_capability(admin_client=mock_admin_client, namespace="openshift-cnv")
+            check_vm_creation_capability(client=mock_admin_client, namespace="openshift-cnv")
 
         assert "Dry-run VM creation failed" in str(exc_info.value), (
             "Expected 'Dry-run VM creation failed' in exception message for API error"
@@ -1111,7 +1111,7 @@ class TestCheckVmCreationCapability:
         mock_admin_client = MagicMock()
 
         with pytest.raises(ClusterSanityError) as exc_info:
-            check_vm_creation_capability(admin_client=mock_admin_client, namespace="openshift-cnv")
+            check_vm_creation_capability(client=mock_admin_client, namespace="openshift-cnv")
 
         assert "Unexpected error during dry-run VM creation" in str(exc_info.value), (
             "Expected 'Unexpected error during dry-run VM creation' in exception message"
@@ -1129,7 +1129,7 @@ class TestCheckVmCreationCapability:
         mock_admin_client = MagicMock()
 
         with pytest.raises(ClusterSanityError) as exc_info:
-            check_vm_creation_capability(admin_client=mock_admin_client, namespace="openshift-cnv")
+            check_vm_creation_capability(client=mock_admin_client, namespace="openshift-cnv")
 
         assert "Connection error during dry-run VM creation" in str(exc_info.value), (
             "Expected 'Connection error during dry-run VM creation' in exception message"
@@ -1147,7 +1147,7 @@ class TestCheckVmCreationCapability:
         mock_admin_client = MagicMock()
 
         with pytest.raises(ClusterSanityError) as exc_info:
-            check_vm_creation_capability(admin_client=mock_admin_client, namespace="openshift-cnv")
+            check_vm_creation_capability(client=mock_admin_client, namespace="openshift-cnv")
 
         assert "Connection error during dry-run VM creation" in str(exc_info.value), (
             "Expected 'Connection error during dry-run VM creation' in exception message for timeout"


### PR DESCRIPTION
##### What this PR does / why we need it:

Add test implementations, fixtures, and utilities for role aggregation opt-out RBAC enforcement. Tests verify that disabling aggregation (Manual) revokes VM access and re-enabling (AggregateToDefault) restores role-specific permissions (admin delete-collection, edit dry-run create, view list).

##### Which issue(s) this PR fixes:

Part of role-aggregation tier 2 testing

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-69075


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded upgrade-time validation of RBAC role aggregation for admin, edit, and view permissions.
  * Added coverage confirming VirtualMachine access is restricted while aggregation is disabled and restored after re-enabling it.
  * Added role-specific checks for VirtualMachine listing, deletion, and server-side dry-run creation.
  * Improved validation of permission transitions and access behavior during aggregation changes.
  * Updated sanity checks and unit tests to reflect the revised VirtualMachine creation capability interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->