### PR TITLE
[Main][Storage]: Remove CNV-76658 jira from hotplug test

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -15,10 +15,8 @@ from ocp_resources.storage_profile import StorageProfile
 
 from tests.storage.utils import assert_disk_bus
 from tests.utils import create_windows2022_dv_from_registry, create_windows2022_vm_with_vtpm_from_registry
-from utilities.constants import Images
 from utilities.constants.storage import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.jira import is_jira_open
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,
@@ -136,23 +134,13 @@ def param_substring_scope_class(storage_class_name_scope_class):
 @pytest.fixture(scope="class")
 def fedora_vm_for_hotplug_scope_class(unprivileged_client, namespace, param_substring_scope_class, cpu_for_migration):
     name = f"fedora-hotplug-{param_substring_scope_class}"
-    memory_requests = None
-    cpu_requests = None
-
-    if is_jira_open(jira_id="CNV-76658"):
-        memory_requests = f"{float(Images.Fedora.DEFAULT_MEMORY_SIZE[:-2]) * 2}Gi"
-        cpu_requests = 1
 
     with VirtualMachineForTests(
         client=unprivileged_client,
         name=name,
-        memory_requests=memory_requests,
-        memory_limits=memory_requests,
         namespace=namespace.name,
         body=fedora_vm_body(name=name),
         cpu_model=cpu_for_migration,
-        cpu_limits=cpu_requests,
-        cpu_requests=cpu_requests,
     ) as vm:
         running_vm(vm=vm)
         yield vm


### PR DESCRIPTION

##### What this PR does / why we need it:
The Jira is resolved, so the memory/CPU override in fedora_vm_for_hotplug_scope_class is no longer needed.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

