### PR TITLE
[WIP] Replace static inventory tests with dynamic subtest-based validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ from utilities.virt import (
     VirtualMachineForTests,
     fedora_vm_body,
     get_base_templates_list,
+    get_hyperconverged_kubevirt,
     running_vm,
     start_and_fetch_processid_on_linux_vm,
     vm_instance_from_template,
@@ -214,6 +215,12 @@ def prometheus():
         verify_ssl=False,
         bearer_token=utilities.infra.get_prometheus_k8s_token(duration="86400s"),
     )
+
+
+@pytest.fixture(scope="class")
+def kubevirt_resource_scope_class(admin_client, installing_cnv, hco_namespace):
+    if not installing_cnv:
+        return get_hyperconverged_kubevirt(admin_client=admin_client, hco_namespace=hco_namespace)
 
 
 @pytest.fixture(scope="session")

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -14,7 +14,6 @@ from utilities.constants.aaq import (
 )
 from utilities.constants.architecture import MULTIARCH
 from utilities.constants.components import (
-    CNV_OPERATORS,
     CNV_PROMETHEUS_RULES,
     HCO_CATALOG_SOURCE,
     VM_CONSOLE_PROXY_CLUSTER_RESOURCES,
@@ -198,7 +197,6 @@ data_import_cron_matrix = [
 cnv_crypto_policy_matrix = [TLS_OLD_POLICY, TLS_CUSTOM_POLICY]
 
 cnv_prometheus_rules_matrix = CNV_PROMETHEUS_RULES
-cnv_operators_matrix = CNV_OPERATORS
 cnv_vm_console_proxy_cluster_resource_matrix = VM_CONSOLE_PROXY_CLUSTER_RESOURCES
 cnv_vm_console_proxy_namespace_resource_matrix = VM_CONSOLE_PROXY_NAMESPACE_RESOURCES
 

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -14,10 +14,6 @@ from utilities.constants.aaq import (
 )
 from utilities.constants.architecture import MULTIARCH
 from utilities.constants.components import (
-    ALL_CNV_DAEMONSETS,
-    ALL_CNV_DEPLOYMENTS,
-    ALL_CNV_PODS,
-    ALL_HCO_RELATED_OBJECTS,
     CNV_OPERATORS,
     CNV_PROMETHEUS_RULES,
     HCO_CATALOG_SOURCE,
@@ -25,7 +21,6 @@ from utilities.constants.components import (
     VM_CONSOLE_PROXY_NAMESPACE_RESOURCES,
 )
 from utilities.constants.hco import (
-    ALL_CNV_CRDS,
     PRODUCTION_CATALOG_SOURCE,
     TLS_CUSTOM_POLICY,
     TLS_OLD_POLICY,
@@ -200,16 +195,9 @@ data_import_cron_matrix = [
     {"rhel10": {"instance_type": U1_MEDIUM_STR, "preference": RHEL10_PREFERENCE}},
 ]
 
-cnv_pod_matrix = ALL_CNV_PODS
-cnv_crd_matrix = ALL_CNV_CRDS
 cnv_crypto_policy_matrix = [TLS_OLD_POLICY, TLS_CUSTOM_POLICY]
 
-cnv_related_object_matrix = ALL_HCO_RELATED_OBJECTS
 cnv_prometheus_rules_matrix = CNV_PROMETHEUS_RULES
-
-cnv_deployment_matrix = ALL_CNV_DEPLOYMENTS
-cnv_daemonset_matrix = ALL_CNV_DAEMONSETS
-pod_resource_validation_matrix = [{"cpu": 5}, {"memory": None}]
 cnv_operators_matrix = CNV_OPERATORS
 cnv_vm_console_proxy_cluster_resource_matrix = VM_CONSOLE_PROXY_CLUSTER_RESOURCES
 cnv_vm_console_proxy_namespace_resource_matrix = VM_CONSOLE_PROXY_NAMESPACE_RESOURCES

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -14,17 +14,12 @@ from utilities.constants.aaq import (
 )
 from utilities.constants.architecture import MULTIARCH
 from utilities.constants.components import (
-    ALL_CNV_DAEMONSETS,
-    ALL_CNV_DEPLOYMENTS,
-    ALL_CNV_PODS,
-    ALL_HCO_RELATED_OBJECTS,
     CNV_OPERATORS,
     HCO_CATALOG_SOURCE,
     VM_CONSOLE_PROXY_CLUSTER_RESOURCES,
     VM_CONSOLE_PROXY_NAMESPACE_RESOURCES,
 )
 from utilities.constants.hco import (
-    ALL_CNV_CRDS,
     PRODUCTION_CATALOG_SOURCE,
     TLS_CUSTOM_POLICY,
     TLS_OLD_POLICY,
@@ -199,14 +194,9 @@ data_import_cron_matrix = [
     {"rhel10": {"instance_type": U1_MEDIUM_STR, "preference": RHEL10_PREFERENCE}},
 ]
 
-cnv_pod_matrix = ALL_CNV_PODS
-cnv_crd_matrix = ALL_CNV_CRDS
 cnv_crypto_policy_matrix = [TLS_OLD_POLICY, TLS_CUSTOM_POLICY]
 
-cnv_related_object_matrix = ALL_HCO_RELATED_OBJECTS
-cnv_deployment_matrix = ALL_CNV_DEPLOYMENTS
-cnv_daemonset_matrix = ALL_CNV_DAEMONSETS
-pod_resource_validation_matrix = [{"cpu": 5}, {"memory": None}]
+cnv_prometheus_rules_matrix = CNV_PROMETHEUS_RULES
 cnv_operators_matrix = CNV_OPERATORS
 cnv_vm_console_proxy_cluster_resource_matrix = VM_CONSOLE_PROXY_CLUSTER_RESOURCES
 cnv_vm_console_proxy_namespace_resource_matrix = VM_CONSOLE_PROXY_NAMESPACE_RESOURCES

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -14,7 +14,7 @@ from utilities.constants.aaq import (
 )
 from utilities.constants.architecture import MULTIARCH
 from utilities.constants.components import (
-    CNV_OPERATORS,
+    CNV_PROMETHEUS_RULES,
     HCO_CATALOG_SOURCE,
     VM_CONSOLE_PROXY_CLUSTER_RESOURCES,
     VM_CONSOLE_PROXY_NAMESPACE_RESOURCES,
@@ -197,7 +197,6 @@ data_import_cron_matrix = [
 cnv_crypto_policy_matrix = [TLS_OLD_POLICY, TLS_CUSTOM_POLICY]
 
 cnv_prometheus_rules_matrix = CNV_PROMETHEUS_RULES
-cnv_operators_matrix = CNV_OPERATORS
 cnv_vm_console_proxy_cluster_resource_matrix = VM_CONSOLE_PROXY_CLUSTER_RESOURCES
 cnv_vm_console_proxy_namespace_resource_matrix = VM_CONSOLE_PROXY_NAMESPACE_RESOURCES
 

--- a/tests/global_config_sno_hpp.py
+++ b/tests/global_config_sno_hpp.py
@@ -2,21 +2,11 @@ from typing import Any
 
 import pytest_testconfig
 
-from utilities.constants.components import (
-    ALL_CNV_DAEMONSETS,
-    ALL_CNV_DEPLOYMENTS,
-    ALL_CNV_PODS,
-)
 from utilities.constants.storage import HPP_CAPABILITIES
 from utilities.storage import HppCsiStorageClass
 
 global config
 global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")
-
-
-cnv_deployment_matrix = ALL_CNV_DEPLOYMENTS
-cnv_pod_matrix = ALL_CNV_PODS
-cnv_daemonset_matrix = ALL_CNV_DAEMONSETS
 
 
 storage_class_matrix = [

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -151,25 +151,6 @@ def hco_spec_scope_module(hyperconverged_resource_scope_module):
     return hyperconverged_resource_scope_module.instance.to_dict()["spec"]
 
 
-@pytest.fixture()
-def xfail_if_sriov_conforma_jira_open_and_hco_operator(admin_client, hco_namespace, request):
-    try:
-        is_hco_operator = request.getfixturevalue("cnv_deployment_by_name").name == HCO_OPERATOR
-    except pytest.FixtureLookupError:
-        is_hco_operator = any(pod.name.startswith(HCO_OPERATOR) for pod in request.getfixturevalue("cnv_pods_by_type"))
-    if not is_hco_operator:
-        return
-    hco_version = get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)
-    if hco_version.startswith("4.23") and is_jira_open(jira_id="CNV-92888"):
-        pytest.xfail(
-            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
-        )
-    if hco_version.startswith("5.0") and is_jira_open(jira_id="CNV-92889"):
-        pytest.xfail(
-            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
-        )
-
-
 @pytest.fixture(scope="class")
 def hco_version_scope_class(admin_client, hco_namespace):
     return get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -4,40 +4,25 @@ import pkgutil
 import re
 
 import pytest
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.cdi import CDI
-from ocp_resources.deployment import Deployment
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.network_addons_config import NetworkAddonsConfig
-from ocp_resources.storage_class import StorageClass
+from ocp_resources.pod import Pod
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
-    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
-    EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
-    FG_ENABLED,
-    HCO_DEFAULT_FEATUREGATES,
     RESOURCE_NAME_STR,
     RESOURCE_NAMESPACE_STR,
     RESOURCE_TYPE_STR,
-    S390X_SPECIFIC_KUBEVIRT_FEATUREGATES,
 )
 from tests.install_upgrade_operators.utils import (
     get_network_addon_config,
     get_resource_by_name,
-    get_resource_from_related_object,
-)
-from utilities.constants.architecture import MULTIARCH
-from utilities.constants.components import (
-    HCO_OPERATOR,
-    HOSTPATH_PROVISIONER_CSI,
-    HPP_POOL,
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile, get_hco_version
 from utilities.infra import (
-    get_daemonset_by_name,
-    get_deployment_by_name,
-    get_pod_by_name_prefix,
+    get_daemonsets,
+    get_deployments,
     wait_for_version_explorer_response,
 )
 from utilities.jira import is_jira_open
@@ -50,6 +35,24 @@ from utilities.storage import get_hyperconverged_cdi
 from utilities.virt import get_hyperconverged_kubevirt
 
 LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def discovered_cnv_deployments(admin_client, hco_namespace):
+    """Discover all CNV deployments from the cluster."""
+    return get_deployments(admin_client=admin_client, namespace=hco_namespace.name)
+
+
+@pytest.fixture(scope="session")
+def discovered_cnv_pods(admin_client, hco_namespace):
+    """Discover all CNV pods from the cluster."""
+    return list(Pod.get(client=admin_client, namespace=hco_namespace.name))
+
+
+@pytest.fixture(scope="session")
+def discovered_cnv_daemonsets(admin_client, hco_namespace):
+    """Discover all CNV daemonsets from the cluster."""
+    return get_daemonsets(admin_client=admin_client, namespace=hco_namespace.name)
 
 
 @pytest.fixture(scope="session")
@@ -74,65 +77,6 @@ def iib_build_info(cnv_source, cnv_image_url, admin_client):
             log_message=f"Version Explorer returned empty response for IIB {iib_number}.",
         )
     return {}
-
-
-@pytest.fixture()
-def cnv_deployment_by_name(admin_client, hco_namespace, hpp_cr_installed, cnv_deployment_matrix__function__):
-    deployment_name = cnv_deployment_matrix__function__
-    if deployment_name == HPP_POOL:
-        if not hpp_cr_installed:
-            pytest.xfail(f"{deployment_name} deployment shouldn't be present on the cluster if HPP CR is not installed")
-        hpp_pool_deployments = list(
-            Deployment.get(
-                client=admin_client,
-                namespace=hco_namespace.name,
-                label_selector=f"{StorageClass.Provisioner.HOSTPATH_CSI}/storagePool=hpp-csi-pvc-block-hpp",
-            )
-        )
-        assert hpp_pool_deployments, "HPP pool deployment not found on this cluster"
-        return hpp_pool_deployments[0]
-
-    return get_deployment_by_name(
-        namespace_name=hco_namespace.name,
-        deployment_name=deployment_name,
-        admin_client=admin_client,
-    )
-
-
-@pytest.fixture()
-def cnv_daemonset_by_name(
-    admin_client,
-    hco_namespace,
-    hpp_cr_installed,
-    cnv_daemonset_matrix__function__,
-):
-    daemonset_name = cnv_daemonset_matrix__function__
-    if daemonset_name == HOSTPATH_PROVISIONER_CSI and not hpp_cr_installed:
-        pytest.xfail(f"{daemonset_name} daemonset shouldn't be present on the cluster if HPP CR is not installed")
-    return get_daemonset_by_name(
-        admin_client=admin_client,
-        namespace_name=hco_namespace.name,
-        daemonset_name=daemonset_name,
-    )
-
-
-@pytest.fixture()
-def cnv_pods_by_type(
-    admin_client,
-    hco_namespace,
-    hpp_cr_installed,
-    cnv_pod_matrix__function__,
-):
-    pod_prefix = cnv_pod_matrix__function__
-    if pod_prefix.startswith((HOSTPATH_PROVISIONER_CSI, HPP_POOL)) and not hpp_cr_installed:
-        pytest.xfail(f"{pod_prefix} pods shouldn't be present on the cluster if HPP CR is not installed")
-    pod_list = get_pod_by_name_prefix(
-        client=admin_client,
-        namespace=hco_namespace.name,
-        pod_prefix=pod_prefix,
-        get_all=True,
-    )
-    return pod_list
 
 
 @pytest.fixture(scope="session")
@@ -251,34 +195,6 @@ def machine_config_pools_conditions_scope_module(machine_config_pools):
 
 
 @pytest.fixture()
-def ocp_resource_by_name(admin_client, ocp_resources_submodule_list, related_object_from_hco_status):
-    return get_resource_from_related_object(
-        related_obj=related_object_from_hco_status,
-        ocp_resources_submodule_list=ocp_resources_submodule_list,
-        admin_client=admin_client,
-    )
-
-
-@pytest.fixture()
-def related_object_from_hco_status(
-    hco_status_related_objects,
-    cnv_related_object_matrix__function__,
-):
-    LOGGER.info(cnv_related_object_matrix__function__)
-    kind_name = list(cnv_related_object_matrix__function__.values())[0]
-    related_object_name = list(cnv_related_object_matrix__function__.keys())[0]
-
-    LOGGER.info(f"Looking for related object {related_object_name}, kind {kind_name}")
-    for obj in hco_status_related_objects:
-        if obj.name == related_object_name and obj.kind == kind_name:
-            return obj
-    raise ResourceNotFoundError(
-        f"Related object {related_object_name}, kind {kind_name} not found in "
-        f"hco.status.relatedObjects: {hco_status_related_objects}"
-    )
-
-
-@pytest.fixture()
 def updated_resource(
     request,
     admin_client,
@@ -298,17 +214,6 @@ def updated_resource(
         wait_for_reconcile_post_update=True,
     ):
         yield cr
-
-
-@pytest.fixture()
-def expected_value(request, is_s390x_cluster):
-    expected = request.param.copy()
-    if expected == EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES and is_s390x_cluster:
-        expected |= S390X_SPECIFIC_KUBEVIRT_FEATUREGATES
-    if expected == HCO_DEFAULT_FEATUREGATES:
-        if py_config["cluster_type"] == MULTIARCH:
-            expected[ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT] = FG_ENABLED
-    return expected
 
 
 @pytest.fixture(scope="session")

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -11,14 +11,20 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
+    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
+    EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
+    FG_ENABLED,
+    HCO_DEFAULT_FEATUREGATES,
     RESOURCE_NAME_STR,
     RESOURCE_NAMESPACE_STR,
     RESOURCE_TYPE_STR,
+    S390X_SPECIFIC_KUBEVIRT_FEATUREGATES,
 )
 from tests.install_upgrade_operators.utils import (
     get_network_addon_config,
     get_resource_by_name,
 )
+from utilities.constants.architecture import MULTIARCH
 from utilities.hco import ResourceEditorValidateHCOReconcile, get_hco_version
 from utilities.infra import (
     get_daemonsets,
@@ -195,6 +201,17 @@ def updated_resource(
         wait_for_reconcile_post_update=True,
     ):
         yield cr
+
+
+@pytest.fixture()
+def expected_value(request, is_s390x_cluster):
+    expected = request.param.copy()
+    if expected == EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES and is_s390x_cluster:
+        expected |= S390X_SPECIFIC_KUBEVIRT_FEATUREGATES
+    if expected == HCO_DEFAULT_FEATUREGATES:
+        if py_config["cluster_type"] == MULTIARCH:
+            expected[ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT] = FG_ENABLED
+    return expected
 
 
 @pytest.fixture(scope="session")

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -11,10 +11,13 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import py_config
 
 from tests.install_upgrade_operators.constants import (
+    DEVELOPER_CONFIGURATION,
     ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
     EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
+    FEATUREGATES,
     FG_ENABLED,
     HCO_DEFAULT_FEATUREGATES,
+    KEY_PATH_SEPARATOR,
     RESOURCE_NAME_STR,
     RESOURCE_NAMESPACE_STR,
     RESOURCE_TYPE_STR,
@@ -23,6 +26,7 @@ from tests.install_upgrade_operators.constants import (
 from tests.install_upgrade_operators.utils import (
     get_network_addon_config,
     get_resource_by_name,
+    get_resource_key_value,
 )
 from utilities.constants.architecture import MULTIARCH
 from utilities.hco import ResourceEditorValidateHCOReconcile, get_hco_version
@@ -40,6 +44,10 @@ from utilities.pytest_utils import exit_pytest_execution
 from utilities.storage import get_hyperconverged_cdi
 from utilities.virt import get_hyperconverged_kubevirt
 
+KUBEVIRT_FEATUREGATES_KEY = (
+    f"configuration{KEY_PATH_SEPARATOR}{DEVELOPER_CONFIGURATION}{KEY_PATH_SEPARATOR}{FEATUREGATES}"
+)
+CDI_FEATUREGATES_KEY = f"config{KEY_PATH_SEPARATOR}{FEATUREGATES}"
 LOGGER = logging.getLogger(__name__)
 
 
@@ -217,3 +225,63 @@ def expected_value(request, is_s390x_cluster):
 @pytest.fixture(scope="session")
 def jira_76659_open():
     return is_jira_open(jira_id="CNV-76659")
+
+
+@pytest.fixture()
+def initial_kubevirt_fg(kubevirt_resource_scope_class):
+    initial_featuregate = get_resource_key_value(
+        resource=kubevirt_resource_scope_class, key_name=KUBEVIRT_FEATUREGATES_KEY
+    )
+    assert initial_featuregate, "KubeVirt featureGates are empty before reconciliation test"
+    LOGGER.info(f"KubeVirt featureGates before deletion: {initial_featuregate}")
+    return set(initial_featuregate)
+
+
+@pytest.fixture()
+def removed_kubevirt_fg(admin_client, kubevirt_resource_scope_class):
+    with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
+        patches={
+            kubevirt_resource_scope_class: {
+                "spec": {"configuration": {"developerConfiguration": {"featureGates": None}}}
+            }
+        },
+        action="replace",
+        list_resource_reconcile=[KubeVirt],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+
+
+@pytest.fixture()
+def kubevirt_fg_after_removed(kubevirt_resource_scope_class):
+    actual = get_resource_key_value(resource=kubevirt_resource_scope_class, key_name=KUBEVIRT_FEATUREGATES_KEY)
+    if isinstance(actual, list):
+        return set(actual)
+
+
+@pytest.fixture()
+def initial_cdi_fg(cdi_resource_scope_function):
+    initial_featuregate = get_resource_key_value(resource=cdi_resource_scope_function, key_name=CDI_FEATUREGATES_KEY)
+    assert initial_featuregate, "CDI featureGates are empty before reconciliation test"
+    LOGGER.info(f"CDI featureGates before deletion: {initial_featuregate}")
+    return set(initial_featuregate)
+
+
+@pytest.fixture()
+def removed_cdi_fg(admin_client, cdi_resource_scope_function):
+    with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
+        patches={cdi_resource_scope_function: {"spec": {}}},
+        action="replace",
+        list_resource_reconcile=[CDI],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+
+
+@pytest.fixture()
+def cdi_fg_after_removed(cdi_resource_scope_function):
+    actual = get_resource_key_value(resource=cdi_resource_scope_function, key_name=CDI_FEATUREGATES_KEY)
+    if isinstance(actual, list):
+        return set(actual)

--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -23,6 +23,33 @@ RESOURCE_TYPE_STR = "resource_type"
 RESOURCE_NAME_STR = "resource_name"
 RESOURCE_NAMESPACE_STR = "resource_namespace"
 KEY_NAME_STR = "key_name"
+EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
+    "CPUManager",
+    "DecentralizedLiveMigration",
+    "DeclarativeHotplugVolumes",
+    "HostDevices",
+    "HypervStrictCheck",
+    "KubevirtSeccompProfile",
+    "Snapshot",
+}
+S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
+EXPECTED_CDI_HARDCODED_FEATUREGATES = {
+    "DataVolumeClaimAdoption",
+    "HonorWaitForFirstConsumer",
+    "WebhookPvcRendering",
+}
+HCO_DEFAULT_FEATUREGATES = {
+    DEPLOY_KUBE_SECONDARY_DNS: FG_DISABLED,
+    PERSISTENT_RESERVATION: FG_DISABLED,
+    "alignCPUs": FG_DISABLED,
+    "downwardMetrics": FG_DISABLED,
+    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_DISABLED,
+    "decentralizedLiveMigration": FG_ENABLED,
+    "declarativeHotplugVolumes": FG_ENABLED,
+    "objectGraph": FG_DISABLED,
+    "incrementalBackup": FG_DISABLED,
+    "containerPathVolumes": FG_DISABLED,
+}
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"
 KUBEMACPOOL_SERVICE = "kubemacpool-service"

--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -23,33 +23,6 @@ RESOURCE_TYPE_STR = "resource_type"
 RESOURCE_NAME_STR = "resource_name"
 RESOURCE_NAMESPACE_STR = "resource_namespace"
 KEY_NAME_STR = "key_name"
-EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
-    "CPUManager",
-    "DecentralizedLiveMigration",
-    "DeclarativeHotplugVolumes",
-    "HostDevices",
-    "HypervStrictCheck",
-    "KubevirtSeccompProfile",
-    "Snapshot",
-}
-S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
-EXPECTED_CDI_HARDCODED_FEATUREGATES = {
-    "DataVolumeClaimAdoption",
-    "HonorWaitForFirstConsumer",
-    "WebhookPvcRendering",
-}
-HCO_DEFAULT_FEATUREGATES = {
-    DEPLOY_KUBE_SECONDARY_DNS: FG_DISABLED,
-    PERSISTENT_RESERVATION: FG_DISABLED,
-    "alignCPUs": FG_DISABLED,
-    "downwardMetrics": FG_DISABLED,
-    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_DISABLED,
-    "decentralizedLiveMigration": FG_ENABLED,
-    "declarativeHotplugVolumes": FG_ENABLED,
-    "objectGraph": FG_DISABLED,
-    "incrementalBackup": FG_DISABLED,
-    "containerPathVolumes": FG_DISABLED,
-}
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"
 KUBEMACPOOL_SERVICE = "kubemacpool-service"

--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -23,35 +23,6 @@ RESOURCE_TYPE_STR = "resource_type"
 RESOURCE_NAME_STR = "resource_name"
 RESOURCE_NAMESPACE_STR = "resource_namespace"
 KEY_NAME_STR = "key_name"
-EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
-    "CPUManager",
-    "DecentralizedLiveMigration",
-    "DeclarativeHotplugVolumes",
-    "ExternalNetResourceInjection",
-    "HostDevices",
-    "HypervStrictCheck",
-    "KubevirtSeccompProfile",
-    "Snapshot",
-    "Template",
-}
-S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
-EXPECTED_CDI_HARDCODED_FEATUREGATES = {
-    "DataVolumeClaimAdoption",
-    "HonorWaitForFirstConsumer",
-    "WebhookPvcRendering",
-}
-HCO_DEFAULT_FEATUREGATES = {
-    DEPLOY_KUBE_SECONDARY_DNS: FG_DISABLED,
-    PERSISTENT_RESERVATION: FG_DISABLED,
-    "alignCPUs": FG_DISABLED,
-    "downwardMetrics": FG_DISABLED,
-    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_DISABLED,
-    "decentralizedLiveMigration": FG_ENABLED,
-    "declarativeHotplugVolumes": FG_ENABLED,
-    "objectGraph": FG_DISABLED,
-    "incrementalBackup": FG_DISABLED,
-    "containerPathVolumes": FG_DISABLED,
-}
 CUSTOM_DATASOURCE_NAME = "custom-datasource"
 WORKLOAD_UPDATE_STRATEGY_KEY_NAME = "workloadUpdateStrategy"
 KUBEMACPOOL_SERVICE = "kubemacpool-service"

--- a/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
@@ -11,6 +11,7 @@ import pytest
 from utilities.jira import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
+VIRT_PLATFORM_AUTOPILOT_METRICS = "virt-platform-autopilot-metrics"
 pytestmark = pytest.mark.post_upgrade
 VIRT_PLATFORM_AUTOPILOT_METRICS = "virt-platform-autopilot-metrics"
 

--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -39,16 +39,6 @@ OPERATOR_API_GROUP_MAPPING = {
 }
 
 
-@pytest.fixture()
-def global_permission_from_csv(cnv_operators_matrix__function__, csv_permissions):
-    for service_account_name, all_permissions in csv_permissions.items():
-        if cnv_operators_matrix__function__ == service_account_name:
-            return {
-                "permission": all_permissions.get("permission", []),
-                "cluster_permission": all_permissions.get("cluster_permission", []),
-            }
-
-
 @pytest.fixture(scope="module")
 def csv_permissions(admin_client):
     return get_csv_permissions(
@@ -59,26 +49,31 @@ def csv_permissions(admin_client):
 
 
 @pytest.mark.polarion("CNV-9548")
-def test_global_csv_permissions(cnv_operators_matrix__function__, global_permission_from_csv):
-    error_message = f"Found global permission for {cnv_operators_matrix__function__}"
-    errors = {}
-    for key in global_permission_from_csv:
-        error_list = []
-        for _permission_entry in global_permission_from_csv[key]:
-            LOGGER.info(f"Permission is: {_permission_entry}")
-            if "*" in _permission_entry["verbs"]:
-                # allow kubevirt operators to have global permissions on their own component resources
-                operator_api_group = OPERATOR_API_GROUP_MAPPING.get(cnv_operators_matrix__function__)
-                if operator_api_group and all(operator_api_group in entry for entry in _permission_entry["apiGroups"]):
-                    continue
-                else:
-                    error_list.append(_permission_entry)
-        if error_list:
-            errors[key] = error_list
-    if errors:
-        LOGGER.error(yaml.dump(errors))
-        if cnv_operators_matrix__function__ in JIRA_LINKS.keys() and is_jira_open(
-            jira_id=JIRA_LINKS[cnv_operators_matrix__function__]
-        ):
-            pytest.xfail(error_message)
-        raise AssertionError(error_message)
+def test_global_csv_permissions(subtests, csv_permissions):
+    for operator_name, all_permissions in csv_permissions.items():
+        with subtests.test(msg=operator_name):
+            errors = {}
+            permissions = {
+                "permission": all_permissions.get("permission", []),
+                "cluster_permission": all_permissions.get("cluster_permission", []),
+            }
+            for key, permission_entries in permissions.items():
+                error_list = []
+                for _permission_entry in permission_entries:
+                    LOGGER.info(f"Permission is: {_permission_entry}")
+                    if "*" in _permission_entry["verbs"]:
+                        operator_api_group = OPERATOR_API_GROUP_MAPPING.get(operator_name)
+                        if operator_api_group and all(
+                            operator_api_group in entry for entry in _permission_entry["apiGroups"]
+                        ):
+                            continue
+                        else:
+                            error_list.append(_permission_entry)
+                if error_list:
+                    errors[key] = error_list
+            if errors:
+                error_message = f"Found global permission for {operator_name}"
+                LOGGER.error(yaml.dump(errors))
+                if operator_name in JIRA_LINKS and is_jira_open(jira_id=JIRA_LINKS[operator_name]):
+                    pytest.xfail(error_message)
+                pytest.fail(error_message)

--- a/tests/install_upgrade_operators/deployment/conftest.py
+++ b/tests/install_upgrade_operators/deployment/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-from utilities.constants.components import KUBEVIRT_MIGRATION_CONTROLLER
 from utilities.infra import get_deployment_by_name
 
 
@@ -13,9 +12,3 @@ def deployment_by_name(request, admin_client, hco_namespace):
     yield get_deployment_by_name(
         namespace_name=hco_namespace.name, deployment_name=deployment_name, admin_client=admin_client
     )
-
-
-@pytest.fixture()
-def xfail_if_jira_76659_open_and_migration_controller_deployment(jira_76659_open, cnv_deployment_by_name):
-    if cnv_deployment_by_name.name == KUBEVIRT_MIGRATION_CONTROLLER and jira_76659_open:
-        pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} deployment is not running due to CNV-76659 bug")

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from packaging.version import Version
 
 from tests.install_upgrade_operators.deployment.utils import (
     assert_cnv_deployment_container_env_image_not_in_upstream,
@@ -14,6 +15,8 @@ from utilities.constants.components import (
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
 )
+from utilities.hco import get_hco_version
+from utilities.jira import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
@@ -84,12 +87,17 @@ def test_cnv_deployment_priority_class_name(subtests, discovered_cnv_deployments
             )
 
 
-
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-8264")
-def test_cnv_deployment_container_image(subtests, discovered_cnv_deployments):
+def test_cnv_deployment_container_image(subtests, discovered_cnv_deployments, admin_client, hco_namespace):
+    hco_version = Version(version=get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name))
     for deployment in discovered_cnv_deployments:
         with subtests.test(msg=deployment.name):
+            if deployment.name == HCO_OPERATOR:
+                if hco_version >= Version("4.23") and is_jira_open(jira_id="CNV-92888"):
+                    pytest.xfail("sriov-dp-admission-controller upstream registry violation (CNV-92888)")
+                if hco_version >= Version("5.0") and is_jira_open(jira_id="CNV-92889"):
+                    pytest.xfail("sriov-dp-admission-controller upstream registry violation (CNV-92889)")
             assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=deployment)
             assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=deployment)

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from tests.install_upgrade_operators.deployment.utils import (
@@ -10,7 +12,10 @@ from utilities.constants.components import (
     HCO_OPERATOR,
     HCO_WEBHOOK,
     HPP_POOL,
+    KUBEVIRT_MIGRATION_CONTROLLER,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
@@ -66,22 +71,25 @@ def test_request_param(deployment_by_name, cpu_min_value):
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-7675")
-def test_cnv_deployment_priority_class_name(
-    cnv_deployment_by_name,
-    xfail_if_jira_76659_open_and_migration_controller_deployment,
-):
-    if cnv_deployment_by_name.name.startswith(HPP_POOL):
-        pytest.xfail("HPP pool deployment doesn't have priority class name")
-    elif not cnv_deployment_by_name.instance.spec.template.spec.priorityClassName:
-        pytest.fail(
-            f"For cnv deployment {cnv_deployment_by_name.name}, spec.template.spec.priorityClassName has not been set."
-        )
+def test_cnv_deployment_priority_class_name(subtests, discovered_cnv_deployments, jira_76659_open):
+    for deployment in discovered_cnv_deployments:
+        with subtests.test(msg=deployment.name):
+            if deployment.name.startswith(HPP_POOL):
+                LOGGER.info(f"Skipping HPP pool deployment {deployment.name}: no priorityClassName expected")
+                continue
+            if deployment.name == KUBEVIRT_MIGRATION_CONTROLLER and jira_76659_open:
+                pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} deployment is not running due to CNV-76659 bug")
+            assert deployment.instance.spec.template.spec.priorityClassName, (
+                f"Deployment {deployment.name} has no priorityClassName set"
+            )
 
 
-@pytest.mark.usefixtures("xfail_if_sriov_conforma_jira_open_and_hco_operator")
+
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-8264")
-def test_cnv_deployment_container_image(cnv_deployment_by_name):
-    assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)
-    assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)
+def test_cnv_deployment_container_image(subtests, discovered_cnv_deployments):
+    for deployment in discovered_cnv_deployments:
+        with subtests.test(msg=deployment.name):
+            assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=deployment)
+            assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=deployment)

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -78,7 +78,7 @@ def test_cnv_deployment_priority_class_name(subtests, discovered_cnv_deployments
     for deployment in discovered_cnv_deployments:
         with subtests.test(msg=deployment.name):
             if deployment.name.startswith(HPP_POOL):
-                LOGGER.info(f"Skipping HPP pool deployment {deployment.name}: no priorityClassName expected")
+                LOGGER.warning(f"Skipping HPP pool deployment {deployment.name}: no priorityClassName expected")
                 continue
             if deployment.name == KUBEVIRT_MIGRATION_CONTROLLER and jira_76659_open:
                 pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} deployment is not running due to CNV-76659 bug")

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -1,68 +1,68 @@
+import logging
+
 import pytest
 from ocp_resources.cdi import CDI
 from ocp_resources.kubevirt import KubeVirt
-from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.constants import (
     DEVELOPER_CONFIGURATION,
-    EXPECTED_CDI_HARDCODED_FEATUREGATES,
-    EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
     FEATUREGATES,
     KEY_PATH_SEPARATOR,
-    RESOURCE_NAME_STR,
-    RESOURCE_NAMESPACE_STR,
-    RESOURCE_TYPE_STR,
 )
 from tests.install_upgrade_operators.utils import get_resource_key_value
-from utilities.constants.components import (
-    CDI_KUBEVIRT_HYPERCONVERGED,
-    KUBEVIRT_KUBEVIRT_HYPERCONVERGED,
-)
+from utilities.hco import ResourceEditorValidateHCOReconcile
+from utilities.virt import get_hyperconverged_kubevirt
+
+LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.sno, pytest.mark.s390x, pytest.mark.skip_must_gather_collection]
 
