### PR TITLE
refactor: Extract upgrade fixtures from tests/conftest.py

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -79,6 +79,8 @@ pytest_plugins = [
     "tests.fixtures.network.cluster",
     "tests.fixtures.images.validation_os_images",
     "tests.fixtures.network.multiarch",
+    "tests.fixtures.upgrade.config",
+    "tests.fixtures.upgrade.resources",
 ]
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1902,6 +1902,11 @@ def audit_logs(session_start_time):
 
 
 @pytest.fixture(scope="session")
+def installing_cnv(pytestconfig):
+    return pytestconfig.option.install
+
+
+@pytest.fixture(scope="session")
 def fips_enabled_cluster(workers_utility_pods):
     """
     Check if FIPS is enabled on cluster

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,9 +70,7 @@ from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
 import utilities.hco
-from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster, supported_cluster_ip_versions
-from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
-from libs.net.vmspec import lookup_iface_status
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 from tests.utils import download_and_extract_tar
 from utilities.artifactory import get_artifactory_header, get_http_image_url, get_test_artifact_server_url
 from utilities.bitwarden import get_cnv_tests_secret_by_name
@@ -111,9 +109,7 @@ from utilities.constants.hco import (
     DATA_SOURCE_NAME,
     FEATURE_GATES,
     HCO_SUBSCRIPTION,
-    HOTFIX_STR,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
-    UpgradeStreams,
 )
 from utilities.constants.images import OS_FLAVOR_RHEL
 from utilities.constants.instance_types import (
@@ -133,7 +129,7 @@ from utilities.constants.pytest import (
     UNPRIVILEGED_PASSWORD,
     UNPRIVILEGED_USER,
 )
-from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, StorageClassNames
+from utilities.constants.storage import StorageClassNames
 from utilities.constants.timeouts import (
     TIMEOUT_3MIN,
     TIMEOUT_4MIN,
@@ -141,7 +137,6 @@ from utilities.constants.timeouts import (
 )
 from utilities.constants.virt import (
     CNV_VM_SSH_KEY_PATH,
-    ES_NONE,
     MIGRATION_POLICY_VM_LABEL,
     NODE_HUGE_PAGES_1GI_KEY,
     VIRTIO,
@@ -183,25 +178,19 @@ from utilities.infra import (
 from utilities.network import (
     EthernetNetworkConfigurationPolicy,
     MacPool,
-    cloud_init_network_data,
     enable_hyperconverged_ovs_annotations,
     get_cluster_cni_type,
-    network_device,
-    network_nad,
-    wait_for_node_marked_by_bridge,
     wait_for_ovs_daemonset_resource,
     wait_for_ovs_status,
 )
 from utilities.operator import (
     disable_default_sources_in_operatorhub,
-    get_hco_csv_name_by_version,
     get_machine_config_pool_by_name,
 )
 from utilities.pytest_utils import exit_pytest_execution
 from utilities.sanity import cluster_sanity
 from utilities.ssp import get_data_import_crons, get_ssp_resource
 from utilities.storage import (
-    construct_datavolume_source_dict,
     create_or_update_data_source,
     data_volume,
     get_default_storage_class,
@@ -1645,186 +1634,6 @@ def term_handler_scope_session():
 
 
 @pytest.fixture(scope="session")
-def upgrade_bridge_on_all_nodes(
-    admin_client,
-    label_schedulable_nodes,
-    hosts_common_available_ports,
-):
-    with network_device(
-        interface_type=LINUX_BRIDGE,
-        nncp_name="upgrade-bridge",
-        interface_name="br1upgrade",
-        node_selector_labels=NODE_TYPE_WORKER_LABEL,
-        ports=[hosts_common_available_ports[0]],
-        client=admin_client,
-    ) as br:
-        yield br
-
-
-@pytest.fixture(scope="session")
-def bridge_on_one_node(admin_client, worker_node1):
-    with network_device(
-        interface_type=LINUX_BRIDGE,
-        nncp_name="upgrade-br-marker",
-        interface_name="upg-br-mark",
-        node_selector=get_node_selector_dict(node_selector=worker_node1.name),
-        client=admin_client,
-    ) as br:
-        yield br
-
-
-@pytest.fixture(scope="session")
-def upgrade_bridge_marker_nad(admin_client, bridge_on_one_node, kmp_enabled_namespace, worker_node1):
-    with network_nad(
-        nad_type=LINUX_BRIDGE,
-        nad_name=bridge_on_one_node.bridge_name,
-        interface_name=bridge_on_one_node.bridge_name,
-        namespace=kmp_enabled_namespace,
-        client=admin_client,
-    ) as nad:
-        wait_for_node_marked_by_bridge(bridge_nad=nad, node=worker_node1)
-        yield nad
-
-
-@pytest.fixture(scope="session")
-def running_vm_upgrade_a(
-    unprivileged_client,
-    upgrade_bridge_marker_nad,
-    kmp_enabled_namespace,
-    upgrade_br1test_nad,
-):
-    name = "vm-upgrade-a"
-    cloud_init_data = cloud_init_network_data(
-        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=1)}}}
-    )
-    with VirtualMachineForTests(
-        name=name,
-        namespace=kmp_enabled_namespace.name,
-        networks={upgrade_bridge_marker_nad.name: upgrade_bridge_marker_nad.name},
-        interfaces=[upgrade_bridge_marker_nad.name],
-        client=unprivileged_client,
-        cloud_init_data=cloud_init_data,
-        body=fedora_vm_body(name=name),
-        eviction_strategy=ES_NONE,
-    ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
-        ip_families = supported_cluster_ip_versions()
-        lookup_iface_status(
-            vm=vm,
-            iface_name=upgrade_bridge_marker_nad.name,
-            predicate=lambda interface: (
-                len(filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))) == len(ip_families)
-            ),
-        )
-        yield vm
-
-
-@pytest.fixture(scope="session")
-def running_vm_upgrade_b(
-    unprivileged_client,
-    upgrade_bridge_marker_nad,
-    kmp_enabled_namespace,
-    upgrade_br1test_nad,
-):
-    name = "vm-upgrade-b"
-    cloud_init_data = cloud_init_network_data(
-        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=2)}}}
-    )
-    with VirtualMachineForTests(
-        name=name,
-        namespace=kmp_enabled_namespace.name,
-        networks={upgrade_bridge_marker_nad.name: upgrade_bridge_marker_nad.name},
-        interfaces=[upgrade_bridge_marker_nad.name],
-        client=unprivileged_client,
-        cloud_init_data=cloud_init_data,
-        body=fedora_vm_body(name=name),
-        eviction_strategy=ES_NONE,
-    ) as vm:
-        running_vm(vm=vm, wait_for_cloud_init=True)
-        ip_families = supported_cluster_ip_versions()
-        lookup_iface_status(
-            vm=vm,
-            iface_name=upgrade_bridge_marker_nad.name,
-            predicate=lambda interface: (
-                len(filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))) == len(ip_families)
-            ),
-        )
-        yield vm
-
-
-@pytest.fixture(scope="session")
-def upgrade_br1test_nad(admin_client, upgrade_namespace_scope_session, upgrade_bridge_on_all_nodes):
-    with network_nad(
-        nad_type=LINUX_BRIDGE,
-        nad_name=upgrade_bridge_on_all_nodes.bridge_name,
-        interface_name=upgrade_bridge_on_all_nodes.bridge_name,
-        namespace=upgrade_namespace_scope_session,
-        client=admin_client,
-    ) as nad:
-        yield nad
-
-
-@pytest.fixture(scope="session")
-def cnv_upgrade_stream(admin_client, pytestconfig, cnv_current_version, cnv_target_version):
-    """
-    Verify if the upgrade can be performed by comparing the current and target versions.
-
-    Args:
-        admin_client: The admin client instance.
-        pytestconfig: The pytest configuration object.
-        cnv_current_version: The current CNV version.
-        cnv_target_version: The target CNV version.
-    """
-    upgrade_stream = determine_upgrade_stream(
-        current_version=cnv_current_version,
-        target_version=cnv_target_version,
-    )
-
-    LOGGER.info(
-        f"CNV upgrade:\n"
-        f"Current version: {cnv_current_version},\n"
-        f"Target version: {cnv_target_version},\n"
-        f"Upgrade stream: {upgrade_stream},\n"
-    )
-    return upgrade_stream
-
-
-def determine_upgrade_stream(current_version, target_version):
-    current_cnv_version = parse(version=current_version.split("-")[0])
-    target_cnv_version = parse(version=target_version.split("-")[0])
-
-    if current_cnv_version.major < target_cnv_version.major:
-        return UpgradeStreams.X_STREAM
-    elif current_cnv_version.minor < target_cnv_version.minor:
-        return UpgradeStreams.Y_STREAM
-    elif current_cnv_version.micro < target_cnv_version.micro:
-        return UpgradeStreams.Z_STREAM
-    elif HOTFIX_STR in current_version:
-        # if we reach here, this is an upgrade out of hotfix to next z-stream
-        return UpgradeStreams.Z_STREAM
-    else:
-        if target_cnv_version <= current_cnv_version:
-            # Upgrade only if a newer CNV version is requested
-            raise ValueError(
-                f"Cannot upgrade to older/identical versions,"
-                f"current: {cnv_current_version} target: {target_cnv_version}"
-            )
-        raise ValueError(
-            f"Unknown upgrade stream. Current cnv version: {current_cnv_version}, "
-            f"target cnv version: {target_cnv_version}."
-        )
-
-
-@pytest.fixture(scope="session")
-def upgrade_namespace_scope_session(admin_client, unprivileged_client):
-    yield from create_ns(
-        unprivileged_client=unprivileged_client,
-        admin_client=admin_client,
-        name="test-upgrade-namespace",
-    )
-
-
-@pytest.fixture(scope="session")
 def kmp_enabled_namespace(kmp_vm_label, unprivileged_client, admin_client):
     # Enabling label "allocate" (or any other non-configured label) - Allocates.
     kmp_vm_label[KMP_VM_ASSIGNMENT_LABEL] = KMP_ENABLED_LABEL
@@ -1849,21 +1658,6 @@ def rhel_latest_os_params():
         }
 
     raise ValueError("Failed to get latest RHEL OS parameters")
-
-
-@pytest.fixture(scope="session")
-def hco_target_csv_name(cnv_target_version):
-    return get_hco_csv_name_by_version(cnv_target_version=cnv_target_version) if cnv_target_version else None
-
-
-@pytest.fixture(scope="session")
-def cnv_target_version(pytestconfig):
-    return pytestconfig.option.cnv_version
-
-
-@pytest.fixture(scope="session")
-def cnv_channel(pytestconfig):
-    return pytestconfig.option.cnv_channel
 
 
 @pytest.fixture()
@@ -2105,21 +1899,6 @@ def audit_logs(session_start_time):
             LOGGER.info(f"Node {node}: processing {len(final_logs)} audit log(s) (filtered from {len(logs)} total)")
 
     return filtered_nodes_logs
-
-
-@pytest.fixture(scope="session")
-def installing_cnv(pytestconfig):
-    return pytestconfig.option.install
-
-
-@pytest.fixture(scope="session")
-def is_production_source(cnv_source):
-    return cnv_source == "production"
-
-
-@pytest.fixture(scope="session")
-def cnv_source(pytestconfig):
-    return pytestconfig.option.cnv_source or "osbs"
 
 
 @pytest.fixture(scope="session")
@@ -2461,11 +2240,6 @@ def rhel_vm_with_cluster_instance_type_and_preference(namespace, unprivileged_cl
 
 
 @pytest.fixture(scope="session")
-def upgrade_skip_default_sc_setup(pytestconfig):
-    return pytestconfig.option.upgrade_skip_default_sc_setup
-
-
-@pytest.fixture(scope="session")
 def updated_default_storage_class_ocs_virt(
     admin_client,
     upgrade_skip_default_sc_setup,
@@ -2507,50 +2281,6 @@ def updated_default_storage_class_ocs_virt(
             )
     else:
         yield
-
-
-@pytest.fixture(scope="session")
-def dvs_for_upgrade(
-    admin_client,
-    worker_node1,
-    rhel_latest_os_params,
-    updated_default_storage_class_ocs_virt,
-):
-    golden_images_namespace_name = py_config["golden_images_namespace"]
-    dvs_list = []
-    artifactory_secret = utilities.artifactory.get_artifactory_secret(namespace=golden_images_namespace_name)
-    artifactory_config_map = utilities.artifactory.get_artifactory_config_map(namespace=golden_images_namespace_name)
-
-    for sc in py_config["storage_class_matrix"]:
-        storage_class = [*sc][0]
-        dv = DataVolume(
-            client=admin_client,
-            name=f"dv-for-product-upgrade-{storage_class}",
-            namespace=golden_images_namespace_name,
-            source_dict=construct_datavolume_source_dict(
-                source="http",
-                url=rhel_latest_os_params["rhel_image_path"],
-                secret_name=artifactory_secret.name,
-                cert_configmap_name=artifactory_config_map.name,
-            ),
-            storage_class=storage_class,
-            size=rhel_latest_os_params["rhel_dv_size"],
-            annotations=BIND_IMMEDIATE_ANNOTATION,
-            api_name="storage",
-        )
-        dv.create()
-        dvs_list.append(dv)
-    for dv in dvs_list:
-        dv.wait_for_dv_success()
-
-    yield dvs_list
-
-    for dv in dvs_list:
-        dv.clean_up()
-    utilities.artifactory.cleanup_artifactory_secret_and_config_map(
-        artifactory_secret=artifactory_secret,
-        artifactory_config_map=artifactory_config_map,
-    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/fixtures/upgrade/config.py
+++ b/tests/fixtures/upgrade/config.py
@@ -1,0 +1,67 @@
+import logging
+
+import pytest
+
+from utilities.operator import determine_upgrade_stream, get_hco_csv_name_by_version
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session")
+def cnv_target_version(pytestconfig):
+    return pytestconfig.option.cnv_version
+
+
+@pytest.fixture(scope="session")
+def cnv_channel(pytestconfig):
+    return pytestconfig.option.cnv_channel
+
+
+@pytest.fixture(scope="session")
+def cnv_upgrade_stream(admin_client, pytestconfig, cnv_current_version, cnv_target_version):
+    """
+    Verify if the upgrade can be performed by comparing the current and target versions.
+
+    Args:
+        admin_client: The admin client instance.
+        pytestconfig: The pytest configuration object.
+        cnv_current_version: The current CNV version.
+        cnv_target_version: The target CNV version.
+    """
+    upgrade_stream = determine_upgrade_stream(
+        current_version=cnv_current_version,
+        target_version=cnv_target_version,
+    )
+
+    LOGGER.info(
+        f"CNV upgrade:\n"
+        f"Current version: {cnv_current_version},\n"
+        f"Target version: {cnv_target_version},\n"
+        f"Upgrade stream: {upgrade_stream},\n"
+    )
+    return upgrade_stream
+
+
+@pytest.fixture(scope="session")
+def hco_target_csv_name(cnv_target_version):
+    return get_hco_csv_name_by_version(cnv_target_version=cnv_target_version) if cnv_target_version else None
+
+
+@pytest.fixture(scope="session")
+def upgrade_skip_default_sc_setup(pytestconfig):
+    return pytestconfig.option.upgrade_skip_default_sc_setup
+
+
+@pytest.fixture(scope="session")
+def installing_cnv(pytestconfig):
+    return pytestconfig.option.install
+
+
+@pytest.fixture(scope="session")
+def cnv_source(pytestconfig):
+    return pytestconfig.option.cnv_source or "osbs"
+
+
+@pytest.fixture(scope="session")
+def is_production_source(cnv_source):
+    return cnv_source == "production"

--- a/tests/fixtures/upgrade/config.py
+++ b/tests/fixtures/upgrade/config.py
@@ -53,11 +53,6 @@ def upgrade_skip_default_sc_setup(pytestconfig):
 
 
 @pytest.fixture(scope="session")
-def installing_cnv(pytestconfig):
-    return pytestconfig.option.install
-
-
-@pytest.fixture(scope="session")
 def cnv_source(pytestconfig):
     return pytestconfig.option.cnv_source or "osbs"
 

--- a/tests/fixtures/upgrade/resources.py
+++ b/tests/fixtures/upgrade/resources.py
@@ -1,0 +1,193 @@
+import pytest
+from ocp_resources.datavolume import DataVolume
+from pytest_testconfig import config as py_config
+
+from libs.net.cluster import supported_cluster_ip_versions
+from libs.net.ip import filter_link_local_addresses, random_cidr_addresses_by_family
+from libs.net.vmspec import lookup_iface_status
+from utilities.artifactory import (
+    cleanup_artifactory_secret_and_config_map,
+    get_artifactory_config_map,
+    get_artifactory_secret,
+)
+from utilities.constants.cluster import NODE_TYPE_WORKER_LABEL
+from utilities.constants.networking import LINUX_BRIDGE
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION
+from utilities.constants.virt import ES_NONE
+from utilities.infra import create_ns, get_node_selector_dict
+from utilities.network import cloud_init_network_data, network_device, network_nad, wait_for_node_marked_by_bridge
+from utilities.storage import construct_datavolume_source_dict
+from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
+
+
+@pytest.fixture(scope="session")
+def upgrade_namespace_scope_session(admin_client, unprivileged_client):
+    yield from create_ns(
+        unprivileged_client=unprivileged_client,
+        admin_client=admin_client,
+        name="test-upgrade-namespace",
+    )
+
+
+@pytest.fixture(scope="session")
+def upgrade_bridge_on_all_nodes(
+    admin_client,
+    label_schedulable_nodes,
+    hosts_common_available_ports,
+):
+    with network_device(
+        interface_type=LINUX_BRIDGE,
+        nncp_name="upgrade-bridge",
+        interface_name="br1upgrade",
+        node_selector_labels=NODE_TYPE_WORKER_LABEL,
+        ports=[hosts_common_available_ports[0]],
+        client=admin_client,
+    ) as br:
+        yield br
+
+
+@pytest.fixture(scope="session")
+def bridge_on_one_node(admin_client, worker_node1):
+    with network_device(
+        interface_type=LINUX_BRIDGE,
+        nncp_name="upgrade-br-marker",
+        interface_name="upg-br-mark",
+        node_selector=get_node_selector_dict(node_selector=worker_node1.name),
+        client=admin_client,
+    ) as br:
+        yield br
+
+
+@pytest.fixture(scope="session")
+def upgrade_bridge_marker_nad(admin_client, bridge_on_one_node, kmp_enabled_namespace, worker_node1):
+    with network_nad(
+        nad_type=LINUX_BRIDGE,
+        nad_name=bridge_on_one_node.bridge_name,
+        interface_name=bridge_on_one_node.bridge_name,
+        namespace=kmp_enabled_namespace,
+        client=admin_client,
+    ) as nad:
+        wait_for_node_marked_by_bridge(bridge_nad=nad, node=worker_node1)
+        yield nad
+
+
+@pytest.fixture(scope="session")
+def upgrade_br1test_nad(admin_client, upgrade_namespace_scope_session, upgrade_bridge_on_all_nodes):
+    with network_nad(
+        nad_type=LINUX_BRIDGE,
+        nad_name=upgrade_bridge_on_all_nodes.bridge_name,
+        interface_name=upgrade_bridge_on_all_nodes.bridge_name,
+        namespace=upgrade_namespace_scope_session,
+        client=admin_client,
+    ) as nad:
+        yield nad
+
+
+@pytest.fixture(scope="session")
+def running_vm_upgrade_a(
+    unprivileged_client,
+    upgrade_bridge_marker_nad,
+    kmp_enabled_namespace,
+    upgrade_br1test_nad,
+):
+    name = "vm-upgrade-a"
+    cloud_init_data = cloud_init_network_data(
+        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=1)}}}
+    )
+    with VirtualMachineForTests(
+        name=name,
+        namespace=kmp_enabled_namespace.name,
+        networks={upgrade_bridge_marker_nad.name: upgrade_bridge_marker_nad.name},
+        interfaces=[upgrade_bridge_marker_nad.name],
+        client=unprivileged_client,
+        cloud_init_data=cloud_init_data,
+        body=fedora_vm_body(name=name),
+        eviction_strategy=ES_NONE,
+    ) as vm:
+        running_vm(vm=vm, wait_for_cloud_init=True)
+        ip_families = supported_cluster_ip_versions()
+        lookup_iface_status(
+            vm=vm,
+            iface_name=upgrade_bridge_marker_nad.name,
+            predicate=lambda interface: (
+                len(filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))) == len(ip_families)
+            ),
+        )
+        yield vm
+
+
+@pytest.fixture(scope="session")
+def running_vm_upgrade_b(
+    unprivileged_client,
+    upgrade_bridge_marker_nad,
+    kmp_enabled_namespace,
+    upgrade_br1test_nad,
+):
+    name = "vm-upgrade-b"
+    cloud_init_data = cloud_init_network_data(
+        data={"ethernets": {"eth1": {"addresses": random_cidr_addresses_by_family(net_seed=0, host_address=2)}}}
+    )
+    with VirtualMachineForTests(
+        name=name,
+        namespace=kmp_enabled_namespace.name,
+        networks={upgrade_bridge_marker_nad.name: upgrade_bridge_marker_nad.name},
+        interfaces=[upgrade_bridge_marker_nad.name],
+        client=unprivileged_client,
+        cloud_init_data=cloud_init_data,
+        body=fedora_vm_body(name=name),
+        eviction_strategy=ES_NONE,
+    ) as vm:
+        running_vm(vm=vm, wait_for_cloud_init=True)
+        ip_families = supported_cluster_ip_versions()
+        lookup_iface_status(
+            vm=vm,
+            iface_name=upgrade_bridge_marker_nad.name,
+            predicate=lambda interface: (
+                len(filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))) == len(ip_families)
+            ),
+        )
+        yield vm
+
+
+@pytest.fixture(scope="session")
+def dvs_for_upgrade(
+    admin_client,
+    worker_node1,
+    rhel_latest_os_params,
+    updated_default_storage_class_ocs_virt,
+):
+    golden_images_namespace_name = py_config["golden_images_namespace"]
+    dvs_list = []
+    artifactory_secret = get_artifactory_secret(namespace=golden_images_namespace_name)
+    artifactory_config_map = get_artifactory_config_map(namespace=golden_images_namespace_name)
+
+    for sc in py_config["storage_class_matrix"]:
+        storage_class = [*sc][0]
+        dv = DataVolume(
+            client=admin_client,
+            name=f"dv-for-product-upgrade-{storage_class}",
+            namespace=golden_images_namespace_name,
+            source_dict=construct_datavolume_source_dict(
+                source="http",
+                url=rhel_latest_os_params["rhel_image_path"],
+                secret_name=artifactory_secret.name,
+                cert_configmap_name=artifactory_config_map.name,
+            ),
+            storage_class=storage_class,
+            size=rhel_latest_os_params["rhel_dv_size"],
+            annotations=BIND_IMMEDIATE_ANNOTATION,
+            api_name="storage",
+        )
+        dv.create()
+        dvs_list.append(dv)
+    for dv in dvs_list:
+        dv.wait_for_dv_success()
+
+    yield dvs_list
+
+    for dv in dvs_list:
+        dv.clean_up()
+    cleanup_artifactory_secret_and_config_map(
+        artifactory_secret=artifactory_secret,
+        artifactory_config_map=artifactory_config_map,
+    )

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -18,12 +18,13 @@ from ocp_resources.operator_hub import OperatorHub
 from ocp_resources.pod import Pod
 from ocp_resources.resource import Resource, ResourceEditor
 from ocp_resources.subscription import Subscription
+from packaging.version import parse
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 import utilities.infra
 from utilities.constants.cluster import BASE_EXCEPTIONS_DICT
-from utilities.constants.hco import DEFAULT_RESOURCE_CONDITIONS
+from utilities.constants.hco import DEFAULT_RESOURCE_CONDITIONS, HOTFIX_STR, UpgradeStreams
 from utilities.constants.timeouts import (
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
@@ -622,3 +623,42 @@ def wait_for_cluster_operator_stabilize(admin_client, wait_timeout=TIMEOUT_20MIN
 
 def get_hco_csv_name_by_version(cnv_target_version: str) -> str:
     return f"kubevirt-hyperconverged-operator.v{cnv_target_version}"
+
+
+def determine_upgrade_stream(current_version: str, target_version: str) -> str:
+    """Determine the CNV upgrade stream by comparing current and target versions.
+
+    Args:
+        current_version: The current CNV version string (e.g. "4.15.1-hotfix").
+        target_version: The target CNV version string (e.g. "4.16.0").
+
+    Returns:
+        The upgrade stream identifier: one of UpgradeStreams.X_STREAM,
+        UpgradeStreams.Y_STREAM, or UpgradeStreams.Z_STREAM.
+
+    Raises:
+        ValueError: If the target version is not newer than the current version,
+            or if the stream cannot be determined.
+    """
+    current_cnv_version = parse(version=current_version.split("-")[0])
+    target_cnv_version = parse(version=target_version.split("-")[0])
+
+    if current_cnv_version.major < target_cnv_version.major:
+        return UpgradeStreams.X_STREAM
+    elif current_cnv_version.minor < target_cnv_version.minor:
+        return UpgradeStreams.Y_STREAM
+    elif current_cnv_version.micro < target_cnv_version.micro:
+        return UpgradeStreams.Z_STREAM
+    elif HOTFIX_STR in current_version:
+        # if we reach here, this is an upgrade out of hotfix to next z-stream
+        return UpgradeStreams.Z_STREAM
+    else:
+        if target_cnv_version <= current_cnv_version:
+            raise ValueError(
+                f"Cannot upgrade to older/identical versions,"
+                f"current: {current_cnv_version} target: {target_cnv_version}"
+            )
+        raise ValueError(
+            f"Unknown upgrade stream. Current cnv version: {current_cnv_version}, "
+            f"target cnv version: {target_cnv_version}."
+        )

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -31,6 +31,7 @@ from utilities.operator import (
     get_mcp_updating_transition_times,
     get_mcps_with_all_machines_ready,
     get_mcps_with_different_transition_times,
+    get_mcps_with_true_condition_status,
     get_nodes_not_ready,
     get_operator_hub,
     update_image_in_catalog_source,
@@ -683,6 +684,50 @@ class TestWaitForMcpReadyMachineCount:
         mock_consecutive_checks.assert_called_once()
 
 
+class TestGetMcpsWithTrueConditionStatus:
+    """Test cases for get_mcps_with_true_condition_status function."""
+
+    @patch("utilities.operator.Resource")
+    def test_returns_mcps_with_matching_true_condition(self, mock_resource_class):
+        """MCP names whose condition type is True are included in the result set."""
+        mock_resource_class.Condition.Status.TRUE = "True"
+
+        mock_mcp_worker = MagicMock()
+        mock_mcp_worker.name = "worker"
+        mock_mcp_worker.instance.status.conditions = [
+            {"type": "Updated", "status": "True"},
+            {"type": "Updating", "status": "False"},
+        ]
+        mock_mcp_master = MagicMock()
+        mock_mcp_master.name = "master"
+        mock_mcp_master.instance.status.conditions = [
+            {"type": "Updated", "status": "False"},
+        ]
+
+        result = get_mcps_with_true_condition_status(
+            condition_type="Updated",
+            machine_config_pools_list=[mock_mcp_worker, mock_mcp_master],
+        )
+
+        assert result == {"worker"}
+
+    @patch("utilities.operator.Resource")
+    def test_returns_empty_set_when_no_mcps_match(self, mock_resource_class):
+        """Empty set is returned when no MCP has the condition as True."""
+        mock_resource_class.Condition.Status.TRUE = "True"
+
+        mock_mcp = MagicMock()
+        mock_mcp.name = "worker"
+        mock_mcp.instance.status.conditions = [{"type": "Updated", "status": "False"}]
+
+        result = get_mcps_with_true_condition_status(
+            condition_type="Updated",
+            machine_config_pools_list=[mock_mcp],
+        )
+
+        assert result == set()
+
+
 class TestConsecutiveChecksForMcpCondition:
     """Test cases for consecutive_checks_for_mcp_condition function"""
 
@@ -739,6 +784,29 @@ class TestConsecutiveChecksForMcpCondition:
             )
 
         mock_collect_data.assert_called_once()
+
+    def test_consecutive_checks_reset_then_succeed(self):
+        """Consecutive-check counter resets to zero when some MCPs miss the condition."""
+        mock_mcp1 = MagicMock()
+        mock_mcp1.name = "worker"
+        mock_mcp2 = MagicMock()
+        mock_mcp2.name = "master"
+
+        mock_sampler = MagicMock()
+        mock_sampler.__iter__ = MagicMock(
+            return_value=iter([
+                {"worker"},  # partial match → reset (line 143)
+                {"worker", "master"},
+                {"worker", "master"},
+                {"worker", "master"},
+            ])
+        )
+        mock_sampler.wait_timeout = 600
+
+        consecutive_checks_for_mcp_condition(
+            mcp_sampler=mock_sampler,
+            machine_config_pools_list=[mock_mcp1, mock_mcp2],
+        )
 
 
 class TestWaitForMcpUpdateEnd:
@@ -822,6 +890,41 @@ class TestWaitForMcpUpdateStart:
 
         # Should not raise because MCPs reached Updated
         wait_for_mcp_update_start([mock_mcp], initial_times)
+
+        mock_collect_data.assert_called_once()
+
+    @patch("utilities.operator.collect_mcp_data_on_update_timeout")
+    @patch("utilities.operator.get_mcps_with_true_condition_status")
+    @patch("utilities.operator.TimeoutSampler")
+    @patch("utilities.operator.MachineConfigPool")
+    def test_wait_for_update_start_timeout_no_updated_raises(
+        self,
+        mock_mcp_class,
+        mock_sampler,
+        mock_get_true_status,
+        mock_collect_data,
+    ):
+        """Timeout with zero MCPs reaching Updated re-raises TimeoutExpiredError."""
+        mock_mcp_class.Status.UPDATING = "Updating"
+        mock_mcp_class.Status.UPDATED = "Updated"
+
+        mock_mcp = MagicMock()
+        mock_mcp.name = "worker"
+
+        class MockSamplerIterator:
+            wait_timeout = 600
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                raise TimeoutExpiredError("Timeout")
+
+        mock_sampler.return_value = MockSamplerIterator()
+        mock_get_true_status.return_value = set()
+
+        with pytest.raises(TimeoutExpiredError):
+            wait_for_mcp_update_start([mock_mcp], {"worker": "2024-01-15T10:00:00Z"})
 
         mock_collect_data.assert_called_once()
 
@@ -1023,6 +1126,50 @@ class TestWaitForCatalogsourceReady:
 
         with pytest.raises(TimeoutExpiredError):
             wait_for_catalogsource_ready(mock_admin_client, "test-catalog")
+
+    @patch("utilities.operator.TimeoutSampler")
+    @patch("utilities.operator.utilities.infra.get_pods")
+    @patch("utilities.operator.py_config")
+    @patch("utilities.operator.Namespace")
+    @patch("utilities.operator.Pod")
+    def test_wait_catalogsource_ready_inner_func_filters_non_running_pods(
+        self,
+        mock_pod_class,
+        mock_namespace_class,
+        mock_config,
+        mock_get_pods,
+        mock_sampler,
+    ):
+        """Inner pod-filter function excludes pods not in Running phase."""
+        mock_admin_client = MagicMock()
+        mock_config.__getitem__.return_value = "openshift-marketplace"
+        mock_pod_class.Status.RUNNING = "Running"
+
+        mock_pod_running = MagicMock()
+        mock_pod_running.name = "catalog-pod-1"
+        mock_pod_running.instance.status.phase = "Running"
+
+        mock_pod_not_running = MagicMock()
+        mock_pod_not_running.name = "catalog-pod-2"
+        mock_pod_not_running.instance.status.phase = "Pending"
+
+        mock_get_pods.return_value = [mock_pod_running, mock_pod_not_running]
+
+        captured_func = None
+
+        def capture_sampler(*args, **kwargs):
+            nonlocal captured_func
+            captured_func = kwargs.get("func")
+            mock_instance = MagicMock()
+            mock_instance.__iter__ = MagicMock(return_value=iter([[]]))
+            return mock_instance
+
+        mock_sampler.side_effect = capture_sampler
+
+        wait_for_catalogsource_ready(mock_admin_client, "test-catalog")
+
+        result = captured_func()
+        assert result == ["catalog-pod-2"]
 
 
 class TestCreateOperatorGroup:
@@ -1313,6 +1460,55 @@ class TestWaitForAllNodesReady:
         with pytest.raises(TimeoutExpiredError):
             wait_for_all_nodes_ready([MagicMock()])
 
+    @patch("utilities.operator.TimeoutSampler")
+    @patch("utilities.operator.get_nodes_not_ready")
+    def test_wait_all_nodes_ready_reset_then_succeed(
+        self,
+        mock_get_nodes,
+        mock_sampler,
+    ):
+        """Consecutive-check counter resets to zero when not-ready nodes appear mid-run."""
+        mock_node = MagicMock()
+        mock_node.name = "node1"
+        not_ready = [mock_node]
+
+        mock_sampler_instance = MagicMock()
+        mock_sampler_instance.__iter__ = MagicMock(return_value=iter([not_ready, [], [], []]))
+        mock_sampler.return_value = mock_sampler_instance
+
+        wait_for_all_nodes_ready([mock_node])
+
+        mock_sampler.assert_called_once()
+
+    @patch("utilities.operator.TimeoutSampler")
+    @patch("utilities.operator.get_nodes_not_ready")
+    def test_wait_all_nodes_ready_timeout_with_not_ready_nodes(
+        self,
+        mock_get_nodes,
+        mock_sampler,
+    ):
+        """Timeout logs not-ready node names and re-raises TimeoutExpiredError."""
+        mock_node = MagicMock()
+        mock_node.name = "node1"
+        not_ready = [mock_node]
+
+        class MockSamplerIterator:
+            _yielded = False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if not self._yielded:
+                    self._yielded = True
+                    return not_ready
+                raise TimeoutExpiredError("Timeout")
+
+        mock_sampler.return_value = MockSamplerIterator()
+
+        with pytest.raises(TimeoutExpiredError):
+            wait_for_all_nodes_ready([mock_node])
+
 
 class TestGetNodesNotReady:
     """Test cases for get_nodes_not_ready function"""
@@ -1367,6 +1563,28 @@ class TestWaitForNodesToHaveSameKubeletVersion:
                 return self
 
             def __next__(self):
+                raise TimeoutExpiredError("Timeout")
+
+        mock_sampler.return_value = MockSamplerIterator()
+
+        with pytest.raises(TimeoutExpiredError):
+            wait_for_nodes_to_have_same_kubelet_version([MagicMock()])
+
+    @patch("utilities.operator.TimeoutSampler")
+    def test_wait_same_version_timeout_with_version_mismatch(self, mock_sampler):
+        """Timeout with mismatched kubelet versions logs the divergence and re-raises."""
+        divergent_versions = {"node1": "v1.24.0", "node2": "v1.25.0"}
+
+        class MockSamplerIterator:
+            _yielded = False
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if not self._yielded:
+                    self._yielded = True
+                    return divergent_versions
                 raise TimeoutExpiredError("Timeout")
 
         mock_sampler.return_value = MockSamplerIterator()
@@ -1598,3 +1816,10 @@ class TestDetermineUpgradeStream:
         """Identical current and target versions raise ValueError."""
         with pytest.raises(ValueError, match="Cannot upgrade to older/identical versions"):
             determine_upgrade_stream(current_version="4.15.1", target_version="4.15.1")
+
+    def test_unknown_stream_raises_value_error(self):
+        """Post-release target with equal major.minor.micro raises unknown-stream ValueError."""
+        # "4.15.1.post1" parses with the same major/minor/micro as "4.15.1" but is
+        # semantically newer, so none of the x/y/z-stream branches fire.
+        with pytest.raises(ValueError, match="Unknown upgrade stream"):
+            determine_upgrade_stream(current_version="4.15.1", target_version="4.15.1.post1")

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -19,6 +19,7 @@ from utilities.operator import (
     create_operator,
     create_operator_group,
     create_subscription,
+    determine_upgrade_stream,
     disable_default_sources_in_operatorhub,
     get_catalog_source,
     get_cluster_operator_status_conditions,
@@ -1563,3 +1564,37 @@ class TestUpdateImageInCatalogSource:
 
         mock_create_catalog.assert_called_once()
         mock_wait_manifest.assert_called_once()
+
+
+class TestDetermineUpgradeStream:
+    """Test cases for determine_upgrade_stream function."""
+
+    def test_x_stream_upgrade(self):
+        """Major version bump is identified as x-stream."""
+        assert determine_upgrade_stream(current_version="3.11.0", target_version="4.0.0") == "x-stream"
+
+    def test_y_stream_upgrade(self):
+        """Minor version bump is identified as y-stream."""
+        assert determine_upgrade_stream(current_version="4.15.3", target_version="4.16.0") == "y-stream"
+
+    def test_z_stream_upgrade(self):
+        """Patch version bump is identified as z-stream."""
+        assert determine_upgrade_stream(current_version="4.15.1", target_version="4.15.2") == "z-stream"
+
+    def test_z_stream_from_hotfix(self):
+        """Hotfix build upgrading to the same semver release is z-stream."""
+        assert determine_upgrade_stream(current_version="4.15.1-hotfix", target_version="4.15.1") == "z-stream"
+
+    def test_version_suffix_stripped_before_comparison(self):
+        """Build metadata suffix (e.g. -1234) is stripped before semver comparison."""
+        assert determine_upgrade_stream(current_version="4.15.1-1234567", target_version="4.15.2") == "z-stream"
+
+    def test_downgrade_raises_value_error(self):
+        """Attempting to downgrade raises ValueError."""
+        with pytest.raises(ValueError, match="Cannot upgrade to older/identical versions"):
+            determine_upgrade_stream(current_version="4.16.0", target_version="4.15.0")
+
+    def test_same_version_raises_value_error(self):
+        """Identical current and target versions raise ValueError."""
+        with pytest.raises(ValueError, match="Cannot upgrade to older/identical versions"):
+            determine_upgrade_stream(current_version="4.15.1", target_version="4.15.1")


### PR DESCRIPTION
##### What this PR does / why we need it:
Move upgrade-domain fixtures out of the monolithic `tests/conftest.py` into two domain modules:
- `tests/fixtures/upgrade/config.py` — `cnv_target_version`, `cnv_channel`, `cnv_upgrade_stream`, `hco_target_csv_name`, `upgrade_skip_default_sc_setup`, `installing_cnv`, `cnv_source`, `is_production_source`
- `tests/fixtures/upgrade/resources.py` — `upgrade_bridge_on_all_nodes`, `bridge_on_one_node`, `upgrade_bridge_marker_nad`, `upgrade_br1test_nad`, `running_vm_upgrade_a`, `running_vm_upgrade_b`, `upgrade_namespace_scope_session`, `dvs_for_upgrade`

Move `determine_upgrade_stream()` helper to `utilities/operator.py` with type hints and a Google-style docstring.

Register new modules in `pytest_plugins` (root `conftest.py`).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Part of series of `tests/conftest.py` refactor

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-80951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved upgrade test coverage for networking, virtual machines, storage volumes, and version transitions.
  - Expanded operator unit tests for upgrade-stream classification (major/minor/patch), hotfix handling, and downgrade/invalid inputs.
  - Added validation of additional readiness/sampling edge cases across MCPs, catalog sources, and node readiness.
- **Refactor**
  - Centralized upgrade test configuration and resource setup into dedicated components to make test execution more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->