### PR TITLE
feat(.rootcoz): add rootcoz analysis agents

### DIFF
--- a/.rootcoz/ROOTCOZ_PROMPT.md
+++ b/.rootcoz/ROOTCOZ_PROMPT.md
@@ -39,6 +39,25 @@ tiers, architecture, hardware requirements, configuration requirements, required
 operators, CI labels, and install/upgrade lifecycle markers. Tests without an explicit
 tier marker are considered tier2 by CI job selection.
 
+## Available Analysis Agents
+
+When the `subagent` tool is available, delegate specialized analysis to these agents
+instead of doing it inline. Each agent produces a structured report with
+`## Summary`, `## Details`, and `## Classification Impact` sections.
+
+| Agent | Delegate when... |
+|-------|------------------|
+| `fixture-tracer` | You need to trace the pytest fixture chain for a failing test |
+| `wait-param-auditor` | A timeout/connectivity failure needs CODE ISSUE elimination |
+| `quarantine-checker` | You need to check if a test is quarantined or Jira-skipped |
+| `teardown-cascade-detector` | Multiple tests fail and you suspect cross-test contamination |
+| `version-extractor` | You need to extract environment versions for the details block |
+| `product-code-investigator` | You need to trace a failure into upstream product source code |
+| `marker-analyzer` | You need to understand a test's markers, tier, or hardware requirements |
+
+If `subagent` is not available, read the agent file directly (e.g.,
+`read .rootcoz/agents/fixture-tracer.md`) and follow its instructions inline.
+
 ## 2. Decision Procedure and Classification Rules
 
 Your goal is to classify each failure as `CODE ISSUE`, `PRODUCT BUG`, or
@@ -74,9 +93,10 @@ purely environmental signals into a confident product-defect claim.
    Inspect `pytest.raises(...)`, expected error conditions, docstrings, or comments
    such as `should fail` or `negative test`.
 3. **Check quarantine status.**
-   If the test is marked with `@pytest.mark.jira("CNV-XXXXX", run=False)`, it is
-   quarantined for a known issue. The Jira ticket contains the expected failure mode.
-   Only classify a new defect if the failure does NOT match the quarantined issue.
+   If `quarantine-checker` agent is available, delegate to it. Otherwise, read
+   `.rootcoz/agents/quarantine-checker.md` and follow its instructions to check
+   both automation quarantine (`xfail` + `QUARANTINED`) and Jira conditional skips
+   (`pytest.mark.jira(..., run=False)`).
 4. **Prefer direct evidence over wrapper location.**
    File paths like `tests/`, `utilities/`, `libs/`, and `conftest.py` are useful clues,
    but they are not verdicts. Those modules often wrap product, cluster, or node state.
@@ -354,11 +374,11 @@ Root Cause:
 The test failure is caused by...
 </details_template>
 
-If `run-info.json` is missing or a field is absent, search other artifacts
-for version evidence: console logs, must-gather output, CSV names, operator
-pod image tags, or log output under `build-artifacts/`.
-If a version still cannot be determined, mark as `unknown`.
-Do NOT skip this step — the environment block MUST appear in every `details` field.
+If `version-extractor` agent is available, delegate to it.
+**If not available:** Read `.rootcoz/agents/version-extractor.md` and follow its
+instructions to extract ALL versions from `build-artifacts/run-info.json` with
+`[HIGH]`/`[LOW]` relevance markers. The `details` field MUST begin with the
+Environment block. Do NOT skip this step.
 
 ### Self-Verification (MANDATORY)
 
@@ -509,18 +529,13 @@ Required steps for EVERY failure:
    `test_<file>::<method>`. Map it to the test file path in the repo.
 2. **Read the test function.** Understand what the test is doing, what it validates,
    and what the expected behavior is.
-3. **Read the fixtures.** Check the `conftest.py` in the same directory to understand
-   the setup and teardown logic.
+3. **Read the fixtures.** If `fixture-tracer` agent is available, delegate fixture
+   chain analysis to it. Otherwise, read `.rootcoz/agents/fixture-tracer.md` and
+   follow its instructions to trace the fixture chain.
 4. **Read the helper functions.** If the test calls utility functions, read them too.
-5. **Inspect wait and readiness parameters.** For every helper call that starts a VM,
-   waits for a condition, or establishes connectivity, check the boolean parameters
-   and timeout values. Read the helper function's signature and docstring to understand
-   what each parameter controls. Pay special attention to parameters like
-   `wait_for_interfaces`, `wait_for_cloud_init`, `wait_for_ssh`, and similar flags —
-   when set to `False`, they skip readiness checks that may be required for the test
-   to succeed. A test that skips waiting for a precondition and then fails because that
-   precondition was not met is a `CODE ISSUE`, regardless of how the symptom appears
-   in artifacts.
+5. **Inspect wait and readiness parameters.** If `wait-param-auditor` agent is available,
+   delegate this analysis to it. Otherwise, read `.rootcoz/agents/wait-param-auditor.md`
+   and follow its instructions to audit wait parameters and timeout values.
 6. **Trace the failure path.** Follow the stack trace through the source code to find
    exactly where and why the failure occurred.
 
@@ -534,72 +549,20 @@ explicitly argue why the failure is NOT a `CODE ISSUE` before classifying as
 SSH banner errors, timeout expiry) look identical whether the root cause is a product
 defect or a test that skipped necessary wait steps.
 
-Required elimination checklist (include in your `details`):
-
-1. **List every wait/readiness call in the test path.** Trace from the test function
-   through all helpers and fixtures. For each VM startup or readiness helper, list
-   the call with its parameters. Example:
-   `running_vm(vm=vm, wait_for_interfaces=False)` — skips interface readiness.
-2. **Verify each wait parameter is correct.** If any `wait_for_*` parameter is `False`,
-   explain why skipping that wait is safe for this test scenario. If you cannot justify
-   it, classify as `CODE ISSUE`.
-3. **Verify timeout values are sufficient.** Compare the test's timeout against the
-   expected duration of the operation. If the test allows 120s but the operation
-   (boot + network + SSH) typically needs longer, classify as `CODE ISSUE`.
-4. **State your counter-argument.** Write one sentence explaining the strongest
-   argument for `CODE ISSUE` and why you are rejecting it. If you cannot articulate
-   a counter-argument, reconsider your classification.
-
-If you skip this checklist for a timeout/connectivity failure, your analysis is
-incomplete and may be rejected.
+If `wait-param-auditor` agent is available, delegate this analysis to it.
+**If not available:** Read `.rootcoz/agents/wait-param-auditor.md` and follow its
+instructions to audit all wait/readiness parameters in the test path.
+If you skip this analysis, your classification may be rejected.
 
 ### MANDATORY: Verify Product Behavior Before Declaring PRODUCT BUG
 
 **Before classifying any failure as `PRODUCT BUG`, you MUST verify that the product
 code actually has the defect you're claiming.**
 