+KUBEVIRT_FEATUREGATES_KEY = (
+    f"configuration{KEY_PATH_SEPARATOR}{DEVELOPER_CONFIGURATION}{KEY_PATH_SEPARATOR}{FEATUREGATES}"
+)
+CDI_FEATUREGATES_KEY = f"config{KEY_PATH_SEPARATOR}{FEATUREGATES}"
+
 
 class TestHardcodedFeatureGates:
-    @pytest.mark.parametrize(
-        ("updated_resource", "expected_value", "key_name"),
-        [
-            pytest.param(
-                {
-                    RESOURCE_TYPE_STR: KubeVirt,
-                    RESOURCE_NAME_STR: KUBEVIRT_KUBEVIRT_HYPERCONVERGED,
-                    RESOURCE_NAMESPACE_STR: py_config["hco_namespace"],
-                    "patch": {"spec": {"configuration": {"developerConfiguration": {"featureGates": None}}}},
-                },
-                EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
-                f"configuration{KEY_PATH_SEPARATOR}{DEVELOPER_CONFIGURATION}{KEY_PATH_SEPARATOR}{FEATUREGATES}",
-                marks=pytest.mark.polarion("CNV-6427"),
-                id="delete_featuregates_kubevirt_cr",
-            ),
-            pytest.param(
-                {
-                    RESOURCE_TYPE_STR: CDI,
-                    RESOURCE_NAME_STR: CDI_KUBEVIRT_HYPERCONVERGED,
-                    "patch": {"spec": {}},
-                },
-                EXPECTED_CDI_HARDCODED_FEATUREGATES,
-                f"config{KEY_PATH_SEPARATOR}{FEATUREGATES}",
-                marks=(pytest.mark.polarion("CNV-6640")),
-                id="delete_featuregates_cdi_cr",
-            ),
-        ],
-        indirect=["updated_resource", "expected_value"],
-    )
-    def test_managed_cr_featuregate_reconcile(
-        self,
-        updated_resource,
-        expected_value,
-        key_name,
-    ):
-        actual_value = get_resource_key_value(resource=updated_resource, key_name=key_name)
-        if isinstance(actual_value, list):
-            actual_value = set(actual_value)
-        assert actual_value == expected_value, (
-            f"For {updated_resource.name}, actual featuregates:"
-            f" {actual_value} does not match expected "
-            f"featuregates: {expected_value}"
+    @pytest.mark.polarion("CNV-6427")
+    def test_managed_cr_featuregate_reconcile_kubevirt(self, admin_client, hco_namespace):
+        kubevirt_resource = get_hyperconverged_kubevirt(admin_client=admin_client, hco_namespace=hco_namespace)
+        featuregates_before = get_resource_key_value(resource=kubevirt_resource, key_name=KUBEVIRT_FEATUREGATES_KEY)
+        assert featuregates_before, "KubeVirt featureGates are empty before reconciliation test"
+        expected = set(featuregates_before)
+        LOGGER.info(f"KubeVirt featureGates before deletion: {expected}")
+
+        with ResourceEditorValidateHCOReconcile(
+            patches={
+                kubevirt_resource: {"spec": {"configuration": {"developerConfiguration": {"featureGates": None}}}}
+            },
+            action="replace",
+            list_resource_reconcile=[KubeVirt],
+            wait_for_reconcile_post_update=True,
+        ):
+            kubevirt_resource.reload()
+            actual = get_resource_key_value(resource=kubevirt_resource, key_name=KUBEVIRT_FEATUREGATES_KEY)
+            if isinstance(actual, list):
+                actual = set(actual)
+            assert actual == expected, f"KubeVirt featureGates not reconciled. Expected: {expected}, actual: {actual}"
+
+    @pytest.mark.polarion("CNV-6640")
+    def test_managed_cr_featuregate_reconcile_cdi(self, admin_client, cdi_resource_scope_function):
+        featuregates_before = get_resource_key_value(
+            resource=cdi_resource_scope_function, key_name=CDI_FEATUREGATES_KEY
         )
+        assert featuregates_before, "CDI featureGates are empty before reconciliation test"
+        expected = set(featuregates_before)
+        LOGGER.info(f"CDI featureGates before deletion: {expected}")
+
+        with ResourceEditorValidateHCOReconcile(
+            patches={cdi_resource_scope_function: {"spec": {}}},
+            action="replace",
+            list_resource_reconcile=[CDI],
+            wait_for_reconcile_post_update=True,
+        ):
+            cdi_resource_scope_function.reload()
+            actual = get_resource_key_value(resource=cdi_resource_scope_function, key_name=CDI_FEATUREGATES_KEY)
+            if isinstance(actual, list):
+                actual = set(actual)
+            assert actual == expected, f"CDI featureGates not reconciled. Expected: {expected}, actual: {actual}"

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -1,26 +1,25 @@
-import logging
-
 import pytest
 from ocp_resources.cdi import CDI
 from ocp_resources.kubevirt import KubeVirt
+from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.constants import (
     DEVELOPER_CONFIGURATION,
+    EXPECTED_CDI_HARDCODED_FEATUREGATES,
+    EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
     FEATUREGATES,
     KEY_PATH_SEPARATOR,
+    RESOURCE_NAME_STR,
+    RESOURCE_NAMESPACE_STR,
+    RESOURCE_TYPE_STR,
 )
 from tests.install_upgrade_operators.utils import get_resource_key_value
-from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.virt import get_hyperconverged_kubevirt
-
-LOGGER = logging.getLogger(__name__)
+from utilities.constants.components import (
+    CDI_KUBEVIRT_HYPERCONVERGED,
+    KUBEVIRT_KUBEVIRT_HYPERCONVERGED,
+)
 
 pytestmark = [pytest.mark.sno, pytest.mark.s390x, pytest.mark.skip_must_gather_collection]
-
-KUBEVIRT_FEATUREGATES_KEY = (
-    f"configuration{KEY_PATH_SEPARATOR}{DEVELOPER_CONFIGURATION}{KEY_PATH_SEPARATOR}{FEATUREGATES}"
-)
-CDI_FEATUREGATES_KEY = f"config{KEY_PATH_SEPARATOR}{FEATUREGATES}"
 
 
 class TestHardcodedFeatureGates:
@@ -33,6 +32,7 @@ class TestHardcodedFeatureGates:
         LOGGER.info(f"KubeVirt featureGates before deletion: {expected}")
 
         with ResourceEditorValidateHCOReconcile(
+            admin_client=admin_client,
             patches={
                 kubevirt_resource: {"spec": {"configuration": {"developerConfiguration": {"featureGates": None}}}}
             },
@@ -40,7 +40,6 @@ class TestHardcodedFeatureGates:
             list_resource_reconcile=[KubeVirt],
             wait_for_reconcile_post_update=True,
         ):
-            kubevirt_resource.reload()
             actual = get_resource_key_value(resource=kubevirt_resource, key_name=KUBEVIRT_FEATUREGATES_KEY)
             if isinstance(actual, list):
                 actual = set(actual)
@@ -56,12 +55,12 @@ class TestHardcodedFeatureGates:
         LOGGER.info(f"CDI featureGates before deletion: {expected}")
 
         with ResourceEditorValidateHCOReconcile(
+            admin_client=admin_client,
             patches={cdi_resource_scope_function: {"spec": {}}},
             action="replace",
             list_resource_reconcile=[CDI],
             wait_for_reconcile_post_update=True,
         ):
-            cdi_resource_scope_function.reload()
             actual = get_resource_key_value(resource=cdi_resource_scope_function, key_name=CDI_FEATUREGATES_KEY)
             if isinstance(actual, list):
                 actual = set(actual)

--- a/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
+++ b/tests/install_upgrade_operators/feature_gates/test_featuregate_reconcile.py
@@ -1,67 +1,19 @@
 import pytest
-from ocp_resources.cdi import CDI
-from ocp_resources.kubevirt import KubeVirt
-from pytest_testconfig import config as py_config
-
-from tests.install_upgrade_operators.constants import (
-    DEVELOPER_CONFIGURATION,
-    EXPECTED_CDI_HARDCODED_FEATUREGATES,
-    EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,
-    FEATUREGATES,
-    KEY_PATH_SEPARATOR,
-    RESOURCE_NAME_STR,
-    RESOURCE_NAMESPACE_STR,
-    RESOURCE_TYPE_STR,
-)
-from tests.install_upgrade_operators.utils import get_resource_key_value
-from utilities.constants.components import (
-    CDI_KUBEVIRT_HYPERCONVERGED,
-    KUBEVIRT_KUBEVIRT_HYPERCONVERGED,
-)
 
 pytestmark = [pytest.mark.sno, pytest.mark.s390x, pytest.mark.skip_must_gather_collection]
 
 
 class TestHardcodedFeatureGates:
     @pytest.mark.polarion("CNV-6427")
-    def test_managed_cr_featuregate_reconcile_kubevirt(self, admin_client, hco_namespace):
-        kubevirt_resource = get_hyperconverged_kubevirt(admin_client=admin_client, hco_namespace=hco_namespace)
-        featuregates_before = get_resource_key_value(resource=kubevirt_resource, key_name=KUBEVIRT_FEATUREGATES_KEY)
-        assert featuregates_before, "KubeVirt featureGates are empty before reconciliation test"
-        expected = set(featuregates_before)
-        LOGGER.info(f"KubeVirt featureGates before deletion: {expected}")
-
-        with ResourceEditorValidateHCOReconcile(
-            admin_client=admin_client,
-            patches={
-                kubevirt_resource: {"spec": {"configuration": {"developerConfiguration": {"featureGates": None}}}}
-            },
-            action="replace",
-            list_resource_reconcile=[KubeVirt],
-            wait_for_reconcile_post_update=True,
-        ):
-            actual = get_resource_key_value(resource=kubevirt_resource, key_name=KUBEVIRT_FEATUREGATES_KEY)
-            if isinstance(actual, list):
-                actual = set(actual)
-            assert actual == expected, f"KubeVirt featureGates not reconciled. Expected: {expected}, actual: {actual}"
+    def test_managed_cr_featuregate_reconcile_kubevirt(
+        self, initial_kubevirt_fg, removed_kubevirt_fg, kubevirt_fg_after_removed
+    ):
+        assert initial_kubevirt_fg == kubevirt_fg_after_removed, (
+            f"KubeVirt featureGates not reconciled. Expected: {initial_kubevirt_fg}, actual: {kubevirt_fg_after_removed}"
+        )
 
     @pytest.mark.polarion("CNV-6640")
-    def test_managed_cr_featuregate_reconcile_cdi(self, admin_client, cdi_resource_scope_function):
-        featuregates_before = get_resource_key_value(
-            resource=cdi_resource_scope_function, key_name=CDI_FEATUREGATES_KEY
+    def test_managed_cr_featuregate_reconcile_cdi(self, initial_cdi_fg, removed_cdi_fg, cdi_fg_after_removed):
+        assert initial_cdi_fg == cdi_fg_after_removed, (
+            f"CDI featureGates not reconciled. Expected: {initial_cdi_fg}, actual: {cdi_fg_after_removed}"
         )
-        assert featuregates_before, "CDI featureGates are empty before reconciliation test"
-        expected = set(featuregates_before)
-        LOGGER.info(f"CDI featureGates before deletion: {expected}")
-
-        with ResourceEditorValidateHCOReconcile(
-            admin_client=admin_client,
-            patches={cdi_resource_scope_function: {"spec": {}}},
-            action="replace",
-            list_resource_reconcile=[CDI],
-            wait_for_reconcile_post_update=True,
-        ):
-            actual = get_resource_key_value(resource=cdi_resource_scope_function, key_name=CDI_FEATUREGATES_KEY)
-            if isinstance(actual, list):
-                actual = set(actual)
-            assert actual == expected, f"CDI featureGates not reconciled. Expected: {expected}, actual: {actual}"

--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -5,7 +5,6 @@ import shlex
 
 import pytest
 import yaml
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.pod import Pod
@@ -134,19 +133,6 @@ def kubevirt_crd_resources(admin_client, custom_resource_definitions):
         if "kubevirt.io" in resource.instance.spec.group:
             kubevirt_resources.append(resource)
     return kubevirt_resources
-
-
-@pytest.fixture(scope="module")
-def kubevirt_crd_names(kubevirt_crd_resources):
-    return [crd.name for crd in kubevirt_crd_resources]
-
-
-@pytest.fixture()
-def kubevirt_crd_by_type(cnv_crd_matrix__function__, kubevirt_crd_resources, kubevirt_crd_names):
-    for crd in kubevirt_crd_resources:
-        if crd.name == cnv_crd_matrix__function__:
-            return crd
-    raise ResourceNotFoundError(f"CRD: {cnv_crd_matrix__function__} not found in kubevirt crds: {kubevirt_crd_names}")
 
 
 @pytest.fixture(scope="package")

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -28,7 +28,6 @@ from utilities.constants.components import (
     BRIDGE_MARKER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
     KUBE_CNI_LINUX_BRIDGE_PLUGIN,
-    KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
 )
 from utilities.constants.hco import VM_CRD
 from utilities.constants.namespaces import NamespacesNames

--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -28,6 +28,7 @@ from utilities.constants.components import (
     BRIDGE_MARKER,
     CLUSTER_NETWORK_ADDONS_OPERATOR,
     KUBE_CNI_LINUX_BRIDGE_PLUGIN,
+    KUBEMACPOOL_MAC_CONTROLLER_MANAGER,
 )
 from utilities.constants.hco import VM_CRD
 from utilities.constants.namespaces import NamespacesNames
@@ -315,69 +316,75 @@ class TestMustGatherCluster:
             )
 
     @pytest.mark.polarion("CNV-2724")
-    def test_crd_resources(self, admin_client, must_gather_for_test, kubevirt_crd_by_type):
-        crd_name = kubevirt_crd_by_type.name
-        for version in kubevirt_crd_by_type.instance.spec.versions:
-            if not version.served:
-                LOGGER.warning(f"Skipping {version.name} for {crd_name} because it is not served")
-                continue
-            resource_objs = admin_client.resources.get(
-                api_version=version.name,
-                kind=kubevirt_crd_by_type.instance.spec.names.kind,
-            )
-
-            for resource_item in resource_objs.get().to_dict()["items"]:
-                resource_metadata = resource_item["metadata"]
-                name = resource_metadata["name"]
-                if "namespace" in resource_metadata:
-                    if crd_name == VM_CRD:
-                        resource_file = os.path.join(
-                            must_gather_for_test,
-                            f"namespaces/{resource_metadata['namespace']}/{Resource.ApiGroup.KUBEVIRT_IO}"
-                            f"/virtualmachines/custom/{name}.yaml",
-                        )
-                    else:
-                        resource_file = os.path.join(
-                            must_gather_for_test,
-                            f"namespaces/{resource_metadata['namespace']}/crs/{crd_name}/{name}.yaml",
-                        )
-                else:
-                    resource_file = os.path.join(
-                        must_gather_for_test,
-                        f"cluster-scoped-resources/{crd_name}/{name}.yaml",
-                    )
-
-                try:
-                    with open(resource_file) as resource_file:
-                        file_content = yaml.safe_load(
-                            resource_file.read(),
-                        )
-                    resource_name_from_file = file_content["metadata"]["name"]
-                    resource_uid_from_file = file_content["metadata"]["uid"]
-                    actual_resource_uid = resource_metadata["uid"]
-                    assert name == resource_name_from_file, (
-                        f"Actual resource name: {name}, must-gather collected resource name: {resource_name_from_file}"
-                    )
-
-                    assert actual_resource_uid == resource_uid_from_file, (
-                        f"Resource uid: {actual_resource_uid} does not "
-                        "match with must-gather data:"
-                        f" {resource_uid_from_file}"
-                    )
-                except FileNotFoundError:
-                    # Skip volatile DataVolumes from openshift-virtualization-os-images (managed by DataImportCron)
-                    if (
-                        crd_name == f"datavolumes.{Resource.ApiGroup.CDI_KUBEVIRT_IO}"
-                        and resource_metadata.get("namespace") == NamespacesNames.OPENSHIFT_VIRTUALIZATION_OS_IMAGES
-                    ):
-                        LOGGER.warning(
-                            f"Skipping volatile DataVolume {name} "
-                            f"from {NamespacesNames.OPENSHIFT_VIRTUALIZATION_OS_IMAGES}"
-                        )
+    @pytest.mark.polarion("CNV-2724")
+    def test_crd_resources(self, subtests, admin_client, must_gather_for_test, kubevirt_crd_resources):
+        for crd in kubevirt_crd_resources:
+            crd_name = crd.name
+            with subtests.test(msg=crd_name):
+                for version in crd.instance.spec.versions:
+                    if not version.served:
+                        LOGGER.warning(f"Skipping {version.name} for {crd_name} because it is not served")
                         continue
-                    # Re-raise for any other missing resource file
-                    LOGGER.error(f"Resource file not found: {resource_file}")
-                    raise
+                    resource_objs = admin_client.resources.get(
+                        api_version=version.name,
+                        kind=crd.instance.spec.names.kind,
+                    )
+
+                    for resource_item in resource_objs.get().to_dict()["items"]:
+                        resource_metadata = resource_item["metadata"]
+                        name = resource_metadata["name"]
+                        if "namespace" in resource_metadata:
+                            if crd_name == VM_CRD:
+                                resource_file = os.path.join(
+                                    must_gather_for_test,
+                                    f"namespaces/{resource_metadata['namespace']}"
+                                    f"/{Resource.ApiGroup.KUBEVIRT_IO}"
+                                    f"/virtualmachines/custom/{name}.yaml",
+                                )
+                            else:
+                                resource_file = os.path.join(
+                                    must_gather_for_test,
+                                    f"namespaces/{resource_metadata['namespace']}/crs/{crd_name}/{name}.yaml",
+                                )
+                        else:
+                            resource_file = os.path.join(
+                                must_gather_for_test,
+                                f"cluster-scoped-resources/{crd_name}/{name}.yaml",
+                            )
+
+                        try:
+                            with open(resource_file) as resource_file:
+                                file_content = yaml.safe_load(
+                                    resource_file.read(),
+                                )
+                            resource_name_from_file = file_content["metadata"]["name"]
+                            resource_uid_from_file = file_content["metadata"]["uid"]
+                            actual_resource_uid = resource_metadata["uid"]
+                            assert name == resource_name_from_file, (
+                                f"Actual resource name: {name}, "
+                                f"must-gather collected resource name: {resource_name_from_file}"
+                            )
+
+                            assert actual_resource_uid == resource_uid_from_file, (
+                                f"Resource uid: {actual_resource_uid} does not "
+                                "match with must-gather data:"
+                                f" {resource_uid_from_file}"
+                            )
+                        except FileNotFoundError:
+                            # Skip volatile DataVolumes from openshift-virtualization-os-images
+                            if (
+                                crd_name == f"datavolumes.{Resource.ApiGroup.CDI_KUBEVIRT_IO}"
+                                and resource_metadata.get("namespace")
+                                == NamespacesNames.OPENSHIFT_VIRTUALIZATION_OS_IMAGES
+                            ):
+                                LOGGER.warning(
+                                    f"Skipping volatile DataVolume {name} "
+                                    f"from {NamespacesNames.OPENSHIFT_VIRTUALIZATION_OS_IMAGES}"
+                                )
+                                continue
+                            # Re-raise for any other missing resource file
+                            LOGGER.error(f"Resource file not found: {resource_file}")
+                            raise
 
 
 @pytest.mark.sriov

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -1,6 +1,7 @@
 import logging
 
 import pytest
+from packaging.version import Version
 
 from tests.install_upgrade_operators.pod_validation.utils import (
     assert_cnv_pod_container_env_image_not_in_upstream,
@@ -10,10 +11,13 @@ from tests.install_upgrade_operators.pod_validation.utils import (
     validate_priority_class_value,
 )
 from utilities.constants.components import (
+    HCO_OPERATOR,
     HOSTPATH_PROVISIONER_CSI,
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
 )
+from utilities.hco import get_hco_version
+from utilities.jira import is_jira_open
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
@@ -58,10 +62,15 @@ def test_pods_resource_request(
             )
 
 
-@pytest.mark.usefixtures("xfail_if_sriov_conforma_jira_open_and_hco_operator")
 @pytest.mark.polarion("CNV-8267")
-def test_cnv_pod_container_image(subtests, discovered_cnv_pods):
+def test_cnv_pod_container_image(subtests, discovered_cnv_pods, admin_client, hco_namespace):
+    hco_version = Version(version=get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name))
     for pod in discovered_cnv_pods:
         with subtests.test(msg=pod.name):
+            if pod.name.startswith(HCO_OPERATOR):
+                if hco_version >= Version("4.23") and is_jira_open(jira_id="CNV-92888"):
+                    pytest.xfail("sriov-dp-admission-controller upstream registry violation (CNV-92888)")
+                if hco_version >= Version("5.0") and is_jira_open(jira_id="CNV-92889"):
+                    pytest.xfail("sriov-dp-admission-controller upstream registry violation (CNV-92889)")
             assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=[pod])
             assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=[pod])

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -18,38 +18,50 @@ from utilities.constants.components import (
 pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
 LOGGER = logging.getLogger(__name__)
-
-
-@pytest.fixture()
-def xfail_if_jira_76659_open_and_migration_controller_pod(jira_76659_open, cnv_pods_by_type):
-    if any(pod.name.startswith(KUBEVIRT_MIGRATION_CONTROLLER) for pod in cnv_pods_by_type) and jira_76659_open:
-        pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} pod has no priority class name due to CNV-76659 bug")
+HPP_PREFIXES = (HPP_POOL, HOSTPATH_PROVISIONER_CSI)
 
 
 @pytest.mark.polarion("CNV-7262")
 def test_pods_priority_class_value(
-    cnv_pods_by_type,
-    xfail_if_jira_76659_open_and_migration_controller_pod,
+    subtests,
+    discovered_cnv_pods,
+    jira_76659_open,
 ):
