### PR TITLE
[Storage] Remove HPP destructive tests

### DIFF
--- a/tests/storage/hpp/conftest.py
+++ b/tests/storage/hpp/conftest.py
@@ -1,16 +1,11 @@
 import pytest
 from ocp_resources.persistent_volume import PersistentVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
-from ocp_resources.resource import ResourceEditor
 
 from tests.storage.hpp.utils import (
     DV_NAME,
     HPP_KEY,
-    HPP_NODE_PLACEMENT_DICT,
-    TYPE,
     VM_NAME,
-    update_node_taint,
-    wait_for_desired_hpp_pods_running,
 )
 from tests.utils import create_cirros_vm
 from utilities.constants.timeouts import TIMEOUT_5MIN
@@ -87,32 +82,6 @@ def update_node_labels(worker_node1):
     yield
     for worker_resource in worker_resources:
         worker_resource.restore()
-
-
-@pytest.fixture()
-def updated_hpp_with_node_placement(
-    worker_node2,
-    worker_node3,
-    hostpath_provisioner_scope_module,
-    request,
-    hpp_daemonset_scope_session,
-    schedulable_nodes,
-):
-    node_placement_type = request.param[TYPE]
-    with ResourceEditor(
-        patches={hostpath_provisioner_scope_module: HPP_NODE_PLACEMENT_DICT[node_placement_type]}
-    ) as updated_resource:
-        if node_placement_type == "tolerations":
-            with update_node_taint(node=worker_node2), update_node_taint(node=worker_node3):
-                # Wait for 1 hpp pod to be running, and for others to be deleted
-                wait_for_desired_hpp_pods_running(hpp_daemonset=hpp_daemonset_scope_session, number_of_pods=1)
-                yield updated_resource
-        else:
-            # Wait for 1 hpp pod to be running, and for others to be deleted
-            wait_for_desired_hpp_pods_running(hpp_daemonset=hpp_daemonset_scope_session, number_of_pods=1)
-            yield updated_resource
-    # Wait for hpp pods to be restored
-    wait_for_desired_hpp_pods_running(hpp_daemonset=hpp_daemonset_scope_session, number_of_pods=len(schedulable_nodes))
 
 
 @pytest.fixture()

--- a/tests/storage/hpp/test_hostpath.py
+++ b/tests/storage/hpp/test_hostpath.py
@@ -21,13 +21,12 @@ from ocp_resources.service_account import ServiceAccount
 from ocp_resources.service_monitor import ServiceMonitor
 
 from utilities.constants.components import HOSTPATH_PROVISIONER_OPERATOR, HPP_POOL
-from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_5MIN
+from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.infra import get_pod_by_name_prefix
 
 LOGGER = logging.getLogger(__name__)
 
 HOSTPATH_PROVISIONER_ADMIN = "hostpath-provisioner-admin"
-VOLUME_BINDING_MODE = "volumeBindingMode"
 
 pytestmark = pytest.mark.hpp
 
@@ -74,13 +73,6 @@ def verify_hpp_app_label(hpp_resources, cnv_version):
                     resource.labels[f"{resource.ApiGroup.APP_KUBERNETES_IO}/managed-by"]
                     == HOSTPATH_PROVISIONER_OPERATOR
                 ), f"Missing label {Resource.ApiGroup.APP_KUBERNETES_IO}/managed-by for {resource.name}"
-
-
-@pytest.fixture(scope="module")
-def hpp_operator_deployment(hco_namespace):
-    hpp_operator_deployment = Deployment(name=HOSTPATH_PROVISIONER_OPERATOR, namespace=hco_namespace.name)
-    assert hpp_operator_deployment.exists
-    return hpp_operator_deployment
 
 
 @pytest.fixture(scope="module")