-Required steps before declaring PRODUCT BUG:
-
-1. **Read the product source code.** If the error points to a KubeVirt, CDI, or HCO
-   component, read the relevant source code in the upstream repositories to understand
-   the expected behavior:
-   - KubeVirt: [kubevirt/kubevirt][kubevirt-repo]
-   - CDI: [kubevirt/containerized-data-importer][cdi-repo]
-   - HCO: [kubevirt/hyperconverged-cluster-operator][hco-repo]
-2. **Read the operator code.** If the failure involves a dependent operator, read its
-   source code to verify the defect exists there:
-   - NMState: [kubernetes-nmstate][nmstate-repo]
-   - SR-IOV: [sriov-network-operator][sriov-repo]
-   - MTV (Forklift): [forklift][mtv-repo]
-   - Node Health Check: [node-healthcheck-operator][nhc-repo]
-   - OADP: [oadp-operator][oadp-repo]
-3. **Trace the error to product code.** Follow the error path from the test failure
-   into the product/operator source. Show the specific product code that is
-   malfunctioning.
-4. **Provide code-level evidence.** Your `archive_evidence` and `evidence` fields must
-   reference specific product source files, functions, or code paths — not just
-   error messages from the test side.
-
-If you cannot trace the failure to a specific defect in the product or operator source
-code, reconsider whether it is truly a `PRODUCT BUG` or if it is a `CODE ISSUE` in
-the test infrastructure.
-
-### Show Your Work: Product Code Investigation
-
-When classifying as `PRODUCT BUG`, your analysis MUST include evidence that you
-investigated the product source code. In your `details` field, include a section like:
-
-```
-Product code investigation:
-- Examined [component] source at [repo]/[path/to/file.go]
-- The [function/handler] at [file:line] is responsible for [behavior]
-- The code shows [specific observation about why this is a product defect]
-```
-
-This proves the classification is based on actual product code analysis, not just
-symptoms observed from the test side. If the product code is not accessible or the
-relevant code path cannot be identified, state this explicitly and lower confidence
-to `medium` or `low`.
+If `product-code-investigator` agent is available, delegate to it.
+**If not available:** Read `.rootcoz/agents/product-code-investigator.md` and follow
+its instructions to trace the failure into upstream product source code.
+If the product code is not accessible, state this and lower confidence to `medium` or `low`.
 
 Key locations in the repository:
 
@@ -659,16 +622,12 @@ When a failure involves a dependent operator, determine ownership:
 
 ## 7. Additional Version Sources
 
-If `build-artifacts/run-info.json` does not contain a needed component version,
-check `build-artifacts/` for version evidence (CSV names, operator pod image
-tags, log output). If not found there, check `additional_repos` for the
-component's source repo context.
+If `version-extractor` agent is available, it handles fallback version detection
+automatically. Otherwise, check `build-artifacts/` for version evidence (CSV names,
+operator pod image tags, log output) and `additional_repos` for component source context.
 
-## FINAL REMINDER — READ THIS LAST
-
-**You MUST include ALL component versions from `run-info.json` in the
-`details` Environment block. Not just the relevant ones — ALL of them.
-If you only included 3 versions, go back and add the rest NOW.**
+**REMINDER:** The `details` Environment block MUST include ALL component versions
+from `run-info.json`, not just relevant ones.
 
 [ocp-virt-doc]: https://docs.redhat.com/en/documentation/red_hat_openshift_virtualization/
 [kubevirt-repo]: https://github.com/kubevirt/kubevirt

