### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # openshift-virtualization-tests
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/RedHatQE/openshift-virtualization-tests)
+
 This repository contains tests to verify the functionality of OpenShift with
 [OpenShift Virtualization](https://www.redhat.com/en/technologies/cloud-computing/openshift/virtualization), formerly named `CNV` (Container Native Virtualization)
 


### PR DESCRIPTION
##### What this PR does / why we need it:

Adds a [DeepWiki](https://deepwiki.com) badge to the README for AI-powered repository exploration.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

Docs-only change — single badge addition to README.

##### jira-ticket: