### PR TITLE
test: dummy PR for CodeRabbit linked-repo validation

### DIFF
--- a/tests/storage/scratch_space_selection/test_scratch_space_std.py
+++ b/tests/storage/scratch_space_selection/test_scratch_space_std.py
@@ -1,4 +1,4 @@
-"""Scratch space storage class selection STD.
+"""Scratch space storage class selection STD (partial — 1 of 4 P0 scenarios).
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/scratch_space_sc_selection_logic.md
 

--- a/tests/storage/scratch_space_selection/test_scratch_space_std.py
+++ b/tests/storage/scratch_space_selection/test_scratch_space_std.py
@@ -1,4 +1,4 @@
-"""Scratch space storage class selection STD (partial — linked-repo smoke test).
+"""Scratch space storage class selection STD.
 
 STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/scratch_space_sc_selection_logic.md
 

--- a/tests/storage/scratch_space_selection/test_scratch_space_std.py
+++ b/tests/storage/scratch_space_selection/test_scratch_space_std.py
@@ -1,0 +1,38 @@
+"""Scratch space storage class selection STD (partial — linked-repo smoke test).
+
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/scratch_space_sc_selection_logic.md
+
+Preconditions:
+    - Cluster with CDI and HCO installed
+    - At least two storage classes available
+"""
+
+import pytest
+
+__test__ = False
+
+
+class TestScratchSpaceImportConversion:
+    """
+    STD for scratch space allocation during import with conversion.
+
+    Preconditions:
+        - Source image requires format conversion
+        - Target DataVolume storage class is configured
+    """
+
+    @pytest.mark.polarion("CNV-72238")
+    def test_import_conversion_uses_target_dv_storage_class(self):
+        """
+        Verify import requiring conversion allocates scratch space using target DataVolume storage class.
+
+        Preconditions:
+            - HTTP DataSource or registry import source available
+
+        Steps:
+            1. Create a DataVolume import that requires conversion
+            2. Inspect the scratch space PVC created during import
+
+        Expected:
+            Scratch space PVC uses the same storage class as the target DataVolume
+        """


### PR DESCRIPTION
## Summary
- Adds a partial STD placeholder (`__test__ = False`) for the scratch-space storage class selection feature.
- References STP: `stps/sig-storage/scratch_space_sc_selection_logic.md` in the linked `openshift-virtualization-tests-design-docs` repo.
- Covers **1 of 4** P0 scenarios from that STP — intentionally incomplete.

**Do not merge** — close after confirming CodeRabbit linked-repo STP cross-check behavior.

##### What this PR does / why we need it:
Dummy PR to validate that CodeRabbit cross-references the linked `RedHatQE/openshift-virtualization-tests-design-docs` repository when reviewing STD changes. The STP defines four P0 scenarios (import conversion, upload, HCO→CDI propagation, HCO-configured import) but this PR only adds STD for the first one. CodeRabbit should flag the three missing scenarios by consulting the linked repo.

##### Which issue(s) this PR fixes:


##### Special notes for reviewer:
- Placeholder STD only (`__test__ = False`); no test implementation.
- Expected CodeRabbit feedback: missing STP scenario coverage for upload, HCO→CDI propagation, and HCO-configured import scenarios defined in the linked STP.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that scratch space created during import conversion uses the target DataVolume’s storage class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->