### PR TITLE
[cnv-4.22] net, multiarch: implement pod network connectivity tests

### DIFF
--- a/tests/network/primary_network/multiarch/conftest.py
+++ b/tests/network/primary_network/multiarch/conftest.py
@@ -1,0 +1,31 @@
+from collections.abc import Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.vm import BaseVirtualMachine
+from utilities.constants.architecture import AMD_64, ARM_64
+
+
+@pytest.fixture(scope="class")
+def arm_vm(namespace: Namespace, unprivileged_client: DynamicClient) -> Generator[BaseVirtualMachine]:
+    spec = base_vmspec()
+    spec.template.spec.architecture = ARM_64
+    vm = fedora_vm(namespace=namespace.name, name="arm-vm", client=unprivileged_client, spec=spec)
+    with vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def amd_vm(namespace: Namespace, unprivileged_client: DynamicClient) -> Generator[BaseVirtualMachine]:
+    spec = base_vmspec()
+    spec.template.spec.architecture = AMD_64
+    vm = fedora_vm(namespace=namespace.name, name="amd-vm", client=unprivileged_client, spec=spec)
+    with vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm

--- a/tests/network/primary_network/multiarch/conftest.py
+++ b/tests/network/primary_network/multiarch/conftest.py
@@ -6,7 +6,7 @@ from ocp_resources.namespace import Namespace
 
 from libs.vm.factory import base_vmspec, fedora_vm
 from libs.vm.vm import BaseVirtualMachine
-from utilities.constants.architecture import AMD_64, ARM_64
+from utilities.constants import AMD_64, ARM_64
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/primary_network/multiarch/libmultiarch.py
+++ b/tests/network/primary_network/multiarch/libmultiarch.py
@@ -1,0 +1,16 @@
+from libs.net.vmspec import lookup_iface_status_ip
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.libs.connectivity import build_ping_command
+
+
+def ping_between_vms(source_vm: BaseVirtualMachine, destination_vm: BaseVirtualMachine, ip_family: int = 4) -> None:
+    """Ping from source VM to destination VM over the pod network.
+
+    Args:
+        source_vm: VM that initiates the ping.
+        destination_vm: VM whose pod network IP is the ping target.
+        ip_family: IP version to use (4 or 6).
+    """
+    dst_ip = lookup_iface_status_ip(vm=destination_vm, iface_name="default", ip_family=ip_family)
+    ping_cmd = build_ping_command(dst_ip=str(dst_ip), count=10, timeout=10)
+    source_vm.console(commands=[ping_cmd], timeout=20)

--- a/tests/network/primary_network/multiarch/test_pod_network.py
+++ b/tests/network/primary_network/multiarch/test_pod_network.py
@@ -7,14 +7,16 @@ https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
 
 import pytest
 
+from tests.network.primary_network.multiarch.libmultiarch import ping_between_vms
+
 
 @pytest.mark.multiarch
 @pytest.mark.single_nic
 @pytest.mark.ipv4
 class TestMultiArchPodNetwork:
     """
-    Test connectivity between VM on ARM architectures and VM on AMD over pod network.
-    Intended to run on multi-architecture cluster with AMD64 and ARM64 worker nodes
+    Test connectivity between VM on ARM architecture and VM on AMD over pod network.
+    Intended to run on multi-architecture cluster with AMD64 and ARM64 worker nodes.
 
     Preconditions:
         - VM on ARM64 node
@@ -22,9 +24,9 @@ class TestMultiArchPodNetwork:
     """
 
     @pytest.mark.polarion("CNV-15968")
-    def test_pod_network_connectivity_arm_to_amd(self):
+    def test_pod_network_connectivity_arm_to_amd(self, arm_vm, amd_vm):
         """
-        Test connectivity from VM on ARM architectures to VM on AMD over pod network.
+        Test connectivity from VM on ARM architecture to VM on AMD over pod network.
 
         Steps:
             1. ICMP (ping) from ARM VM to AMD VM
@@ -32,11 +34,12 @@ class TestMultiArchPodNetwork:
         Expected:
             - 0 packet loss
         """
+        ping_between_vms(source_vm=arm_vm, destination_vm=amd_vm)
 
     @pytest.mark.polarion("CNV-15969")
-    def test_pod_network_connectivity_amd_to_arm(self):
+    def test_pod_network_connectivity_amd_to_arm(self, arm_vm, amd_vm):
         """
-        Test connectivity from VM on AMD architectures to VM on ARM over pod network.
+        Test connectivity from VM on AMD architecture to VM on ARM over pod network.
 
         Steps:
             1. ICMP (ping) from AMD VM to ARM VM
@@ -44,6 +47,4 @@ class TestMultiArchPodNetwork:
         Expected:
             - 0 packet loss
         """
-
-    test_pod_network_connectivity_arm_to_amd.__test__ = False
-    test_pod_network_connectivity_amd_to_arm.__test__ = False
+        ping_between_vms(source_vm=amd_vm, destination_vm=arm_vm)


### PR DESCRIPTION
##### What this PR does / why we need it:
Cherry-pick of #5394 to cnv-4.22 with constants import fixed
(`utilities.constants.architecture` → `utilities.constants`).

##### Which issue(s) this PR fixes:
Replaces #5616 (broken auto cherry-pick)

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-89416