### PR TITLE
[4.22] [CCLM] Add cross-storage cross-cluster migration tests + STDs

### DIFF
--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -22,3 +22,15 @@ QUAY_FEDORA_CONTAINER_IMAGE = f"docker://{Images.Fedora.FEDORA_CONTAINER_IMAGE}"
 
 TEST_FILE_NAME = "test-file.txt"
 TEST_FILE_CONTENT = "test-content"
+
+STORAGE_CLASS_A = "storage_class_a"
+STORAGE_CLASS_B = "storage_class_b"
+
+NO_STORAGE_CLASS_FAILURE_MESSAGE = (
+    f"Test failed: {'{storage_class}'} storage class is not deployed. "
+    f"Available storage classes: {'{cluster_storage_classes_names}'}. "
+    "Ensure the correct storage_class is set in the global_config, "
+    "or override it with the pytest params: "
+    f"--tc={STORAGE_CLASS_A}:<storage_class_name> "
+    f"--tc={STORAGE_CLASS_B}:<storage_class_name>"
+)

--- a/tests/storage/cross_cluster_live_migration/conftest.py
+++ b/tests/storage/cross_cluster_live_migration/conftest.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 import requests
 import yaml
+from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import NotFoundError
 from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
@@ -347,13 +348,16 @@ def local_cluster_mtv_provider_for_local_cluster(admin_client, mtv_namespace):
 
 
 @pytest.fixture(scope="module")
-def remote_cluster_storage_classes_names(remote_admin_client):
+def remote_cluster_storage_classes_names(remote_admin_client: DynamicClient) -> list[str]:
+    """Get list of all storage class names available in the remote cluster."""
     return [sc.name for sc in list(StorageClass.get(client=remote_admin_client))]
 
 
 @pytest.fixture(scope="class")