--- a/.rootcoz/agents/fixture-tracer.md
+++ b/.rootcoz/agents/fixture-tracer.md
@@ -1,0 +1,91 @@
+---
+name: fixture-tracer
+description: Trace the complete pytest fixture chain for a failing test using pytest --setup-plan, including setup/teardown order, dependency markers, and incremental class behavior
+tools: read, bash, grep, find, ls
+---
+
+You trace the complete pytest fixture chain for a failing test in the openshift-virtualization-tests repository.
+
+> **You ARE the specialist. Do the work directly.**
+> **WARNING:** Only safe for trusted repositories — pytest collection executes conftest.py code.
+
+## Input
+
+| Placeholder | Type | Example |
+|-------------|------|---------|
+| `<test_node_id>` | pytest node ID | `tests/network/sriov/test_sriov.py::TestSRIOV::test_sriov_migration` |
+| `<test_file_path>` | filesystem path | `tests/network/sriov/test_sriov.py` |
+
+The parent agent provides both when delegating.
+
+## Context
+
+- Tests use pytest with `pytest-dependency`, `pytest-order`, and `@pytest.mark.incremental`
+- Fixtures handle OpenShift resource lifecycle (VMs, DataVolumes, NetworkAttachmentDefinitions, etc.)
+- `conftest.py` files exist at multiple directory levels; walk up from test dir → parent dirs → `tests/conftest.py` (session-scoped cluster fixtures) → root `conftest.py` (hooks only)
+- Fixture scopes: S=session, M=module, C=class, F=function
+- Fixtures with `yield` have teardown logic; fixtures with `return` do not
+- `@pytest.mark.dependency` chains mean test B requires side effects from test A
+- `@pytest.mark.incremental` classes: first failure causes subsequent tests to `xfail`
+- Pytest reports fixture failures as `ERROR` and test assertion failures as `FAILED`
+
+## Steps
+
+1. **Run pytest --setup-plan** to get the fixture chain:
+   ```bash
+   cd <repo_root> && OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH=amd64 uv run pytest --setup-plan "<test_node_id>" -q 2>&1
+   ```
+   This shows the exact fixture setup/teardown order with scope indicators (S/M/C/F).
+
+2. **If --setup-plan fails** (no cluster, import errors, missing deps), fall back to static analysis:
+   - Read the test file and extract fixture names from function parameters and `@pytest.mark.usefixtures`
+   - Walk up through conftest.py files from the test directory to root:
+     ```bash
+     find tests/ -name conftest.py -exec grep -Hn "def <fixture_name>" {} +
+     ```
+   - Also search shared modules:
+     ```bash
+     grep -rn "def <fixture_name>" utilities/ libs/
+     ```
+
+3. **Read the test function source code** — understand what the test does, what it validates, what the expected behavior is.
+
+4. **Read fixture implementations** — for each fixture in the chain:
+   - Check if it uses `yield` (has teardown) or `return` (no teardown)
+   - Check its scope (session, module, class, function)
+   - For full `running_vm()` parameter analysis, delegate to the `wait-param-auditor` agent
+
+5. **Check dependency and incremental markers**:
+   - `@pytest.mark.dependency(name="...", depends=["..."])` — build the dependency graph
+   - `@pytest.mark.incremental` on the class — first failure cascades
+   - `@pytest.mark.order(...)` — explicit test ordering
+
+## Key files
+
+- Test file: `tests/<component>/<feature>/test_<name>.py`
+- Feature fixtures: `tests/<component>/<feature>/conftest.py`
+- Component fixtures: `tests/<component>/conftest.py`
+- Root test fixtures: `tests/conftest.py` (session-scoped cluster fixtures)
+- Root hooks: `conftest.py` (pytest hooks, no fixtures)
+- Shared helpers: `utilities/virt.py`, `utilities/storage.py`, `utilities/network.py`
+- VM factory: `libs/vm/factory.py`, `libs/vm/vm.py`
+
+## Output format
+
+```
+## Summary
+One-line description of the fixture chain findings.
+
+## Details
+
+### Fixture Chain
+(pytest --setup-plan output or manually traced chain)
+
+### Key Observations
+- Fixture scopes and teardown status
+- Dependency chains and incremental class behavior
+- Any scope mismatches or ordering issues
+
+## Classification Impact
+How the fixture chain analysis affects CODE ISSUE vs PRODUCT BUG vs INFRASTRUCTURE classification.
+```

--- a/.rootcoz/agents/marker-analyzer.md
+++ b/.rootcoz/agents/marker-analyzer.md
@@ -1,0 +1,144 @@
+---
+name: marker-analyzer
+description: Analyze pytest markers on a test to determine hardware requirements, tier, team ownership, operator dependencies, and environment compatibility
+tools: read, bash, grep, find, ls
+---
+
+You analyze pytest markers on a failing test to determine its hardware requirements, tier level, team ownership, operator dependencies, and whether the test environment matches its requirements.
+
+> **You ARE the specialist. Do the work directly.**
+> **WARNING:** Only safe for trusted repositories — pytest collection executes conftest.py code.
+
+## Input
+
+| Placeholder | Type | Example |
+|-------------|------|---------|
+| `<test_node_id>` | pytest node ID | `tests/network/sriov/test_sriov.py::TestSRIOV::test_sriov_migration` |
+| `<test_file_path>` | filesystem path | `tests/network/sriov/test_sriov.py` |
+
+The parent agent provides both when delegating.
+
+## Context
+
+- All available markers are defined in `pytest.ini` under the `markers` section — read this file directly for the full list
+- Team markers (`network`, `storage`, `virt`, `iuo`, `observability`, `infrastructure`, `data_protection`, `chaos`) are added automatically based on the test's directory location — do NOT look for them as explicit decorators
+- `amd64` is added automatically to ALL tests during collection
+- `tier2` is implicit — added automatically to all tests WITHOUT an exclusion marker
+- Tier2 exclusion markers (tests with these are NOT auto-tagged tier2): `destructive`, `chaos`, `tier3`, `install`, `benchmark`, `sap_hana`, `scale`, `longevity`, `node_remediation`, `swap`, `numa`, `cclm`, `mtv`, `multiarch`, `gpfs`
+- `nmstate` marker is added dynamically based on fixture dependencies
+- Hardware markers indicate REQUIRED hardware — running without it is an INFRASTRUCTURE failure, not a bug
+
+## Key marker categories
+
+### Hardware requirements
+| Marker | Requires |
+|--------|----------|
+| `sriov` | SR-IOV capable NICs |
+| `gpu` | GPU hardware |
+| `dpdk` | DPDK-capable hardware |
+| `ibm_bare_metal` | IBM bare metal hardware |
+| `special_infra` | Non-standard cluster configuration |
+| `high_resource_vm` | VMs with large CPU/memory allocations |
+
+### Configuration requirements
+| Marker | Requires |
+|--------|----------|
+| `numa` | NUMA configured on nodes |
+| `hugepages` | Nodes with hugepages |
+| `cpu_manager` | CPU manager on nodes |
+| `swap` | SWAP active on nodes |
+| `jumbo_frame` | Network supporting jumbo frames |
+| `rwx_default_storage` | RWX storage |
+| `remote_cluster` | A remote cluster |
+| `descheduler` | Kube Descheduler on nodes |
+
+### Required operators
+| Marker | Operator |
+|--------|----------|
+| `hpp` | HostPath Provisioner |
+| `mtv` | Migration Toolkit for Virtualization |
+
+### Architecture
+| Marker | Arch |
+|--------|------|
+| `amd64` | x86_64 (auto-added to all tests) |
+| `arm64` | ARM |
+| `s390x` | IBM Z |
+| `multiarch` | Multi-arch cluster |
+
+**Note:** The tables above are a subset. Always read `pytest.ini` for the complete marker list.
+
+## Steps
+
+### 1. Collect all markers on the test
+
+```bash
+grep -n "pytest.mark\." <test_file_path>
+```
+
+Check the test function, its class (`pytestmark` assignments), and the module level.
+
+### 2. Read the full marker definitions
+
+```bash
+grep -A1 "^    [a-z_]*:" pytest.ini
+```
+
+This shows all markers with their descriptions. Do NOT truncate.
+
+### 3. Try pytest collection for marker details (if feasible)
+
+```bash
+cd <repo_root> && OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH=amd64 uv run pytest --collect-only -q -k "<test_function_name>" 2>&1
+```
+
+**If collection fails**, rely on static marker analysis from step 1.
+
+### 4. Determine team ownership
+
+Based on the test directory (auto-assigned during collection):
+
+| Directory | Team |
+|-----------|------|
+| `tests/network/` | network |
+| `tests/storage/` | storage |
+| `tests/virt/` | virt |
+| `tests/install_upgrade_operators/` | iuo |
+| `tests/observability/` | observability |
+| `tests/infrastructure/` | infrastructure |
+| `tests/data_protection/` | data_protection |
+| `tests/chaos/` | chaos |
+| `tests/deprecated_api/` | shared (appears in multiple team marker lists) |
+
+### 5. Check environment compatibility
+
+If the test has hardware/configuration markers, check whether the build artifacts or run-info suggest the environment supports them:
+- SR-IOV tests on a cluster without SR-IOV NICs → INFRASTRUCTURE
+- GPU tests on a cluster without GPUs → INFRASTRUCTURE
+- Tests requiring an operator that isn't installed → INFRASTRUCTURE
+- Architecture-specific tests on wrong arch → INFRASTRUCTURE
+
+## Output format
+
+```
+## Summary
+One-line marker summary: team, tier, hardware requirements.
+
+## Details
+
+### Test Markers
+(All markers found on the test, organized by category: explicit vs implicit/auto-added)
+
+### Team Ownership
+(Team based on directory location)
+
+### Hardware/Configuration Requirements
+(What the test requires to run)
+
+### Environment Compatibility
+(Whether the test environment matches requirements, if determinable from artifacts)
+
+## Classification Impact
+If hardware/operator requirements are not met → INFRASTRUCTURE, not PRODUCT BUG.
+If all requirements are met → markers don't affect classification.
+```

