### PR TITLE
Add arm64 storage class matrix with io2-csi to global_config_arm64

### DIFF
--- a/tests/global_config_arm64.py
+++ b/tests/global_config_arm64.py
@@ -1,19 +1,41 @@
 from typing import Any
 
 import pytest_testconfig
+from ocp_resources.datavolume import DataVolume
 
 from utilities.constants import (
     ARM_64,
     EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS,
+    HPP_CAPABILITIES,
     PREFERENCE_STR,
     Images,
+    StorageClassNames,
 )
+from utilities.storage import HppCsiStorageClass
 
 global config
 global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")
 
 Images.Cirros.RAW_IMG_XZ = "cirros-0.4.0-aarch64-disk.raw.xz"
 EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR] = f"rhel.9.{ARM_64}"
+
+
+storage_class_matrix = [
+    {
+        StorageClassNames.IO2_CSI: {
+            "volume_mode": DataVolume.VolumeMode.BLOCK,
+            "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": True,
+            "default": True,
+        }
+    },
+    {HppCsiStorageClass.Name.HOSTPATH_CSI_BASIC: HPP_CAPABILITIES},
+]
+
+storage_class_a = StorageClassNames.IO2_CSI
+storage_class_b = StorageClassNames.IO2_CSI
 
 
 for _dir in dir():


### PR DESCRIPTION
##### What this PR does / why we need it:

Smoke tests on arm64 crash with `IndexError` during `pytest_sessionstart` because `--storage-class-matrix=io2-csi` is passed by the Jenkins job but `io2-csi` is not defined in the arm64 global config `storage_class_matrix`.

This adds the arm64-specific `storage_class_matrix` (with `io2-csi` as default) to `tests/global_config_arm64.py`, matching what cnv-4.19+ already have.

**Traceback:**
```
INTERNALERROR> File "utilities/pytest_utils.py", line 113, in config_default_storage_class
INTERNALERROR>     default_storage_class_configuration = [
INTERNALERROR>                                           ^
INTERNALERROR> IndexError: list index out of range
```

##### Which issue(s) this PR fixes:

Fixes new `test-pytest-cnv-4.18-smoke-arm64` crash (zero tests ran)

##### Special notes for reviewer:

cnv-4.18 does not have `TRIDENT_CSI_NFS` constant, so only `io2-csi` and `hostpath-csi-basic` are included (unlike cnv-4.19+ which also has trident).

##### jira-ticket:


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude <noreply@anthropic.com>