@@ -238,25 +230,6 @@ def test_hpp_daemonset(hpp_daemonset_scope_module):
 @pytest.mark.s390x
 def test_hpp_operator_pod(hpp_operator_pod):
     assert hpp_operator_pod.status == Pod.Status.RUNNING, f"HPP operator pod {hpp_operator_pod.name} is not running"
-
-
-@pytest.mark.destructive
-@pytest.mark.polarion("CNV-3277")
-def test_hpp_operator_recreate_after_deletion(
-    hpp_operator_deployment,
-    storage_class_matrix_hpp_matrix__module__,
-):
-    """
-    Check that Hostpath-provisioner operator will be created again by HCO after its deletion.
-    The Deployment is deleted, then its RepliceSet and Pod will be deleted and created again.
-    """
-    pre_delete_binding_mode = storage_class_matrix_hpp_matrix__module__.instance[VOLUME_BINDING_MODE]
-    hpp_operator_deployment.delete()
-    hpp_operator_deployment.wait_for_replicas(timeout=TIMEOUT_5MIN)
-    recreated_binding_mode = storage_class_matrix_hpp_matrix__module__.instance[VOLUME_BINDING_MODE]
-    assert pre_delete_binding_mode == recreated_binding_mode, (
-        f"Pre delete binding mode: {pre_delete_binding_mode}, differs from recreated: {recreated_binding_mode}"
-    )
 
 
 @pytest.mark.sno

--- a/tests/storage/hpp/test_hpp_node_placement.py
+++ b/tests/storage/hpp/test_hpp_node_placement.py
@@ -8,58 +8,14 @@ import pytest
 
 from tests.storage.hpp.utils import (
     DV_NAME,
-    HCO_NODE_PLACEMENT,
-    NODE_SELECTOR,
-    TYPE,
     VM_NAME,
     edit_hpp_with_node_selector,
 )
-from utilities.constants.cluster import NODE_STR
 from utilities.storage import check_disk_count_in_vm
 
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.hpp
-
-
-@pytest.mark.destructive
-@pytest.mark.parametrize(
-    (
-        "updated_hpp_with_node_placement",
-        "hyperconverged_with_node_placement",
-        "cirros_vm_for_node_placement_tests",
-    ),
-    [
-        pytest.param(
-            {TYPE: NODE_SELECTOR},
-            HCO_NODE_PLACEMENT,
-            {DV_NAME: "dv-5711", VM_NAME: "vm-5711", NODE_STR: None},
-            marks=pytest.mark.polarion("CNV-5711"),
-        ),
-        pytest.param(
-            {TYPE: "affinity"},
-            HCO_NODE_PLACEMENT,
-            {DV_NAME: "dv-5712", VM_NAME: "vm-5712", NODE_STR: None},
-            marks=pytest.mark.polarion("CNV-5712"),
-        ),
-        pytest.param(
-            {TYPE: "tolerations"},
-            HCO_NODE_PLACEMENT,
-            {DV_NAME: "dv-5713", VM_NAME: "vm-5713", NODE_STR: None},
-            marks=pytest.mark.polarion("CNV-5713"),
-        ),
-    ],
-    indirect=True,
-)
-def test_create_dv_on_right_node_with_node_placement(
-    worker_node1,
-    update_node_labels,
-    updated_hpp_with_node_placement,
-    hyperconverged_with_node_placement,
-    cirros_vm_for_node_placement_tests,
-):
-    # The VM should be created on the node that have the node labels
-    assert cirros_vm_for_node_placement_tests.vmi.node.name == worker_node1.name
 
 
 @pytest.mark.post_upgrade


### PR DESCRIPTION
##### What this PR does / why we need it:

Remove destructive HPP tests:
- `test_hpp_operator_recreate_after_deletion`
- `test_create_dv_on_right_node_with_node_placement`
- now-unused `updated_hpp_with_node_placement` fixture

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined the storage Hostpath test suite by removing obsolete node-placement and operator-recreation test coverage.
  * Simplified test setup for Hostpath-related scenarios, keeping the remaining test flow focused on current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->