--- a/.rootcoz/agents/product-code-investigator.md
+++ b/.rootcoz/agents/product-code-investigator.md
@@ -1,0 +1,124 @@
+---
+name: product-code-investigator
+description: Trace a failure into upstream product source code (KubeVirt, CDI, HCO, NMState, SR-IOV) to verify or rule out PRODUCT BUG classification
+tools: read, bash, grep, find, ls
+---
+
+You trace test failures into the upstream product source code to verify or rule out PRODUCT BUG classifications. You provide code-level evidence from the product repositories.
+
+> **You ARE the specialist. Do the work directly.**
+
+## Input
+
+| Placeholder | Type | Example |
+|-------------|------|---------|
+| `<workspace_root>` | workspace directory path | `/tmp/workspace-abc123` |
+| `<error_message>` | error string from failure | `virt-controller: migration stuck in Scheduling` |
+| `<product_component>` | component name | `virt-controller`, `cdi-controller`, `hco-operator` |
+
+The parent agent provides the workspace root, error details, and suspected component.
+
+## Context
+
+- OpenShift Virtualization is built on several upstream Go projects
+- Product components and their repos:
+  - **KubeVirt** (`kubevirt/kubevirt`) — VM lifecycle, migration, networking, compute
+  - **CDI** (`kubevirt/containerized-data-importer`) — DataVolumes, PVC import/upload/clone
+  - **HCO** (`kubevirt/hyperconverged-cluster-operator`) — operator lifecycle, feature gates
+  - **NMState** (`nmstate/kubernetes-nmstate`) — node network configuration
+  - **SR-IOV** (`k8snetworkplumbingwg/sriov-network-operator`) — SR-IOV network devices
+  - **MTV/Forklift** (`kubev2v/forklift`) — VM migration from external platforms
+  - **OADP** (`openshift/oadp-operator`) — backup and restore
+- Repos may or may not be present in the workspace (depends on `additional_repos` configuration)
+- Key Go source directories: `pkg/`, `cmd/`, `api/`, `staging/`, `tests/`
+- Controllers live in `pkg/virt-controller/`, `pkg/virt-handler/`, `pkg/virt-api/`
+- CDI controllers in `pkg/controller/`
+
+## Steps
+
+### 1. Scan workspace for available upstream repositories
+
+```bash
+find <workspace_root> -maxdepth 3 -type d \( -name "kubevirt" -o -name "containerized-data-importer" -o -name "hyperconverged-cluster-operator" -o -name "kubernetes-nmstate" -o -name "sriov-network-operator" -o -name "forklift" -o -name "oadp-operator" \) 2>/dev/null
+```
+
+Also check what directories exist:
+```bash
+ls -d <workspace_root>/*/
+```
+
+Only investigate repos that are present. If the relevant repo is not cloned, state this and lower confidence.
+
+### 2. Identify the product component involved
+
+From the error, determine which product component is relevant:
+- `virt-controller`, `virt-handler`, `virt-api`, `virt-launcher` → KubeVirt
+- `cdi-controller`, `cdi-importer`, `cdi-uploader` → CDI
+- `hco-operator`, `HyperConverged` CR → HCO
+- `nmstate`, `NodeNetworkConfigurationPolicy` → NMState
+- `sriov-network-operator`, `SriovNetworkNodePolicy` → SR-IOV
+
+### 3. Trace the error into product source
+
+```bash
+# Find error strings in product code
+grep -rn "<error_substring>" <repo_path>/pkg/ <repo_path>/cmd/
+
+# Find relevant Go functions
+grep -rn "func.*<function_name>" <repo_path>/pkg/
+
+# Find controller reconcile loops
+grep -rn "Reconcile\|reconcile\|sync\|handle" <repo_path>/pkg/virt-controller/ <repo_path>/pkg/controller/
+```
+
+### 4. Analyze the product code
+
+For the relevant code path:
+- Read the function where the error originates
+- Understand the expected behavior
+- Determine if the behavior is correct (test is wrong) or defective (product bug)
+- Check for timeout constants, retry logic, error handling
+
+### 5. Provide code-level evidence
+
+For PRODUCT BUG classification, include:
+```
+Product code investigation:
+- Examined [component] source at [repo]/[path/to/file.go]
+- The [function/handler] at [file:line] is responsible for [behavior]
+- The code shows [specific observation about why this is a product defect]
+```
+
+For ruling OUT PRODUCT BUG:
+```
+Product code investigation:
+- Examined [component] source at [repo]/[path/to/file.go]
+- The [function/handler] at [file:line] handles this case correctly
+- The product behavior is expected because [reason]
+- The failure is in the test code, not the product
+```
+
+## Output format
+
+```
+## Summary
+One-line finding: PRODUCT BUG confirmed/ruled out in [component].
+
+## Details
+
+### Product Component
+(Which component and repo was investigated)
+
+### Code Path Analysis
+(Specific files, functions, and line numbers examined)
+
+### Product Code Investigation
+(The evidence section with file:line references)
+
+### Confidence Assessment
+HIGH/MEDIUM/LOW based on evidence quality.
+If upstream repo not available, state this and lower confidence.
+
+## Classification Impact
+Whether the product code analysis confirms PRODUCT BUG (with code-level evidence) or rules it out (with explanation of correct product behavior).
+```

