### PR TITLE
tests: extract storage fixtures from tests/conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -100,6 +100,9 @@ pytest_plugins = [
     "tests.fixtures.network.mac_pool",
     "tests.fixtures.network.nmstate",
     "tests.fixtures.network.sriov",
+    "tests.fixtures.storage.storage_classes",
+    "tests.fixtures.images.golden_images",
+    "tests.fixtures.storage.data_volumes",
 ]
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,15 +18,8 @@ import paramiko
 import pytest
 import requests
 from bs4 import BeautifulSoup
-from ocp_resources.cluster_role import ClusterRole
-from ocp_resources.cluster_service_version import ClusterServiceVersion
-from ocp_resources.data_source import DataSource
 from ocp_resources.datavolume import DataVolume
-from ocp_resources.hostpath_provisioner import HostPathProvisioner
 from ocp_resources.migration_policy import MigrationPolicy
-from ocp_resources.namespace import Namespace
-from ocp_resources.role_binding import RoleBinding
-from ocp_resources.storage_class import StorageClass
 from ocp_resources.virtual_machine_cluster_instancetype import (
     VirtualMachineClusterInstancetype,
 )
@@ -54,9 +47,7 @@ from utilities.constants.cluster import (
     NODE_TYPE_WORKER_LABEL,
     OC_ADM_LOGS_COMMAND,
 )
-from utilities.constants.components import RHEL9_STR
 from utilities.constants.hco import (
-    DATA_SOURCE_NAME,
     HOTFIX_STR,
     UpgradeStreams,
 )
@@ -67,7 +58,7 @@ from utilities.constants.instance_types import (
     PREFERENCE_STR,
 )
 from utilities.constants.networking import LINUX_BRIDGE