-    if any(pod.name.startswith((HPP_POOL, HOSTPATH_PROVISIONER_CSI)) for pod in cnv_pods_by_type):
-        pytest.xfail("HPP pods don't have priority class name")
-    validate_cnv_pods_priority_class_name_exists(pod_list=cnv_pods_by_type)
-    validate_priority_class_value(pod_list=cnv_pods_by_type)
+    for pod in discovered_cnv_pods:
+        with subtests.test(msg=pod.name):
+            if pod.name.startswith(HPP_PREFIXES):
+                pytest.xfail("HPP pods don't have priority class name")
+            if pod.name.startswith(KUBEVIRT_MIGRATION_CONTROLLER) and jira_76659_open:
+                pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} pod has no priority class name due to CNV-76659 bug")
+            validate_cnv_pods_priority_class_name_exists(pod_list=[pod])
+            validate_priority_class_value(pod_list=[pod])
 
 
 @pytest.mark.polarion("CNV-7306")
+@pytest.mark.parametrize(
+    "resource_type",
+    [
+        pytest.param({"cpu": 5}, id="cpu"),
+        pytest.param({"memory": None}, id="memory"),
+    ],
+)
 def test_pods_resource_request(
-    cnv_pods_by_type,
-    pod_resource_validation_matrix__function__,
+    subtests,
+    discovered_cnv_pods,
+    resource_type,
 ):