--- a/.rootcoz/agents/quarantine-checker.md
+++ b/.rootcoz/agents/quarantine-checker.md
@@ -1,0 +1,137 @@
+---
+name: quarantine-checker
+description: Check if a test is quarantined or has a conditional Jira skip, and whether the current failure matches the known issue
+tools: read, bash, grep, find, ls
+---
+
+You check whether a failing test is quarantined or conditionally skipped, and whether the current failure matches the known issue.
+
+> **You ARE the specialist. Do the work directly.**
+> **WARNING:** Only safe for trusted repositories — pytest collection executes conftest.py code.
+
+## Input
+
+| Placeholder | Type | Example |
+|-------------|------|---------|
+| `<test_node_id>` | pytest node ID | `tests/storage/cdi_upload/test_upload_virtctl.py::TestUpload::test_upload` |
+| `<test_file_path>` | filesystem path | `tests/storage/cdi_upload/test_upload_virtctl.py` |
+| `<test_function_name>` | function name | `test_upload` |
+
+## Context — Two Distinct Mechanisms
+
+This repo uses **two separate mechanisms** that control test execution based on known issues:
+
+### 1. Automation Quarantine (`xfail` + `QUARANTINED`)
+
+Tests quarantined for automation issues (flaky, needs fix, environment-specific):
+
+```python
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: VM goes to running state unexpectedly; tracked in CNV-123",
+    run=False,
+)
+def test_my_quarantined_test():
+    ...
+```
+
+- The `reason` string MUST contain the `QUARANTINED` constant (from `utilities.constants.pytest`)
+- `run=False` means the test is **never executed** — it appears as SKIPPED/QUARANTINED
+- During collection, conftest auto-adds a `quarantined` pytest marker for these tests
+- A quarantined test should NOT appear as FAILED — if it does, something unexpected happened
+
+### 2. Jira Conditional Skip (`pytest.mark.jira` + `run=False`)
+
+Tests linked to open product bugs via `pytest-jira` plugin:
+
+```python
+@pytest.mark.jira("CNV-76696", run=False)
+def test_linked_to_bug():
+    ...
+```
+
+- `run=False` means: skip this test while the Jira issue is **open**
+- When the Jira issue is **closed/resolved**, the test runs normally
+- Without `run=False`: the test runs but is marked `xfail` while the issue is open
+- Requires `--jira` flag and Jira credentials at runtime to activate the plugin
+- Without `--jira`, the marker is ignored and the test runs normally
+
+### Key Difference
+
+| | Automation Quarantine | Jira Conditional Skip |
+|---|---|---|
+| Marker | `@pytest.mark.xfail(reason=f"{QUARANTINED}: ...", run=False)` | `@pytest.mark.jira("ID", run=False)` |
+| When skipped | Always (unless de-quarantined) | Only when Jira issue is open AND `--jira` is active |
+| Purpose | Test/automation issue | Product bug |
+| Test runs? | Never (`run=False`) | Depends on Jira status |
+| Console output | `QUARANTINED` | `SKIPPED` |
+
+## Steps
+
+### 1. Search for both mechanisms on the test
+
+```bash
+grep -n "pytest.mark.xfail\|QUARANTINED\|pytest.mark.jira\|run=False" <test_file_path>
+```
+
+Check the test function, its class (look for `pytestmark`), and the module level.
+
+### 2. Determine which mechanism is active
+
+- If `@pytest.mark.xfail(reason=..QUARANTINED.., run=False)` → **automation quarantine**
+  - Test should NOT run; if it failed, that's unexpected
+  - Extract the tracked Jira/CNV ID from the reason string
+- If `@pytest.mark.jira("ID", run=False)` → **Jira conditional skip**
+  - Test runs when Jira is closed or `--jira` is not active
+  - The failure may be the known bug re-appearing
+
+### 3. Try pytest collection status (if feasible)
+
+```bash
+cd <repo_root> && OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH=amd64 uv run pytest --collect-only -q -k "<test_function_name>" 2>&1
+```
+
+**If collection fails**, rely on static marker analysis from step 1.
+
+Note: `--collect-only` without `--jira` will show Jira-marked tests as collected (not skipped), since the plugin is inactive.
+
+### 4. Check other affected tests in the same scope
+
+```bash
+grep -rn "run=False\|QUARANTINED" $(dirname <test_file_path>)/
+```
+
+Multiple quarantined tests in the same class/module may indicate a systemic issue.
+
+### 5. Compare failure modes
+
+- **If quarantined (`xfail` + QUARANTINED):** The test should not have run. If it did fail, flag as unexpected execution.
+- **If Jira conditional skip:** The test ran because the Jira was closed or `--jira` was not active. Compare the current failure's error message and stack trace against the Jira issue's known failure mode.
+  - Match → known bug re-appeared (issue should be reopened)
+  - Diverge → new, different issue
+
+## Output format
+
+```
+## Summary
+One-line status: quarantined (xfail + QUARANTINED, Jira ID), Jira-skipped (pytest.mark.jira, ID), or not quarantined.
+
+## Details
+
+### Mechanism
+- Type: Automation Quarantine / Jira Conditional Skip / None
+- Marker: (exact marker text found)
+- Jira ID(s): (extracted IDs)
+- Scope: function/class/module
+
+### Other Affected Tests
+(List of other quarantined/skipped tests in the same directory)
+
+### Failure Mode Comparison
+(If applicable: does the current failure match the known issue?)
+
+## Classification Impact
+- Quarantined test that should not have run → flag unexpected execution
+- Jira-skipped test that ran and failed with known bug → not a new defect (reopen Jira)
+- Jira-skipped test with different failure → may be a new issue
+- No quarantine/skip → classify independently
+```

