### PR TITLE
infra: Update dv_for_data_source to create the dv from public quay

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/conftest.py
+++ b/tests/infrastructure/golden_images/update_boot_source/conftest.py
@@ -40,6 +40,11 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture()
+def data_source_by_name_scope_function(request, admin_client, golden_images_namespace):
+    return DataSource(client=admin_client, name=request.param, namespace=golden_images_namespace.name)
+
+
+@pytest.fixture()
 def enabled_common_boot_image_import_feature_gate_scope_function(
     admin_client,
     hyperconverged_resource_scope_function,

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -17,20 +17,15 @@ from tests.infrastructure.golden_images.constants import (
     PVC_NOT_FOUND_ERROR,
 )
 from tests.utils import get_parameters_from_template
-from utilities.artifactory import (
-    cleanup_artifactory_secret_and_config_map,
-    get_artifactory_config_map,
-    get_artifactory_secret,
-    get_http_image_url,
-)
 from utilities.constants import Images
 from utilities.constants.hco import DATA_SOURCE_NAME
 from utilities.constants.images import DEFAULT_FEDORA_REGISTRY_URL
 from utilities.constants.pytest import QUARANTINED
-from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, REGISTRY_STR
 from utilities.constants.timeouts import (
+    TIMEOUT_1MIN,
     TIMEOUT_5MIN,
-    TIMEOUT_10MIN,
+    TIMEOUT_10MIN, TIMEOUT_30SEC,
 )
 from utilities.exceptions import ResourceValueError
 from utilities.ssp import wait_for_condition_message_value
@@ -47,20 +42,13 @@ pytestmark = pytest.mark.post_upgrade
 
 @contextmanager
 def dv_for_data_source(name, data_source, admin_client):
-    artifactory_secret = get_artifactory_secret(namespace=data_source.namespace)
-    artifactory_config_map = get_artifactory_config_map(namespace=data_source.namespace)
     with DataVolume(
         client=admin_client,
         name=name,
         namespace=data_source.namespace,
-        source_dict=construct_datavolume_source_dict(
-            # underlying OS is not relevant
-            source="http",
-            url=get_http_image_url(image_directory=Images.Cirros.DIR, image_name=Images.Cirros.QCOW2_IMG),
-            secret_name=artifactory_secret.name,
-            cert_configmap_name=artifactory_config_map.name,
-        ),
-        size=Images.Cirros.DEFAULT_DV_SIZE,
+        # underlying OS is not relevant
+        source_dict=construct_datavolume_source_dict(source=REGISTRY_STR, url=DEFAULT_FEDORA_REGISTRY_URL),
+        size=Images.Fedora.DEFAULT_DV_SIZE,
         storage_class=py_config["default_storage_class"],
         annotations=BIND_IMMEDIATE_ANNOTATION,
         api_name="storage",
@@ -71,9 +59,6 @@ def dv_for_data_source(name, data_source, admin_client):
             expected_message=DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE,
         )
         yield dv
-    cleanup_artifactory_secret_and_config_map(
-        artifactory_secret=artifactory_secret, artifactory_config_map=artifactory_config_map
-    )
 
 
 def opt_in_status_str(opt_in):
@@ -100,7 +85,7 @@ def wait_for_data_source_reconciliation_after_update(
 def wait_for_data_source_unchanged_referenced_volume(data_source, volume_name):
     try:
         for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_10MIN,
+            wait_timeout=TIMEOUT_30SEC,
             sleep=5,
             func=lambda: data_source.source.name != volume_name,
         ):
@@ -265,8 +250,8 @@ def data_sources_from_templates_scope_function(admin_client, data_sources_names_
 
 
 @pytest.fixture()
-def data_source_by_name_scope_function(request, unprivileged_client, golden_images_namespace):
-    return DataSource(client=unprivileged_client, name=request.param, namespace=golden_images_namespace.name)
+def data_source_by_name_scope_function(request, admin_client, golden_images_namespace):
+    return DataSource(client=admin_client, name=request.param, namespace=golden_images_namespace.name)
 
 
 @pytest.fixture(scope="class")

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -5,7 +5,6 @@ import pytest
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.data_source import DataSource
-from ocp_resources.datavolume import DataVolume
 from ocp_resources.resource import ResourceEditor
 from pytest_testconfig import py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -16,20 +15,19 @@ from tests.infrastructure.golden_images.constants import (
     DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE,
     PVC_NOT_FOUND_ERROR,
 )
+from tests.infrastructure.golden_images.update_boot_source.utils import (
+    fedora_dv_for_data_source,
+    wait_for_data_source_unchanged_referenced_volume,
+)
 from tests.utils import get_parameters_from_template
-from utilities.constants import Images
 from utilities.constants.hco import DATA_SOURCE_NAME
 from utilities.constants.images import DEFAULT_FEDORA_REGISTRY_URL
 from utilities.constants.pytest import QUARANTINED
-from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, REGISTRY_STR
 from utilities.constants.timeouts import (
-    TIMEOUT_1MIN,
     TIMEOUT_5MIN,
-    TIMEOUT_10MIN, TIMEOUT_30SEC,
+    TIMEOUT_10MIN,
 )
-from utilities.exceptions import ResourceValueError
 from utilities.ssp import wait_for_condition_message_value
-from utilities.storage import construct_datavolume_source_dict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -38,27 +36,6 @@ DUMMY_VOLUME_NAME = "dummy"
 DATA_SOURCE_MANAGED_BY_CDI_LABEL = f"{DataSource.ApiGroup.CDI_KUBEVIRT_IO}/dataImportCron"
 
 pytestmark = pytest.mark.post_upgrade
-
-
-@contextmanager
-def dv_for_data_source(name, data_source, admin_client):
-    with DataVolume(
-        client=admin_client,
-        name=name,
-        namespace=data_source.namespace,
-        # underlying OS is not relevant
-        source_dict=construct_datavolume_source_dict(source=REGISTRY_STR, url=DEFAULT_FEDORA_REGISTRY_URL),
-        size=Images.Fedora.DEFAULT_DV_SIZE,
-        storage_class=py_config["default_storage_class"],
-        annotations=BIND_IMMEDIATE_ANNOTATION,
-        api_name="storage",
-    ) as dv:
-        dv.wait_for_dv_success()
-        wait_for_condition_message_value(
-            resource=data_source,
-            expected_message=DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE,
-        )
-        yield dv
 
 
 def opt_in_status_str(opt_in):
@@ -80,23 +57,6 @@ def wait_for_data_source_reconciliation_after_update(
     except TimeoutExpiredError:
         LOGGER.error(f"dataSource {data_source.name} was not reconciled")
         raise
-
-
-def wait_for_data_source_unchanged_referenced_volume(data_source, volume_name):
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_30SEC,
-            sleep=5,
-            func=lambda: data_source.source.name != volume_name,
-        ):
-            if sample:
-                raise ResourceValueError(
-                    f"DataSource {data_source.name} volume reference was updated, "
-                    f"expected {volume_name}, "
-                    f"spec: {data_source.instance.spec}"
-                )
-    except TimeoutExpiredError:
-        return
 
 
 def wait_for_data_source_updated_referenced_volume(data_source, volume_name):
@@ -249,11 +209,6 @@ def data_sources_from_templates_scope_function(admin_client, data_sources_names_
     ]
 
 
-@pytest.fixture()
-def data_source_by_name_scope_function(request, admin_client, golden_images_namespace):
-    return DataSource(client=admin_client, name=request.param, namespace=golden_images_namespace.name)
-
-
 @pytest.fixture(scope="class")
 def data_source_by_name_scope_class(request, admin_client, golden_images_namespace):
     return DataSource(client=admin_client, name=request.param, namespace=golden_images_namespace.name)
@@ -305,10 +260,8 @@ def opted_out_data_source_scope_class(
 def uploaded_dv_for_dangling_data_source_scope_function(admin_client, data_source_by_name_scope_function):
     expected_pvc_name = data_source_by_name_scope_function.instance.spec.source.pvc.name
     LOGGER.info(f"Create DV {expected_pvc_name} for DataSource {data_source_by_name_scope_function.name}")
-    with dv_for_data_source(
-        name=expected_pvc_name,
-        data_source=data_source_by_name_scope_function,
-        admin_client=admin_client,
+    with fedora_dv_for_data_source(
+        name=expected_pvc_name, data_source=data_source_by_name_scope_function, client=admin_client
     ) as dv:
         yield dv
 
@@ -317,10 +270,10 @@ def uploaded_dv_for_dangling_data_source_scope_function(admin_client, data_sourc
 def created_dv_for_data_import_cron_managed_data_source_scope_function(
     admin_client, golden_images_namespace, data_source_by_name_scope_function
 ):
-    with dv_for_data_source(
+    with fedora_dv_for_data_source(
         name=data_source_by_name_scope_function.instance.spec.source.pvc.name,
         data_source=data_source_by_name_scope_function,
-        admin_client=admin_client,
+        client=admin_client,
     ) as dv:
         yield dv
 
@@ -329,10 +282,10 @@ def created_dv_for_data_import_cron_managed_data_source_scope_function(
 def created_dv_for_data_import_cron_managed_data_source_scope_class(
     admin_client, golden_images_namespace, data_source_by_name_scope_class
 ):
-    with dv_for_data_source(
+    with fedora_dv_for_data_source(
         name=data_source_by_name_scope_class.instance.spec.source.pvc.name,
         data_source=data_source_by_name_scope_class,
-        admin_client=admin_client,
+        client=admin_client,
     ) as dv:
         yield dv
 

--- a/tests/infrastructure/golden_images/update_boot_source/utils.py
+++ b/tests/infrastructure/golden_images/update_boot_source/utils.py
@@ -1,33 +1,46 @@
 import logging
 import re
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import requests
 from bs4 import BeautifulSoup
-from kubernetes.dynamic import DynamicClient
-from ocp_resources.data_source import DataSource
-from ocp_resources.namespace import Namespace
+from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.template import Template
 from ocp_resources.volume_snapshot import VolumeSnapshot
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.data_source import DataSource
+    from ocp_resources.namespace import Namespace
+
 from packaging.version import Version
+from pytest_testconfig import py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.infrastructure.golden_images.constants import DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE
+from utilities.constants import Images
 from utilities.constants.images import DEFAULT_FEDORA_REGISTRY_URL
-from utilities.constants.storage import WILDCARD_CRON_EXPRESSION
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, REGISTRY_STR, WILDCARD_CRON_EXPRESSION
 from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
     TIMEOUT_30SEC,
 )
+from utilities.exceptions import ResourceValueError
 from utilities.infra import generate_openshift_pull_secret_file
 from utilities.ssp import (
     get_data_import_crons,
     matrix_auto_boot_data_import_cron_prefixes,
+    wait_for_condition_message_value,
 )
 from utilities.storage import (
     DATA_IMPORT_CRON_SUFFIX,
     RESOURCE_MANAGED_BY_DATA_IMPORT_CRON_LABEL,
+    construct_datavolume_source_dict,
 )
 from utilities.virt import get_oc_image_info
 
@@ -234,3 +247,68 @@ def wait_for_created_volume_from_data_import_cron(custom_data_source: DataSource
             f"DataSource conditions: {custom_data_source.instance.get('status', {}).get('conditions')}"
         )
         raise
+
+
+@contextmanager
+def fedora_dv_for_data_source(name: str, data_source: DataSource, client: DynamicClient) -> Generator[DataVolume]:
+    """
+    Creates a registry-sourced DataVolume using the default Fedora image, waits for the DV to
+    succeed, then waits for the DataSource to report it is ready for consumption.
+
+    Args:
+        name (str): Name for the DataVolume to create.
+        data_source (DataSource): The DataSource whose namespace the DV is created in.
+            The DataSource is also monitored for readiness after the DV succeeds.
+        client (DynamicClient): Client used to create the DataVolume.
+
+    Yields:
+        DataVolume: The created and ready DataVolume resource.
+    """
+    with DataVolume(
+        client=client,
+        name=name,
+        namespace=data_source.namespace,
+        source_dict=construct_datavolume_source_dict(source=REGISTRY_STR, url=DEFAULT_FEDORA_REGISTRY_URL),
+        size=Images.Fedora.DEFAULT_DV_SIZE,
+        storage_class=py_config["default_storage_class"],
+        annotations=BIND_IMMEDIATE_ANNOTATION,
+        api_name="storage",
+    ) as dv:
+        dv.wait_for_dv_success()
+        wait_for_condition_message_value(
+            resource=data_source,
+            expected_message=DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE,
+        )
+        yield dv
+
+
+def wait_for_data_source_unchanged_referenced_volume(data_source: DataSource, volume_name: str) -> None:
+    """
+    Assert that a DataSource's referenced volume does not change within a short observation window.
+
+    Polls the DataSource and raises ResourceValueError immediately if the
+    source name diverges from ``volume_name``. A TimeoutExpiredError (meaning no change was
+    observed) is treated as success and suppressed.
+
+    Args:
+        data_source (DataSource): The DataSource resource to observe.
+        volume_name (str): The volume name that must remain as the DataSource's source reference.
+
+    Raises:
+        ResourceValueError: If the DataSource's source reference changes to a different volume
+            before the observation window expires.
+    """
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_30SEC,
+            sleep=TIMEOUT_5SEC,
+            func=lambda: data_source.source.name != volume_name,
+        ):
+            if sample:
+                raise ResourceValueError(
+                    f"DataSource {data_source.name} volume reference was updated, "
+                    f"expected {volume_name}, "
+                    f"spec: {data_source.instance.spec}"
+                )
+    except TimeoutExpiredError:
+        return


### PR DESCRIPTION
##### What this PR does / why we need it:
 - Updates `dv_for_data_source` in `test_ssp_data_sources.py` to create the `DataVolume` from a public Quay registry (using Images.Fedora via DEFAULT_FEDORA_REGISTRY_URL) instead of an Artifactory-hosted HTTP image, removing the dependency on Artifactory.
 - Decrease the wait timeout for verifying the `DataSource` does not change reference, since the testing environments are more stable now and can manage to finish the import in less then 5 minutes.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-86274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated golden-image bootstrapping validations to use shared registry-based DataSource and DataVolume helpers.
  * Centralized DataVolume creation and DataSource readiness/wait behavior to reduce duplication across tests.
  * Improved referenced-volume stability checks by reusing a shared “unchanged” verification helper.
  * Adjusted test fixture setup to create DataSource resources with administrative access and updated fixture scope/parameterization accordingly.
  * Added utilities for creating Fedora registry-sourced DataVolumes and waiting for successful readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->