-def remote_cluster_source_storage_class(request, remote_cluster_storage_classes_names):
-    # Storage class for the original VMs creation in the remote cluster
+def remote_cluster_source_storage_class(
+    request: pytest.FixtureRequest, remote_cluster_storage_classes_names: list[str]
+) -> str:
+    """Storage class for creating VMs in the remote cluster before migration."""
     return get_storage_class_for_storage_migration(
         storage_class=request.param["source_storage_class"],
         cluster_storage_classes_names=remote_cluster_storage_classes_names,
@@ -361,10 +365,11 @@ def remote_cluster_source_storage_class(request, remote_cluster_storage_classes_
 
 
 @pytest.fixture(scope="class")
-def local_cluster_target_storage_class(request, cluster_storage_classes_names):
-    # Storage class for the target VMs in the local cluster
+def local_cluster_target_storage_class(request: pytest.FixtureRequest, cluster_storage_classes_names: list[str]) -> str:
+    """Storage class for migrated VMs in the local cluster."""
     return get_storage_class_for_storage_migration(
-        storage_class=request.param["target_storage_class"], cluster_storage_classes_names=cluster_storage_classes_names
+        storage_class=request.param["target_storage_class"],
+        cluster_storage_classes_names=cluster_storage_classes_names,
     )
 
 

--- a/tests/storage/cross_cluster_live_migration/conftest.py
+++ b/tests/storage/cross_cluster_live_migration/conftest.py
@@ -18,6 +18,7 @@ from ocp_resources.provider import Provider
 from ocp_resources.resource import get_client
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
+from ocp_resources.storage_class import StorageClass
 from ocp_resources.storage_map import StorageMap
 from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
@@ -33,6 +34,7 @@ from tests.storage.cross_cluster_live_migration.utils import (
     configure_hco_live_migration_network,
     get_vm_boot_id_via_console,
 )
+from tests.storage.utils import get_storage_class_for_storage_migration
 from utilities.artifactory import (
     get_artifactory_config_map,
     get_artifactory_secret,
@@ -345,8 +347,35 @@ def local_cluster_mtv_provider_for_local_cluster(admin_client, mtv_namespace):
 
 
 @pytest.fixture(scope="module")
+def remote_cluster_storage_classes_names(remote_admin_client):
+    return [sc.name for sc in list(StorageClass.get(client=remote_admin_client))]
+
+
+@pytest.fixture(scope="class")
+def remote_cluster_source_storage_class(request, remote_cluster_storage_classes_names):
+    # Storage class for the original VMs creation in the remote cluster
+    return get_storage_class_for_storage_migration(
+        storage_class=request.param["source_storage_class"],
+        cluster_storage_classes_names=remote_cluster_storage_classes_names,
+    )
+
+
+@pytest.fixture(scope="class")
+def local_cluster_target_storage_class(request, cluster_storage_classes_names):
+    # Storage class for the target VMs in the local cluster
+    return get_storage_class_for_storage_migration(
+        storage_class=request.param["target_storage_class"], cluster_storage_classes_names=cluster_storage_classes_names
+    )
+
+
+@pytest.fixture(scope="class")
 def local_cluster_mtv_storage_map(
-    admin_client, local_cluster_mtv_provider_for_local_cluster, local_cluster_mtv_provider_for_remote_cluster
+    admin_client,
+    local_cluster_mtv_provider_for_local_cluster,
+    local_cluster_mtv_provider_for_remote_cluster,
+    unique_suffix,
+    remote_cluster_source_storage_class,
+    local_cluster_target_storage_class,
 ):
     """
     Create a StorageMap resource for MTV migration.
@@ -354,13 +383,13 @@ def local_cluster_mtv_storage_map(
     """
     mapping = [
         {
-            "source": {"name": py_config["default_storage_class"]},
-            "destination": {"storageClass": py_config["default_storage_class"]},
+            "source": {"name": remote_cluster_source_storage_class},
+            "destination": {"storageClass": local_cluster_target_storage_class},
         }
     ]
     with StorageMap(
         client=admin_client,
-        name="storage-map",
+        name=f"storage-map-{unique_suffix}",
         namespace=local_cluster_mtv_provider_for_local_cluster.namespace,
         source_provider_name=local_cluster_mtv_provider_for_remote_cluster.name,
         source_provider_namespace=local_cluster_mtv_provider_for_remote_cluster.namespace,
@@ -429,7 +458,10 @@ def remote_cluster_rhel10_data_source(remote_admin_client, remote_cluster_golden
 
 @pytest.fixture(scope="class")
 def vm_for_cclm_from_template_with_data_source(
-    remote_admin_client, remote_cluster_source_test_namespace, remote_cluster_rhel10_data_source
+    remote_admin_client,
+    remote_cluster_source_test_namespace,
+    remote_cluster_rhel10_data_source,
+    remote_cluster_source_storage_class,
 ):
     with VirtualMachineForTests(
         name="vm-from-template-and-data-source",
@@ -438,7 +470,7 @@ def vm_for_cclm_from_template_with_data_source(
         os_flavor=OS_FLAVOR_RHEL,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=remote_cluster_rhel10_data_source,
-            storage_class=py_config["default_storage_class"],
+            storage_class=remote_cluster_source_storage_class,
         ),
         memory_guest=Images.Rhel.DEFAULT_MEMORY_SIZE,
     ) as vm:
@@ -448,7 +480,10 @@ def vm_for_cclm_from_template_with_data_source(
 
 @pytest.fixture(scope="class")
 def vm_for_cclm_with_instance_type(
-    remote_admin_client, remote_cluster_source_test_namespace, remote_cluster_rhel10_data_source
+    remote_admin_client,
+    remote_cluster_source_test_namespace,
+    remote_cluster_rhel10_data_source,
+    remote_cluster_source_storage_class,
 ):
     with VirtualMachineForTests(
         name="vm-with-instance-type",
@@ -459,7 +494,7 @@ def vm_for_cclm_with_instance_type(
         vm_preference=VirtualMachineClusterPreference(name=RHEL10_PREFERENCE, client=remote_admin_client),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=remote_cluster_rhel10_data_source,
-            storage_class=py_config["default_storage_class"],
+            storage_class=remote_cluster_source_storage_class,
         ),
     ) as vm:
         vm.start()
@@ -490,6 +525,7 @@ def remote_cluster_artifactory_config_map_scope_class(remote_admin_client, remot
 def vm_for_cclm_windows_with_instance_type(
     remote_admin_client,
     remote_cluster_source_test_namespace,
+    remote_cluster_source_storage_class,
     remote_cluster_artifactory_secret_scope_class,
     remote_cluster_artifactory_config_map_scope_class,
 ):
@@ -505,7 +541,7 @@ def vm_for_cclm_windows_with_instance_type(
             cert_configmap_name=remote_cluster_artifactory_config_map_scope_class.name,
         ),
         size=Images.Windows.CONTAINER_DISK_DV_SIZE,
-        storage_class=py_config["default_storage_class"],
+        storage_class=remote_cluster_source_storage_class,
     )
     dv.to_dict()
     dv.res["metadata"].pop("namespace", None)

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -1,6 +1,7 @@
 import pytest
+from pytest_testconfig import config as py_config
 
-from tests.storage.constants import TEST_FILE_CONTENT, TEST_FILE_NAME
+from tests.storage.constants import STORAGE_CLASS_A, STORAGE_CLASS_B, TEST_FILE_CONTENT, TEST_FILE_NAME
 from tests.storage.cross_cluster_live_migration.utils import (
     assert_vms_are_stopped,
     assert_vms_can_be_deleted,
@@ -13,6 +14,8 @@ from utilities.constants import TIMEOUT_10MIN, TIMEOUT_50MIN
 
 TESTS_CLASS_NAME_SEVERAL_VMS = "TestCCLMSeveralVMs"
 TESTS_CLASS_NAME_WINDOWS_VM = "TestCCLMWindowsWithVTPM"
+TESTS_CLASS_NAME_STORAGE_A_TO_B = "TestCCLMFromStorageAtoB"
+TESTS_CLASS_NAME_STORAGE_B_TO_A = "TestCCLMFromStorageBtoA"
 
 pytestmark = [
     pytest.mark.cclm,
@@ -25,9 +28,11 @@ pytestmark = [
 
 
 @pytest.mark.parametrize(
-    "vms_for_cclm",
+    "remote_cluster_source_storage_class, local_cluster_target_storage_class, vms_for_cclm",
     [
         pytest.param(
+            {"source_storage_class": py_config[STORAGE_CLASS_B]},
+            {"target_storage_class": py_config[STORAGE_CLASS_B]},
             {
                 "vms_fixtures": [
                     "vm_for_cclm_from_template_with_data_source",
@@ -38,6 +43,7 @@ pytestmark = [
     ],
     indirect=True,
 )
+@pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
 class TestCCLMSeveralVMs:
     @pytest.mark.polarion("CNV-11995")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster")
@@ -93,16 +99,18 @@ class TestCCLMSeveralVMs:
 
 
 @pytest.mark.parametrize(
-    "dv_wait_timeout, vms_for_cclm",
+    "remote_cluster_source_storage_class, local_cluster_target_storage_class, dv_wait_timeout, vms_for_cclm",
     [
         pytest.param(
+            {"source_storage_class": py_config[STORAGE_CLASS_B]},
+            {"target_storage_class": py_config[STORAGE_CLASS_B]},
             {"dv_wait_timeout": TIMEOUT_50MIN},
             {"vms_fixtures": ["vm_for_cclm_windows_with_instance_type"]},
         )
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("dv_wait_timeout")
+@pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class", "dv_wait_timeout")
 class TestCCLMWindowsWithVTPM:
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_WINDOWS_VM}::test_migrate_windows_vm_from_remote_to_local_cluster")
     @pytest.mark.polarion("CNV-11999")
@@ -137,5 +145,83 @@ class TestCCLMWindowsWithVTPM:
         assert_vms_can_be_deleted(vms=vms_for_cclm)
 
     @pytest.mark.polarion("CNV-15236")
+    def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
+        assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)
+
+
+@pytest.mark.parametrize(
+    "remote_cluster_source_storage_class, local_cluster_target_storage_class, vms_for_cclm",
+    [
+        pytest.param(
+            {"source_storage_class": py_config[STORAGE_CLASS_A]},
+            {"target_storage_class": py_config[STORAGE_CLASS_B]},
+            {
+                "vms_fixtures": [
+                    "vm_for_cclm_with_instance_type",
+                ]
+            },
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
+class TestCCLMFromStorageAtoB:
+    @pytest.mark.polarion("CNV-15955")
+    @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster")
+    def test_migrate_vm_from_remote_to_local_cluster(
+        self,
+        written_file_to_vms_before_cclm,
+        vms_boot_id_before_cclm,
+        mtv_migration,
+    ):
+        mtv_migration.wait_for_condition(
+            condition=mtv_migration.Condition.Type.SUCCEEDED,
+            status=mtv_migration.Condition.Status.TRUE,
+            timeout=TIMEOUT_10MIN,
+            stop_condition=mtv_migration.Status.FAILED,
+        )
+
+    @pytest.mark.dependency(
+        depends=[f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster"]
+    )
+    @pytest.mark.polarion("CNV-15956")
+    def test_verify_vms_not_rebooted_after_migration(self, local_vms_after_cclm_migration, vms_boot_id_before_cclm):
+        verify_vms_boot_id_after_cross_cluster_live_migration(
+            local_vms=local_vms_after_cclm_migration, initial_boot_id=vms_boot_id_before_cclm
+        )
+
+    @pytest.mark.dependency(
+        depends=[f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster"]
+    )
+    @pytest.mark.polarion("CNV-15957")
+    def test_verify_file_persisted_after_migration(self, local_vms_after_cclm_migration):
+        for vm in local_vms_after_cclm_migration:
+            check_file_in_vm(
+                vm=vm,
+                file_name=TEST_FILE_NAME,
+                file_content=TEST_FILE_CONTENT,
+                username=vm.username,
+                password=vm.password,
+            )
+
+    @pytest.mark.dependency(
+        depends=[f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster"]
+    )
+    @pytest.mark.polarion("CNV-15958")
+    def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        assert_vms_are_stopped(vms=vms_for_cclm)
+
+    @pytest.mark.dependency(
+        depends=[f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster"]
+    )
+    @pytest.mark.polarion("CNV-15954")
+    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
+        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+
+    @pytest.mark.polarion("CNV-15959")
+    def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        assert_vms_can_be_deleted(vms=vms_for_cclm)
+
+    @pytest.mark.polarion("CNV-15960")
     def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
         assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -15,7 +15,6 @@ from utilities.constants import TIMEOUT_10MIN, TIMEOUT_50MIN
 TESTS_CLASS_NAME_SEVERAL_VMS = "TestCCLMSeveralVMs"
 TESTS_CLASS_NAME_WINDOWS_VM = "TestCCLMWindowsWithVTPM"
 TESTS_CLASS_NAME_STORAGE_A_TO_B = "TestCCLMFromStorageAtoB"
-TESTS_CLASS_NAME_STORAGE_B_TO_A = "TestCCLMFromStorageBtoA"
 
 pytestmark = [
     pytest.mark.cclm,

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -1,7 +1,7 @@
 """
 Cross-cluster live migration tests.
 
-Jira epic: https://redhat.atlassian.net/browse/CNV-50823
+Jira epic: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
 """
 
 import pytest

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -1,3 +1,9 @@
+"""
+Cross-cluster live migration tests.
+
+Jira epic: https://redhat.atlassian.net/browse/CNV-50823
+"""
+
 import pytest
 from pytest_testconfig import config as py_config
 

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -4,6 +4,10 @@ Cross-cluster live migration tests.
 Jira: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 from pytest_testconfig import config as py_config
 
@@ -17,6 +21,11 @@ from tests.storage.cross_cluster_live_migration.utils import (
 )
 from tests.storage.utils import check_file_in_vm
 from utilities.constants import TIMEOUT_10MIN, TIMEOUT_50MIN
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 TESTS_CLASS_NAME_SEVERAL_VMS = "TestCCLMSeveralVMs"
 TESTS_CLASS_NAME_WINDOWS_VM = "TestCCLMWindowsWithVTPM"

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -50,6 +50,17 @@ pytestmark = [
 )
 @pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
 class TestCCLMSeveralVMs:
+    """
+    Tests for cross-cluster live migration of multiple VMs.
+
+    Preconditions:
+        - Two OpenShift clusters (source and target) with live migration network configured
+        - MTV installed on the target cluster with Provider, StorageMap, and NetworkMap configured
+        - Several running VMs on the source cluster, accessible via console
+        - Test file written to the source VMs before migration
+        - Boot IDs recorded for all source VMs before migration
+    """
+
     @pytest.mark.polarion("CNV-11995")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster")
     def test_migrate_vm_from_remote_to_local_cluster(
@@ -58,6 +69,15 @@ class TestCCLMSeveralVMs:
         vms_boot_id_before_cclm,
         mtv_migration,
     ):
+        """
+        Test that multiple VMs can be live migrated from the source cluster to the target cluster.
+
+        Steps:
+            1. Wait for the MTV migration to reach Succeeded condition
+
+        Expected:
+            - Migration succeeds for all VMs
+        """
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
             status=mtv_migration.Condition.Status.TRUE,
@@ -68,6 +88,19 @@ class TestCCLMSeveralVMs:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-11910")
     def test_verify_vms_not_rebooted_after_migration(self, local_vms_after_cclm_migration, vms_boot_id_before_cclm):
+        """
+        Test that VMs are not rebooted during cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Read boot ID from each migrated VM on the target cluster
+            2. Compare current boot IDs with boot IDs recorded before migration
+
+        Expected:
+            - Boot IDs are unchanged for all migrated VMs
+        """
         verify_vms_boot_id_after_cross_cluster_live_migration(
             local_vms=local_vms_after_cclm_migration, initial_boot_id=vms_boot_id_before_cclm
         )
@@ -75,6 +108,18 @@ class TestCCLMSeveralVMs:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-14332")
     def test_verify_file_persisted_after_migration(self, local_vms_after_cclm_migration):
+        """
+        Test that files written before migration are preserved after cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Read the test file from each migrated VM on the target cluster
+
+        Expected:
+            - File content on each migrated VM equals the content written before migration
+        """
         for vm in local_vms_after_cclm_migration:
             check_file_in_vm(
                 vm=vm,
@@ -87,19 +132,64 @@ class TestCCLMSeveralVMs:
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-14333")
     def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        """
+        Test that source VMs on the source cluster are stopped after cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Check the status of each source VM on the source cluster
+
+        Expected:
+            - All source VMs are in "Stopped" state
+        """
         assert_vms_are_stopped(vms=vms_for_cclm)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME_SEVERAL_VMS}::test_migrate_vm_from_remote_to_local_cluster"])
     @pytest.mark.polarion("CNV-12038")
-    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
-        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+    def test_compute_live_migrate_vms_after_cclm(
+        self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
+    ):
+        """
+        Test that VMs can be compute live migrated within the target cluster after cross-cluster live migration.
+
+        Preconditions:
+            - Source VMs successfully migrated to the target cluster
+
+        Steps:
+            1. Trigger intra-cluster live migration for each migrated VM on the target cluster
+            2. Wait for each migration to complete
+
+        Expected:
+            - All migrated VMs are successfully live migrated within the target cluster
+        """
+        verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14334")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        """
+        Test that source VMs on the source cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete each source VM on the source cluster
+
+        Expected:
+            - All source VMs are successfully deleted
+        """
         assert_vms_can_be_deleted(vms=vms_for_cclm)
 
     @pytest.mark.polarion("CNV-15237")
     def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
+        """
+        Test that migrated VMs on the target cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete each migrated VM on the target cluster
+
+        Expected:
+            - All migrated VMs are successfully deleted
+        """
         assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)
 
 
@@ -117,6 +207,15 @@ class TestCCLMSeveralVMs:
 )
 @pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class", "dv_wait_timeout")
 class TestCCLMWindowsWithVTPM:
+    """
+    Tests for cross-cluster live migration of a Windows VM with vTPM.
+
+    Preconditions:
+        - Two OpenShift clusters (source and target) with live migration network configured
+        - MTV installed on the target cluster with Provider, StorageMap, and NetworkMap configured
+        - Running Windows VM on the source cluster
+    """
+
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_WINDOWS_VM}::test_migrate_windows_vm_from_remote_to_local_cluster")
     @pytest.mark.polarion("CNV-11999")
     def test_migrate_windows_vm_from_remote_to_local_cluster(
@@ -124,6 +223,15 @@ class TestCCLMWindowsWithVTPM:
         booted_vms_for_cclm,
         mtv_migration,
     ):
+        """
+        Test that a Windows VM can be live migrated from the source cluster to the target cluster.
+
+        Steps:
+            1. Wait for the MTV migration to reach Succeeded condition
+
+        Expected:
+            - Migration succeeds for the Windows VM
+        """
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
             status=mtv_migration.Condition.Status.TRUE,
@@ -136,21 +244,66 @@ class TestCCLMWindowsWithVTPM:
     )
     @pytest.mark.polarion("CNV-14335")
     def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        """
+        Test that the source Windows VM on the source cluster is stopped after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Wait for the source VM on the source cluster to reach Stopped state
+
+        Expected:
+            - Source VM is in "Stopped" state
+        """
         wait_for_vms_to_be_stopped(vms=vms_for_cclm)
 
     @pytest.mark.dependency(
         depends=[f"{TESTS_CLASS_NAME_WINDOWS_VM}::test_migrate_windows_vm_from_remote_to_local_cluster"]
     )
     @pytest.mark.polarion("CNV-12474")
-    def test_compute_live_migrate_windows_vms_after_cclm(self, local_vms_after_cclm_migration):
-        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+    def test_compute_live_migrate_windows_vms_after_cclm(
+        self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
+    ):
+        """
+        Test that a Windows VM can be compute live migrated within the target cluster after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Trigger intra-cluster live migration for the migrated Windows VM on the target cluster
+            2. Wait for migration to complete
+
+        Expected:
+            - Migrated Windows VM is successfully live migrated within the target cluster
+        """
+        verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-14336")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        """
+        Test that the source Windows VM on the source cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the source VM on the source cluster
+
+        Expected:
+            - Source VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=vms_for_cclm)
 
     @pytest.mark.polarion("CNV-15236")
     def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
+        """
+        Test that the migrated Windows VM on the target cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the migrated VM on the target cluster
+
+        Expected:
+            - Migrated VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)
 
 
@@ -171,6 +324,18 @@ class TestCCLMWindowsWithVTPM:
 )
 @pytest.mark.usefixtures("remote_cluster_source_storage_class", "local_cluster_target_storage_class")
 class TestCCLMFromStorageAtoB:
+    """
+    Tests for cross-cluster live migration of a VM across different storage classes.
+
+    Preconditions:
+        - Two OpenShift clusters (source and target) with live migration network configured
+        - MTV installed on the target cluster with Provider, StorageMap, and NetworkMap configured
+        - Running VM on the source cluster, accessible via console
+        - Different storage classes used on source and target clusters
+        - Test file written to the source VM before migration
+        - Boot ID recorded for the source VM before migration
+    """
+
     @pytest.mark.polarion("CNV-15955")
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster")
     def test_migrate_vm_from_remote_to_local_cluster(
@@ -179,6 +344,15 @@ class TestCCLMFromStorageAtoB:
         vms_boot_id_before_cclm,
         mtv_migration,
     ):
+        """
+        Test that a VM can be cross-cluster live migrated when source and target storage classes are different.
+
+        Steps:
+            1. Wait for the MTV migration to reach Succeeded condition
+
+        Expected:
+            - Migration succeeds for the VM
+        """
         mtv_migration.wait_for_condition(
             condition=mtv_migration.Condition.Type.SUCCEEDED,
             status=mtv_migration.Condition.Status.TRUE,
@@ -191,6 +365,19 @@ class TestCCLMFromStorageAtoB:
     )
     @pytest.mark.polarion("CNV-15956")
     def test_verify_vms_not_rebooted_after_migration(self, local_vms_after_cclm_migration, vms_boot_id_before_cclm):
+        """
+        Test that VM is not rebooted during cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Read boot ID from the migrated VM on the target cluster
+            2. Compare current boot ID with boot ID recorded before migration
+
+        Expected:
+            - Boot ID is unchanged for the migrated VM
+        """
         verify_vms_boot_id_after_cross_cluster_live_migration(
             local_vms=local_vms_after_cclm_migration, initial_boot_id=vms_boot_id_before_cclm
         )
@@ -200,6 +387,18 @@ class TestCCLMFromStorageAtoB:
     )
     @pytest.mark.polarion("CNV-15957")
     def test_verify_file_persisted_after_migration(self, local_vms_after_cclm_migration):
+        """
+        Test that files written before migration are preserved after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Read the test file from the migrated VM on the target cluster
+
+        Expected:
+            - File content on the migrated VM equals the content written before migration
+        """
         for vm in local_vms_after_cclm_migration:
             check_file_in_vm(
                 vm=vm,
@@ -214,19 +413,64 @@ class TestCCLMFromStorageAtoB:
     )
     @pytest.mark.polarion("CNV-15958")
     def test_source_vms_are_stopped_after_cclm(self, vms_for_cclm):
+        """
+        Test that source VM on the source cluster is stopped after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Check the status of the source VM on the source cluster
+
+        Expected:
+            - Source VM is in "Stopped" state
+        """
         assert_vms_are_stopped(vms=vms_for_cclm)
 
     @pytest.mark.dependency(
         depends=[f"{TESTS_CLASS_NAME_STORAGE_A_TO_B}::test_migrate_vm_from_remote_to_local_cluster"]
     )
     @pytest.mark.polarion("CNV-15954")
-    def test_compute_live_migrate_vms_after_cclm(self, local_vms_after_cclm_migration):
-        verify_compute_live_migration_after_cclm(local_vms=local_vms_after_cclm_migration)
+    def test_compute_live_migrate_vms_after_cclm(
+        self, admin_client: DynamicClient, local_vms_after_cclm_migration: list[VirtualMachineForTests]
+    ):
+        """
+        Test that a VM can be compute live migrated within the target cluster after cross-cluster live migration.
+
+        Preconditions:
+            - Source VM successfully migrated to the target cluster
+
+        Steps:
+            1. Trigger intra-cluster live migration for the migrated VM on the target cluster
+            2. Wait for migration to complete
+
+        Expected:
+            - Migrated VM is successfully live migrated within the target cluster
+        """
+        verify_compute_live_migration_after_cclm(client=admin_client, local_vms=local_vms_after_cclm_migration)
 
     @pytest.mark.polarion("CNV-15959")
     def test_source_vms_can_be_deleted(self, vms_for_cclm):
+        """
+        Test that source VM on the source cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the source VM on the source cluster
+
+        Expected:
+            - Source VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=vms_for_cclm)
 
     @pytest.mark.polarion("CNV-15960")
     def test_target_vms_can_be_deleted(self, local_vms_after_cclm_migration):
+        """
+        Test that migrated VM on the target cluster can be deleted after cross-cluster live migration.
+
+        Steps:
+            1. Delete the migrated VM on the target cluster
+
+        Expected:
+            - Migrated VM is successfully deleted
+        """
         assert_vms_can_be_deleted(vms=local_vms_after_cclm_migration)

--- a/tests/storage/cross_cluster_live_migration/test_cclm.py
+++ b/tests/storage/cross_cluster_live_migration/test_cclm.py
@@ -1,7 +1,7 @@
 """
 Cross-cluster live migration tests.
 
-Jira epic: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
+Jira: https://redhat.atlassian.net/browse/CNV-50823 # <skip-jira-utils-check>
 """
 
 import pytest

--- a/tests/storage/cross_cluster_live_migration/utils.py
+++ b/tests/storage/cross_cluster_live_migration/utils.py
@@ -74,11 +74,12 @@ def configure_hco_live_migration_network(
     )
 
 
-def verify_compute_live_migration_after_cclm(local_vms: list[VirtualMachineForTests]) -> None:
+def verify_compute_live_migration_after_cclm(client: DynamicClient, local_vms: list[VirtualMachineForTests]) -> None:
     """
     Verify compute live migration for VMs after Cross-Cluster Live Migration (CCLM).
 
     Args:
+        client: DynamicClient used to create migration resources.
         local_vms: List of VirtualMachineForTests objects in the local cluster
 
     Raises:
@@ -87,7 +88,7 @@ def verify_compute_live_migration_after_cclm(local_vms: list[VirtualMachineForTe
     vms_failed_migration = {}
     for vm in local_vms:
         try:
-            migrate_vm_and_verify(vm=vm, check_ssh_connectivity=True)
+            migrate_vm_and_verify(vm=vm, client=client, check_ssh_connectivity=True)
         except Exception as migration_exception:
             vms_failed_migration[vm.name] = migration_exception
     assert not vms_failed_migration, f"Failed VM migrations: {vms_failed_migration}"

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -21,10 +21,9 @@ from tests.storage.storage_migration.constants import (
 )
 from tests.storage.storage_migration.utils import (
     build_namespaces_spec_for_storage_migration,
-    get_storage_class_for_storage_migration,
     wait_for_storage_migration_completed,
 )
-from tests.storage.utils import create_windows_directory
+from tests.storage.utils import create_windows_directory, get_storage_class_for_storage_migration
 from utilities.artifactory import get_http_image_url
 from utilities.constants import (
     OS_FLAVOR_FEDORA,

--- a/tests/storage/storage_migration/constants.py
+++ b/tests/storage/storage_migration/constants.py
@@ -4,17 +4,5 @@ WINDOWS_TEST_DIRECTORY_PATH = r"C:\Users\TestFolder"
 WINDOWS_FILE_BEFORE_STORAGE_MIGRATION = f"{FILE_BEFORE_STORAGE_MIGRATION}.txt"
 WINDOWS_FILE_WITH_PATH = f"{WINDOWS_TEST_DIRECTORY_PATH}\\{WINDOWS_FILE_BEFORE_STORAGE_MIGRATION}"
 
-STORAGE_CLASS_A = "storage_class_a"
-STORAGE_CLASS_B = "storage_class_b"
-
-NO_STORAGE_CLASS_FAILURE_MESSAGE = (
-    f"Test failed: {'{storage_class}'} storage class is not deployed. "
-    f"Available storage classes: {'{cluster_storage_classes_names}'}. "
-    "Ensure the correct storage_class is set in the global_config, "
-    "or override it with the pytest params: "
-    f"--tc={STORAGE_CLASS_A}:<storage_class_name> "
-    f"--tc={STORAGE_CLASS_B}:<storage_class_name>"
-)
-
 HOTPLUGGED_DEVICE = "/dev/sda"
 MOUNT_HOTPLUGGED_DEVICE_PATH = "/mnt/hotplug"

--- a/tests/storage/storage_migration/test_storage_class_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_migration.py
@@ -2,11 +2,10 @@ import pytest
 from pytest_testconfig import config as py_config
 
 from tests.os_params import FEDORA_LATEST, FEDORA_LATEST_LABELS
+from tests.storage.constants import STORAGE_CLASS_A, STORAGE_CLASS_B
 from tests.storage.storage_migration.constants import (
     CONTENT,
     FILE_BEFORE_STORAGE_MIGRATION,
-    STORAGE_CLASS_A,
-    STORAGE_CLASS_B,
     WINDOWS_FILE_WITH_PATH,
 )
 from tests.storage.storage_migration.utils import (

--- a/tests/storage/storage_migration/utils.py
+++ b/tests/storage/storage_migration/utils.py
@@ -1,6 +1,5 @@
 import shlex
 
-import pytest
 from ocp_resources.multi_namespace_virtual_machine_storage_migration import MultiNamespaceVirtualMachineStorageMigration
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pyhelper_utils.shell import run_ssh_commands
@@ -10,7 +9,6 @@ from tests.storage.storage_migration.constants import (
     CONTENT,
     FILE_BEFORE_STORAGE_MIGRATION,
     MOUNT_HOTPLUGGED_DEVICE_PATH,
-    NO_STORAGE_CLASS_FAILURE_MESSAGE,
 )
 from tests.storage.utils import check_file_in_vm
 from utilities.constants import TIMEOUT_2MIN, TIMEOUT_5SEC, TIMEOUT_10MIN, TIMEOUT_10SEC
@@ -74,17 +72,6 @@ def verify_storage_migration_succeeded(
             file_content=CONTENT,
         )
         verify_vm_storage_class_updated(vm=vm, target_storage_class=target_storage_class)
-
-
-def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_classes_names: list[str]) -> str:
-    if storage_class in cluster_storage_classes_names:
-        return storage_class
-    else:
-        pytest.fail(
-            NO_STORAGE_CLASS_FAILURE_MESSAGE.format(
-                storage_class=storage_class, cluster_storage_classes_names=cluster_storage_classes_names
-            )
-        )
 
 
 def verify_file_in_hotplugged_disk(vm: VirtualMachineForTests, file_name: str, file_content: str) -> None:

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -509,6 +509,18 @@ def check_file_in_vm(
 
 
 def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_classes_names: list[str]) -> str:
+    """Validate that the requested storage class exists in the cluster.
+
+    Args:
+        storage_class: Name of the storage class to validate.
+        cluster_storage_classes_names: List of available storage class names in the cluster.
+
+    Returns:
+        The validated storage class name if it exists.
+
+    Raises:
+        pytest.Failed: If the storage class is not found in the cluster.
+    """
     if storage_class in cluster_storage_classes_names:
         return storage_class
 

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -4,6 +4,7 @@ import shlex
 from collections.abc import Generator
 from contextlib import contextmanager
 
+import pytest
 import requests
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cluster_role import ClusterRole
@@ -23,6 +24,7 @@ from pyhelper_utils.shell import run_ssh_commands
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.storage.constants import NO_STORAGE_CLASS_FAILURE_MESSAGE
 from utilities import console
 from utilities.artifactory import (
     cleanup_artifactory_secret_and_config_map,
@@ -504,3 +506,14 @@ def check_file_in_vm(
         vm_console.expect(pattern=file_name, timeout=TIMEOUT_20SEC)
         vm_console.sendline(f"cat {file_name}")
         vm_console.expect(pattern=file_content, timeout=TIMEOUT_20SEC)
+
+
+def get_storage_class_for_storage_migration(storage_class: str, cluster_storage_classes_names: list[str]) -> str:
+    if storage_class in cluster_storage_classes_names:
+        return storage_class
+
+    pytest.fail(
+        NO_STORAGE_CLASS_FAILURE_MESSAGE.format(
+            storage_class=storage_class, cluster_storage_classes_names=cluster_storage_classes_names
+        )
+    )


### PR DESCRIPTION
##### What this PR does / why we need it:
Manual cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/4650 and https://github.com/RedHatQE/openshift-virtualization-tests/pull/5480

1. Cross-storage CCLM support (PR #4650)

  - conftest.py — Adds `remote_cluster_source_storage_class`, `local_cluster_target_storage_class` fixtures and wires them into `local_cluster_mtv_storage_map` and VM fixtures instead of hardcoding `py_config["default_storage_class"]`.
  - test_cclm.py — Adds `TestCCLMFromStorageAtoB` class that migrates from `STORAGE_CLASS_A` to `STORAGE_CLASS_B`. Existing test classes updated to parametrize storage classes (both use STORAGE_CLASS_B for same-storage).
  - Shared code moved — `STORAGE_CLASS_A/B`, `NO_STORAGE_CLASS_FAILURE_MESSAGE`, and `get_storage_class_for_storage_migration` moved from `storage_migration/` to shared `storage/constants.py`
  and `storage/utils.py` for reuse by CCLM.

2. STD docstrings (PR #5480)

  - All tests now have proper STD docstrings.

3. Conflict resolution fix (our change)

  - utils.py — `verify_compute_live_migration_after_cclm` now accepts `client: DynamicClient` and passes it to `migrate_vm_and_verify`. This was needed because the upstream PRs added the client parameter at the call sites but the function signature didn't have it on this branch.
  - test_cclm.py — Added TYPE_CHECKING imports for DynamicClient and VirtualMachineForTests used in the type hints.


##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