-    validate_cnv_pods_resource_request(
-        cnv_pods=cnv_pods_by_type,
-        resource=pod_resource_validation_matrix__function__,
-    )
+    for pod in discovered_cnv_pods:
+        with subtests.test(msg=pod.name):
+            validate_cnv_pods_resource_request(
+                cnv_pods=[pod],
+                resource=resource_type,
+            )
 
 
 @pytest.mark.usefixtures("xfail_if_sriov_conforma_jira_open_and_hco_operator")
 @pytest.mark.polarion("CNV-8267")
-def test_cnv_pod_container_image(cnv_pods_by_type):
-    assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)
-    assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)
+def test_cnv_pod_container_image(subtests, discovered_cnv_pods):
+    for pod in discovered_cnv_pods:
+        with subtests.test(msg=pod.name):
+            assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=[pod])
+            assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=[pod])

--- a/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_relationship_labels.py
@@ -4,7 +4,6 @@ import logging
 import pytest
 
 from tests.install_upgrade_operators.relationship_labels.constants import (
-    EXPECTED_RELATED_OBJECTS_LABELS_DICT_MAP,
     EXPECTED_VIRT_DAEMONSETS_LABELS_DICT_MAP,
     EXPECTED_VIRT_DEPLOYMENTS_LABELS_DICT_MAP,
     EXPECTED_VIRT_PODS_LABELS_DICT_MAP,
@@ -26,85 +25,62 @@ pytestmark = [
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="class")
-def expected_label_dictionary(hco_version_scope_class, request):
+def _build_expected_labels(labels_dict_map: dict, hco_version: str) -> dict:
+    """Build expected labels dict with the current HCO version filled in.
+
+    Args:
+        labels_dict_map: Static expected labels map with VERSION_LABEL_KEY set to None.
+        hco_version: Current HCO version string.
+
+    Returns:
+        dict: Deep copy with VERSION_LABEL_KEY populated.
     """
-    Populate each labels dict (RELATED_OBJECTS_LABELS_DICT_MAP / COMPONENT_LABELS_DICT_MAP)
-    with updates cnv current version, deepcopy and return  updated expected labels dict
-    """
-    expected_labels_dict = request.param["expected_labels_dict"]
-    updated_expected_labels_dict = copy.deepcopy(expected_labels_dict)
-    for deployment_labels in updated_expected_labels_dict.values():
-        deployment_labels[VERSION_LABEL_KEY] = hco_version_scope_class
-    return updated_expected_labels_dict
+    updated = copy.deepcopy(labels_dict_map)
+    for component_labels in updated.values():
+        component_labels[VERSION_LABEL_KEY] = hco_version
+    return updated
 
 
 class TestRelationshipLabels:
-    @pytest.mark.parametrize(
-        "expected_label_dictionary",
-        [
-            pytest.param(
-                {"expected_labels_dict": EXPECTED_VIRT_DEPLOYMENTS_LABELS_DICT_MAP},
-                marks=pytest.mark.polarion("CNV-7190"),
-            ),
-        ],
-        indirect=True,
-    )
-    def test_verify_mismatch_relationship_labels_deployments(self, expected_label_dictionary, cnv_deployment_by_name):
-        verify_component_labels_by_resource(
-            component=cnv_deployment_by_name,
-            expected_component_labels=expected_label_dictionary,
-        )
-
-    @pytest.mark.parametrize(
-        "expected_label_dictionary",
-        [
-            pytest.param(
-                {"expected_labels_dict": EXPECTED_VIRT_DAEMONSETS_LABELS_DICT_MAP},
-                marks=pytest.mark.polarion("CNV-7269"),
-            ),
-        ],
-        indirect=True,
-    )
-    def test_verify_mismatch_relationship_labels_daemonsets(self, expected_label_dictionary, cnv_daemonset_by_name):
-        verify_component_labels_by_resource(
-            component=cnv_daemonset_by_name,
-            expected_component_labels=expected_label_dictionary,
-        )
-
-    @pytest.mark.parametrize(
-        "expected_label_dictionary",
-        [
-            pytest.param(
-                {"expected_labels_dict": EXPECTED_VIRT_PODS_LABELS_DICT_MAP},
-                marks=pytest.mark.polarion("CNV-10307"),
-            ),
-        ],
-        indirect=True,
-    )
-    def test_verify_mismatch_relationship_labels_pods(self, expected_label_dictionary, cnv_pods_by_type):
-        for pod in cnv_pods_by_type:
-            verify_component_labels_by_resource(
-                component=pod,
-                expected_component_labels=expected_label_dictionary,
-            )
-
-    @pytest.mark.parametrize(
-        "expected_label_dictionary",
-        [
-            pytest.param(
-                {"expected_labels_dict": EXPECTED_RELATED_OBJECTS_LABELS_DICT_MAP},
-                marks=pytest.mark.polarion("CNV-7189"),
-            ),
-        ],
-        indirect=True,
-    )
-    def test_verify_relationship_labels_hco_components(
-        self,
-        expected_label_dictionary,
-        ocp_resource_by_name,
+    @pytest.mark.polarion("CNV-7190")
+    def test_verify_mismatch_relationship_labels_deployments(
+        self, subtests, discovered_cnv_deployments, hco_version_scope_class
     ):
-        verify_component_labels_by_resource(
-            component=ocp_resource_by_name,
-            expected_component_labels=expected_label_dictionary,
+        expected_labels = _build_expected_labels(
+            labels_dict_map=EXPECTED_VIRT_DEPLOYMENTS_LABELS_DICT_MAP,
+            hco_version=hco_version_scope_class,
         )
+        for deployment in discovered_cnv_deployments:
+            with subtests.test(msg=deployment.name):
+                verify_component_labels_by_resource(
+                    component=deployment,
+                    expected_component_labels=expected_labels,
+                )
+
+    @pytest.mark.polarion("CNV-7269")
+    def test_verify_mismatch_relationship_labels_daemonsets(
+        self, subtests, discovered_cnv_daemonsets, hco_version_scope_class
+    ):
+        expected_labels = _build_expected_labels(
+            labels_dict_map=EXPECTED_VIRT_DAEMONSETS_LABELS_DICT_MAP,
+            hco_version=hco_version_scope_class,
+        )
+        for daemonset in discovered_cnv_daemonsets:
+            with subtests.test(msg=daemonset.name):
+                verify_component_labels_by_resource(
+                    component=daemonset,
+                    expected_component_labels=expected_labels,
+                )
+
+    @pytest.mark.polarion("CNV-10307")
+    def test_verify_mismatch_relationship_labels_pods(self, subtests, discovered_cnv_pods, hco_version_scope_class):
+        expected_labels = _build_expected_labels(
+            labels_dict_map=EXPECTED_VIRT_PODS_LABELS_DICT_MAP,
+            hco_version=hco_version_scope_class,
+        )
+        for pod in discovered_cnv_pods:
+            with subtests.test(msg=pod.name):
+                verify_component_labels_by_resource(
+                    component=pod,
+                    expected_component_labels=expected_labels,
+                )

--- a/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
+++ b/tests/install_upgrade_operators/security/scc/test_cnv_deployment_required_scc.py
@@ -3,12 +3,8 @@ Test to verify all HCO deployments have 'openshift.io/required-scc' annotation.
 """
 
 import pytest
-from ocp_resources.deployment import Deployment
 
-from utilities.constants.components import (
-    ALL_CNV_DEPLOYMENTS,
-    HPP_POOL,
-)
+from utilities.constants.components import HPP_POOL
 
 REQUIRED_SCC_ANNOTATION = "openshift.io/required-scc"
 REQUIRED_SCC_VALUE = "restricted-v2"
@@ -17,20 +13,19 @@ pytestmark = [pytest.mark.s390x, pytest.mark.skip_must_gather_collection]
 
 
 @pytest.fixture(scope="module")
-def required_scc_deployment_check(admin_client, hco_namespace):
+def required_scc_deployment_check(discovered_cnv_deployments):
     missing_required_scc_annotation = []
     incorrect_required_scc_annotation_value = {}
 
-    for name in ALL_CNV_DEPLOYMENTS:
-        if name.startswith(HPP_POOL):
+    for deployment in discovered_cnv_deployments:
+        if deployment.name.startswith(HPP_POOL):
             continue
-        dp = Deployment(client=admin_client, name=name, namespace=hco_namespace.name)
-        scc = dp.instance.spec.template.metadata.annotations.get(REQUIRED_SCC_ANNOTATION)
+        scc = deployment.instance.spec.template.metadata.annotations.get(REQUIRED_SCC_ANNOTATION)
 
         if scc is None:
-            missing_required_scc_annotation.append(dp.name)
+            missing_required_scc_annotation.append(deployment.name)
         elif scc != REQUIRED_SCC_VALUE:
-            incorrect_required_scc_annotation_value[dp.name] = scc
+            incorrect_required_scc_annotation_value[deployment.name] = scc
 
     return {
         "missing_required_scc_annotation": missing_required_scc_annotation,

--- a/tests/install_upgrade_operators/strict_reconciliation/conftest.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/conftest.py
@@ -4,7 +4,6 @@ import pytest
 from ocp_resources.cdi import CDI
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.network_addons_config import NetworkAddonsConfig
-from ocp_resources.resource import ResourceEditor
 
 from tests.install_upgrade_operators.strict_reconciliation.constants import (
     CUSTOM_HCO_CR_SPEC,
@@ -15,9 +14,6 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
     wait_for_hco_related_object_version_change,
     wait_for_resource_version_update,
 )
-from tests.utils import wait_for_cr_labels_change
-from utilities.constants.cluster import VERSION_LABEL_KEY
-from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.hco import ResourceEditorValidateHCOReconcile
 
 LOGGER = logging.getLogger(__name__)
@@ -181,20 +177,3 @@ def reconciled_cr_post_hco_update(
 @pytest.fixture()
 def pre_update_resource_version(related_object_from_hco_status):
     return related_object_from_hco_status["resourceVersion"]
-
-
-@pytest.fixture()
-def updated_resource_labels(ocp_resource_by_name):
-    expected_labels = ocp_resource_by_name.labels
-    expected_labels.custom_label = ocp_resource_by_name.name
-    with ResourceEditor(
-        patches={
-            ocp_resource_by_name: {
-                "metadata": {
-                    "labels": {VERSION_LABEL_KEY: None, "custom_label": ocp_resource_by_name.name},
-                }
-            }
-        }
-    ):
-        wait_for_cr_labels_change(expected_value=expected_labels, component=ocp_resource_by_name, timeout=TIMEOUT_1MIN)
-        yield expected_labels

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -1,8 +1,15 @@
+import logging
+
 import pytest
+from ocp_resources.resource import ResourceEditor
 
 from tests.install_upgrade_operators.strict_reconciliation.utils import (
     validate_related_objects,
 )
+from tests.install_upgrade_operators.utils import get_resource_from_related_object
+from tests.utils import wait_for_cr_labels_change
+from utilities.constants.cluster import VERSION_LABEL_KEY
+from utilities.constants.timeouts import TIMEOUT_1MIN
 
 pytestmark = [
     pytest.mark.post_upgrade,
@@ -12,20 +19,48 @@ pytestmark = [
     pytest.mark.skip_must_gather_collection,
 ]
 
+LOGGER = logging.getLogger(__name__)
+
 
 class TestRelatedObjects:
     @pytest.mark.polarion("CNV-7267")
     def test_hco_related_objects(
         self,
+        subtests,
         admin_client,
         hco_namespace,
-        ocp_resource_by_name,
-        pre_update_resource_version,
-        updated_resource_labels,
+        hco_status_related_objects,
+        ocp_resources_submodule_list,
     ):
-        validate_related_objects(
-            admin_client=admin_client,
-            hco_namespace=hco_namespace,
-            resource=ocp_resource_by_name,
-            pre_update_resource_version=pre_update_resource_version,
-        )
+        for related_object in hco_status_related_objects:
+            object_name = related_object.name
+            with subtests.test(msg=f"{object_name}-{related_object.kind}"):
+                ocp_resource = get_resource_from_related_object(
+                    related_obj=related_object,
+                    ocp_resources_submodule_list=ocp_resources_submodule_list,
+                    admin_client=admin_client,
+                )
+                pre_update_resource_version = related_object["resourceVersion"]
+
+                expected_labels = ocp_resource.labels
+                expected_labels.custom_label = ocp_resource.name
+                with ResourceEditor(
+                    patches={
+                        ocp_resource: {
+                            "metadata": {
+                                "labels": {VERSION_LABEL_KEY: None, "custom_label": ocp_resource.name},
+                            }
+                        }
+                    }
+                ):
+                    wait_for_cr_labels_change(
+                        expected_value=expected_labels,
+                        component=ocp_resource,
+                        timeout=TIMEOUT_1MIN,
+                    )
+                    validate_related_objects(
+                        admin_client=admin_client,
+                        hco_namespace=hco_namespace,
+                        resource=ocp_resource,
+                        pre_update_resource_version=pre_update_resource_version,
+                    )

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -689,6 +689,7 @@ def get_all_console_links(console_cli_downloads_spec_links):
         requests.exceptions.SSLError: [],
         requests.exceptions.ConnectionError: [],
         requests.exceptions.Timeout: [],
+        requests.exceptions.HTTPError: [],
     },
 )
 def _download_file(url: str, local_file_name: str) -> str:

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -353,6 +353,7 @@ def wait_for_consistent_resource_conditions(
                 client=dynamic_client,
                 namespace=namespace,
                 name=resource_name,
+                _request_timeout=TIMEOUT_1MIN,
             )
         ),
         exceptions_dict=exceptions_dict,


### PR DESCRIPTION
 ##### What this PR does / why we need it:                                                                                                    
   
  Remove 8 static inventory / upstream-covered tests and convert remaining                                                                     
  IUO validation tests from static matrix parametrization to dynamic cluster
  discovery with pytest-subtests.                                                                                                              
                                                            
  Static constants (ALL_CNV_DEPLOYMENTS, ALL_CNV_PODS, etc.) drove
  both "no new X" change-detection tests and parametrized validation tests.

  Static constants (ALL_CNV_DEPLOYMENTS, ALL_CNV_PODS, etc.) drove
  both "no new X" change-detection tests and parametrized validation tests.
  Every new CNV component required manually updating these lists which causing
  false CI failures (10 in a CNV 5.0 run, zero real bugs) and leaving new
  components unvalidated until constants were updated.

  In order to solve this problem and make these tests more robust, these things done in this PR:

  - Remove 8 tests (4 static inventory + 1 upstream-covered labels + 3 upstream-covered feature gate defaults)
  - Add session-scoped discovery fixtures that query the cluster for all
    deployments/pods/daemonsets, validate base components exist (fail if missing), and log extras
  - Convert validation tests (image, SCC, priority class, labels, reconciliation)
    from static matrix parametrization to dynamic subtests over discovered resources
  - Convert feature gate reconciliation tests to dynamic: snapshot current gates
    before deletion and verify they return to the same state (no static constants needed)
  - Remove static feature gate constants (EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES,                                                            
    EXPECTED_CDI_HARDCODED_FEATUREGATES, HCO_DEFAULT_FEATUREGATES,                                                                             
    S390X_SPECIFIC_KUBEVIRT_FEATUREGATES)                                                                                                      
                                                                                                                                               
  New components are now automatically validated without constants updates.                                                                    
  Missing base components trigger assertion failures.                                                                                                                                                               
                                                                                                                                               
  ##### Which issue(s) this PR fixes:                                                                                                                                                            
                                                                                                                                               
  ##### Special notes for reviewer:                                                                                                            
                                                                                                                       
                                                                                                                                               
  ##### jira-ticket: