### PR TITLE
[virt] add virt dual-stream migration tests

### DIFF
--- a/tests/network/l2_bridge/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/l2_bridge/rhel9_rhel10_cluster/conftest.py
@@ -14,7 +14,7 @@ from libs.vm.affinity import new_node_affinity
 from libs.vm.oper import run_vms
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.l2_bridge.libl2bridge import secondary_network_vm
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 
 LINUX_BRIDGE_NETWORK_NAME: Final[str] = "linux-bridge-1"
 

--- a/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/l2_bridge/rhel9_rhel10_cluster/test_connectivity.py
@@ -17,7 +17,7 @@ import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
 from libs.vm.affinity import new_node_affinity
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 from utilities.virt import migrate_vm_and_verify
 
 if TYPE_CHECKING:

--- a/tests/network/libs/nodes.py
+++ b/tests/network/libs/nodes.py
@@ -1,5 +1,0 @@
-from typing import Final
-
-from utilities.constants.cluster import NODE_ROLE_KUBERNETES_IO
-
-RHCOS9_WORKER_LABEL: Final[str] = f"{NODE_ROLE_KUBERNETES_IO}/worker-rhcos9"

--- a/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
@@ -17,12 +17,12 @@ from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cloudinit
 from tests.network.libs import cluster_user_defined_network as libcudn
 from tests.network.libs.cloudinit import EthernetDevice
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
 from tests.network.localnet.liblocalnet import (
     GUEST_2ND_IFACE_NAME,
     LOCALNET_BR_EX_INTERFACE,
     localnet_vm,
 )
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 
 _SERVER_HOST_ADDRESS: Final[int] = 1
 _CLIENT_HOST_ADDRESS: Final[int] = 2

--- a/tests/network/localnet/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/localnet/rhel9_rhel10_cluster/test_connectivity.py
@@ -14,7 +14,7 @@ import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
 from libs.vm.affinity import new_node_affinity
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 from utilities.virt import migrate_vm_and_verify
 
 

--- a/tests/network/primary_network/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/primary_network/rhel9_rhel10_cluster/conftest.py
@@ -8,8 +8,8 @@ from libs.net.vmspec import lookup_iface_status
 from libs.vm.affinity import new_node_affinity
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs.connectivity import build_ping_command
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
 from tests.network.primary_network.rhel9_rhel10_cluster.lib_helpers import primary_network_vm
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 
 
 @pytest.fixture()

--- a/tests/network/primary_network/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/primary_network/rhel9_rhel10_cluster/test_connectivity.py
@@ -13,7 +13,7 @@ import pytest
 from libs.net.vmspec import lookup_iface_status
 from libs.vm.affinity import new_node_affinity
 from tests.network.libs.connectivity import build_ping_command
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 from utilities.virt import migrate_vm_and_verify
 
 

--- a/tests/network/user_defined_network/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/user_defined_network/rhel9_rhel10_cluster/conftest.py
@@ -11,8 +11,8 @@ from libs.net.udn import UDN_BINDING_DEFAULT_PLUGIN_NAME
 from libs.net.vmspec import lookup_iface_status
 from libs.vm.affinity import new_node_affinity
 from libs.vm.vm import BaseVirtualMachine
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
 from tests.network.libs.vm_factory import udn_vm
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 
 _UDN_PRIMARY_IFACE_NAME = "udn-primary"
 

--- a/tests/network/user_defined_network/rhel9_rhel10_cluster/test_connectivity.py
+++ b/tests/network/user_defined_network/rhel9_rhel10_cluster/test_connectivity.py
@@ -12,7 +12,7 @@ import pytest
 
 from libs.net.traffic_generator import is_tcp_connection
 from libs.vm.affinity import new_node_affinity