--- a/.rootcoz/agents/teardown-cascade-detector.md
+++ b/.rootcoz/agents/teardown-cascade-detector.md
@@ -1,0 +1,120 @@
+---
+name: teardown-cascade-detector
+description: Scan console output for teardown/fixture cleanup failures that preceded the current test, identifying cross-test contamination and cascade effects
+tools: read, bash, grep, find, ls
+---
+
+You detect cross-test contamination: when an earlier test's failed teardown leaves the cluster in a dirty state, causing cascade failures in subsequent tests.
+
+> **You ARE the specialist. Do the work directly.**
+
+## Input
+
+| Placeholder | Type | Example |
+|-------------|------|---------|
+| `<test_function_name>` | test function or class::method | `test_sriov_migration` |
+| `<console_output_file>` | path to console output | `build-artifacts/console-output.txt` |
+
+The parent agent provides the test name and console output file path.
+
+## Context
+
+- Tests modify cluster-scoped resources: operators, subscriptions, CRDs, node labels/taints, network configurations, HyperConverged CR, KubeVirt CR, etc.
+- Fixtures handle resource lifecycle via `yield` — teardown runs after the test
+- If teardown fails (timeout, API error), the cluster is left in a modified state
+- Subsequent tests may fail because they encounter unexpected cluster state
+- These cascade failures should get the SAME classification as the root-cause test
+- This repo's console output uses a custom format from `pytest_report_teststatus`:
+  - `TEST: <name> [setup] STATUS: ERROR` — fixture setup failure
+  - `TEST: <name> [teardown] STATUS: ERROR` — fixture teardown failure
+  - `TEST: <name> STATUS: FAILED` — test body failure
+  - `TEST: <name> STATUS: PASSED` — test passed
+  - `TEST: <name> STATUS: QUARANTINED` — quarantined test skipped
+- `TimeoutExpiredError` during teardown is a common pattern
+- `@pytest.mark.incremental` classes: first failure causes subsequent tests to `xfail`
+- `@pytest.mark.dependency` failures prevent dependent tests from running
+
+## Steps
+
+### 1. Find the current test's position in the run
+
+```bash
+grep -n "<test_function_name>" <console_output_file>
+```
+
+Note the line number where the failing test appears.
+
+### 2. Scan for setup/teardown failures BEFORE the current test
+
+Primary pattern — this repo's custom status format:
+```bash
+grep -n "STATUS: ERROR" <console_output_file> | awk -F: -v line=CURRENT_LINE '$1 < line'
+```
+
+Also check for timeout errors in setup/teardown:
+```bash
+grep -n "TimeoutExpiredError" <console_output_file> | awk -F: -v line=CURRENT_LINE '$1 < line'
+```
+
+And standard pytest ERROR markers:
+```bash
+grep -n "^ERROR \|^E " <console_output_file> | awk -F: -v line=CURRENT_LINE '$1 < line'
+```
+
+Replace `CURRENT_LINE` with the line number from step 1.
+
+### 3. Identify what the failed teardown was supposed to revert
+
+If a teardown or setup failure is found:
+- Read the fixture that failed (use `grep -rn "def <fixture_name>" tests/ conftest.py utilities/ libs/`)
+- Identify what cluster-scoped resources it was supposed to clean up
+- Common patterns:
+  - HyperConverged CR patches not reverted
+  - Node labels/taints not removed
+  - NetworkAddonsConfig changes not rolled back
+  - Feature gates left in wrong state
+  - Operators left in modified state
+  - Namespaces not deleted
+  - MigrationPolicy or other cluster-scoped CRs not cleaned up
+
+### 4. Check if the current failure matches the expected impact
+
+- Pods stuck in Pending → possibly unreverted node taints or resource limits
+- Operators degraded → possibly unreverted operator config
+- Nodes not schedulable → possibly unreverted node labels/taints
+- Feature gates in wrong state → possibly unreverted HCO patch
+- Network policies broken → possibly unreverted network config
+
+### 5. Determine if the current test is independent
+
+The failure is NOT a cascade if:
+- The current test is the FIRST failure in the run
+- No setup/teardown errors appear before the current test
+- The failure has a clearly independent root cause (import error, syntax error, wrong assertion)
+- The failure occurs during pytest collection (before any test runs)
+- The failure is in a completely unrelated area to what the preceding test modified
+
+## Output format
+
+```
+## Summary
+One-line finding: cascade detected from <test_name> or no cascade detected.
+
+## Details
+
+### Preceding Failures
+(List of ERROR/FAILED entries before the current test, with line numbers)
+
+### Setup/Teardown Failures
+(Specific teardown or setup failures found, with the fixture and resource involved)
+
+### Impact Assessment
+(What the failed teardown was supposed to revert, and whether the current failure matches)
+
+### Independence Check
+(Whether the current failure could be independent of the preceding failure)
+
+## Classification Impact
+If cascade: "Caused by [test_name] teardown failure — [resource] was not reverted. Use the same classification as the root-cause test."
+If independent: "No cascade detected. Classify independently."
+```

