### PR TITLE
net, stability: Change bridge_nncp scope from package to module

### DIFF
--- a/tests/fixtures/network/l2_bridge.py
+++ b/tests/fixtures/network/l2_bridge.py
@@ -10,7 +10,7 @@ from utilities.constants.cluster import WORKER_NODE_LABEL_KEY
 from utilities.constants.networking import LINUX_BRIDGE
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="module")
 def bridge_nncp(
     nmstate_dependent_placeholder: None,
     admin_client: DynamicClient,


### PR DESCRIPTION
##### What this PR does / why we need it:
`scope="package"` in a fixture loaded via root-level pytest_plugins behaves like `scope="session"` due to a known pytest bug (https://github.com/pytest-dev/pytest/issues/7232). The NNCP was held for the entire session, unnecessarily blocking an available NIC and causing failures in nmstate and other network tests that use the same interface.

##### Which issue(s) this PR fixes:
`scope="module"` is correctly finalized at module boundaries regardless of where the fixture is defined, confirmed against the Jenkins logs.

##### Special notes for reviewer: -

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