-from tests.network.libs.nodes import RHCOS9_WORKER_LABEL
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 from utilities.virt import migrate_vm_and_verify
 
 

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/conftest.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/conftest.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from tests.virt.cluster.migration_and_maintenance.rhel9_rhel10_cluster.utils import is_windows_vm
 from utilities.constants.virt import REGEDIT_PROC_NAME
 from utilities.virt import (
     VirtualMachineForTests,
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
     from ocp_resources.namespace import Namespace
 
 
-@pytest.fixture
+@pytest.fixture()
 def dual_stream_migration_vm(
     request: pytest.FixtureRequest,
     unprivileged_client: DynamicClient,
@@ -38,8 +39,8 @@ def dual_stream_migration_vm(
         yield vm
 
 
-@pytest.fixture
+@pytest.fixture()
 def vm_background_process_id(dual_stream_migration_vm: VirtualMachineForTests) -> int:
-    if "windows" in dual_stream_migration_vm.name:
+    if is_windows_vm(vm=dual_stream_migration_vm):
         return start_and_fetch_processid_on_windows_vm(vm=dual_stream_migration_vm, process_name=REGEDIT_PROC_NAME)
     return start_and_fetch_processid_on_linux_vm(vm=dual_stream_migration_vm, process_name="ping", args="localhost")

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/conftest.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/conftest.py
@@ -5,13 +5,8 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from tests.virt.cluster.migration_and_maintenance.rhel9_rhel10_cluster.utils import is_windows_vm
-from utilities.constants.virt import REGEDIT_PROC_NAME
 from utilities.virt import (
-    VirtualMachineForTests,
     VirtualMachineForTestsFromTemplate,
-    start_and_fetch_processid_on_linux_vm,
-    start_and_fetch_processid_on_windows_vm,
     vm_instance_from_template,
 )
 
@@ -37,10 +32,3 @@ def dual_stream_migration_vm(
         vm_affinity=request.param.get("vm_affinity"),
     ) as vm:
         yield vm
-
-
-@pytest.fixture()
-def vm_background_process_id(dual_stream_migration_vm: VirtualMachineForTests) -> int:
-    if is_windows_vm(vm=dual_stream_migration_vm):
-        return start_and_fetch_processid_on_windows_vm(vm=dual_stream_migration_vm, process_name=REGEDIT_PROC_NAME)
-    return start_and_fetch_processid_on_linux_vm(vm=dual_stream_migration_vm, process_name="ping", args="localhost")

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/conftest.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/conftest.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from utilities.constants.virt import REGEDIT_PROC_NAME
+from utilities.virt import (
+    VirtualMachineForTests,
+    VirtualMachineForTestsFromTemplate,
+    start_and_fetch_processid_on_linux_vm,
+    start_and_fetch_processid_on_windows_vm,
+    vm_instance_from_template,
+)
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.namespace import Namespace
+
+
+@pytest.fixture
+def dual_stream_migration_vm(
+    request: pytest.FixtureRequest,
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    golden_image_data_volume_template_for_test_scope_function: dict[str, Any],
+    modern_cpu_for_migration: str | None,
+) -> Generator[VirtualMachineForTestsFromTemplate]:
+    with vm_instance_from_template(
+        request=request,
+        unprivileged_client=unprivileged_client,
+        namespace=namespace,
+        data_volume_template=golden_image_data_volume_template_for_test_scope_function,
+        vm_cpu_model=modern_cpu_for_migration,
+        vm_affinity=request.param.get("vm_affinity"),
+    ) as vm:
+        yield vm
+
+
+@pytest.fixture
+def vm_background_process_id(dual_stream_migration_vm: VirtualMachineForTests) -> int:
+    if "windows" in dual_stream_migration_vm.name:
+        return start_and_fetch_processid_on_windows_vm(vm=dual_stream_migration_vm, process_name=REGEDIT_PROC_NAME)
+    return start_and_fetch_processid_on_linux_vm(vm=dual_stream_migration_vm, process_name="ping", args="localhost")

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/test_live_migration.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/test_live_migration.py
@@ -3,19 +3,64 @@ Live Migration Between RHCOS 9 and RHCOS 10 Worker Nodes
 
 STP:
 https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-virt/dual-stream-cluster-rhcos9-rhcos10/stp.md
-
-Markers:
-    - mixed_os_nodes
-    - rwx_default_storage
 """
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 
-__test__ = False
+from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, WINDOWS_LATEST, WINDOWS_LATEST_LABELS
+from tests.virt.cluster.migration_and_maintenance.rhel9_rhel10_cluster.utils import (
+    RHCOS9_AFFINITY,
+    RHCOS10_AFFINITY,
+    assert_vm_did_not_restart,
+    set_vm_affinity,
+)
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
+from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+pytestmark = [
+    pytest.mark.mixed_os_nodes,
+    pytest.mark.rwx_default_storage,
+]
 
 
-@pytest.mark.polarion("CNV-16274")
-def test_vm_migrates_from_rhcos10_to_rhcos9_node():
+@pytest.mark.parametrize(
+    "golden_image_data_source_for_test_scope_function, dual_stream_migration_vm",
+    [
+        pytest.param(
+            {"os_dict": RHEL_LATEST},
+            {
+                "vm_name": "migrate-rhcos10-to-rhcos9-rhel",
+                "template_labels": RHEL_LATEST_LABELS,
+                "vm_affinity": RHCOS10_AFFINITY,
+            },
+            marks=pytest.mark.polarion("CNV-16274"),
+            id="RHEL-VM",
+        ),
+        pytest.param(
+            {"os_dict": WINDOWS_LATEST},
+            {
+                "vm_name": "migrate-rhcos10-to-rhcos9-windows",
+                "template_labels": WINDOWS_LATEST_LABELS,
+                "vm_affinity": RHCOS10_AFFINITY,
+            },
+            marks=[pytest.mark.special_infra, pytest.mark.high_resource_vm],
+            id="WIN-VM",
+        ),
+    ],
+    indirect=True,
+)
+def test_vm_migrates_from_rhcos10_to_rhcos9_node(
+    admin_client: DynamicClient,
+    dual_stream_migration_vm: VirtualMachineForTests,
+    vm_background_process_id: int,
+) -> None:
     """
     Test that live migration from an RHCOS 10 worker node to an RHCOS 9 worker node
     completes successfully without restarting the VM.
@@ -31,10 +76,45 @@ def test_vm_migrates_from_rhcos10_to_rhcos9_node():
         - Live migration completes successfully and the VM is running on an RHCOS 9 worker node
         - The VM did not restart during migration
     """
+    set_vm_affinity(vm=dual_stream_migration_vm, affinity=RHCOS9_AFFINITY)
+    migrate_vm_and_verify(vm=dual_stream_migration_vm, client=admin_client, check_ssh_connectivity=True)
+    assert RHCOS9_WORKER_LABEL in dual_stream_migration_vm.vmi.get_node(privileged_client=admin_client).labels.keys(), (
+        f"VM {dual_stream_migration_vm.name} is not running on an RHCOS 9 node after migration"
+    )
+    assert_vm_did_not_restart(vm=dual_stream_migration_vm, pre_migrate_pid=vm_background_process_id)
 
 
-@pytest.mark.polarion("CNV-16275")
-def test_vm_migrates_from_rhcos9_to_rhcos10_node():
+@pytest.mark.parametrize(
+    "golden_image_data_source_for_test_scope_function, dual_stream_migration_vm",
+    [
+        pytest.param(
+            {"os_dict": RHEL_LATEST},
+            {
+                "vm_name": "migrate-rhcos9-to-rhcos10-rhel",
+                "template_labels": RHEL_LATEST_LABELS,
+                "vm_affinity": RHCOS9_AFFINITY,
+            },
+            marks=pytest.mark.polarion("CNV-16275"),
+            id="RHEL-VM",
+        ),
+        pytest.param(
+            {"os_dict": WINDOWS_LATEST},
+            {
+                "vm_name": "migrate-rhcos9-to-rhcos10-windows",
+                "template_labels": WINDOWS_LATEST_LABELS,
+                "vm_affinity": RHCOS9_AFFINITY,
+            },
+            marks=[pytest.mark.special_infra, pytest.mark.high_resource_vm],
+            id="WIN-VM",
+        ),
+    ],
+    indirect=True,
+)
+def test_vm_migrates_from_rhcos9_to_rhcos10_node(
+    admin_client: DynamicClient,
+    dual_stream_migration_vm: VirtualMachineForTests,
+    vm_background_process_id: int,
+) -> None:
     """
     Test that live migration from an RHCOS 9 worker node to an RHCOS 10 worker node
     completes successfully without restarting the VM.
@@ -50,3 +130,9 @@ def test_vm_migrates_from_rhcos9_to_rhcos10_node():
         - Live migration completes successfully and the VM is running on an RHCOS 10 worker node
         - The VM did not restart during migration
     """
+    set_vm_affinity(vm=dual_stream_migration_vm, affinity=RHCOS10_AFFINITY)
+    migrate_vm_and_verify(vm=dual_stream_migration_vm, client=admin_client, check_ssh_connectivity=True)
+    assert (
+        RHCOS9_WORKER_LABEL not in dual_stream_migration_vm.vmi.get_node(privileged_client=admin_client).labels.keys()
+    ), f"VM {dual_stream_migration_vm.name} is not running on an RHCOS 10 node after migration"
+    assert_vm_did_not_restart(vm=dual_stream_migration_vm, pre_migrate_pid=vm_background_process_id)

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/test_live_migration.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/test_live_migration.py
@@ -15,11 +15,11 @@ from tests.os_params import RHEL_LATEST, RHEL_LATEST_LABELS, WINDOWS_LATEST, WIN
 from tests.virt.cluster.migration_and_maintenance.rhel9_rhel10_cluster.utils import (
     RHCOS9_AFFINITY,
     RHCOS10_AFFINITY,
-    assert_vm_did_not_restart,
     set_vm_affinity,
 )
+from tests.virt.utils import verify_guest_boot_time
 from utilities.constants.cluster import RHCOS9_WORKER_LABEL
-from utilities.virt import VirtualMachineForTests, migrate_vm_and_verify
+from utilities.virt import VirtualMachineForTests, get_vm_boot_time, migrate_vm_and_verify
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
@@ -59,7 +59,6 @@ pytestmark = [
 def test_vm_migrates_from_rhcos10_to_rhcos9_node(
     admin_client: DynamicClient,
     dual_stream_migration_vm: VirtualMachineForTests,
-    vm_background_process_id: int,
 ) -> None:
     """
     Test that live migration from an RHCOS 10 worker node to an RHCOS 9 worker node
@@ -69,19 +68,22 @@ def test_vm_migrates_from_rhcos10_to_rhcos9_node(
         - Under-test VM running on an RHCOS 10 worker node
 
     Steps:
-        1. Record guest session continuity indicator
+        1. Record VM boot time
         2. Live migrate the under-test VM to an RHCOS 9 worker node
 
     Expected:
         - Live migration completes successfully and the VM is running on an RHCOS 9 worker node
         - The VM did not restart during migration
     """
+    boot_time = get_vm_boot_time(vm=dual_stream_migration_vm)
     set_vm_affinity(vm=dual_stream_migration_vm, affinity=RHCOS9_AFFINITY)
     migrate_vm_and_verify(vm=dual_stream_migration_vm, client=admin_client, check_ssh_connectivity=True)
     assert RHCOS9_WORKER_LABEL in dual_stream_migration_vm.vmi.get_node(privileged_client=admin_client).labels.keys(), (
         f"VM {dual_stream_migration_vm.name} is not running on an RHCOS 9 node after migration"
     )
-    assert_vm_did_not_restart(vm=dual_stream_migration_vm, pre_migrate_pid=vm_background_process_id)
+    verify_guest_boot_time(
+        vm_list=[dual_stream_migration_vm], initial_boot_time={dual_stream_migration_vm.name: boot_time}
+    )
 
 
 @pytest.mark.parametrize(
@@ -113,7 +115,6 @@ def test_vm_migrates_from_rhcos10_to_rhcos9_node(
 def test_vm_migrates_from_rhcos9_to_rhcos10_node(
     admin_client: DynamicClient,
     dual_stream_migration_vm: VirtualMachineForTests,
-    vm_background_process_id: int,
 ) -> None:
     """
     Test that live migration from an RHCOS 9 worker node to an RHCOS 10 worker node
@@ -123,16 +124,19 @@ def test_vm_migrates_from_rhcos9_to_rhcos10_node(
         - Under-test VM running on an RHCOS 9 worker node
 
     Steps:
-        1. Record guest session continuity indicator
+        1. Record VM boot time
         2. Live migrate the under-test VM to an RHCOS 10 worker node
 
     Expected:
         - Live migration completes successfully and the VM is running on an RHCOS 10 worker node
         - The VM did not restart during migration
     """
+    boot_time = get_vm_boot_time(vm=dual_stream_migration_vm)
     set_vm_affinity(vm=dual_stream_migration_vm, affinity=RHCOS10_AFFINITY)
     migrate_vm_and_verify(vm=dual_stream_migration_vm, client=admin_client, check_ssh_connectivity=True)
     assert (
         RHCOS9_WORKER_LABEL not in dual_stream_migration_vm.vmi.get_node(privileged_client=admin_client).labels.keys()
     ), f"VM {dual_stream_migration_vm.name} is not running on an RHCOS 10 node after migration"
-    assert_vm_did_not_restart(vm=dual_stream_migration_vm, pre_migrate_pid=vm_background_process_id)
+    verify_guest_boot_time(
+        vm_list=[dual_stream_migration_vm], initial_boot_time={dual_stream_migration_vm.name: boot_time}
+    )

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/utils.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/utils.py
@@ -2,12 +2,17 @@ from typing import Any, Final
 
 from ocp_resources.resource import ResourceEditor
 
-from tests.virt.utils import build_node_affinity_dict
 from utilities.constants.cluster import RHCOS9_WORKER_LABEL
 from utilities.constants.virt import REGEDIT_PROC_NAME
 from utilities.virt import VirtualMachineForTests, fetch_pid_from_linux_vm, fetch_pid_from_windows_vm
 
-RHCOS9_AFFINITY: Final[dict[str, Any]] = build_node_affinity_dict(values=[""], key=RHCOS9_WORKER_LABEL)
+RHCOS9_AFFINITY: Final[dict[str, Any]] = {
+    "nodeAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [{"matchExpressions": [{"key": RHCOS9_WORKER_LABEL, "operator": "Exists"}]}]
+        }
+    }
+}
 RHCOS10_AFFINITY: Final[dict[str, Any]] = {
     "nodeAffinity": {
         "requiredDuringSchedulingIgnoredDuringExecution": {
@@ -15,6 +20,18 @@ RHCOS10_AFFINITY: Final[dict[str, Any]] = {
         }
     }
 }
+
+
+def is_windows_vm(vm: VirtualMachineForTests) -> bool:
+    """Return True if the VM is a Windows VM based on its name.
+
+    Args:
+        vm (VirtualMachineForTests): The VM to check.
+
+    Returns:
+        bool: True if the VM name contains "windows", False otherwise.
+    """
+    return "windows" in vm.name
 
 
 def set_vm_affinity(vm: VirtualMachineForTests, affinity: dict[str, Any]) -> None:
@@ -37,7 +54,7 @@ def assert_vm_did_not_restart(vm: VirtualMachineForTests, pre_migrate_pid: int) 
         vm (VirtualMachineForTests): The VM to inspect.
         pre_migrate_pid (int): PID recorded before migration via vm_background_process_id fixture.
     """
-    if "windows" in vm.name:
+    if is_windows_vm(vm=vm):
         post_pid = fetch_pid_from_windows_vm(vm=vm, process_name=REGEDIT_PROC_NAME)
     else:
         post_pid = fetch_pid_from_linux_vm(vm=vm, process_name="ping")

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/utils.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/utils.py
@@ -1,0 +1,44 @@
+from typing import Any, Final
+
+from ocp_resources.resource import ResourceEditor
+
+from tests.virt.utils import build_node_affinity_dict
+from utilities.constants.cluster import RHCOS9_WORKER_LABEL
+from utilities.constants.virt import REGEDIT_PROC_NAME
+from utilities.virt import VirtualMachineForTests, fetch_pid_from_linux_vm, fetch_pid_from_windows_vm
+
+RHCOS9_AFFINITY: Final[dict[str, Any]] = build_node_affinity_dict(values=[""], key=RHCOS9_WORKER_LABEL)
+RHCOS10_AFFINITY: Final[dict[str, Any]] = {
+    "nodeAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": {
+            "nodeSelectorTerms": [{"matchExpressions": [{"key": RHCOS9_WORKER_LABEL, "operator": "DoesNotExist"}]}]
+        }
+    }
+}
+
+
+def set_vm_affinity(vm: VirtualMachineForTests, affinity: dict[str, Any]) -> None:
+    """Update the VM template node affinity in-place via a strategic merge patch.
+
+    Args:
+        vm (VirtualMachineForTests): The VM whose template affinity should be replaced.
+        affinity (dict[str, Any]): Kubernetes affinity dict to apply (e.g. RHCOS9_AFFINITY or RHCOS10_AFFINITY).
+    """
+    ResourceEditor(patches={vm: {"spec": {"template": {"spec": {"affinity": affinity}}}}}).update()
+
+
+def assert_vm_did_not_restart(vm: VirtualMachineForTests, pre_migrate_pid: int) -> None:
+    """Assert that a background process PID is unchanged, proving the VM was not restarted.
+
+    Fetches the current PID of the background process started before migration and compares
+    it with the recorded pre-migration PID. A changed PID indicates the VM restarted.
+
+    Args:
+        vm (VirtualMachineForTests): The VM to inspect.
+        pre_migrate_pid (int): PID recorded before migration via vm_background_process_id fixture.
+    """
+    if "windows" in vm.name:
+        post_pid = fetch_pid_from_windows_vm(vm=vm, process_name=REGEDIT_PROC_NAME)
+    else:
+        post_pid = fetch_pid_from_linux_vm(vm=vm, process_name="ping")
+    assert post_pid == pre_migrate_pid, f"VM restarted during migration: PID changed {pre_migrate_pid} -> {post_pid}"

--- a/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/utils.py
+++ b/tests/virt/cluster/migration_and_maintenance/rhel9_rhel10_cluster/utils.py
@@ -1,10 +1,11 @@
-from typing import Any, Final
+from typing import TYPE_CHECKING, Any, Final
 
 from ocp_resources.resource import ResourceEditor
 
 from utilities.constants.cluster import RHCOS9_WORKER_LABEL
-from utilities.constants.virt import REGEDIT_PROC_NAME
-from utilities.virt import VirtualMachineForTests, fetch_pid_from_linux_vm, fetch_pid_from_windows_vm
+
+if TYPE_CHECKING:
+    from utilities.virt import VirtualMachineForTests
 
 RHCOS9_AFFINITY: Final[dict[str, Any]] = {
     "nodeAffinity": {
@@ -22,18 +23,6 @@ RHCOS10_AFFINITY: Final[dict[str, Any]] = {
 }
 
 
-def is_windows_vm(vm: VirtualMachineForTests) -> bool:
-    """Return True if the VM is a Windows VM based on its name.
-
-    Args:
-        vm (VirtualMachineForTests): The VM to check.
-
-    Returns:
-        bool: True if the VM name contains "windows", False otherwise.
-    """
-    return "windows" in vm.name
-
-
 def set_vm_affinity(vm: VirtualMachineForTests, affinity: dict[str, Any]) -> None:
     """Update the VM template node affinity in-place via a strategic merge patch.
 
@@ -42,20 +31,3 @@ def set_vm_affinity(vm: VirtualMachineForTests, affinity: dict[str, Any]) -> Non
         affinity (dict[str, Any]): Kubernetes affinity dict to apply (e.g. RHCOS9_AFFINITY or RHCOS10_AFFINITY).
     """
     ResourceEditor(patches={vm: {"spec": {"template": {"spec": {"affinity": affinity}}}}}).update()
-
-
-def assert_vm_did_not_restart(vm: VirtualMachineForTests, pre_migrate_pid: int) -> None:
-    """Assert that a background process PID is unchanged, proving the VM was not restarted.
-
-    Fetches the current PID of the background process started before migration and compares
-    it with the recorded pre-migration PID. A changed PID indicates the VM restarted.
-
-    Args:
-        vm (VirtualMachineForTests): The VM to inspect.
-        pre_migrate_pid (int): PID recorded before migration via vm_background_process_id fixture.
-    """
-    if is_windows_vm(vm=vm):
-        post_pid = fetch_pid_from_windows_vm(vm=vm, process_name=REGEDIT_PROC_NAME)
-    else:
-        post_pid = fetch_pid_from_linux_vm(vm=vm, process_name="ping")
-    assert post_pid == pre_migrate_pid, f"VM restarted during migration: PID changed {pre_migrate_pid} -> {post_pid}"

--- a/utilities/constants/cluster.py
+++ b/utilities/constants/cluster.py
@@ -13,6 +13,8 @@ Not here:
 - Pytest/test-runner strings → ``pytest.py``
 """
 
+from typing import Final
+
 from kubernetes.dynamic.exceptions import InternalServerError
 from ocp_resources.resource import Resource
 from urllib3.exceptions import (
@@ -28,6 +30,7 @@ NODE_STR = "node"
 NODE_TYPE_WORKER_LABEL = {"node-type": "worker"}
 NODE_ROLE_KUBERNETES_IO = "node-role.kubernetes.io"
 WORKER_NODE_LABEL_KEY = f"{NODE_ROLE_KUBERNETES_IO}/worker"
+RHCOS9_WORKER_LABEL: Final[str] = f"{NODE_ROLE_KUBERNETES_IO}/worker-rhcos9"
 VERSION_LABEL_KEY = f"{Resource.ApiGroup.APP_KUBERNETES_IO}/version"
 CPU_MODEL_LABEL_PREFIX = f"cpu-model.node.{Resource.ApiGroup.KUBEVIRT_IO}"
 TSC_FREQUENCY = "tsc-frequency"


### PR DESCRIPTION
##### What this PR does / why we need it:
Implements CNV-16274 and CNV-16275: two standalone parametrized tests
(RHEL + Windows) that verify live migration between RHCOS 9 and RHCOS 10
worker nodes completes without restarting the VM, by checking guest boot timers.

Assisted-by: Cursor Agent (claude-sonnet-4-6)

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-88298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded live-migration coverage using fixture-driven, parametrized test flows for mixed OS scenarios.
  * Added VM affinity helpers to target specific node groups during migration/verification.

* **Bug Fixes**
  * Standardized worker-node label usage across network and virtualization tests for consistent node placement assertions.
  * Improved live-migration verification to confirm workloads keep expected placement and guest boot timing remains stable.

* **Tests**
  * Enhanced test setup for local network address generation consistency across clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->