### PR TITLE
Manual cherry-pick to 4.21: net, sriov: memory hotplug tests (#5349)

### DIFF
--- a/libs/net/ip.py
+++ b/libs/net/ip.py
@@ -1,6 +1,9 @@
+import ipaddress
 import random
 from functools import cache
 from typing import Final
+
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 
 _MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION: Final[int] = 16
 _MAX_NUM_OF_RANDOM_HEXTETS_PER_SESSION: Final[int] = 16
@@ -9,6 +12,48 @@ _IPV6_ADDRESS_SUBNET_PREFIX_VMI: Final[str] = "fd00:1234:5678"
 TCP_HEADER_SIZE: Final[int] = 20
 IPV4_HEADER_SIZE: Final[int] = 20
 ICMPV4_HEADER_SIZE: Final[int] = 8
+
+
+def random_cidr_addresses_by_family(net_seed: int, host_address: int) -> list[str]:
+    """Return CIDR-formatted addresses for each IP family supported by the cluster.
+
+    This library uses /24 for IPv4 and /64 for IPv6 VM subnets, matching the
+    subnet definitions in this module. VMs with the same net_seed share the
+    same subnet, allowing direct L2 communication without routing. Only
+    families supported by the cluster are included.
+
+    Args:
+        net_seed: Index into the cached pool of random network prefixes.
+        host_address: Host portion of the address — must be unique per VM in the test.
+
+    Returns:
+        List of CIDR strings (e.g. ["192.168.1.1/24", "fd00::1/64"]).
+    """
+    return [
+        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
+        for ip in random_ip_addresses_by_family(net_seed=net_seed, host_address=host_address)
+    ]
+
+
+def random_ip_addresses_by_family(
+    net_seed: int,
+    host_address: int,
+) -> list[str]:
+    """Generate IP addresses for each IP family supported by the cluster network stack.
+
+    Args:
+        net_seed: Seed index for selecting the random network portion of the address.
+        host_address: Host portion of the address, used to place VMs on the same subnet.
+
+    Returns:
+        List of IP address strings, one per IP family supported by the cluster.
+    """
+    ips = []
+    if ipv4_supported_cluster():
+        ips.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
+    if ipv6_supported_cluster():
+        ips.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
+    return ips
 
 
 def random_ipv4_address(net_seed: int, host_address: int) -> str:
@@ -75,3 +120,18 @@ def _random_hextets(count: int) -> list[int]:
         list[int]: A list of unique random integers representing hextet values.
     """
     return random.sample(range(1, 0xFFFE), count)
+
+
+def filter_link_local_addresses(ip_addresses: list[str]) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Filter out link-local IP addresses from a list of IP address strings.
+
+    Link-local addresses (169.254.0.0/16 for IPv4, fe80::/10 for IPv6) are
+    automatically assigned and typically not used for inter-VM communication.
+
+    Args:
+        ip_addresses: List of IP address strings to filter.
+
+    Returns:
+        List of IP address objects with link-local addresses removed.
+    """
+    return [ip for addr in ip_addresses if not (ip := ipaddress.ip_interface(address=addr).ip).is_link_local]

--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -47,16 +47,23 @@ class TcpServer:
     Args:
         vm (BaseVirtualMachine): The virtual machine where the server runs.
         port (int): The port on which the server listens for client connections.
+        bind_ip (str): The IP address to bind the server to (optional).
+        bind_dev (str): Guest network device to bind the server socket to via SO_BINDTODEVICE
+            (e.g. "eth1"). Forces responses out this interface, bypassing ECMP routing.
     """
 
     def __init__(
         self,
         vm: BaseVirtualMachine,
         port: int,
+        bind_ip: str | None = None,
+        bind_dev: str | None = None,
     ):
         self._vm = vm
         self._port = port
         self._cmd = f"{_IPERF_BIN} --server --port {self._port} --one-off"
+        self._cmd += f" --bind {bind_ip}" if bind_ip else ""
+        self._cmd += f" --bind-dev {bind_dev}" if bind_dev else ""
 
     def __enter__(self) -> "TcpServer":
         self._vm.console(
@@ -92,6 +99,8 @@ class VMTcpClient(BaseTcpClient):
         server_port (int): The port on which the server listens for connections.
         maximum_segment_size (int): Define explicitly the TCP payload size (in bytes).
                                     Default value is 0 (do not change mss).
+        bind_dev (str): Guest network device to bind the client socket to via SO_BINDTODEVICE
+            (e.g. "eth1"). Forces traffic out this interface, bypassing ECMP routing.
     """
 
     def __init__(
@@ -100,9 +109,11 @@ class VMTcpClient(BaseTcpClient):
         server_ip: str,
         server_port: int,
         maximum_segment_size: int = 0,
+        bind_dev: str | None = None,
     ):
         super().__init__(server_ip=server_ip, server_port=server_port)
         self._vm = vm
+        self._cmd += f" --bind-dev {bind_dev}" if bind_dev else ""
         self._cmd += f" --set-mss {maximum_segment_size}" if maximum_segment_size else ""
 
     def __enter__(self) -> "VMTcpClient":

--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -121,6 +121,33 @@ def wait_for_missing_iface_status(vm: BaseVirtualMachine, iface_name: str) -> bo
     return True
 
 
+def wait_for_ifaces_status(
+    vm: BaseVirtualMachine,
+    ip_addresses_by_spec_net_name: dict[str, list[str]],
+) -> None:
+    """Wait for all VM interfaces to be ready.
+
+    Args:
+        vm: The virtual machine to wait for.
+        ip_addresses_by_spec_net_name: Mapping of spec network name to its expected IP addresses.
+            Primary (masquerade) interfaces are detected automatically from the VM spec.
+    """
+    for iface in vm.template_spec.domain.devices.interfaces:  # type: ignore
+        if iface.masquerade is not None:
+            lookup_iface_status(vm=vm, iface_name=iface.name)
+        else:
+            lookup_iface_status(
+                vm=vm,
+                iface_name=iface.name,
+                predicate=lambda iface_status: (
+                    "guest-agent" in iface_status["infoSource"]
+                    and all(
+                        ip in iface_status.get("ipAddresses", []) for ip in ip_addresses_by_spec_net_name[iface.name]
+                    )
+                ),
+            )
+
+
 def lookup_primary_network(vm: BaseVirtualMachine) -> Network:
     for network in vm.instance.spec.template.spec.networks:
         if network.pod is not None:

--- a/libs/vm/oper.py
+++ b/libs/vm/oper.py
@@ -1,0 +1,49 @@
+import logging
+
+from kubernetes.client import ApiException
+
+from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.vm import BaseVirtualMachine
+
+LOGGER = logging.getLogger(__name__)
+
+
+def run_vm(
+    vm: BaseVirtualMachine,
+    ip_addresses_by_spec_net_name: dict[str, list[str]],
+) -> BaseVirtualMachine:
+    """Start a VM, wait for agent connection, and verify interface IP addresses.
+
+    Args:
+        vm: The virtual machine to start.
+        ip_addresses_by_spec_net_name: Mapping of spec network name to expected IP addresses.
+
+    Returns:
+        The same VM, running with all interfaces reporting expected IPs.
+    """
+    vm.start(wait=True)
+    vm.wait_for_agent_connected()
+    wait_for_ifaces_status(vm=vm, ip_addresses_by_spec_net_name=ip_addresses_by_spec_net_name)
+    return vm
+
+
+def run_vms(vms: tuple[BaseVirtualMachine, ...]) -> tuple[BaseVirtualMachine, ...]:
+    """Start all VMs in parallel then wait for each to be ready and agent-connected.
+
+    Args:
+        vms: VMs to start.
+
+    Returns:
+        The same tuple of VMs, all running with guest agent connected.
+    """
+    for vm in vms:
+        try:
+            vm.start()  # type: ignore[no-untyped-call]
+        except ApiException as vm_exception:
+            if "VM is already running" in vm_exception.body:
+                LOGGER.warning(f"VM {vm.name} is already running")
+                continue
+    for vm in vms:
+        vm.wait_for_ready_status(status=True)  # type: ignore[no-untyped-call]
+        vm.wait_for_agent_connected()
+    return vms

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -76,6 +76,7 @@ class Interface:
     sriov: dict[Any, Any] | None = None
     binding: NetBinding | None = None
     state: str | None = None
+    macAddress: str | None = None  # noqa: N815
 
 
 @dataclass

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -48,6 +48,7 @@ class CPU:
 @dataclass
 class Memory:
     guest: str
+    maxGuest: str | None = None  # noqa: N815
 
 
 @dataclass

--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -12,7 +12,20 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.virtual_machine import VirtualMachine, VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
-from libs.vm.spec import CloudInitNoCloud, ContainerDisk, Devices, Disk, Metadata, SpecDisk, VMISpec, VMSpec, Volume
+from libs.vm.spec import (
+    Affinity,
+    CloudInitNoCloud,
+    ContainerDisk,
+    Devices,
+    Disk,
+    Memory,
+    Metadata,
+    Network,
+    SpecDisk,
+    VMISpec,
+    VMSpec,
+    Volume,
+)
 from tests.network.libs import cloudinit
 from utilities import infra
 from utilities.constants import CLOUD_INIT_DISK_NAME
@@ -102,6 +115,53 @@ class BaseVirtualMachine(VirtualMachine):
             self: {"spec": {"template": {"metadata": {"annotations": self._spec.template.metadata.annotations}}}}
         }
         ResourceEditor(patches=patches).update()
