### PR TITLE
feat(coderabbit): surface STP coverage and special_infra findings in PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,6 +30,30 @@ reviews:
         These rules apply only to feature/integration tests under `tests/`.
         DO still enforce: code quality, type hints, naming conventions, and all other coding standards.
 
+    - path: "tests/**"
+      instructions: |
+        ## STP traceability — inline comments required
+        When an `STP:` link is present and linked-repo analysis finds missing or misaligned
+        scenarios, you MUST post an INLINE review comment on the `STP:` line (or the module
+        docstring when the STP line is unchanged) containing:
+        - **STP coverage: X/Y scenarios**
+        - A table of each STP scenario → covered / missing / misaligned
+        - CRITICAL severity for missing P0 scenarios without documented exclusion in the PR
+          description (justification + follow-up Jira link per scenario)
+        Do NOT report STP coverage gaps only in PR conversation chat.
+
+        ## special_infra marker enforcement
+        Newly added tests that use hardware or special-configuration markers from `pytest.ini`
+        MUST also declare `@pytest.mark.special_infra` at module (`pytestmark`), class, or test
+        level. Flag missing `special_infra` as HIGH.
+
+        Triggering markers (require `special_infra`): `gpu`, `sriov`, `bgp`, `ibm_bare_metal`,
+        `dpdk`, `swap`, `cpu_manager`, `numa`, `hugepages`, `jumbo_frame`, `rwx_default_storage`,
+        `descheduler`, `high_resource_vm`.
+
+        Exempt (do NOT require `special_infra`): `single_nic`, `remote_cluster`, `mixed_os_nodes`,
+        `cclm`, and operator-only markers (`hpp`, `mtv`, `tekton`, `service_mesh`, `nmstate`).
+
     - path: "**"
       instructions: |
         ## PR Template Validation
@@ -131,6 +155,40 @@ reviews:
           Flag a missing `# <skip-jira-utils-check>` on a `Jira:` line as HIGH severity.
 
           Pass if no new test files and no new test functions are added in this PR.
+
+      - name: "STP scenario coverage"
+        mode: error
+        instructions: |
+          Apply when this PR adds or modifies `test_*.py` under `tests/` that reference an
+          `STP:` URL in a module, class, or test docstring. SKIP `utilities/unittests/`.
+
+          Using linked repo `RedHatQE/openshift-virtualization-tests-design-docs`, read the
+          referenced STP and compare its test scenarios to STD/test declarations in the PR diff.
+
+          PASS if every STP scenario has a corresponding STD/test declaration in the PR (or
+          existing file), OR the PR description documents intentional exclusion with a
+          follow-up Jira link per excluded scenario.
+
+          FAIL with a table: scenario summary | STP tier/priority | status (covered/missing).
+          List every missing scenario explicitly.
+
+      - name: "special_infra marker required"
+        mode: error
+        instructions: |
+          For newly added test functions or `test_*.py` files under `tests/`:
+
+          If the test uses a hardware or special-configuration marker from `pytest.ini` that
+          requires non-standard cluster capabilities, it MUST also declare
+          `@pytest.mark.special_infra` at module (`pytestmark`), class, or test level.
+
+          Triggering markers: `gpu`, `sriov`, `bgp`, `ibm_bare_metal`, `dpdk`, `swap`,
+          `cpu_manager`, `numa`, `hugepages`, `jumbo_frame`, `rwx_default_storage`,
+          `descheduler`, `high_resource_vm`.
+
+          Exempt: `single_nic`, `remote_cluster`, `mixed_os_nodes`, `cclm`, operator-only
+          markers (`hpp`, `mtv`, `tekton`, `service_mesh`, `nmstate`), `utilities/unittests/`.
+
+          PASS if no new tests use a triggering marker without `special_infra`.
 
   # Auto-review configuration
   auto_review:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -172,24 +172,6 @@ reviews:
           FAIL with a table: scenario summary | STP tier/priority | status (covered/missing).
           List every missing scenario explicitly.
 
-      - name: "special_infra marker required"
-        mode: error
-        instructions: |
-          For newly added test functions or `test_*.py` files under `tests/`:
-
-          If the test uses a hardware or special-configuration marker from `pytest.ini` that
-          requires non-standard cluster capabilities, it MUST also declare
-          `@pytest.mark.special_infra` at module (`pytestmark`), class, or test level.
-
-          Triggering markers: `gpu`, `sriov`, `bgp`, `ibm_bare_metal`, `dpdk`, `swap`,
-          `cpu_manager`, `numa`, `hugepages`, `jumbo_frame`, `rwx_default_storage`,
-          `descheduler`, `high_resource_vm`.
-
-          Exempt: `single_nic`, `remote_cluster`, `mixed_os_nodes`, `cclm`, operator-only
-          markers (`hpp`, `mtv`, `tekton`, `service_mesh`, `nmstate`), `utilities/unittests/`.
-
-          PASS if no new tests use a triggering marker without `special_infra`.
-
   # Auto-review configuration
   auto_review:
     enabled: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ New feature tests MUST follow the STD-first workflow:
 ### Coverage Tracking
 
 - **STP link REQUIRED** — every new feature test file MUST include an STP link in the module, class, or test docstring
