### PR TITLE
storage: Refactor data_volume_template functions

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -653,28 +653,31 @@ def data_volume_template_dict_with_pvc_source(
     size: str | None = None,
     storage_class: str | None = None,
 ) -> dict[str, Any]:
-    source_dv_pvc_spec = source_dv.pvc.instance.spec
     dv = DataVolume(
         name=target_dv_name,
         namespace=target_dv_namespace,
+        client=source_dv.client,
         source_dict=construct_datavolume_source_dict(
             source="pvc",
             source_pvc_name=source_dv.name,
             source_pvc_namespace=source_dv.namespace,
         ),
-        storage_class=storage_class or source_dv_pvc_spec.storageClassName,
-        volume_mode=volume_mode or source_dv_pvc_spec.volumeMode,
+        storage_class=storage_class,
+        volume_mode=volume_mode,
         size=size or source_dv.size,
-        api_name=source_dv.api_name,
+        api_name="storage",
     )
     dv.to_dict()
     return dv.res
 
 
-def data_volume_template_with_source_ref_dict(data_source, storage_class=None):
+def data_volume_template_with_source_ref_dict(
+    data_source: DataSource, storage_class: str | None = None
+) -> dict[str, Any]:
     dv = DataVolume(
         name=utilities.infra.unique_name(name=data_source.name),
         namespace=data_source.namespace,
+        client=data_source.client,
         size=get_dv_size_from_datasource(data_source=data_source),
         storage_class=storage_class,
         api_name="storage",


### PR DESCRIPTION
##### What this PR does / why we need it:
 - Passes an explicit client to the `DataVolume` objects built in `data_volume_template_dict_with_pvc_source` and `data_volume_template_with_source_ref_dict`
 - Simplifies `data_volume_template_dict_with_pvc_source` to no longer fall back to the source PVC's `storageClassName/volumeMode/api_name`, using the caller-provided storage_class/volume_mode and a fixed `api_name="storage"` instead.

##### Which issue(s) this PR fixes:
`FutureWarning` showing when running tests

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-68519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating storage-backed data volume templates.
  * Ensured generated templates consistently use the originating storage connection.
  * Prevented unintended automatic overrides of storage class and volume mode settings when values are not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->