### PR TITLE
[Storage] Remove jira markers from Importer Pod Annotation test

### DIFF
--- a/tests/storage/cdi_import/test_import_registry.py
+++ b/tests/storage/cdi_import/test_import_registry.py
@@ -181,7 +181,6 @@ def test_public_registry_data_volume_archive(unprivileged_client, namespace, sto
             return
 
 
-@pytest.mark.jira("CNV-92373", run=False)
 @pytest.mark.polarion("CNV-5509")
 @pytest.mark.s390x
 def test_importer_pod_annotation(importer_pod_annotations, linux_nad):


### PR DESCRIPTION
Signed-off-by: Emanuele Prella <eprella@redhat.com>

##### What this PR does / why we need it:
Remove Jira marker that prevented test to be run.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
CNV-92373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test markers for the importer pod annotation test.
  * Removed an obsolete test tracking annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->