### PR TITLE
net, tests, hot-plug: Avoid redundant VMI interface lookup

### DIFF
--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -6,6 +6,7 @@ from ipaddress import ip_interface
 from typing import Final
 
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.client import ResourceField
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -202,12 +203,12 @@ def create_bridge_interface_for_hot_plug(
         yield br
 
 
-def set_secondary_static_ip_address(vm, ipv4_address, vmi_interface):
-    guest_vm_interface = get_guest_vm_interface_name_by_vmi_interface_name(
-        vm=vm,
-        vm_interface_name=vmi_interface,
+def set_secondary_static_ip_address(
+    vm: VirtualMachineForTests, ipv4_address: str, vmi_interface: ResourceField
+) -> None:
+    console_command = (
+        f"sudo ip addr add {ipv4_address}/{IPV4_ADDRESS_SUBNET_PREFIX_LENGTH} dev {vmi_interface.interfaceName}"
     )
-    console_command = f"sudo ip addr add {ipv4_address}/{IPV4_ADDRESS_SUBNET_PREFIX_LENGTH} dev {guest_vm_interface}"
     LOGGER.info(f"Sending command to {vm.name} console: '{console_command}'")
     with console.Console(vm=vm) as vm_console:
         vm_console.sendline(console_command)
@@ -215,8 +216,8 @@ def set_secondary_static_ip_address(vm, ipv4_address, vmi_interface):
     # Verify the IP address was set successfully.
     # The function fails on timeout if the interface or its address are not found,
     # so there's no need to check its return code.
-    hot_plugged_interface_ip = lookup_iface_status_ip(vm=vm, iface_name=vmi_interface, ip_family=4)
-    LOGGER.info(f"{vm.name}/{vmi_interface} set with IP address {hot_plugged_interface_ip}")
+    hot_plugged_interface_ip = lookup_iface_status_ip(vm=vm, iface_name=vmi_interface.name, ip_family=4)
+    LOGGER.info(f"{vm.name}/{vmi_interface.name} set with IP address {hot_plugged_interface_ip}")
 
 
 def hot_plug_interface_and_set_address(
@@ -236,18 +237,10 @@ def hot_plug_interface_and_set_address(
     set_secondary_static_ip_address(
         vm=vm,
         ipv4_address=ipv4_address,
-        vmi_interface=iface.name,
+        vmi_interface=iface,
     )
 
     return iface
-
-
-def get_guest_vm_interface_name_by_vmi_interface_name(vm, vm_interface_name):
-    vmi_interfaces = vm.vmi.interfaces
-    for interface in vmi_interfaces:
-        if interface["name"] == vm_interface_name:
-            return interface["interfaceName"]
-    raise VMInterfaceStatusNotFoundError(f"Interface {vm_interface_name} not found in VM {vm.name} status")
 
 
 @contextlib.contextmanager

--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -110,7 +110,7 @@ def hot_plugged_interface_with_address(running_vm_for_nic_hot_plug, index_number
     set_secondary_static_ip_address(
         vm=running_vm_for_nic_hot_plug,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
-        vmi_interface=hot_plugged_interface.name,
+        vmi_interface=hot_plugged_interface,
     )
 
 
@@ -151,7 +151,7 @@ def hot_plugged_second_interface_with_address(
     set_secondary_static_ip_address(
         vm=running_vm_with_secondary_and_hot_plugged_interfaces,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
-        vmi_interface=hot_plugged_interface_on_vm_created_with_secondary_interface.name,
+        vmi_interface=hot_plugged_interface_on_vm_created_with_secondary_interface,
     )
 
 


### PR DESCRIPTION
hot_plug_interface() already returns the full interface status including interfaceName. Pass it through to set_secondary_static_ip_address() instead of re-querying VMI status for the same value.

This PR replaces https://github.com/RedHatQE/openshift-virtualization-tests/pull/5419, which required fixes, but its original author is away and I cannot push to their fork (in order to  apply these fixes).

Assisted-by: Claude <noreply@anthropic.com>
Assisted-by: Yossi Segev <ysegev@redhat.com>

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-88390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot-plug network behavior when assigning secondary static IP addresses, ensuring the address is applied to the correct guest interface.
  * Strengthened IP verification to confirm the assigned address on the intended interface.
* **Tests**
  * Updated hot-plug networking tests and fixtures to pass full interface details into the secondary static IP workflow, aligning with the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->