### PR TITLE
fix: inject synthetic JUnit testcase on sanity failure

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -51,6 +51,7 @@ from utilities.exceptions import MissingEnvironmentVariableError, StorageSanityE
 from utilities.junit_ai_utils import enrich_junit_xml, setup_ai_analysis
 from utilities.logger import setup_logging
 from utilities.pytest_utils import (
+    InjectFailurePlugin,
     assert_incremental_classes_fully_collected,
     config_default_storage_class,
     deploy_run_in_progress_config_map,
@@ -583,6 +584,8 @@ def pytest_configure(config):
         ).construct_storage_class_matrix(storage_config=config.getoption("conformance_storage_class_config"))
 
         py_config["default_storage_class"] = conformance_storage_class
+
+    config.pluginmanager.register(plugin=InjectFailurePlugin(), name="inject-failure-junit")
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -9,9 +9,12 @@ import shutil
 import socket
 import sys
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any
+from xml.etree import ElementTree
 
 import pytest
+from _pytest.junitxml import bin_xml_escape, xml_key  # Internal pytest API — verify after pytest upgrades
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.namespace import Namespace
@@ -50,6 +53,72 @@ from utilities.os_utils import (
 )
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class _FailureInfo:
+    """Stores failure info from exit_pytest_execution for JUnit XML injection.
+
+    Used as a module-level singleton — set by exit_pytest_execution,
+    read by inject_failure_junit in pytest_sessionfinish.
+    """
+
+    message: str = ""
+    log_message: str = ""
+    return_code: int = 0
+    recorded: bool = False
+
+
+_failure_info = _FailureInfo()
+
+
+class InjectFailurePlugin:
+    """Plugin to inject synthetic failure testcase into JUnit XML before LogXML writes."""
+
+    @staticmethod
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+        inject_failure_junit(session=session)
+
+
+def inject_failure_junit(session: pytest.Session) -> None:
+    """Inject a synthetic error testcase into JUnit XML for early pytest exit failures.
+
+    When pytest exits before running any tests, the JUnit XML report contains zero
+    testcases. CI systems ignore empty reports, making failures invisible. This
+    function adds a synthetic error testcase to ensure the failure is reported.
+
+    Note:
+        Must execute before LogXML.pytest_sessionfinish writes the report.
+        InjectFailurePlugin ensures this via @pytest.hookimpl(tryfirst=True).
+
+    Args:
+        session: The pytest session object, used to access the junitxml writer.
+    """
+    if not _failure_info.recorded:
+        return
+
+    xml_writer = session.config.stash.get(xml_key, None)
+    if xml_writer is None:
+        LOGGER.info("No junitxml writer active (--junitxml not passed), skipping synthetic testcase injection")
+        return
+
+    return_code = _failure_info.return_code
+    log_message = _failure_info.log_message
+
+    sanitized_name = re.sub(r"[^a-z0-9_]", "", _failure_info.message.lower().replace(" ", "_"))[:80]
+    name = sanitized_name or "execution_failure"
+
+    node_id = f"pytest_exit::{name}"
+    reporter = xml_writer.node_reporter(report=node_id)
+    reporter.attrs["classname"] = "pytest_exit"
+    reporter.attrs["name"] = name
+
+    error_node = ElementTree.Element("error", attrib={"message": f"Pytest execution failed (exit code: {return_code})"})
+    error_node.text = bin_xml_escape(arg=log_message)
+    reporter.append(error_node)
+
+    LOGGER.info(f"Injected synthetic failure testcase into JUnit XML (exit code: {return_code})")
 
 
 def get_base_matrix_name(matrix_name):
