### PR TITLE
[4.20] Add ARM64 Fedora container image config

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -126,7 +126,12 @@ class ArchImages:
         Rhel.LATEST_RELEASE_STR = Rhel.RHEL9_6_IMG
 
         Windows = Windows()
-        Fedora = Fedora()
+        Fedora = Fedora(
+            FEDORA42_IMG="Fedora-Cloud-Base-Generic-42-1.1.aarch64.qcow2",
+            FEDORA_CONTAINER_IMAGE="quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64",
+            DISK_DEMO="fedora-cloud-registry-disk-demo",
+        )
+        Fedora.LATEST_RELEASE_STR = Fedora.FEDORA42_IMG
         Centos = Centos()
         Cdi = Cdi()
 


### PR DESCRIPTION
## Summary
- ARM64 `Fedora` was uninitialized (`Fedora()`), leaving `FEDORA_CONTAINER_IMAGE` as `None`
- This caused `test_container_disk_vm` to fail on `test-pytest-cnv-4.20-smoke-arm64` with `oc image info None`
- Backports the ARM64 Fedora config already present on `main`

## Test plan
- [ ] `test-pytest-cnv-4.20-smoke-arm64` build passes with `test_container_disk_vm` green
- [ ] No regressions in other ARM64 smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)