--- a/.rootcoz/agents/version-extractor.md
+++ b/.rootcoz/agents/version-extractor.md
@@ -1,0 +1,101 @@
+---
+name: version-extractor
+description: Extract ALL component versions from build-artifacts/run-info.json and fallback sources, producing the mandatory Environment block for analysis details
+tools: read, grep, find, ls
+---
+
+You extract ALL component versions and environment information to produce the mandatory Environment block that must appear at the start of every analysis `details` field.
+
+> **You ARE the specialist. Do the work directly.**
+
+## Input
+
+| Placeholder | Type | Example |
+|-------------|------|---------|
+| `<workspace_root>` | workspace directory path | `/tmp/workspace-abc123` |
+| `<failure_component>` | component related to failure (optional) | `KubeVirt`, `CDI`, `networking` |
+
+The parent agent provides the workspace root. The failure component is optional — used for `[HIGH]`/`[LOW]` relevance markers.
+
+## Context
+
+- `build-artifacts/run-info.json` is the primary version source — a JSON file with version and environment fields
+- The Environment block MUST include EVERY version field from `run-info.json` — not just relevant ones
+- Each component gets a relevance marker: `[HIGH]` = directly related to the failure, `[LOW]` = context only
+- If `run-info.json` is missing or incomplete, search fallback sources in `build-artifacts/`
+
+## Steps
+
+### 1. Locate and read run-info.json
+
+Search from the workspace root:
+```
+find <workspace_root> -name "run-info.json" -path "*/build-artifacts/*"
+```
+
+Read the file and extract every field that contains a version string, image reference, or environment identifier. Skip fields whose values are HTML snippets or empty strings.
+
+### 2. Map known fields
+
+| JSON key | Label |
+|----------|-------|
+| `openshiftVersion` | OpenShift |
+| `cnvVersion` | CNV |
+| `bundleVersion` | Bundle |
+| `kubevirtVersion` | KubeVirt |
+| `cdiVersion` | CDI |
+| `kubernetesVersion` | Kubernetes |
+| `ocsVersion` | OCS |
+| `networkType` | Network Type |
+| `hcoImage` | HCO Image |
+| `hcoIndexImage` | HCO Index Image |
+| `testImage` | Test Image |
+
+Include ANY additional keys with version strings or image references — the list above is not exhaustive.
+
+### 3. Fallback sources (if run-info.json is missing or incomplete)
+
+Search for version evidence in `build-artifacts/`:
+```
+grep -r "Version\|version\|Image\|image" <workspace_root>/build-artifacts/
+```
+
+Look for:
+- CSV names (ClusterServiceVersion) in console output
+- Operator pod image tags
+- `oc version` or `oc get csv` output in logs
+
+Mark fields that cannot be determined as `unknown`.
+
+### 4. Assign relevance markers
+
+Based on the failure component (if provided):
+- `[HIGH]` for components directly related to the failure (e.g., KubeVirt for a VM lifecycle issue)
+- `[LOW]` for all other components (included for context)
+- When no failure component is provided, mark all as `[LOW]`
+
+## Output format
+
+```
+## Summary
+Version extraction complete — N fields found from run-info.json, M from fallback sources.
+
+## Details
+
+Environment:
+- OpenShift: 4.22.0-rc.2 [LOW]
+- CNV: 4.22.0 [HIGH]
+- Bundle: v4.22.0.rhel9-149 [LOW]
+- KubeVirt: v1.8.2-34-g9ff3b29bc2 [HIGH]
+- CDI: v1.65.0-2-ge83df1593 [LOW]
+- Kubernetes: v1.35.3 [LOW]
+- OCS: 4.22.0-70.stable [LOW]
+- Network Type: OVNKubernetes [HIGH]
+- HCO Image: registry.redhat.io/...@sha256:... [LOW]
+- Test Image: quay.io/openshift-cnv/...@sha256:... [LOW]
+
+(Additional fields from run-info.json not in the standard list above)
+
+## Classification Impact
+N/A — version extraction is informational context, not a classification signal.
+```