+
+    def set_networks(self, networks: list[Network]) -> None:
+        """Replace all secondary networks in the VM spec with a single atomic patch.
+
+        Updates the in-memory spec first so the object stays consistent with the cluster
+        without requiring a re-fetch after the patch.
+
+        Args:
+            networks: Full list of Network entries to apply (including the pod network).
+        """
+        self._spec.template.spec.networks = networks
+        serialized = [asdict(obj=net, dict_factory=self._filter_out_none_values) for net in networks]
+        ResourceEditor(patches={self: {"spec": {"template": {"spec": {"networks": serialized}}}}}).update()
+
+    def set_guest_memory(self, memory_guest: str) -> None:
+        """Set the guest memory and update the VM spec on the cluster.
+
+        On a running VM this triggers an automatic live migration.
+
+        Args:
+            memory_guest: New guest memory value (e.g. "5Gi").
+        """
+        if self._spec.template.spec.domain.memory:
+            self._spec.template.spec.domain.memory.guest = memory_guest
+        else:
+            self._spec.template.spec.domain.memory = Memory(guest=memory_guest)
+        ResourceEditor(
+            patches={self: {"spec": {"template": {"spec": {"domain": {"memory": {"guest": memory_guest}}}}}}}
+        ).update()
+
+    def set_template_affinity(self, affinity: Affinity | None) -> None:
+        """Replace the VM template affinity.
+
+        Serializes without dict_factory so that None-valued fields (e.g. podAffinity: None)
+        are preserved as null in the merge patch, ensuring the old affinity type is removed.
+
+        Args:
+            affinity: Affinity object to set, or None to clear.
+        """
+        self._spec.template.spec.affinity = affinity
+        template_affinity = asdict(obj=affinity) if affinity else None
+        patches = {self: {"spec": {"template": {"spec": {"affinity": template_affinity}}}}}
+        ResourceEditor(patches=patches).update()
+
+    @property
+    def template_spec(self) -> VMISpec:
+        return self._spec.template.spec
 
     @property
     def cloud_init_network_data(self) -> cloudinit.NetworkData:

--- a/tests/network/libs/connectivity.py
+++ b/tests/network/libs/connectivity.py
@@ -1,0 +1,39 @@
+from timeout_sampler import TimeoutExpiredError, retry
+
+from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer, VMTcpClient
+from libs.vm.vm import BaseVirtualMachine
+
+
+@retry(wait_timeout=60, sleep=5, exceptions_dict={})
+def poll_tcp_connectivity(
+    client_vm: BaseVirtualMachine,
+    server_vm: BaseVirtualMachine,
+    server_ip: str,
+    client_bind_dev: str | None = None,
+    server_bind_dev: str | None = None,
+    expect_connectivity: bool = True,
+) -> bool:
+    """Poll TCP connectivity (or its absence) between two VMs, retrying until the expected state is reached.
+
+    Args:
+        client_vm: VM initiating the TCP connection.
+        server_vm: VM running the iperf3 server.
+        server_ip: IP address the server binds to.
+        client_bind_dev: Guest network device name to force the client out (e.g. "eth1").
+            Bypasses ECMP routing when both secondary interfaces share the same subnet.
+        server_bind_dev: Guest network device name to force the server responses out (e.g. "eth1").
+            Bypasses ECMP routing on the server VM when it has multiple secondary interfaces.
+        expect_connectivity: When True polls until connectivity exists; when False polls until it does not.
+
+    Returns:
+        True when the observed reachability matches expect_connectivity.
+    """
+    try:
+        with TcpServer(vm=server_vm, port=IPERF_SERVER_PORT, bind_ip=server_ip, bind_dev=server_bind_dev):
+            with VMTcpClient(
+                vm=client_vm, server_ip=server_ip, server_port=IPERF_SERVER_PORT, bind_dev=client_bind_dev
+            ):
+                reachable = True
+    except TimeoutExpiredError:
+        reachable = False
+    return reachable if expect_connectivity else not reachable

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -1,0 +1,70 @@
+"""SR-IOV library constants and utilities."""
+
+from kubernetes.dynamic import DynamicClient
+
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import CloudInitNoCloud, Interface, Memory, Multus, Network
+from libs.vm.vm import BaseVirtualMachine, add_volume_disk, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import MatchSelector
+
+VM_SRIOV_IFACE_NAME = "sriov1"
+MTU_9000 = 9000
+
+
+def base_sriov_vm(
+    namespace: str,
+    name: str,
+    client: DynamicClient,
+    sriov_network_name: str,
+    sriov_mac: str,
+    addresses: list[str],
+    memory_guest: str = "1Gi",
+    memory_max_guest: str | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with an SR-IOV secondary interface using BaseVirtualMachine.
+
+    The SR-IOV VF is matched by MAC address and renamed to sriov1 via
+    cloud-init set-name.
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name prefix (a unique suffix is appended automatically).
+        client: Kubernetes dynamic client.
+        sriov_network_name: Name of the SR-IOV NetworkAttachmentDefinition.
+        sriov_mac: MAC address to assign to the SR-IOV interface.
+        addresses: CIDR addresses to assign to the SR-IOV interface
+            (e.g. ["172.16.0.1/24", "fd00::1/64"]).
+        memory_guest: Initial guest memory (e.g. "1Gi"). Defaults to "1Gi".
+        memory_max_guest: Maximum guest memory for hot-plug. None disables hot-plug.
+
+    Returns:
+        BaseVirtualMachine configured with an SR-IOV secondary interface.
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.memory = Memory(guest=memory_guest, maxGuest=memory_max_guest)
+    spec.template.spec.domain.devices.interfaces = [  # type: ignore[union-attr]
+        Interface(name=sriov_network_name, sriov={}, macAddress=sriov_mac),
+    ]
+    spec.template.spec.networks = [
+        Network(name=sriov_network_name, multus=Multus(networkName=f"{namespace}/{sriov_network_name}")),
+    ]
+
+    ethernets: dict[str, cloudinit.EthernetDevice] = {}
+    ethernets["sriov"] = cloudinit.EthernetDevice(
+        addresses=addresses,
+        match=MatchSelector(macaddress=sriov_mac),
+        set_name=VM_SRIOV_IFACE_NAME,
+    )
+    disk, volume = cloudinitdisk_storage(
+        data=CloudInitNoCloud(
+            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)),
+            userData=cloudinit.format_cloud_config(userdata=cloudinit.UserData(users=[])),
+        )
+    )
+    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
+
+
+def vm_sriov_mac(mac_suffix_index):
+    return f"02:00:b5:b5:b5:{mac_suffix_index:02x}"

