### PR TITLE
test: dummy PR for CodeRabbit linked-repo validation (storage migration cleanup)

### DIFF
--- a/tests/storage/storage_migration_cleanup/test_storage_mig_cleanup_std.py
+++ b/tests/storage/storage_migration_cleanup/test_storage_mig_cleanup_std.py
@@ -1,0 +1,45 @@
+"""Storage migration cleanup STD (partial — linked-repo smoke test).
+
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/storage_mig_cleanup.md
+
+Preconditions:
+    - Cluster with CDI, HCO, and migration controller installed
+    - ODF (ocs-storagecluster-ceph-rbd-virtualization) and HPP (hostpath-csi-basic) storage classes available
+"""
+
+import pytest
+
+__test__ = False
+
+
+class TestStorageMigrationCleanupPolicy:
+    """
+    STD for storage migration source volume cleanup policies.
+
+    Preconditions:
+        - Two storage classes available (ODF and HPP)
+        - VirtualMachine with disk on source storage class
+    """
+
+    @pytest.mark.polarion("CNV-77501")
+    def test_source_volumes_cleanup_per_plan_and_namespace_policies(self):
+        """
+        Verify source volumes are retained or cleaned up correctly per plan-level
+        and namespace-level cleanup policies.
+
+        Preconditions:
+            - VirtualMachine with disk on source storage class
+            - Migration plan targeting a different storage class
+
+        Steps:
+            1. Configure cleanup policy at migration plan level to delete source volumes
+            2. Execute storage migration for the VM
+            3. Wait for migration to complete successfully
+            4. Inspect source volumes state
+            5. Repeat with namespace-level cleanup policy
+            6. Repeat with both plan-level and namespace-level policies to verify override behavior
+
+        Expected:
+            Source volumes are deleted or retained according to the configured cleanup policy,
+            with namespace-level policy overriding plan-level policy when both are configured
+        """


### PR DESCRIPTION
## Summary
- Adds a partial STD placeholder (`__test__ = False`) for the storage migration cleanup feature.
- References STP: `stps/sig-storage/storage_mig_cleanup.md` in the linked `openshift-virtualization-tests-design-docs` repo.
- Covers **1 of 3** test scenarios from that STP — intentionally incomplete.

**Do not merge** — close after confirming CodeRabbit linked-repo STP cross-check behavior.

##### What this PR does / why we need it:
Dummy PR to validate that CodeRabbit cross-references the linked `RedHatQE/openshift-virtualization-tests-design-docs` repository when reviewing STD changes. The STP defines three test scenarios (P0: cleanup policies, P1: default retention, P2: failed migration preservation) but this PR only adds STD for the P0 scenario. CodeRabbit should flag the two missing scenarios by consulting the linked repo.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
- Placeholder STD only (`__test__ = False`); no test implementation.
- Expected CodeRabbit feedback: missing STP scenario coverage for default retention behavior (P1) and failed migration source volume preservation (P2) scenarios defined in the linked STP.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage documentation for storage migration cleanup behavior, including retention and deletion policies at the migration plan and namespace levels.
  * The new scenario is currently excluded from automated test collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->