### PR TITLE
infra: Add pause unpause windows test

### DIFF
--- a/tests/infrastructure/instance_types/supported_os/test_windows_os.py
+++ b/tests/infrastructure/instance_types/supported_os/test_windows_os.py
@@ -2,16 +2,27 @@ import logging
 
 import pytest
 
-from utilities.guest_support import assert_windows_efi, check_vm_xml_hyperv, check_windows_vm_hvinfo
+from utilities.guest_support import (
+    assert_windows_efi,
+    check_vm_xml_hyperv,
+    check_windows_vm_hvinfo,
+    validate_pause_unpause_windows_vm,
+)
 from utilities.virt import running_vm
 
-pytestmark = [pytest.mark.high_resource_vm, pytest.mark.tier3]
+pytestmark = [pytest.mark.high_resource_vm, pytest.mark.special_infra, pytest.mark.tier3, pytest.mark.sno]
 
 LOGGER = logging.getLogger(__name__)
 TESTS_CLASS_NAME = "TestCommonPreferenceWindows"
 
 
 class TestCommonPreferenceWindows:
+    """
+    Tests for supporting Windows os when using a VM with instance types.
+
+    Jira: https://redhat.atlassian.net/browse/CNV-92873  # <skip-jira-utils-check>
+    """
+
     @pytest.mark.dependency(name=f"{TESTS_CLASS_NAME}::create_vm")
     @pytest.mark.polarion("CNV-12269")
     def test_create_vm(
@@ -26,17 +37,22 @@ class TestCommonPreferenceWindows:
     def test_start_vm(self, golden_image_windows_vm):
         running_vm(vm=golden_image_windows_vm)
 
+    # all the tests following this comment depend on start_vm: requires a running VM
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-12387")
     def test_efi_secureboot_enabled(self, golden_image_windows_vm):
         assert_windows_efi(vm=golden_image_windows_vm)
 
-    @pytest.mark.sno
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
     @pytest.mark.polarion("CNV-12388")
     def test_hyperv(self, admin_client, golden_image_windows_vm):
         check_vm_xml_hyperv(vm=golden_image_windows_vm, admin_client=admin_client)
         check_windows_vm_hvinfo(vm=golden_image_windows_vm)
+
+    @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::start_vm"])
+    @pytest.mark.polarion("CNV-16330")
+    def test_pause_unpause_vm(self, golden_image_windows_vm):
+        validate_pause_unpause_windows_vm(vm=golden_image_windows_vm)
 
     @pytest.mark.dependency(depends=[f"{TESTS_CLASS_NAME}::create_vm"])
     @pytest.mark.polarion("CNV-12271")

--- a/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_os_support.py
@@ -15,10 +15,14 @@ from tests.virt.cluster.common_templates.utils import (
     validate_os_info_virtctl_vs_windows_os,
     validate_user_info_virtctl_vs_windows_os,
 )
-from tests.virt.utils import validate_pause_unpause_windows_vm
 from utilities.constants.images import OS_FLAVOR_WINDOWS
 from utilities.constants.pytest import QUARANTINED
-from utilities.guest_support import assert_windows_efi, check_vm_xml_hyperv, check_windows_vm_hvinfo
+from utilities.guest_support import (
+    assert_windows_efi,
+    check_vm_xml_hyperv,
+    check_windows_vm_hvinfo,
+    validate_pause_unpause_windows_vm,
+)
 from utilities.ssp import validate_os_info_vmi_vs_windows_os
 from utilities.virt import (
     check_vm_xml_smbios,

--- a/tests/virt/node/gpu/gpu_pci_passthrough/test_windows_vm_with_gpu_pci_passthrough.py
+++ b/tests/virt/node/gpu/gpu_pci_passthrough/test_windows_vm_with_gpu_pci_passthrough.py
@@ -11,8 +11,9 @@ from tests.virt.node.gpu.constants import GPU_DEVICE_NAME_STR
 from tests.virt.node.gpu.utils import (
     restart_and_check_gpu_exists,
 )
-from tests.virt.utils import validate_pause_unpause_windows_vm, verify_gpu_device_exists_in_vm
+from tests.virt.utils import verify_gpu_device_exists_in_vm
 from utilities.constants import Images
+from utilities.guest_support import validate_pause_unpause_windows_vm
 
 pytestmark = [
     pytest.mark.post_upgrade,

--- a/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
@@ -16,10 +16,10 @@ from tests.virt.node.gpu.utils import (
 from tests.virt.utils import (
     get_data_volume_template_dict_with_default_storage_class,
     get_gpu_device_name_from_windows_vm,
-    validate_pause_unpause_windows_vm,
     verify_gpu_device_exists_in_vm,
 )
 from utilities.constants import Images
+from utilities.guest_support import validate_pause_unpause_windows_vm
 from utilities.virt import (
     VirtualMachineForTestsFromTemplate,
     running_vm,

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -36,7 +36,6 @@ from utilities.constants.timeouts import (
     TIMEOUT_30MIN,
     TIMEOUT_30SEC,
 )
-from utilities.constants.virt import OS_PROC_NAME
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     is_hco_tainted,
@@ -52,13 +51,10 @@ from utilities.storage import (
 from utilities.virt import (
     VirtualMachineForTests,
     fetch_pid_from_linux_vm,
-    fetch_pid_from_windows_vm,
     get_vm_boot_time,
     kill_processes_by_name_linux,
     migrate_vm_and_verify,
-    pause_unpause_vm_and_check_connectivity,
     start_and_fetch_processid_on_linux_vm,
-    start_and_fetch_processid_on_windows_vm,
     verify_vm_migrated,
     wait_for_migration_finished,
     wait_for_updated_kv_value,
@@ -212,23 +208,6 @@ def flatten_dict(dictionary, parent_key=""):
         else:
             items.append((new_key, value))
     return dict(items)
-
-
-def kill_processes_by_name_windows(vm, process_name):
-    cmd = shlex.split(f"taskkill /F /IM {process_name}")
-    run_ssh_commands(host=vm.ssh_exec, commands=cmd, tcp_timeout=TCP_TIMEOUT_30SEC)
-
-
-def validate_pause_unpause_windows_vm(vm: VirtualMachineForTests, pre_pause_pid: int | None = None) -> None:
-    proc_name = OS_PROC_NAME["windows"]
-    if not pre_pause_pid:
-        pre_pause_pid = start_and_fetch_processid_on_windows_vm(vm=vm, process_name=proc_name)
-    pause_unpause_vm_and_check_connectivity(vm=vm)
-    post_pause_pid = fetch_pid_from_windows_vm(vm=vm, process_name=proc_name)
-    kill_processes_by_name_windows(vm=vm, process_name=proc_name)
-    assert post_pause_pid == pre_pause_pid, (
-        f"PID mismatch!\nPre pause PID is: {pre_pause_pid}\nPost pause PID is: {post_pause_pid}"
-    )
 
 
 def wait_for_virt_launcher_pod(vmi, privileged_client: DynamicClient):

--- a/utilities/guest_support.py
+++ b/utilities/guest_support.py
@@ -10,8 +10,13 @@ from utilities.constants.timeouts import (
     TIMEOUT_15SEC,
     TIMEOUT_90SEC,
 )
-from utilities.constants.virt import HYPERV_FEATURES_LABELS_DOM_XML
-from utilities.virt import VirtualMachineForTests
+from utilities.constants.virt import HYPERV_FEATURES_LABELS_DOM_XML, OS_PROC_NAME
+from utilities.virt import (
+    VirtualMachineForTests,
+    fetch_pid_from_windows_vm,
+    pause_unpause_vm_and_check_connectivity,
+    start_and_fetch_processid_on_windows_vm,
+)
 
 
 def assert_windows_efi(vm: VirtualMachineForTests) -> None:
@@ -148,3 +153,20 @@ def check_windows_vm_hvinfo(vm: VirtualMachineForTests) -> None:
         f"The following hyperV flags are not set correctly in the guest: {failed_windows_hyperv_list}\n"
         f"VM hvinfo dict:{hvinfo_dict}"
     )
+
+
+def validate_pause_unpause_windows_vm(vm: VirtualMachineForTests, pre_pause_pid: int | None = None) -> None:
+    proc_name = OS_PROC_NAME["windows"]
+    if pre_pause_pid is None:
+        pre_pause_pid = start_and_fetch_processid_on_windows_vm(vm=vm, process_name=proc_name)
+    pause_unpause_vm_and_check_connectivity(vm=vm)
+    post_pause_pid = fetch_pid_from_windows_vm(vm=vm, process_name=proc_name)
+    kill_processes_by_name_windows(vm=vm, process_name=proc_name)
+    assert post_pause_pid == pre_pause_pid, (
+        f"PID mismatch!\nPre pause PID is: {pre_pause_pid}\nPost pause PID is: {post_pause_pid}"
+    )
+
+
+def kill_processes_by_name_windows(vm: VirtualMachineForTests, process_name: str) -> None:
+    cmd = shlex.split(f"taskkill /F /IM {process_name}")
+    run_ssh_commands(host=vm.ssh_exec, commands=cmd, tcp_timeout=TCP_TIMEOUT_30SEC)

--- a/utilities/unittests/test_guest_support.py
+++ b/utilities/unittests/test_guest_support.py
@@ -11,6 +11,8 @@ from timeout_sampler import TimeoutExpiredError
 
 # Need to mock circular imports for guest_support
 import utilities
+from utilities.constants.timeouts import TCP_TIMEOUT_30SEC
+from utilities.constants.virt import OS_PROC_NAME
 
 mock_virt = MagicMock()
 sys.modules["utilities.virt"] = mock_virt
@@ -21,6 +23,8 @@ from utilities.guest_support import (
     assert_windows_efi,
     check_vm_xml_hyperv,
     check_windows_vm_hvinfo,
+    kill_processes_by_name_windows,
+    validate_pause_unpause_windows_vm,
 )
 
 
@@ -510,3 +514,82 @@ class TestCheckWindowsVmHvinfo:
 
         with pytest.raises(TimeoutExpiredError):
             check_windows_vm_hvinfo(mock_vm)
+
+
+class TestKillProcessesByNameWindows:
+    """Test cases for kill_processes_by_name_windows function"""
+
+    @patch("utilities.guest_support.run_ssh_commands")
+    def test_kill_processes_by_name_windows(self, mock_run_ssh):
+        """Test that taskkill command is issued for the given process name"""
+        mock_vm = MagicMock()
+        mock_vm.ssh_exec = MagicMock()
+
+        kill_processes_by_name_windows(vm=mock_vm, process_name="notepad.exe")
+
+        mock_run_ssh.assert_called_once_with(
+            host=mock_vm.ssh_exec,
+            commands=["taskkill", "/F", "/IM", "notepad.exe"],
+            tcp_timeout=TCP_TIMEOUT_30SEC,
+        )
+
+
+class TestValidatePauseUnpauseWindowsVm:
+    """Test cases for validate_pause_unpause_windows_vm function"""
+
+    @patch("utilities.guest_support.kill_processes_by_name_windows")
+    @patch("utilities.guest_support.fetch_pid_from_windows_vm")
+    @patch("utilities.guest_support.pause_unpause_vm_and_check_connectivity")
+    @patch("utilities.guest_support.start_and_fetch_processid_on_windows_vm")
+    def test_validate_pause_unpause_windows_vm_matching_pids_starts_process(
+        self, mock_start_and_fetch_pid, mock_pause_unpause, mock_fetch_pid, mock_kill_processes
+    ):
+        """Test that a process is started when no pre-pause PID is supplied and PIDs match after unpause"""
+        mock_vm = MagicMock()
+        mock_start_and_fetch_pid.return_value = 1234
+        mock_fetch_pid.return_value = 1234
+
+        validate_pause_unpause_windows_vm(vm=mock_vm)
+
+        mock_start_and_fetch_pid.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])
+        mock_pause_unpause.assert_called_once_with(vm=mock_vm)
+        mock_fetch_pid.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])
+        mock_kill_processes.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])
+
+    @patch("utilities.guest_support.kill_processes_by_name_windows")
+    @patch("utilities.guest_support.fetch_pid_from_windows_vm")
+    @patch("utilities.guest_support.pause_unpause_vm_and_check_connectivity")
+    @patch("utilities.guest_support.start_and_fetch_processid_on_windows_vm")
+    def test_validate_pause_unpause_windows_vm_uses_provided_pre_pause_pid(
+        self, mock_start_and_fetch_pid, mock_pause_unpause, mock_fetch_pid, mock_kill_processes
+    ):
+        """Test that the provided pre-pause PID is used instead of starting a new process"""
+        mock_vm = MagicMock()
+        mock_fetch_pid.return_value = 5678
+
+        validate_pause_unpause_windows_vm(vm=mock_vm, pre_pause_pid=5678)
+
+        mock_start_and_fetch_pid.assert_not_called()
+        mock_pause_unpause.assert_called_once_with(vm=mock_vm)
+        mock_fetch_pid.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])
+        mock_kill_processes.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])
+
+    @patch("utilities.guest_support.kill_processes_by_name_windows")
+    @patch("utilities.guest_support.fetch_pid_from_windows_vm")
+    @patch("utilities.guest_support.pause_unpause_vm_and_check_connectivity")
+    @patch("utilities.guest_support.start_and_fetch_processid_on_windows_vm")
+    def test_validate_pause_unpause_windows_vm_pid_mismatch(
+        self, mock_start_and_fetch_pid, mock_pause_unpause, mock_fetch_pid, mock_kill_processes
+    ):
+        """Test assertion failure when the PID before and after pause/unpause differ"""
+        mock_vm = MagicMock()
+        mock_start_and_fetch_pid.return_value = 1234
+        mock_fetch_pid.return_value = 4321
+
+        with pytest.raises(AssertionError, match="PID mismatch"):
+            validate_pause_unpause_windows_vm(vm=mock_vm)
+
+        mock_start_and_fetch_pid.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])
+        mock_pause_unpause.assert_called_once_with(vm=mock_vm)
+        mock_fetch_pid.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])
+        mock_kill_processes.assert_called_once_with(vm=mock_vm, process_name=OS_PROC_NAME["windows"])


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds a new `test_pause_unpause_vm` test to the Windows instance types supported OS suite, and moves `validate_pause_unpause_windows_vm` from `tests/virt/utils.py` to `utilities/guest_support.py` so it can be shared across both test modules.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-86485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows VM pause/unpause validation by using shared Windows guest process helpers and adding stricter PID consistency checks around connectivity verification.

* **Tests**
  * Updated Windows pause/unpause integration tests to use the shared validation helper and the correct startup prerequisite/marking.
  * Standardized cluster/template and GPU-related Windows tests to reference the same Windows pause/unpause validation logic.
  * Expanded unit test coverage for Windows guest process termination and pause/unpause PID matching/mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->