--- a/tests/network/sriov/memory_hotplug/conftest.py
+++ b/tests/network/sriov/memory_hotplug/conftest.py
@@ -1,0 +1,78 @@
+import ipaddress
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from libs.net.ip import random_cidr_addresses_by_family
+from libs.vm.oper import run_vm
+from tests.network.sriov.libsriov import base_sriov_vm, vm_sriov_mac
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.namespace import Namespace
+    from ocp_resources.sriov_network import SriovNetwork
+
+    from libs.vm.vm import BaseVirtualMachine
+
+_NET_SEED: Final[int] = 0
+_HOTPLUG_VM_HOST_ADDRESS: Final[int] = 10
+_REF_VM_HOST_ADDRESS: Final[int] = 11
+_INITIAL_MEMORY: Final[str] = "1Gi"
+_MAX_GUEST_MEMORY: Final[str] = "4Gi"
+_SRIOV_CLOUD_INIT_PROFILE: Final[str] = "sriov"
+
+
+@pytest.fixture(scope="class")
+def sriov_vm_with_max_guest(
+    index_number: Generator[int],
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    sriov_network: SriovNetwork,
+) -> Generator[BaseVirtualMachine]:
+    sriov_iface_addresses = random_cidr_addresses_by_family(net_seed=_NET_SEED, host_address=_HOTPLUG_VM_HOST_ADDRESS)
+    with base_sriov_vm(
+        namespace=namespace.name,
+        name="sriov-memory-hotplug-vm",
+        client=unprivileged_client,
+        sriov_network_name=sriov_network.name,
+        sriov_mac=vm_sriov_mac(mac_suffix_index=next(index_number)),
+        addresses=sriov_iface_addresses,
+        memory_guest=_INITIAL_MEMORY,
+        memory_max_guest=_MAX_GUEST_MEMORY,
+    ) as vm:
+        addresses = vm.cloud_init_network_data.ethernets[_SRIOV_CLOUD_INIT_PROFILE].addresses or []
+        run_vm(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                sriov_network.name: [str(ipaddress.ip_interface(addr).ip) for addr in addresses]
+            },
+        )
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def sriov_ref_vm(
+    index_number: Generator[int],
+    unprivileged_client: DynamicClient,
+    namespace: Namespace,
+    sriov_network: SriovNetwork,
+) -> Generator[BaseVirtualMachine]:
+    sriov_iface_addresses = random_cidr_addresses_by_family(net_seed=_NET_SEED, host_address=_REF_VM_HOST_ADDRESS)
+    with base_sriov_vm(
+        namespace=namespace.name,
+        name="sriov-ref-vm",
+        client=unprivileged_client,
+        sriov_network_name=sriov_network.name,
+        sriov_mac=vm_sriov_mac(mac_suffix_index=next(index_number)),
+        addresses=sriov_iface_addresses,
+        memory_guest=_INITIAL_MEMORY,
+    ) as vm:
+        addresses = vm.cloud_init_network_data.ethernets[_SRIOV_CLOUD_INIT_PROFILE].addresses or []
+        run_vm(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                sriov_network.name: [str(ipaddress.ip_interface(addr).ip) for addr in addresses]
+            },
+        )
+        yield vm

