### PR TITLE
Manual CherryPicked: [cnv-4.18] Fix IndexError in config_default_storage_class when storage class not in matrix

### DIFF
--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -7,6 +7,7 @@ import shutil
 import socket
 import sys
 
+import pytest
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import ResourceEditor
@@ -20,6 +21,7 @@ from utilities.constants import (
     POD_SECURITY_NAMESPACE_LABELS,
     TIMEOUT_2MIN,
 )
+from utilities.data_collector import get_data_collector_base_directory, write_to_file
 from utilities.exceptions import MissingEnvironmentVariableError
 from utilities.infra import exit_pytest_execution
 
@@ -85,6 +87,44 @@ def get_matrix_params(pytest_config, matrix_name):
     return _matrix_params if isinstance(_matrix_params, list) else [_matrix_params]
 
 
+def _validate_storage_class_options(
+    cmd_default_storage_class: str | None = None,
+    cmdline_storage_class_matrix: list[str] | None = None,
+) -> None:
+    """Validates that storage class CLI options reference existing storage classes.
+    Args:
+        cmd_default_storage_class: Value from --default-storage-class CLI option.
+        cmdline_storage_class_matrix: Parsed values from --storage-class-matrix CLI option.
+    Raises:
+        ValueError: If any storage class name is not found in py_config["system_storage_class_matrix"].
+    """
+    available_sc_names = [sc_name for sc in py_config["system_storage_class_matrix"] for sc_name in sc]
+
+    if cmdline_storage_class_matrix:
+        # Verify storage classes passed via --storage-class-matrix are supported
+        if invalid_sc_names := set(cmdline_storage_class_matrix) - set(available_sc_names):
+            raise ValueError(
+                f"Storage class(es) {sorted(invalid_sc_names)} from --storage-class-matrix not found. "
+                f"Available storage classes: {available_sc_names}"
+            )
+
+        # Verify default storage class passed via --default-storage-class exists in --storage-class-matrix
+        if cmd_default_storage_class and cmd_default_storage_class not in cmdline_storage_class_matrix:
+            raise ValueError(
+                f"Default storage class '{cmd_default_storage_class}' not in --storage-class-matrix. "
+                f"Matrix storage classes: {cmdline_storage_class_matrix}"
+            )
+
+        return
+
+    # Verify default storage class passed via --default-storage-class is supported (when matrix is not passed from cli)
+    if cmd_default_storage_class and cmd_default_storage_class not in available_sc_names:
+        raise ValueError(
+            f"Default storage class '{cmd_default_storage_class}' not found in system storage class matrix. "
+            f"Available storage classes: {available_sc_names}"
+        )
+
+
 def config_default_storage_class(session):
     # Default storage class selection order:
     # 1. --default-storage-class from command line
@@ -96,26 +136,43 @@ def config_default_storage_class(session):
     global_config_default_sc = py_config["default_storage_class"]
     cmd_default_storage_class = session.config.getoption(name="default_storage_class")
     cmdline_storage_class_matrix = session.config.getoption(name="storage_class_matrix")
+    system_storage_class_matrix = py_config["system_storage_class_matrix"]
+
+    parsed_cmdline_matrix = cmdline_storage_class_matrix.split(",") if cmdline_storage_class_matrix else None
+    try:
+        _validate_storage_class_options(
+            cmd_default_storage_class=cmd_default_storage_class,
+            cmdline_storage_class_matrix=parsed_cmdline_matrix,
+        )
+    except ValueError as error:
+        error_message = str(error)
+        target_location = os.path.join(get_data_collector_base_directory(), "utilities", "pytest_exit_errors")
+        write_to_file(
+            file_name="storage_class_validation_error",
+            content=error_message,
+            base_directory=target_location,
+        )
+        pytest.exit(reason=error_message, returncode=4)
+
     updated_default_sc = None
     if cmd_default_storage_class:
         updated_default_sc = cmd_default_storage_class
-    elif cmdline_storage_class_matrix:
-        cmdline_storage_class_matrix = cmdline_storage_class_matrix.split(",")
+    elif parsed_cmdline_matrix:
         updated_default_sc = (
-            global_config_default_sc
-            if global_config_default_sc in cmdline_storage_class_matrix
-            else cmdline_storage_class_matrix[0]
+            global_config_default_sc if global_config_default_sc in parsed_cmdline_matrix else parsed_cmdline_matrix[0]
         )
 
     # Update only if the requested default sc is not the same as set in global_config
     if updated_default_sc and updated_default_sc != global_config_default_sc:
         py_config["default_storage_class"] = updated_default_sc
-        default_storage_class_configuration = [
+        matching_configurations = [
             sc_dict
-            for sc in py_config["storage_class_matrix"]
+            for sc in system_storage_class_matrix
             for sc_name, sc_dict in sc.items()
             if sc_name == updated_default_sc
-        ][0]
+        ]
+
+        default_storage_class_configuration = matching_configurations[0]
 
         py_config["default_volume_mode"] = default_storage_class_configuration["volume_mode"]
         py_config["default_access_mode"] = default_storage_class_configuration["access_mode"]


### PR DESCRIPTION
What this PR does / why we need it:
When a --storage-class-matrix CLI value does not match any key in the configured storage_class_matrix in tests/global_config*.py
Adding validation before indexing into the list comprehension result.
When the requested storage class is not found in the matrix, raise a clear error message listing the available storage class names instead of crashing with an opaque IndexError.

Which issue(s) this PR fixes:
When a user passes --storage-class-matrix=hostpath-provisioner, for example, but hostpath-provisioner does not match any key in the storage_class_matrix configuration in tests/global_config.py.

Special notes for reviewer:
Manual cherrypick of #4908

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
