### PR TITLE
net, sriov: Add missing special_infra marker

### DIFF
--- a/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
+++ b/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
@@ -16,8 +16,9 @@ from utilities.constants.timeouts import TIMEOUT_2MIN
 
 HOTPLUG_MEMORY_SIZE: Final[str] = "3Gi"
 
+pytestmark = [pytest.mark.special_infra, pytest.mark.sriov]
 
-@pytest.mark.sriov
+
 @pytest.mark.usefixtures("sriov_ref_vm")
 @pytest.mark.incremental
 class TestSriovMemoryHotplug:


### PR DESCRIPTION
##### What this PR does / why we need it:
New SR-IOV test was collected in non-relevant job in CI 


##### Which issue(s) this PR fixes:
Add missing special_infra marker for proper tests collection

##### Special notes for reviewer: -

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization to include both special infrastructure and SR-IOV markers.
  * Existing memory hot-plug, status validation, and connectivity test coverage remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->