--- a/tests/network/sriov/memory_hotplug/lib_helpers.py
+++ b/tests/network/sriov/memory_hotplug/lib_helpers.py
@@ -1,0 +1,27 @@
+from kubernetes.utils.quantity import parse_quantity
+from timeout_sampler import retry
+
+from libs.vm.vm import BaseVirtualMachine
+from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC
+
+
+def hotplug_memory_and_wait(vm: BaseVirtualMachine, memory_guest: str) -> None:
+    """Hot-plug memory on a VM and wait for the guest OS to report the new amount.
+
+    Sets the new guest memory value on the VM, then polls the VMI status
+    guestCurrent field until it reaches the expected value — confirming the
+    live migration triggered by the hot-plug has completed and the guest OS
+    has received the memory.
+
+    Args:
+        vm: The virtual machine to hot-plug memory on.
+        memory_guest: New guest memory value (e.g. "2Gi").
+    """
+    vm.set_guest_memory(memory_guest=memory_guest)
+    _wait_for_guest_memory_in_vmi_status(vm=vm, memory_guest=memory_guest)
+
+
+@retry(wait_timeout=TIMEOUT_5MIN, sleep=TIMEOUT_5SEC)
+def _wait_for_guest_memory_in_vmi_status(vm: BaseVirtualMachine, memory_guest: str) -> bool:
+    current = vm.vmi.instance.status.memory.guestCurrent
+    return bool(current) and parse_quantity(str(current)) == parse_quantity(memory_guest)

