### PR TITLE
Reuse existing NNCP in bridge_nncp fixture to avoid 409 Conflict

### DIFF
--- a/tests/fixtures/network/l2_bridge.py
+++ b/tests/fixtures/network/l2_bridge.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Generator, Iterator
 
 import pytest
@@ -9,6 +10,8 @@ from libs.net.netattachdef import CNIPluginBridgeConfig, NetConfig, NetworkAttac
 from utilities.constants.cluster import WORKER_NODE_LABEL_KEY
 from utilities.constants.networking import LINUX_BRIDGE
 
+LOGGER = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope="package")
 def bridge_nncp(
@@ -16,7 +19,7 @@ def bridge_nncp(
     admin_client: DynamicClient,
     hosts_common_available_ports: list[str],
 ) -> Generator[libnncp.NodeNetworkConfigurationPolicy]:
-    with libnncp.NodeNetworkConfigurationPolicy(
+    nncp = libnncp.NodeNetworkConfigurationPolicy(
         client=admin_client,
         name="l2-bridge-test-nncp",
         desired_state=libnncp.DesiredState(
@@ -33,9 +36,18 @@ def bridge_nncp(
             ]
         ),
         node_selector={WORKER_NODE_LABEL_KEY: ""},
-    ) as nncp_br:
-        nncp_br.wait_for_status_success()
-        yield nncp_br
+    )
+
+    if nncp.exists:
+        LOGGER.info(f"Reusing existing NNCP {nncp.name}")
+        nncp.wait_for_status_success()
+        yield nncp
+        nncp.clean_up()
+
+    else:
+        with nncp as nncp_br:
+            nncp_br.wait_for_status_success()
+            yield nncp_br
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### What this PR does / why we need it:
The bridge_nncp fixture failed with a 409 ConflictError when a stale l2-bridge-test-nncp NNCP from a previous test run already existed on the cluster. Since all consumers only need a working br1-test bridge regardless of the backing port, the fixture now checks for an existing healthy NNCP and reuses it instead of always attempting to create.

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-92424


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an existing network bridge configuration is already present, allowing it to be reused more reliably.
  * Added clearer logging around reuse and cleanup to make setup behavior easier to follow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->