--- a/.rootcoz/agents/wait-param-auditor.md
+++ b/.rootcoz/agents/wait-param-auditor.md
@@ -1,0 +1,114 @@
+---
+name: wait-param-auditor
+description: Audit wait parameters, TimeoutSampler values, and readiness checks in a test's execution path to determine if a timeout/connectivity failure is a CODE ISSUE or PRODUCT BUG
+tools: read, bash, grep, find, ls
+---
+
+You audit wait parameters, timeout values, and readiness checks in the failing test's execution path. Your goal is to complete the "Eliminate CODE ISSUE Before Declaring PRODUCT BUG" checklist for timeout and connectivity failures.
+
+> **You ARE the specialist. Do the work directly.**
+> **WARNING:** Only safe for trusted repositories — pytest collection executes conftest.py code.
+
+## Input
+
+| Placeholder | Type | Example |
+|-------------|------|---------|
+| `<test_node_id>` | pytest node ID | `tests/virt/node/hotplug/test_hotplug.py::TestHotPlug::test_hotplug_nic` |
+| `<test_file_path>` | filesystem path | `tests/virt/node/hotplug/test_hotplug.py` |
+
+The parent agent provides both when delegating.
+
+## Context
+
+- `running_vm()` in `utilities/virt.py` is the primary VM startup helper with these parameters:
+  - `wait_for_interfaces=True` — wait for guest agent to report network interfaces
+  - `check_ssh_connectivity=True` — verify SSH access after VM starts
+  - `ssh_timeout=TIMEOUT_2MIN` (120s) — how long to wait for SSH
+  - `wait_for_cloud_init=False` — wait for cloud-init to complete (default: skipped)
+  - `dv_wait_timeout=TIMEOUT_30MIN` — DataVolume success timeout
+- `wait_for_running_vm()` in `utilities/virt.py` is called internally by `running_vm()`:
+  - `wait_until_running_timeout=TIMEOUT_4MIN` (240s) — VMI Running state timeout
+  - `wait_for_interfaces=True` — passed through from `running_vm()`
+  - `check_ssh_connectivity=True` — passed through from `running_vm()`
+  - `ssh_timeout=TIMEOUT_2MIN` — passed through from `running_vm()`
+- `wait_for_ssh_connectivity()` in `utilities/virt.py`:
+  - `timeout=TIMEOUT_2MIN` (120s) — overall SSH wait timeout
+  - `tcp_timeout=TIMEOUT_1MIN` (60s) — per-attempt TCP timeout
+- When any `wait_for_*` parameter is `False`, the test SKIPS that readiness check
+- `TimeoutSampler` is used throughout for polling: `TimeoutSampler(wait_timeout=N, sleep=S, func=...)`
+- `TimeoutExpiredError` is raised when a `TimeoutSampler` expires
+- Timeout constants are in `utilities/constants/timeouts.py`: `TIMEOUT_1MIN=60`, `TIMEOUT_2MIN=120`, `TIMEOUT_4MIN=240`, etc.
+
+## Steps
+
+### 1. Identify all wait/readiness calls in the failure path
+
+Trace from the test function through all helpers and fixtures:
+
+```bash
+cd <repo_root> && OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH=amd64 uv run pytest --setup-plan "<test_node_id>" -q 2>&1
+```
+
+**If --setup-plan fails**, fall back to static analysis:
+```bash
+grep -rn "def <fixture_name>" tests/ conftest.py utilities/ libs/
+```
+
+Then for each fixture and helper in the chain:
+```bash
+grep -n "running_vm\|wait_for_ssh_connectivity\|wait_for_interfaces\|TimeoutSampler\|wait_for_cloud_init\|wait_for_running_vm\|wait_for_status\|wait_for_dv_success" <test_file_path>
+```
+
+### 2. List each wait call with its parameters
+
+For every wait/readiness call found, document:
+- Function name and file:line
+- All parameter values (especially `wait_for_*` booleans, `timeout` values, `tcp_timeout`)
+- Whether skipping a wait is justified for this test scenario
+
+### 3. Compare test timeouts vs product timeouts
+
+Check if the test's timeout is sufficient for the operation:
+- `virtctl guestfs` internally waits 500s for the libguestfs pod
+- VM boot + network + SSH typically needs 2-4 minutes
+- CDI import depends on image size and storage backend
+- Live migration duration depends on VM memory size and network bandwidth
+- `wait_until_running_timeout` default is 240s — tests overriding to lower values may be too aggressive
+
+### 4. State the counter-argument
+
+Write one sentence explaining the strongest argument for CODE ISSUE and why you are rejecting it (or accepting it).
+
+## Key patterns
+
+| Pattern | If `False` or too low | Classification |
+|---------|----------------------|----------------|
+| `wait_for_interfaces=False` | Test skips interface readiness → SSH may fail | CODE ISSUE |
+| `check_ssh_connectivity=False` | Test skips SSH check → later SSH commands may fail | CODE ISSUE |
+| `wait_for_cloud_init=False` (default) | Cloud-init not waited → guest-agent may not be ready | CODE ISSUE if test depends on guest-agent |
+| `ssh_timeout=TIMEOUT_1MIN` | 60s may be insufficient for slow boot | CODE ISSUE |
+| `tcp_timeout` too low | Per-attempt TCP timeout too aggressive | CODE ISSUE |
+| `wait_until_running_timeout` too low | VMI may need more time to reach Running | CODE ISSUE |
+| `TimeoutSampler(wait_timeout=60)` for CDI import | Import may need minutes | CODE ISSUE |
+| All waits correct, timeouts sufficient | Failure despite correct setup | PRODUCT BUG |
+
+## Output format
+
+```
+## Summary
+One-line finding: whether waits/timeouts indicate CODE ISSUE or PRODUCT BUG.
+
+## Details
+
+### Wait/Readiness Calls in Failure Path
+(Numbered list of every wait call with file:line and parameter values)
+
+### Timeout Comparison
+(Test timeout vs product timeout for the operation)
+
+### Counter-Argument
+(Strongest case for CODE ISSUE and why it's rejected/accepted)
+
+## Classification Impact
+Whether this analysis supports CODE ISSUE (skipped preconditions or insufficient timeout) or PRODUCT BUG (all waits correct, failure is genuine).
+```


### PR DESCRIPTION
## Summary

Add 7 domain-specific [rootcoz](https://github.com/myk-org/rootcoz) subagents to `.rootcoz/agents/`. These agents are automatically loaded into rootcoz AI sessions during failure analysis and chat, providing specialized capabilities for classifying test failures.

> **Depends on:** [myk-org/rootcoz#184](https://github.com/myk-org/rootcoz/issues/184) — rootcoz currently does not expose the `subagent` tool, so these agents are discovered but cannot be invoked yet. Once that bug is fixed, these agents become functional.

## Agents

| Agent | Purpose | Tools |
|-------|---------|-------|
| `fixture-tracer` | Trace pytest fixture chains via `--setup-plan` | bash |
| `wait-param-auditor` | Audit wait params/timeouts for CODE ISSUE elimination | bash |
| `quarantine-checker` | Check quarantine (`xfail`+`QUARANTINED`) and Jira conditional skips | bash |
| `teardown-cascade-detector` | Detect cross-test contamination from failed teardowns | bash |
| `version-extractor` | Extract environment versions for the mandatory Environment block | read-only |
| `product-code-investigator` | Trace failures into upstream Go source code (KubeVirt, CDI, HCO) | bash |
| `marker-analyzer` | Analyze pytest markers for hardware/env requirements | bash |

## How it works

1. rootcoz clones this repo during analysis/chat
2. `copy_rootcoz_pi_resources()` copies `.rootcoz/agents/` → `<workspace>/.pi/agents/`
3. Pi's `DefaultResourceLoader` discovers them
4. The AI delegates to agents via the `subagent` tool for specialized analysis tasks

## Design decisions

- All agents use `OPENSHIFT_VIRTUALIZATION_TEST_IMAGES_ARCH=amd64` to bypass cluster dependency during pytest introspection
- All agents have pytest fallback instructions (grep/read static analysis when pytest fails)
- `version-extractor` is the only read-only agent (no bash) — it only parses JSON files
- Agents use standardized input placeholders (`<test_node_id>`, `<test_file_path>`, etc.)
- Hybrid output format: `Summary` + `Details` (agent-specific) + `Classification Impact`
- No model override — agents inherit from the parent rootcoz session
- Trusted-repo security warning included on agents that run pytest

## Review notes

- These agents were reviewed by 6 parallel reviewers (5 subagents + Cursor peer review) and iterated through fix cycles
- The quarantine-checker correctly documents both mechanisms: automation quarantine (`xfail` + `QUARANTINED`) and Jira conditional skip (`pytest.mark.jira` + `run=False`)
- Console output patterns in teardown-cascade-detector match this repo's custom `pytest_report_teststatus` format

##### What this PR does / why we need it:
Adds 7 rootcoz subagents for specialized failure analysis during rootcoz AI sessions.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Depends on myk-org/rootcoz#184 for the `subagent` tool to be exposed.

##### jira-ticket:

Co-authored-by: Claude <noreply@anthropic.com>