--- a/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
+++ b/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
@@ -1,0 +1,100 @@
+"""
+SR-IOV VM memory hot-plug tests.
+
+Jira: https://redhat.atlassian.net/browse/CNV-69778 # <skip-jira-utils-check>
+"""
+
+from typing import Final
+
+import pytest
+
+from libs.net.ip import filter_link_local_addresses
+from libs.net.vmspec import lookup_iface_status
+from tests.network.libs.connectivity import poll_tcp_connectivity
+from tests.network.sriov.memory_hotplug.lib_helpers import hotplug_memory_and_wait
+from utilities.constants import TIMEOUT_2MIN
+
+HOTPLUG_MEMORY_SIZE: Final[str] = "3Gi"
+
+
+pytestmark = [pytest.mark.special_infra, pytest.mark.sriov]
+
+
+@pytest.mark.usefixtures("sriov_ref_vm")
+@pytest.mark.incremental
+class TestSriovMemoryHotplug:
+    """
+    Tests for SR-IOV VM memory hot-plug.
+
+    Preconditions:
+        - Running under-test VM with SR-IOV interface, 1Gi initial
+          memory, and 4Gi maxGuest configured
+        - Running reference VM with SR-IOV interface on the same
+          SR-IOV network
+    """
+
+    @pytest.mark.polarion("CNV-16278")
+    def test_vmi_status(
+        self,
+        sriov_vm_with_max_guest,
+        sriov_network,
+    ):
+        """
+        Test that after memory hot-plug on SR-IOV VM, the VMI status reflects the
+        new memory and the SR-IOV interface is present in the VMI status.
+
+        Preconditions:
+            - A running under-test VM with an SR-IOV interface, 1Gi initial
+              memory, and 4Gi maxGuest configured
+
+        Steps:
+            1. Hot-plug memory to 3Gi on the under-test VM
+
+        Expected:
+            - VMI status of the under-test VM shows actual guest memory
+              increased to 3Gi
+            - SR-IOV interface is present in the VMI status of the under-test
+              VM with guest-agent and domain as an info source
+        """
+        hotplug_memory_and_wait(vm=sriov_vm_with_max_guest, memory_guest=HOTPLUG_MEMORY_SIZE)
+        lookup_iface_status(
+            vm=sriov_vm_with_max_guest,
+            iface_name=sriov_network.name,
+            timeout=TIMEOUT_2MIN,
+            predicate=lambda iface: all(source in iface["infoSource"] for source in ("domain", "guest-agent")),
+        )
+
+    @pytest.mark.polarion("CNV-16279")
+    def test_connectivity(
+        self,
+        subtests,
+        sriov_vm_with_max_guest,
+        sriov_ref_vm,
+        sriov_network,
+    ):
+        """
+        Test that SR-IOV connectivity is preserved after memory hot-plug.
+
+        Preconditions:
+            - Under-test VM after memory hot-plug with SR-IOV interface present
+            - A running reference VM with an SR-IOV interface on the same
+              SR-IOV network
+
+        Steps:
+            1. Poll TCP connection from the under-test VM to the reference VM over the SR-IOV interface
+
+        Expected:
+            - TCP connectivity between the under-test VM and the reference VM
+              over the SR-IOV interface is eventually preserved after memory hotplug
+        """
+        ref_iface = lookup_iface_status(vm=sriov_ref_vm, iface_name=sriov_network.name)
+        under_test_iface = lookup_iface_status(vm=sriov_vm_with_max_guest, iface_name=sriov_network.name)
+        for server_ip in filter_link_local_addresses(ip_addresses=ref_iface.ipAddresses):
+            with subtests.test(msg=f"IPv{server_ip.version}: {server_ip}"):
+                poll_tcp_connectivity(
+                    client_vm=sriov_vm_with_max_guest,
+                    server_vm=sriov_ref_vm,
+                    server_ip=str(server_ip),
+                    client_bind_dev=under_test_iface.interfaceName,
+                    server_bind_dev=ref_iface.interfaceName,
+                )


### PR DESCRIPTION
##### What this PR does / why we need it:
Manual cherry-pick to 4.21: net, sriov: memory hotplug tests ([#5349](https://github.com/RedHatQE/openshift-virtualization-tests/pull/5349))


##### Which issue(s) this PR fixes:
Auto-cherry-pick failed due to missing infra and helpers


##### Special notes for reviewer:
Missing infra and helpers in 1st commit with the PRs where the change was introduced

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-89771
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