@@ -367,6 +436,11 @@ def exit_pytest_execution(
         junitxml_property (pytest plugin): record_testsuite_property
         message (str): Message to log in an error file. If not provided, `log_message` will be used.
         admin_client (DynamicClient): cluster admin client
+
+    Note:
+        Records the failure details in a module-level store so that
+        inject_failure_junit can emit a synthetic JUnit XML testcase
+        during pytest_sessionfinish.
     """
     target_location = os.path.join(get_data_collector_base_directory(), "utilities", "pytest_exit_errors")
     # collect must-gather for past 5 minutes:
@@ -386,6 +460,12 @@ def exit_pytest_execution(
         )
     if junitxml_property:
         junitxml_property(name="exit_code", value=return_code)
+
+    _failure_info.message = message or log_message
+    _failure_info.log_message = log_message
+    _failure_info.return_code = return_code
+    _failure_info.recorded = True
+
     pytest.exit(reason=log_message, returncode=return_code)
 
 

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 import utilities.constants
+
+# Circular dependencies are already mocked in conftest.py
+from utilities import pytest_utils as pytest_utils_module
 from utilities.constants.architecture import (
     AMD_64,
     ARM_64,
@@ -19,8 +22,6 @@ from utilities.constants.instance_types import (
     RHEL9_PREFERENCE,
 )
 from utilities.exceptions import MissingEnvironmentVariableError, UnsupportedCPUArchitectureError
-
-# Circular dependencies are already mocked in conftest.py
 from utilities.pytest_utils import (
     assert_incremental_classes_fully_collected,
     config_default_storage_class,
@@ -37,6 +38,7 @@ from utilities.pytest_utils import (
     get_current_running_data,
     get_matrix_params,
     get_tests_cluster_markers,
+    inject_failure_junit,
     mark_nmstate_dependent_tests,
     remove_tests_from_list,
     reorder_early_fixtures,
@@ -2536,3 +2538,94 @@ class TestFilterMultiarchTests:
 
         assert result == [item_other]
         config.hook.pytest_deselected.assert_not_called()
+
+
+class TestInjectFailureJunit:
+    """Test cases for inject_failure_junit and _failure_info mechanism"""
+
+    def setup_method(self):
+        pytest_utils_module._failure_info = pytest_utils_module._FailureInfo()
+
+    def teardown_method(self):
+        pytest_utils_module._failure_info = pytest_utils_module._FailureInfo()
+
+    def test_no_op_when_no_failure(self):
+        """Test inject_failure_junit does nothing when no failure was recorded."""
+        mock_session = MagicMock()
+        inject_failure_junit(session=mock_session)
+        mock_session.config.stash.get.assert_not_called()
+
+    def test_no_op_when_junitxml_not_registered(self):
+        """Test inject_failure_junit does nothing when junitxml writer is not active."""
+        pytest_utils_module._failure_info.message = "Test failure"
+        pytest_utils_module._failure_info.log_message = "Detailed failure"
+        pytest_utils_module._failure_info.return_code = 99
+        pytest_utils_module._failure_info.recorded = True
+
+        mock_session = MagicMock()
+        mock_session.config.stash.get.return_value = None
+
+        inject_failure_junit(session=mock_session)
+
+        mock_session.config.stash.get.assert_called_once()
+
+    def test_injects_synthetic_testcase(self):
+        """Test inject_failure_junit creates synthetic error testcase in JUnit XML."""
+        pytest_utils_module._failure_info.message = "Cluster sanity failed"
+        pytest_utils_module._failure_info.log_message = "Detailed cluster sanity failure message"
+        pytest_utils_module._failure_info.return_code = 99
+        pytest_utils_module._failure_info.recorded = True
+
+        mock_session = MagicMock()
+        mock_xml_writer = MagicMock()
+        mock_reporter = MagicMock()
+        mock_reporter.attrs = {}
+        mock_xml_writer.node_reporter.return_value = mock_reporter
+        mock_session.config.stash.get.return_value = mock_xml_writer
+
+        inject_failure_junit(session=mock_session)
+
+        mock_xml_writer.node_reporter.assert_called_once_with(report="pytest_exit::cluster_sanity_failed")
+        assert mock_reporter.attrs["classname"] == "pytest_exit"
+        assert mock_reporter.attrs["name"] == "cluster_sanity_failed"
+        mock_reporter.append.assert_called_once()
+        error_element = mock_reporter.append.call_args[0][0]
+        assert error_element.tag == "error"
+        assert "exit code: 99" in error_element.get("message")
+        assert "Detailed cluster sanity failure message" in error_element.text
+
+    @patch("utilities.pytest_utils.pytest.exit")
+    @patch("utilities.pytest_utils.get_data_collector_base_directory")
+    def test_exit_pytest_execution_stores_failure_info(self, mock_get_base_dir, mock_pytest_exit):
+        """Test exit_pytest_execution stores failure info for JUnit XML injection."""
+        mock_get_base_dir.return_value = "/tmp/test"
+        mock_admin_client = MagicMock()
+
+        exit_pytest_execution(
+            log_message="Storage check failed",
+            return_code=99,
+            message="Cluster sanity checks failed.",
+            admin_client=mock_admin_client,
+        )
+
+        assert pytest_utils_module._failure_info.recorded
+        assert pytest_utils_module._failure_info.message == "Cluster sanity checks failed."
+        assert pytest_utils_module._failure_info.log_message == "Storage check failed"
+        assert pytest_utils_module._failure_info.return_code == 99
+
+    @patch("utilities.pytest_utils.pytest.exit")
+    @patch("utilities.pytest_utils.get_data_collector_base_directory")
+    def test_exit_pytest_execution_uses_log_message_when_no_message(self, mock_get_base_dir, mock_pytest_exit):
+        """Test exit_pytest_execution uses log_message as message when message is None."""
+        mock_get_base_dir.return_value = "/tmp/test"
+        mock_admin_client = MagicMock()
+
+        exit_pytest_execution(
+            log_message="Network sanity failed",
+            return_code=91,
+            admin_client=mock_admin_client,
+        )
+
+        assert pytest_utils_module._failure_info.recorded
+        assert pytest_utils_module._failure_info.message == "Network sanity failed"
+        assert pytest_utils_module._failure_info.return_code == 91


### PR DESCRIPTION
##### What this PR does / why we need it:

When sanity checks fail via `exit_pytest_execution()` (cluster connectivity, storage checks, etc.), pytest exits before running any tests. The JUnit XML report contains zero testcases — CI systems (Jenkins, Report Portal) silently ignore empty reports, making these failures invisible.

This PR injects a synthetic `<error>` testcase into JUnit XML during `pytest_sessionfinish` so the failure appears in CI reports.

**How it works:**
1. `exit_pytest_execution()` stores failure info (message, return code) in a module-level variable before calling `pytest.exit()`
2. `inject_sanity_failure_junit()` is called first in `pytest_sessionfinish` — before junitxml writes the report
3. If failure info exists and junitxml plugin is registered, a synthetic `sanity::sanity_check` error testcase is injected

**Files:**
- `utilities/pytest_utils.py` — `inject_sanity_failure_junit()` function + `_sanity_failure_info` module variable + storage in `exit_pytest_execution()`
- `conftest.py` — hook call in `pytest_sessionfinish`
- `utilities/unittests/test_pytest_utils.py` — 5 unit tests covering: no failure, no junitxml, injection, storage via exit_pytest_execution

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

- Uses `_pytest.junitxml.bin_xml_escape` for safe XML text encoding (same as pytest internals)
- `pytest_sessionfinish` runs even after `pytest.exit()` — this is guaranteed by pytest lifecycle
- Module-level variable is used because `pytest.exit()` raises `SystemExit`, so the info must be stored before the call

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JUnit reporting for scenarios where pytest exits early before any real tests run, adding a synthetic error entry.
  * JUnit output now carries the relevant failure message (or log details) and includes the corresponding exit code for easier diagnosis.

* **Tests**
  * Added unit tests covering JUnit injection behavior both when JUnit reporting is enabled and when it is not, including validation of early-exit failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->