### PR TITLE
[logger] Log timestamps with explicit time-zone

### DIFF
--- a/utilities/logger.py
+++ b/utilities/logger.py
@@ -1,6 +1,6 @@
 import logging
 import multiprocessing
-from datetime import datetime
+from datetime import UTC, datetime
 from logging.handlers import QueueHandler, QueueListener, RotatingFileHandler
 
 from colorlog import ColoredFormatter
@@ -28,7 +28,7 @@ class DuplicateFilter(logging.Filter):
 
 class TestLogFormatter(ColoredFormatter):
     def formatTime(self, record, datefmt=None):
-        return datetime.fromtimestamp(record.created).isoformat()
+        return datetime.fromtimestamp(record.created, tz=UTC).isoformat()
 
 
 def setup_logging(log_level, log_file="/tmp/pytest-tests.log"):


### PR DESCRIPTION
We should be explicit with the time-zone of the loggers timestamps. This provides consistency in 2 levels
1. With the wrapper (until now the logger prints from the wrapper showed a different timestamp than the repo's prints, depending on the executor from which the test is executed.
2. Synced timestamps between all test executions, regardless of the test executor origin.

##### What this PR does / why we need it:
Consistency and alignment.
Without this fix, logger prints from other repos show different timestamps the loggers from this repo (depending on the location of the test executor, for example:
```
2026-07-15T14:55:24.259823 utilities.console INFO vm-with-sec-and-hot-plug-interfaces-1784116195-8545878: waiting for terminal prompt '\$ '
2026-07-15T11:55:24.703124+00:00 timeout_sampler INFO ...
```
`14:55:24` vs. `11:55:24`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log timestamps now include an explicit UTC timezone, improving consistency across environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->