-from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, StorageClassNames
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION
 from utilities.constants.timeouts import (
     TIMEOUT_3MIN,
     TIMEOUT_5MIN,
@@ -93,18 +84,8 @@ from utilities.network import (
 from utilities.operator import (
     get_hco_csv_name_by_version,
 )
-from utilities.pytest_utils import exit_pytest_execution
-from utilities.ssp import get_data_import_crons
 from utilities.storage import (
     construct_datavolume_source_dict,
-    create_or_update_data_source,
-    data_volume,
-    get_default_storage_class,
-    get_storage_class_with_specified_volume_mode,
-    is_snapshot_supported_by_sc,
-    remove_default_storage_classes,
-    update_default_sc,
-    verify_boot_sources_reimported,
 )
 from utilities.virt import (
     VirtualMachineForTests,
@@ -118,11 +99,6 @@ from utilities.virt import (
 
 LOGGER = logging.getLogger(__name__)
 CNV_NOT_INSTALLED = "CNV not yet installed."
-RWX_FS_STORAGE_CLASS_NAMES_LIST = [
-    StorageClassNames.CEPHFS,
-    StorageClassNames.TRIDENT_CSI_FSX,
-    StorageClassNames.PORTWORX_CSI_DB_SHARED,
-]
 
 # Pre-compiled regex for audit log filename parsing: captures date and time components
 AUDIT_LOG_PATTERN = re.compile(r"audit-(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2}\.\d{3})\.log")
@@ -194,132 +170,6 @@ def is_postcopy_migration_bug_open(cluster_has_rhcos10_or_above):
 
 
 @pytest.fixture()
-def data_volume_multi_storage_scope_function(
-    request,
-    namespace,
-    storage_class_matrix__function__,
-):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class_matrix=storage_class_matrix__function__,
-        client=namespace.client,
-    )
-
-
-@pytest.fixture(scope="module")
-def data_volume_multi_storage_scope_module(
-    request,
-    namespace,
-    storage_class_matrix__module__,
-):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class_matrix=storage_class_matrix__module__,
-        client=namespace.client,
-    )
-
-
-@pytest.fixture()
-def golden_image_data_volume_multi_storage_scope_function(
-    admin_client,
-    request,
-    golden_images_namespace,
-    storage_class_matrix__function__,
-):
-    yield from data_volume(
-        request=request,
-        namespace=golden_images_namespace,
-        storage_class_matrix=storage_class_matrix__function__,
-        check_dv_exists=True,
-        client=admin_client,
-    )
-
-
-@pytest.fixture()
-def golden_image_data_source_multi_storage_scope_function(
-    admin_client, golden_image_data_volume_multi_storage_scope_function
-):
-    yield from create_or_update_data_source(
-        admin_client=admin_client,
-        dv=golden_image_data_volume_multi_storage_scope_function,
-    )
-
-
-@pytest.fixture()
-def data_volume_scope_function(request, namespace):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class=request.param["storage_class"],
-        client=namespace.client,
-    )
-
-
-@pytest.fixture(scope="class")
-def data_volume_scope_class(request, namespace):
-    yield from data_volume(
-        request=request,
-        namespace=namespace,
-        storage_class=request.param["storage_class"],
-        client=namespace.client,
-    )
-
-
-@pytest.fixture()
-def golden_image_data_volume_scope_function(request, admin_client, golden_images_namespace):
-    yield from data_volume(
-        request=request,
-        namespace=golden_images_namespace,
-        storage_class=request.param["storage_class"],
-        check_dv_exists=True,
-        client=admin_client,
-    )
-
-
-@pytest.fixture()
-def golden_image_data_source_scope_function(admin_client, golden_image_data_volume_scope_function):
-    yield from create_or_update_data_source(admin_client=admin_client, dv=golden_image_data_volume_scope_function)
-
-
-@pytest.fixture(scope="session")
-def rhel9_data_source_scope_session(golden_images_namespace):
-    return DataSource(
-        client=golden_images_namespace.client,
-        name=RHEL9_STR,
-        namespace=golden_images_namespace.name,
-        ensure_exists=True,
-    )
-
-
-@pytest.fixture(scope="session")
-def rhel10_data_source_scope_session(golden_images_namespace):
-    return DataSource(
-        namespace=golden_images_namespace.name,
-        name="rhel10",
-        client=golden_images_namespace.client,
-        ensure_exists=True,
-    )
-
-
-@pytest.fixture(scope="session")
-def latest_rhel_data_source(golden_images_namespace):
-    """Provide the DataSource for the latest RHEL version supported on this architecture."""
-    return DataSource(
-        client=golden_images_namespace.client,
-        name=py_config["latest_instance_type_rhel_os_dict"][DATA_SOURCE_NAME],
-        namespace=golden_images_namespace.name,
-        ensure_exists=True,
-    )
-
-
-"""
-VM creation from template
-"""
-
-
-@pytest.fixture()
 def vm_instance_from_template_multi_storage_scope_function(
     request,
     unprivileged_client,
@@ -359,117 +209,11 @@ def started_windows_vm(
 
 
 @pytest.fixture(scope="session")
-def golden_images_namespace(
-    admin_client,
-):
-    for ns in Namespace.get(
-        name=py_config["golden_images_namespace"],
-        client=admin_client,
-    ):
-        return ns
-
-
-@pytest.fixture(scope="session")
-def golden_images_cluster_role_edit(
-    admin_client,
-):
-    for cluster_role in ClusterRole.get(
-        name="os-images.kubevirt.io:edit",
-        client=admin_client,
-    ):
-        return cluster_role
-
-
-@pytest.fixture()
-def golden_images_edit_rolebinding(
-    golden_images_namespace,
-    golden_images_cluster_role_edit,
-):
-    with RoleBinding(
-        client=golden_images_namespace.client,
-        name="role-bind-create-dv",
-        namespace=golden_images_namespace.name,
-        subjects_kind="User",
-        subjects_name="unprivileged-user",
-        subjects_namespace=golden_images_namespace.name,
-        role_ref_kind=golden_images_cluster_role_edit.kind,
-        role_ref_name=golden_images_cluster_role_edit.name,
-    ) as role_binding:
-        yield role_binding
-
-
-@pytest.fixture(scope="session")
-def default_sc(admin_client):
-    """
-    Get default Storage Class defined
-    """
-    try:
-        yield get_default_storage_class(client=admin_client)
-    except ValueError:
-        yield
-
-
-@pytest.fixture(scope="session")
-def ocs_storage_class(cluster_storage_classes):
-    """
-    Get the OCS storage class if configured
-    """
-    for sc in cluster_storage_classes:
-        if sc.name == StorageClassNames.CEPH_RBD_VIRTUALIZATION:
-            return sc
-
-
-@pytest.fixture(scope="session")
-def skip_test_if_no_ocs_sc(ocs_storage_class):
-    """
-    Skip test if no OCS storage class available
-    """
-    if not ocs_storage_class:
-        pytest.skip("Skipping test, OCS storage class is not deployed")
-
-
-@pytest.fixture(scope="session")
-def cluster_storage_classes(admin_client):
-    return list(StorageClass.get(client=admin_client))
-
-
-@pytest.fixture(scope="session")
-def cluster_storage_classes_names(cluster_storage_classes):
-    return [sc.name for sc in cluster_storage_classes]
-
-
-@pytest.fixture(scope="module")
-def hostpath_provisioner_scope_module(admin_client):
-    yield HostPathProvisioner(client=admin_client, name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
-
-
-@pytest.fixture(scope="session")
-def hostpath_provisioner_scope_session(admin_client):
-    yield HostPathProvisioner(client=admin_client, name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
-
-
-@pytest.fixture(scope="session")
-def hpp_cr_installed(hostpath_provisioner_scope_session):
-    return hostpath_provisioner_scope_session.exists
-
-
-@pytest.fixture(scope="session")
 def prometheus():
     return Prometheus(
         verify_ssl=False,
         bearer_token=utilities.infra.get_prometheus_k8s_token(duration="86400s"),
     )
-
-
-@pytest.fixture(scope="session")
-def ocs_current_version(ocs_storage_class, admin_client):
-    if ocs_storage_class:
-        for csv in ClusterServiceVersion.get(
-            client=admin_client,
-            namespace="openshift-storage",
-            label_selector=f"{ClusterServiceVersion.ApiGroup.OPERATORS_COREOS_COM}/ocs-operator.openshift-storage",
-        ):
-            return csv.instance.spec.version
 
 
 @pytest.fixture(scope="session")
@@ -720,16 +464,6 @@ def cnv_channel(pytestconfig):
     return pytestconfig.option.cnv_channel
 
 
-@pytest.fixture()
-def golden_images_data_import_crons_scope_function(admin_client, golden_images_namespace):
-    return get_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
-
-
-@pytest.fixture(scope="class")
-def golden_images_data_import_crons_scope_class(admin_client, golden_images_namespace):
-    return get_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
-
-
 @pytest.fixture(autouse=True)
 def autouse_fixtures(
     leftovers_cleanup,  # Must be called first to avoid deleting created resources.
@@ -765,30 +499,6 @@ def generated_ssh_key_for_vm_access(ssh_key_tmpdir_scope_session):
     if os.path.isfile(vm_ssh_key_file):
         os.unlink(vm_ssh_key_file)
     del os.environ[CNV_VM_SSH_KEY_PATH]
-
-
-@pytest.fixture(scope="session")
-def storage_class_for_snapshot(admin_client):
-    available_storage_classes = py_config["storage_class_matrix"]
-    sc_for_snapshot = None
-    sc_names = []
-    for sc in available_storage_classes:
-        sc_name = [*sc][0]
-        if is_snapshot_supported_by_sc(sc_name=sc_name, client=admin_client):
-            sc_for_snapshot = sc_name
-            LOGGER.info(f"Storage class for snapshot: {sc_for_snapshot}")
-            break
-        sc_names.append(sc_name)
-    if not sc_for_snapshot:
-        LOGGER.warning(f"No Storage class among {sc_names} supports snapshots")
-    yield sc_for_snapshot
-
-
-@pytest.fixture(scope="session")
-def skip_if_no_storage_class_for_snapshot(storage_class_for_snapshot):
-    if not storage_class_for_snapshot:
-        sc_names = [[*sc][0] for sc in py_config["storage_class_matrix"]]
-        pytest.skip(f"There's no Storage Class among {sc_names} that supports snapshots, skipping the test")
 
 
 @pytest.fixture()
@@ -1030,33 +740,6 @@ def migration_policy_with_bandwidth_scope_class(admin_client):
         yield mp
 
 
-@pytest.fixture(scope="session")
-def available_storage_classes_names():
-    return [[*sc][0] for sc in py_config["storage_class_matrix"]]
-
-
-@pytest.fixture(scope="session")
-def storage_class_with_filesystem_volume_mode(admin_client, available_storage_classes_names):
-    yield get_storage_class_with_specified_volume_mode(
-        volume_mode=DataVolume.VolumeMode.FILE, sc_names=available_storage_classes_names, client=admin_client
-    )
-
-
-@pytest.fixture(scope="module")
-def skip_test_if_no_block_sc(storage_class_with_block_volume_mode):
-    if not storage_class_with_block_volume_mode:
-        pytest.skip("Skip the test: no Storage class with Block volume mode")
-
-
-@pytest.fixture(scope="session")
-def storage_class_with_block_volume_mode(admin_client, available_storage_classes_names):
-    yield get_storage_class_with_specified_volume_mode(
-        volume_mode=DataVolume.VolumeMode.BLOCK,
-        sc_names=available_storage_classes_names,
-        client=admin_client,
-    )
-
-
 @pytest.fixture(scope="class")
 def vm_for_test(request, namespace, unprivileged_client):
     vm_name = request.param
@@ -1090,28 +773,6 @@ def migrated_vm_multiple_times(request, admin_client, vm_for_migration_test):
         mig_obj.clean_up()
 
 
-@pytest.fixture()
-def removed_default_storage_classes(admin_client, golden_images_namespace, cluster_storage_classes):
-    with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
-        yield
-    if not verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name):
-        pytest.fail("Failed to reimport all boot sources at teardown")
-
-
-@pytest.fixture(scope="module")
-def snapshot_storage_class_name_scope_module(
-    storage_class_matrix_snapshot_matrix__module__,
-):
-    return [*storage_class_matrix_snapshot_matrix__module__][0]
-
-
-@pytest.fixture(scope="module")
-def snapshot_import_cron_format_storage_class_name_scope_module(
-    storage_class_matrix_snapshot_import_cron_format_matrix__module__,
-):
-    return next(iter(storage_class_matrix_snapshot_import_cron_format_matrix__module__))
-
-
 @pytest.fixture(scope="class")
 def rhel_vm_with_cluster_instance_type_and_preference(namespace, unprivileged_client):
     with VirtualMachineForTests(
@@ -1141,50 +802,6 @@ def rhel_vm_with_cluster_instance_type_and_preference(namespace, unprivileged_cl
 @pytest.fixture(scope="session")
 def upgrade_skip_default_sc_setup(pytestconfig):
     return pytestconfig.option.upgrade_skip_default_sc_setup
-
-
-@pytest.fixture(scope="session")
-def updated_default_storage_class_ocs_virt(
-    admin_client,
-    upgrade_skip_default_sc_setup,
-    cluster_storage_classes,
-    available_storage_classes_names,
-    ocs_storage_class,
-    golden_images_namespace,
-):
-    # set ocs-virt as default storage class if it isn't
-    if (
-        not upgrade_skip_default_sc_setup
-        and ocs_storage_class
-        and ocs_storage_class.name in available_storage_classes_names
-        and ocs_storage_class.instance.metadata.get("annotations", {}).get(
-            StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS
-        )
-        != "true"
-    ):
-        boot_source_imported_successfully = False
-        with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
-            with update_default_sc(default=True, storage_class=ocs_storage_class):
-                boot_source_imported_successfully = verify_boot_sources_reimported(
-                    admin_client=admin_client,
-                    namespace=golden_images_namespace.name,
-                )
-                if boot_source_imported_successfully:
-                    yield
-
-        # on teardown, wait for the original sources to re-create
-        verify_boot_sources_reimported(
-            admin_client=admin_client,
-            namespace=golden_images_namespace.name,
-        )
-        if not boot_source_imported_successfully:
-            exit_pytest_execution(
-                admin_client=admin_client,
-                log_message=f"Failed to set {ocs_storage_class.name} as default storage class",
-                filename="default_storage_class_failure.txt",
-            )
-    else:
-        yield
 
 
 @pytest.fixture(scope="session")
@@ -1274,20 +891,6 @@ def downloaded_latest_libosinfo_db(tmpdir_factory, latest_osinfo_db_file_name, o
     )
     osinfo_db_file_name_no_suffix = latest_osinfo_db_file_name.partition(".")[0]
     yield os.path.join(osinfo_path, osinfo_db_file_name_no_suffix)
-
-
-@pytest.fixture(scope="session")
-def rwx_fs_available_storage_classes_names(cluster_storage_classes_names):
-    return [
-        storage_class
-        for storage_class in cluster_storage_classes_names
-        if storage_class in RWX_FS_STORAGE_CLASS_NAMES_LIST
-    ]
-
-
-@pytest.fixture()
-def storage_class_name_scope_function(storage_class_matrix__function__):
-    return [*storage_class_matrix__function__][0]
 
 
 @pytest.fixture(scope="class")

--- a/tests/fixtures/images/golden_images.py
+++ b/tests/fixtures/images/golden_images.py
@@ -1,0 +1,138 @@
+import logging
+
+import pytest
+from ocp_resources.cluster_role import ClusterRole
+from ocp_resources.data_source import DataSource
+from ocp_resources.namespace import Namespace
+from ocp_resources.role_binding import RoleBinding
+from pytest_testconfig import config as py_config
+
+from utilities.constants.components import RHEL9_STR
+from utilities.constants.hco import DATA_SOURCE_NAME
+from utilities.ssp import get_data_import_crons
+from utilities.storage import create_or_update_data_source, data_volume
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def golden_images_namespace(
+    admin_client,
+):
+    for ns in Namespace.get(
+        name=py_config["golden_images_namespace"],
+        client=admin_client,
+    ):
+        return ns
+
+
+@pytest.fixture(scope="session")
+def golden_images_cluster_role_edit(
+    admin_client,
+):
+    for cluster_role in ClusterRole.get(
+        name="os-images.kubevirt.io:edit",
+        client=admin_client,
+    ):
+        return cluster_role
+
+
+@pytest.fixture()
+def golden_images_edit_rolebinding(
+    golden_images_namespace,
+    golden_images_cluster_role_edit,
+):
+    with RoleBinding(
+        client=golden_images_namespace.client,
+        name="role-bind-create-dv",
+        namespace=golden_images_namespace.name,
+        subjects_kind="User",
+        subjects_name="unprivileged-user",
+        subjects_namespace=golden_images_namespace.name,
+        role_ref_kind=golden_images_cluster_role_edit.kind,
+        role_ref_name=golden_images_cluster_role_edit.name,
+    ) as role_binding:
+        yield role_binding
+
+
+@pytest.fixture()
+def golden_image_data_volume_multi_storage_scope_function(
+    admin_client,
+    request,
+    golden_images_namespace,
+    storage_class_matrix__function__,
+):
+    yield from data_volume(
+        request=request,
+        namespace=golden_images_namespace,
+        storage_class_matrix=storage_class_matrix__function__,
+        check_dv_exists=True,
+        client=admin_client,
+    )
+
+
+@pytest.fixture()
+def golden_image_data_source_multi_storage_scope_function(
+    admin_client, golden_image_data_volume_multi_storage_scope_function
+):
+    yield from create_or_update_data_source(
+        admin_client=admin_client,
+        dv=golden_image_data_volume_multi_storage_scope_function,
+    )
+
+
+@pytest.fixture()
+def golden_image_data_volume_scope_function(request, admin_client, golden_images_namespace):
+    yield from data_volume(
+        request=request,
+        namespace=golden_images_namespace,
+        storage_class=request.param["storage_class"],
+        check_dv_exists=True,
+        client=admin_client,
+    )
+
+
+@pytest.fixture()
+def golden_image_data_source_scope_function(admin_client, golden_image_data_volume_scope_function):
+    yield from create_or_update_data_source(admin_client=admin_client, dv=golden_image_data_volume_scope_function)
+
+
+@pytest.fixture(scope="session")
+def rhel9_data_source_scope_session(golden_images_namespace):
+    return DataSource(
+        client=golden_images_namespace.client,
+        name=RHEL9_STR,
+        namespace=golden_images_namespace.name,
+        ensure_exists=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def rhel10_data_source_scope_session(golden_images_namespace):
+    return DataSource(
+        namespace=golden_images_namespace.name,
+        name="rhel10",
+        client=golden_images_namespace.client,
+        ensure_exists=True,
+    )
+
+
+@pytest.fixture()
+def golden_images_data_import_crons_scope_function(admin_client, golden_images_namespace):
+    return get_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
+
+
+@pytest.fixture(scope="class")
+def golden_images_data_import_crons_scope_class(admin_client, golden_images_namespace):
+    return get_data_import_crons(admin_client=admin_client, namespace=golden_images_namespace)
+
+
+@pytest.fixture(scope="session")
+def latest_rhel_data_source(golden_images_namespace):
+    """Provide the DataSource for the latest RHEL version supported on this architecture."""
+    return DataSource(
+        client=golden_images_namespace.client,
+        name=py_config["latest_instance_type_rhel_os_dict"][DATA_SOURCE_NAME],
+        namespace=golden_images_namespace.name,
+        ensure_exists=True,
+    )

--- a/tests/fixtures/storage/data_volumes.py
+++ b/tests/fixtures/storage/data_volumes.py
@@ -1,0 +1,55 @@
+import logging
+
+import pytest
+
+from utilities.storage import data_volume
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def data_volume_multi_storage_scope_function(
+    request,
+    namespace,
+    storage_class_matrix__function__,
+):
+    yield from data_volume(
+        request=request,
+        namespace=namespace,
+        storage_class_matrix=storage_class_matrix__function__,
+        client=namespace.client,
+    )
+
+
+@pytest.fixture(scope="module")
+def data_volume_multi_storage_scope_module(
+    request,
+    namespace,
+    storage_class_matrix__module__,
+):
+    yield from data_volume(
+        request=request,
+        namespace=namespace,
+        storage_class_matrix=storage_class_matrix__module__,
+        client=namespace.client,
+    )
+
+
+@pytest.fixture()
+def data_volume_scope_function(request, namespace):
+    yield from data_volume(
+        request=request,
+        namespace=namespace,
+        storage_class=request.param["storage_class"],
+        client=namespace.client,
+    )
+
+
+@pytest.fixture(scope="class")
+def data_volume_scope_class(request, namespace):
+    yield from data_volume(
+        request=request,
+        namespace=namespace,
+        storage_class=request.param["storage_class"],
+        client=namespace.client,
+    )

--- a/tests/fixtures/storage/storage_classes.py
+++ b/tests/fixtures/storage/storage_classes.py
@@ -1,0 +1,224 @@
+import logging
+
+import pytest
+from ocp_resources.cluster_service_version import ClusterServiceVersion
+from ocp_resources.datavolume import DataVolume
+from ocp_resources.hostpath_provisioner import HostPathProvisioner
+from ocp_resources.storage_class import StorageClass
+from pytest_testconfig import config as py_config
+
+from utilities.constants.storage import StorageClassNames
+from utilities.pytest_utils import exit_pytest_execution
+from utilities.storage import (
+    get_default_storage_class,
+    get_storage_class_with_specified_volume_mode,
+    is_snapshot_supported_by_sc,
+    remove_default_storage_classes,
+    update_default_sc,
+    verify_boot_sources_reimported,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+RWX_FS_STORAGE_CLASS_NAMES_LIST = [
+    StorageClassNames.CEPHFS,
+    StorageClassNames.TRIDENT_CSI_FSX,
+    StorageClassNames.PORTWORX_CSI_DB_SHARED,
+]
+
+
+@pytest.fixture(scope="session")
+def cluster_storage_classes(admin_client):
+    return list(StorageClass.get(client=admin_client))
+
+
+@pytest.fixture(scope="session")
+def cluster_storage_classes_names(cluster_storage_classes):
+    return [sc.name for sc in cluster_storage_classes]
+
+
+@pytest.fixture(scope="session")
+def default_sc(admin_client):
+    """
+    Get default Storage Class defined
+    """
+    try:
+        yield get_default_storage_class(client=admin_client)
+    except ValueError:
+        yield
+
+
+@pytest.fixture(scope="session")
+def available_storage_classes_names():
+    return [[*sc][0] for sc in py_config["storage_class_matrix"]]
+
+
+@pytest.fixture(scope="session")
+def ocs_storage_class(cluster_storage_classes):
+    """
+    Get the OCS storage class if configured
+    """
+    for sc in cluster_storage_classes:
+        if sc.name == StorageClassNames.CEPH_RBD_VIRTUALIZATION:
+            return sc
+
+
+@pytest.fixture(scope="session")
+def skip_test_if_no_ocs_sc(ocs_storage_class):
+    """
+    Skip test if no OCS storage class available
+    """
+    if not ocs_storage_class:
+        pytest.skip("Skipping test, OCS storage class is not deployed")
+
+
+@pytest.fixture(scope="session")
+def ocs_current_version(ocs_storage_class, admin_client):
+    if ocs_storage_class:
+        for csv in ClusterServiceVersion.get(
+            client=admin_client,
+            namespace="openshift-storage",
+            label_selector=f"{ClusterServiceVersion.ApiGroup.OPERATORS_COREOS_COM}/ocs-operator.openshift-storage",
+        ):
+            return csv.instance.spec.version
+
+
+@pytest.fixture(scope="session")
+def storage_class_for_snapshot(admin_client):
+    available_storage_classes = py_config["storage_class_matrix"]
+    sc_for_snapshot = None
+    sc_names = []
+    for sc in available_storage_classes:
+        sc_name = [*sc][0]
+        if is_snapshot_supported_by_sc(sc_name=sc_name, client=admin_client):
+            sc_for_snapshot = sc_name
+            LOGGER.info(f"Storage class for snapshot: {sc_for_snapshot}")
+            break
+        sc_names.append(sc_name)
+    if not sc_for_snapshot:
+        LOGGER.warning(f"No Storage class among {sc_names} supports snapshots")
+    yield sc_for_snapshot
+
+
+@pytest.fixture(scope="session")
+def skip_if_no_storage_class_for_snapshot(storage_class_for_snapshot):
+    if not storage_class_for_snapshot:
+        sc_names = [[*sc][0] for sc in py_config["storage_class_matrix"]]
+        pytest.skip(f"There's no Storage Class among {sc_names} that supports snapshots, skipping the test")
+
+
+@pytest.fixture(scope="session")
+def storage_class_with_filesystem_volume_mode(admin_client, available_storage_classes_names):
+    yield get_storage_class_with_specified_volume_mode(
+        volume_mode=DataVolume.VolumeMode.FILE, sc_names=available_storage_classes_names, client=admin_client
+    )
+
+
+@pytest.fixture(scope="session")
+def storage_class_with_block_volume_mode(admin_client, available_storage_classes_names):
+    yield get_storage_class_with_specified_volume_mode(
+        volume_mode=DataVolume.VolumeMode.BLOCK,
+        sc_names=available_storage_classes_names,
+        client=admin_client,
+    )
+
+
+@pytest.fixture(scope="module")
+def skip_test_if_no_block_sc(storage_class_with_block_volume_mode):
+    if not storage_class_with_block_volume_mode:
+        pytest.skip("Skip the test: no Storage class with Block volume mode")
+
+
+@pytest.fixture()
+def removed_default_storage_classes(admin_client, golden_images_namespace, cluster_storage_classes):
+    with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
+        yield
+    if not verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name):
+        pytest.fail("Failed to reimport all boot sources at teardown")
+
+
+@pytest.fixture(scope="module")
+def snapshot_storage_class_name_scope_module(
+    storage_class_matrix_snapshot_matrix__module__,
+):
+    return [*storage_class_matrix_snapshot_matrix__module__][0]
+
+
+@pytest.fixture(scope="module")
+def snapshot_import_cron_format_storage_class_name_scope_module(
+    storage_class_matrix_snapshot_import_cron_format_matrix__module__,
+):
+    return next(iter(storage_class_matrix_snapshot_import_cron_format_matrix__module__))
+
+
+@pytest.fixture(scope="session")
+def updated_default_storage_class_ocs_virt(
+    admin_client,
+    upgrade_skip_default_sc_setup,
+    cluster_storage_classes,
+    available_storage_classes_names,
+    ocs_storage_class,
+    golden_images_namespace,
+):
+    # set ocs-virt as default storage class if it isn't
+    if (
+        not upgrade_skip_default_sc_setup
+        and ocs_storage_class
+        and ocs_storage_class.name in available_storage_classes_names
+        and ocs_storage_class.instance.metadata.get("annotations", {}).get(
+            StorageClass.Annotations.IS_DEFAULT_VIRT_CLASS
+        )
+        != "true"
+    ):
+        boot_source_imported_successfully = False
+        with remove_default_storage_classes(cluster_storage_classes=cluster_storage_classes):
+            with update_default_sc(default=True, storage_class=ocs_storage_class):
+                boot_source_imported_successfully = verify_boot_sources_reimported(
+                    admin_client=admin_client,
+                    namespace=golden_images_namespace.name,
+                )
+                if boot_source_imported_successfully:
+                    yield
+
+        # on teardown, wait for the original sources to re-create
+        verify_boot_sources_reimported(
+            admin_client=admin_client,
+            namespace=golden_images_namespace.name,
+        )
+        if not boot_source_imported_successfully:
+            exit_pytest_execution(
+                admin_client=admin_client,
+                log_message=f"Failed to set {ocs_storage_class.name} as default storage class",
+                filename="default_storage_class_failure.txt",
+            )
+    else:
+        yield
+
+
+@pytest.fixture(scope="session")
+def rwx_fs_available_storage_classes_names(cluster_storage_classes_names):
+    return [
+        storage_class
+        for storage_class in cluster_storage_classes_names
+        if storage_class in RWX_FS_STORAGE_CLASS_NAMES_LIST
+    ]
+
+
+@pytest.fixture()
+def storage_class_name_scope_function(storage_class_matrix__function__):
+    return [*storage_class_matrix__function__][0]
+
+
+@pytest.fixture(scope="module")
+def hostpath_provisioner_scope_module(admin_client):
+    yield HostPathProvisioner(client=admin_client, name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
+
+
+@pytest.fixture(scope="session")
+def hostpath_provisioner_scope_session(admin_client):
+    yield HostPathProvisioner(client=admin_client, name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
+
+
+@pytest.fixture(scope="session")
+def hpp_cr_installed(hostpath_provisioner_scope_session):
+    return hostpath_provisioner_scope_session.exists


### PR DESCRIPTION
##### What this PR does / why we need it:
Move fixtures from the monolithic `tests/conftest.py` into domain-scoped modules under `tests/fixtures/storage/`:
- `storage_classes.py` — storage class, OCS, HPP, snapshot, volume-mode, RWX-FS, and storage-class-name fixtures; `RWX_FS_STORAGE_CLASS_NAMES_LIST` constant
- `golden_images.py` — golden images namespace, roles, DVs, data sources, data import crons
- `data_volumes.py` — data volume fixtures

New modules are registered in `pytest_plugins` in the root `conftest.py`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Part of `tests/conftest.py` refactor series.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-80951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for storage configurations, data volumes, snapshots, and golden-image workflows.
  * Added validation across filesystem and block storage options, default storage settings, and RWX support.
  * Improved test scenarios for data imports, boot sources, permissions, and supported RHEL image versions.
  * Centralized reusable test coverage to improve consistency and reduce duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->