### PR TITLE
Manual cherry-pick to 4.22: SR-IOV memory hotplug (#5349)

### DIFF
--- a/libs/vm/oper.py
+++ b/libs/vm/oper.py
@@ -2,9 +2,29 @@ import logging
 
 from kubernetes.client import ApiException
 
+from libs.net.vmspec import wait_for_ifaces_status
 from libs.vm.vm import BaseVirtualMachine
 
 LOGGER = logging.getLogger(__name__)
+
+
+def run_vm(
+    vm: BaseVirtualMachine,
+    ip_addresses_by_spec_net_name: dict[str, list[str]],
+) -> BaseVirtualMachine:
+    """Start a VM, wait for agent connection, and verify interface IP addresses.
+
+    Args:
+        vm: The virtual machine to start.
+        ip_addresses_by_spec_net_name: Mapping of spec network name to expected IP addresses.
+
+    Returns:
+        The same VM, running with all interfaces reporting expected IPs.
+    """
+    vm.start(wait=True)
+    vm.wait_for_agent_connected()
+    wait_for_ifaces_status(vm=vm, ip_addresses_by_spec_net_name=ip_addresses_by_spec_net_name)
+    return vm
 
 
 def run_vms(vms: tuple[BaseVirtualMachine, ...]) -> tuple[BaseVirtualMachine, ...]:

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -49,6 +49,7 @@ class CPU:
 @dataclass
 class Memory:
     guest: str
+    maxGuest: str | None = None  # noqa: N815
 
 
 @dataclass

--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -17,6 +17,7 @@ from libs.vm.spec import (
     ContainerDisk,
     Devices,
     Disk,
+    Memory,
     Metadata,
     Network,
     SpecDisk,
@@ -128,6 +129,22 @@ class BaseVirtualMachine(VirtualMachine):
         self._spec.template.spec.networks = networks
         serialized = [asdict(obj=net, dict_factory=self._filter_out_none_values) for net in networks]
         ResourceEditor(patches={self: {"spec": {"template": {"spec": {"networks": serialized}}}}}).update()
+
+    def set_guest_memory(self, memory_guest: str) -> None:
+        """Set the guest memory and update the VM spec on the cluster.
+
+        On a running VM this triggers an automatic live migration.
+
+        Args:
+            memory_guest: New guest memory value (e.g. "5Gi").
+        """
+        if self._spec.template.spec.domain.memory:
+            self._spec.template.spec.domain.memory.guest = memory_guest
+        else:
+            self._spec.template.spec.domain.memory = Memory(guest=memory_guest)
+        ResourceEditor(
+            patches={self: {"spec": {"template": {"spec": {"domain": {"memory": {"guest": memory_guest}}}}}}}
+        ).update()
 
     def set_template_affinity(self, affinity: Affinity | None) -> None:
         """Replace the VM template affinity.

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -1,7 +1,14 @@
 """SR-IOV library constants and utilities."""
 
+from kubernetes.dynamic import DynamicClient
+
 from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from libs.net.ip import random_ipv4_address, random_ipv6_address
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import CloudInitNoCloud, Interface, Memory, Multus, Network
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import MatchSelector
 from utilities.constants import SRIOV
 from utilities.infra import get_node_selector_dict
 from utilities.network import compose_cloud_init_data_dict, sriov_network_dict
@@ -9,6 +16,60 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 VM_SRIOV_IFACE_NAME = "sriov1"
 MTU_9000 = 9000
+
+
+def base_sriov_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    sriov_network_name: str,
+    sriov_mac: str,
+    addresses: list[str],
+    memory_guest: str = "1Gi",
+    memory_max_guest: str | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with an SR-IOV secondary interface using BaseVirtualMachine.
+
+    The SR-IOV VF is matched by MAC address and renamed to sriov1 via
+    cloud-init set-name.
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name prefix (a unique suffix is appended automatically).
+        client: Kubernetes dynamic client.
+        sriov_network_name: Name of the SR-IOV NetworkAttachmentDefinition.
+        sriov_mac: MAC address to assign to the SR-IOV interface.
+        addresses: CIDR addresses to assign to the SR-IOV interface
+            (e.g. ["172.16.0.1/24", "fd00::1/64"]).
+        memory_guest: Initial guest memory (e.g. "1Gi"). Defaults to "1Gi".
+        memory_max_guest: Maximum guest memory for hot-plug. None disables hot-plug.
+
+    Returns:
+        BaseVirtualMachine configured with an SR-IOV secondary interface.
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.memory = Memory(guest=memory_guest, maxGuest=memory_max_guest)
+    spec.template.spec.domain.devices.interfaces = [  # type: ignore[union-attr]
+        Interface(name=sriov_network_name, sriov={}, macAddress=sriov_mac),
+    ]
+    spec.template.spec.networks = [
+        Network(name=sriov_network_name, multus=Multus(networkName=f"{namespace}/{sriov_network_name}")),
+    ]
+
+    ethernets: dict[str, cloudinit.EthernetDevice] = {}
+    ethernets["sriov"] = cloudinit.EthernetDevice(
+        addresses=addresses,
+        match=MatchSelector(macaddress=sriov_mac),
+        set_name=VM_SRIOV_IFACE_NAME,
+    )
+    disk, volume = cloudinitdisk_storage(
+        data=CloudInitNoCloud(
+            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)),
+            userData=cloudinit.format_cloud_config(userdata=cloudinit.UserData(users=[])),
+        )
+    )
+    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
 
 
 def vm_sriov_mac(mac_suffix_index):

--- a/tests/network/sriov/memory_hotplug/conftest.py
+++ b/tests/network/sriov/memory_hotplug/conftest.py
@@ -1,0 +1,78 @@
+import ipaddress
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from libs.net.ip import random_cidr_addresses_by_family
+from libs.vm.oper import run_vm
+from tests.network.sriov.libsriov import base_sriov_vm, vm_sriov_mac
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.namespace import Namespace
+    from ocp_resources.sriov_network import SriovNetwork
+
+    from libs.vm.vm import BaseVirtualMachine
+
+_NET_SEED: Final[int] = 0
+_HOTPLUG_VM_HOST_ADDRESS: Final[int] = 10
+_REF_VM_HOST_ADDRESS: Final[int] = 11
+_INITIAL_MEMORY: Final[str] = "1Gi"
+_MAX_GUEST_MEMORY: Final[str] = "4Gi"
+_SRIOV_CLOUD_INIT_PROFILE: Final[str] = "sriov"
+
+
+@pytest.fixture(scope="class")
+def sriov_vm_with_max_guest(
+    index_number: Generator[int],
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    sriov_network: SriovNetwork,
+) -> Generator[BaseVirtualMachine]:
+    sriov_iface_addresses = random_cidr_addresses_by_family(net_seed=_NET_SEED, host_address=_HOTPLUG_VM_HOST_ADDRESS)
+    with base_sriov_vm(
+        namespace=namespace.name,
+        name="sriov-memory-hotplug-vm",
+        client=unprivileged_client,
+        sriov_network_name=sriov_network.name,
+        sriov_mac=vm_sriov_mac(mac_suffix_index=next(index_number)),
+        addresses=sriov_iface_addresses,
+        memory_guest=_INITIAL_MEMORY,
+        memory_max_guest=_MAX_GUEST_MEMORY,
+    ) as vm:
+        addresses = vm.cloud_init_network_data.ethernets[_SRIOV_CLOUD_INIT_PROFILE].addresses or []
+        run_vm(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                sriov_network.name: [str(ipaddress.ip_interface(addr).ip) for addr in addresses]
+            },
+        )
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def sriov_ref_vm(
+    index_number: Generator[int],
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    sriov_network: SriovNetwork,
+) -> Generator[BaseVirtualMachine]:
+    sriov_iface_addresses = random_cidr_addresses_by_family(net_seed=_NET_SEED, host_address=_REF_VM_HOST_ADDRESS)
+    with base_sriov_vm(
+        namespace=namespace.name,
+        name="sriov-ref-vm",
+        client=unprivileged_client,
+        sriov_network_name=sriov_network.name,
+        sriov_mac=vm_sriov_mac(mac_suffix_index=next(index_number)),
+        addresses=sriov_iface_addresses,
+        memory_guest=_INITIAL_MEMORY,
+    ) as vm:
+        addresses = vm.cloud_init_network_data.ethernets[_SRIOV_CLOUD_INIT_PROFILE].addresses or []
+        run_vm(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                sriov_network.name: [str(ipaddress.ip_interface(addr).ip) for addr in addresses]
+            },
+        )
+        yield vm

--- a/tests/network/sriov/memory_hotplug/lib_helpers.py
+++ b/tests/network/sriov/memory_hotplug/lib_helpers.py
@@ -1,0 +1,27 @@
+from kubernetes.utils.quantity import parse_quantity
+from timeout_sampler import retry
+
+from libs.vm.vm import BaseVirtualMachine
+from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC
+
+
+def hotplug_memory_and_wait(vm: BaseVirtualMachine, memory_guest: str) -> None:
+    """Hot-plug memory on a VM and wait for the guest OS to report the new amount.
+
+    Sets the new guest memory value on the VM, then polls the VMI status
+    guestCurrent field until it reaches the expected value — confirming the
+    live migration triggered by the hot-plug has completed and the guest OS
+    has received the memory.
+
+    Args:
+        vm: The virtual machine to hot-plug memory on.
+        memory_guest: New guest memory value (e.g. "2Gi").
+    """
+    vm.set_guest_memory(memory_guest=memory_guest)
+    _wait_for_guest_memory_in_vmi_status(vm=vm, memory_guest=memory_guest)
+
+
+@retry(wait_timeout=TIMEOUT_5MIN, sleep=TIMEOUT_5SEC)
+def _wait_for_guest_memory_in_vmi_status(vm: BaseVirtualMachine, memory_guest: str) -> bool:
+    current = vm.vmi.instance.status.memory.guestCurrent
+    return bool(current) and parse_quantity(str(current)) == parse_quantity(memory_guest)

--- a/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
+++ b/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
@@ -1,0 +1,98 @@
+"""
+SR-IOV VM memory hot-plug tests.
+
+Jira: https://redhat.atlassian.net/browse/CNV-69778 # <skip-jira-utils-check>
+"""
+
+from typing import Final
+
+import pytest
+
+from libs.net.ip import filter_link_local_addresses
+from libs.net.vmspec import lookup_iface_status
+from tests.network.libs.connectivity import poll_tcp_connectivity
+from tests.network.sriov.memory_hotplug.lib_helpers import hotplug_memory_and_wait
+from utilities.constants import TIMEOUT_2MIN
+
+HOTPLUG_MEMORY_SIZE: Final[str] = "3Gi"
+
+
+@pytest.mark.sriov
+@pytest.mark.usefixtures("sriov_ref_vm")
+@pytest.mark.incremental
+class TestSriovMemoryHotplug:
+    """
+    Tests for SR-IOV VM memory hot-plug.
+
+    Preconditions:
+        - Running under-test VM with SR-IOV interface, 1Gi initial
+          memory, and 4Gi maxGuest configured
+        - Running reference VM with SR-IOV interface on the same
+          SR-IOV network
+    """
+
+    @pytest.mark.polarion("CNV-16278")
+    def test_vmi_status(
+        self,
+        sriov_vm_with_max_guest,
+        sriov_network,
+    ):
+        """
+        Test that after memory hot-plug on SR-IOV VM, the VMI status reflects the
+        new memory and the SR-IOV interface is present in the VMI status.
+
+        Preconditions:
+            - A running under-test VM with an SR-IOV interface, 1Gi initial
+              memory, and 4Gi maxGuest configured
+
+        Steps:
+            1. Hot-plug memory to 3Gi on the under-test VM
+
+        Expected:
+            - VMI status of the under-test VM shows actual guest memory
+              increased to 3Gi
+            - SR-IOV interface is present in the VMI status of the under-test
+              VM with guest-agent and domain as an info source
+        """
+        hotplug_memory_and_wait(vm=sriov_vm_with_max_guest, memory_guest=HOTPLUG_MEMORY_SIZE)
+        lookup_iface_status(
+            vm=sriov_vm_with_max_guest,
+            iface_name=sriov_network.name,
+            timeout=TIMEOUT_2MIN,
+            predicate=lambda iface: all(source in iface["infoSource"] for source in ("domain", "guest-agent")),
+        )
+
+    @pytest.mark.polarion("CNV-16279")
+    def test_connectivity(
+        self,
+        subtests,
+        sriov_vm_with_max_guest,
+        sriov_ref_vm,
+        sriov_network,
+    ):
+        """
+        Test that SR-IOV connectivity is preserved after memory hot-plug.
+
+        Preconditions:
+            - Under-test VM after memory hot-plug with SR-IOV interface present
+            - A running reference VM with an SR-IOV interface on the same
+              SR-IOV network
+
+        Steps:
+            1. Poll TCP connection from the under-test VM to the reference VM over the SR-IOV interface
+
+        Expected:
+            - TCP connectivity between the under-test VM and the reference VM
+              over the SR-IOV interface is eventually preserved after memory hotplug
+        """
+        ref_iface = lookup_iface_status(vm=sriov_ref_vm, iface_name=sriov_network.name)
+        under_test_iface = lookup_iface_status(vm=sriov_vm_with_max_guest, iface_name=sriov_network.name)
+        for server_ip in filter_link_local_addresses(ip_addresses=ref_iface.ipAddresses):
+            with subtests.test(msg=f"IPv{server_ip.version}: {server_ip}"):
+                poll_tcp_connectivity(
+                    client_vm=sriov_vm_with_max_guest,
+                    server_vm=sriov_ref_vm,
+                    server_ip=str(server_ip),
+                    client_bind_dev=under_test_iface.interfaceName,
+                    server_bind_dev=ref_iface.interfaceName,
+                )

--- a/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
+++ b/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
@@ -17,7 +17,9 @@ from utilities.constants import TIMEOUT_2MIN
 HOTPLUG_MEMORY_SIZE: Final[str] = "3Gi"
 
 
-@pytest.mark.sriov
+pytestmark = [pytest.mark.special_infra, pytest.mark.sriov]
+
+
 @pytest.mark.usefixtures("sriov_ref_vm")
 @pytest.mark.incremental
 class TestSriovMemoryHotplug:


### PR DESCRIPTION
##### What this PR does / why we need it:
Manual cherry-pick to 4.22: SR-IOV  memory hotplug https://github.com/RedHatQE/openshift-virtualization-tests/pull/5349

##### Which issue(s) this PR fixes:
- Auto cherry-pick failed to add `def run_vm` helper (https://github.com/RedHatQE/openshift-virtualization-tests/pull/5553) used in SR-IOV memory HP tests
- `special_infra` marker is added for proper tests collection in CI (https://github.com/RedHatQE/openshift-virtualization-tests/pull/5594)

##### Special notes for reviewer: -

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-89770
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