+- **STP scenario coverage REQUIRED** — when an STD or test references an STP, every test scenario defined in that STP MUST have a corresponding STD/test declaration in the same file or PR, unless the scenario is intentionally excluded. Intentional exclusions MUST be documented in the PR description with justification and a follow-up Jira link per excluded scenario. Partial STP coverage without documented exclusions blocks merge.
+- **STD alignment with STP** — STD docstring `Preconditions:`, `Steps:`, and `Expected:` sections MUST align with the STP scenario description for the scenario being covered.
 - **RFE/Jira link REQUIRED when no STP exists** — if there is no STP, the module, class, or test docstring MUST include a link to the RFE or Jira epic (not support cases) for coverage tracking
 
 ### Test Requirements
@@ -99,6 +101,11 @@ New feature tests MUST follow the STD-first workflow:
   - **`tier2` is implicit** — added automatically to all tests that don't have an exclusion marker (see `EXCLUDE_MARKER_FROM_TIER2_MARKER` in `conftest.py` for the full list). Do NOT add `@pytest.mark.tier2` explicitly.
   - **Team markers are implicit** — `network`, `storage`, `virt`, `iuo`, `observability`, `infrastructure`, `data_protection`, and `chaos` are added automatically based on the test's directory location. Do NOT add them explicitly.
   - **`gating` marker** — marks tier2 tests that are part of the gating job. Apply when a test should block release promotion.
+  - **`special_infra` marker REQUIRED for special hardware/configuration** — new tests that require non-standard cluster capabilities MUST include `@pytest.mark.special_infra` at module (`pytestmark`), class, or test level, in addition to the specific requirement marker. See `pytest.ini` marker definitions. This applies when the test uses any of:
+    - **Hardware requirements** (`pytest.ini`): `gpu`, `sriov`, `bgp`, `ibm_bare_metal`
+    - **Configuration requirements** (`pytest.ini`): `dpdk`, `swap`, `cpu_manager`, `numa`, `hugepages`, `jumbo_frame`, `rwx_default_storage`, `descheduler`
+    - **Resource requirements** (`pytest.ini`): `high_resource_vm`
+    - **Exempt** (do NOT require `special_infra`): `single_nic` (runs on minimal-NIC clusters), `remote_cluster`, `mixed_os_nodes`, `cclm`, and operator-only markers (`hpp`, `mtv`, `tekton`, `service_mesh`, `nmstate`)
 - **Each test verifies ONE aspect only** - single purpose, easy to understand
 - **Tests MUST be independent** - use `pytest-dependency` ONLY when test B requires side effects from test A (e.g., cluster-wide configuration).
   For resource dependencies, use shared fixtures instead. **When using `@pytest.mark.dependency`, a comment explaining WHY the dependency exists is REQUIRED.**


### PR DESCRIPTION
## Summary
- Add CodeRabbit **pre-merge checks** for STP scenario coverage (linked design-docs repo) and `special_infra` marker enforcement on new tests.
- Add **`tests/**` path instructions** so STP gaps are posted as **inline review comments** on the `STP:` line, not only in PR conversation chat.
- Update **AGENTS.md** with STP scenario coverage rules and `special_infra` marker requirements aligned with `pytest.ini`.

##### What this PR does / why we need it:
CodeRabbit linked-repo STP analysis worked in chat but findings were hard to see on PRs. This change makes STP mismatch and missing `special_infra` marker violations visible in the pre-merge checks table and (for STP) as inline file comments, and documents the same rules in AGENTS.md for humans and AI reviewers.

##### Which issue(s) this PR fixes:


##### Special notes for reviewer:
- Two new custom pre-merge checks (`STP scenario coverage`, `special_infra marker required`) join the existing `STP link required` check.
- Triggering markers for `special_infra` are listed explicitly; `single_nic`, `remote_cluster`, `mixed_os_nodes`, `cclm`, and operator-only markers are exempt.
- After merge, validate on an STD PR with partial STP coverage — expect ❌ in pre-merge checks and an inline comment on the STP line.

##### jira-ticket:
NONE


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to require traceability between referenced scenarios and test declarations.
  * Clarified alignment requirements for test preconditions, steps, and expected results.
  * Documented when special infrastructure markers are required for tests.

* **Chores**
  * Added automated review checks to flag missing scenario coverage and required infrastructure markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->