### PR TITLE
Manual cherry-pick to 4.19: net, sriov: memory hotplug tests (#5349)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,7 @@ from _pytest.nodes import Collector, Node
 from _pytest.reports import CollectReport, TestReport
 from _pytest.runner import CallInfo
 from kubernetes.dynamic.exceptions import ConflictError
+from ocp_resources.network_config_openshift_io import Network
 from ocp_resources.resource import get_client
 from packaging.version import Version
 from pyhelper_utils.shell import run_command
@@ -780,6 +781,9 @@ def pytest_sessionstart(session):
     # Send --tc=server_url:<url> to override servers URL
     if not skip_if_pytest_flags_exists(pytest_config=session.config):
         py_config["version_explorer_url"] = get_cnv_version_explorer_url(pytest_config=session.config)
+        py_config["cluster_service_network"] = Network(
+            client=get_client(), name="cluster"
+        ).instance.status.serviceNetwork
         if not session.config.getoption("--skip-artifactory-check"):
             py_config["server_url"] = py_config["server_url"] or get_artifactory_server_url(
                 cluster_host_url=get_client().configuration.host,

--- a/libs/net/cluster.py
+++ b/libs/net/cluster.py
@@ -1,0 +1,18 @@
+import ipaddress
+from functools import cache
+
+from pytest_testconfig import py_config
+
+
+@cache
+def ipv4_supported_cluster() -> bool:
+    return _cluster_ip_family_supported(ip_family=4)
+
+
+@cache
+def ipv6_supported_cluster() -> bool:
+    return _cluster_ip_family_supported(ip_family=6)
+
+
+def _cluster_ip_family_supported(ip_family: int) -> bool:
+    return any(ipaddress.ip_network(ip).version == ip_family for ip in py_config.get("cluster_service_network"))

--- a/libs/net/ip.py
+++ b/libs/net/ip.py
@@ -1,11 +1,56 @@
+import ipaddress
 import random
 from functools import cache
 from typing import Final
+
+from libs.net.cluster import ipv4_supported_cluster, ipv6_supported_cluster
 
 _MAX_NUM_OF_RANDOM_OCTETS_PER_SESSION: Final[int] = 16
 _MAX_NUM_OF_RANDOM_HEXTETS_PER_SESSION: Final[int] = 16
 _IPV4_ADDRESS_SUBNET_PREFIX_VMI: Final[str] = "172.16"
 _IPV6_ADDRESS_SUBNET_PREFIX_VMI: Final[str] = "fd00:1234:5678"
+
+
+def random_cidr_addresses_by_family(net_seed: int, host_address: int) -> list[str]:
+    """Return CIDR-formatted addresses for each IP family supported by the cluster.
+
+    This library uses /24 for IPv4 and /64 for IPv6 VM subnets, matching the
+    subnet definitions in this module. VMs with the same net_seed share the
+    same subnet, allowing direct L2 communication without routing. Only
+    families supported by the cluster are included.
+
+    Args:
+        net_seed: Index into the cached pool of random network prefixes.
+        host_address: Host portion of the address — must be unique per VM in the test.
+
+    Returns:
+        List of CIDR strings (e.g. ["192.168.1.1/24", "fd00::1/64"]).
+    """
+    return [
+        f"{ip}/64" if ipaddress.ip_address(ip).version == 6 else f"{ip}/24"
+        for ip in random_ip_addresses_by_family(net_seed=net_seed, host_address=host_address)
+    ]
+
+
+def random_ip_addresses_by_family(
+    net_seed: int,
+    host_address: int,
+) -> list[str]:
+    """Generate IP addresses for each IP family supported by the cluster network stack.
+
+    Args:
+        net_seed: Seed index for selecting the random network portion of the address.
+        host_address: Host portion of the address, used to place VMs on the same subnet.
+
+    Returns:
+        List of IP address strings, one per IP family supported by the cluster.
+    """
+    ips = []
+    if ipv4_supported_cluster():
+        ips.append(random_ipv4_address(net_seed=net_seed, host_address=host_address))
+    if ipv6_supported_cluster():
+        ips.append(random_ipv6_address(net_seed=net_seed, host_address=host_address))
+    return ips
 
 
 def random_ipv4_address(net_seed: int, host_address: int) -> str:
@@ -72,3 +117,18 @@ def _random_hextets(count: int) -> list[int]:
         list[int]: A list of unique random integers representing hextet values.
     """
     return random.sample(range(1, 0xFFFE), count)
+
+
+def filter_link_local_addresses(ip_addresses: list[str]) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Filter out link-local IP addresses from a list of IP address strings.
+
+    Link-local addresses (169.254.0.0/16 for IPv4, fe80::/10 for IPv6) are
+    automatically assigned and typically not used for inter-VM communication.
+
+    Args:
+        ip_addresses: List of IP address strings to filter.
+
+    Returns:
+        List of IP address objects with link-local addresses removed.
+    """
+    return [ip for addr in ip_addresses if not (ip := ipaddress.ip_interface(address=addr).ip).is_link_local]

--- a/libs/net/traffic_generator.py
+++ b/libs/net/traffic_generator.py
@@ -8,6 +8,7 @@ from libs.vm.vm import BaseVirtualMachine
 
 _DEFAULT_CMD_TIMEOUT_SEC: Final[int] = 10
 _IPERF_BIN: Final[str] = "iperf3"
+IPERF_SERVER_PORT: Final[int] = 5201
 
 
 LOGGER = logging.getLogger(__name__)
@@ -27,10 +28,14 @@ class Server:
         self,
         vm: BaseVirtualMachine,
         port: int,
+        bind_ip: str | None = None,
+        bind_dev: str | None = None,
     ):
         self._vm = vm
         self._port = port
         self._cmd = f"{_IPERF_BIN} --server --port {self._port} --one-off"
+        self._cmd += f" --bind {bind_ip}" if bind_ip else ""
+        self._cmd += f" --bind-dev {bind_dev}" if bind_dev else ""
 
     def __enter__(self) -> "Server":
         self._vm.console(
@@ -62,11 +67,13 @@ class Client:
         vm: BaseVirtualMachine,
         server_ip: str,
         server_port: int,
+        bind_dev: str | None = None,
     ):
         self._vm = vm
         self._server_ip = server_ip
         self._server_port = server_port
         self._cmd = f"{_IPERF_BIN} --client {self._server_ip} --time 0 --port {self._server_port}"
+        self._cmd += f" --bind-dev {bind_dev}" if bind_dev else ""
 
     def __enter__(self) -> "Client":
         self._vm.console(

--- a/libs/net/vmspec.py
+++ b/libs/net/vmspec.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any, Final
 
 from kubernetes.dynamic.client import ResourceField
-from timeout_sampler import TimeoutExpiredError, retry
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from libs.vm.spec import Devices, Interface, Network, SpecDisk, VMISpec, Volume
 from libs.vm.vm import BaseVirtualMachine
@@ -28,10 +28,11 @@ def lookup_iface_status(
     vm: BaseVirtualMachine,
     iface_name: str,
     predicate: Callable[[Any], bool] = _default_interface_predicate,
+    timeout: int = LOOKUP_IFACE_STATUS_TIMEOUT_SEC,
 ) -> ResourceField:
     """
-    Returns the network interface status requested if found, otherwise raises VMInterfaceStatusNotFoundError.
-    The interface status information is expected to be sourced from the guest-agent with an IP address.
+    Awaits and returns the network interface status requested if found and the predicate function,
+    otherwise raises VMInterfaceStatusNotFoundError.
 
     Args:
         vm (BaseVirtualMachine): VM in which to search for the network interface.
@@ -39,6 +40,7 @@ def lookup_iface_status(
         predicate (Callable[[dict[str, Any]], bool]): A function that takes a network interface as an argument
             and returns a boolean value. This function should define the condition that
             the interface needs to meet.
+        timeout (int): Lookup operation timeout
 
     Returns:
         iface (ResourceField): The requested interface.
@@ -46,43 +48,56 @@ def lookup_iface_status(
     Raises:
         VMInterfaceStatusNotFoundError: If the requested interface was not found in the vmi status.
     """
+    sampler = TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=RETRY_INTERVAL_SEC,
+        func=_lookup_iface_status,
+        vm=vm,
+        iface_name=iface_name,
+        predicate=predicate,
+    )
     try:
-        return _lookup_iface_status(
-            vm=vm,
-            iface_name=iface_name,
-            predicate=predicate,
-        )
+        for iface in sampler:
+            if iface:
+                return iface
     except TimeoutExpiredError:
         raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
 
 
-@retry(
-    wait_timeout=LOOKUP_IFACE_STATUS_TIMEOUT_SEC,
-    sleep=RETRY_INTERVAL_SEC,
-    exceptions_dict={VMInterfaceStatusNotFoundError: []},
-)
-def _lookup_iface_status(vm: BaseVirtualMachine, iface_name: str, predicate: Callable[[Any], bool]) -> ResourceField:
-    """
-    Returns the interface requested if found and the predicate function (to which the interface is
-    sent) returns True. Else, raise VMInterfaceStatusNotFoundError.
-
-    Args:
-        vm (BaseVirtualMachine): VM in which to search for the network interface.
-        iface_name (str): The name of the requested interface.
-        predicate (Callable[[dict[str, Any]], bool]): A function that takes a network interface as an argument
-            and returns a boolean value. this function should define the condition that
-            the interface needs to meet.
-
-    Returns:
-        iface (ResourceField): The requested interface.
-
-    Raises:
-        VMInterfaceStatusNotFoundError: If the requested interface was not found in the VM.
-    """
+def _lookup_iface_status(
+    vm: BaseVirtualMachine, iface_name: str, predicate: Callable[[Any], bool]
+) -> ResourceField | None:
     for iface in vm.vmi.interfaces:
         if iface.name == iface_name and predicate(iface):
             return iface
-    raise VMInterfaceStatusNotFoundError(f"Network interface named {iface_name} was not found in VM {vm.name}.")
+    return None
+
+
+def wait_for_ifaces_status(
+    vm: BaseVirtualMachine,
+    ip_addresses_by_spec_net_name: dict[str, list[str]],
+) -> None:
+    """Wait for all VM interfaces to be ready.
+
+    Args:
+        vm: The virtual machine to wait for.
+        ip_addresses_by_spec_net_name: Mapping of spec network name to its expected IP addresses.
+            Primary (masquerade) interfaces are detected automatically from the VM spec.
+    """
+    for iface in vm.template_spec.domain.devices.interfaces:  # type: ignore
+        if iface.masquerade is not None:
+            lookup_iface_status(vm=vm, iface_name=iface.name)
+        else:
+            lookup_iface_status(
+                vm=vm,
+                iface_name=iface.name,
+                predicate=lambda iface_status: (
+                    "guest-agent" in iface_status["infoSource"]
+                    and all(
+                        ip in iface_status.get("ipAddresses", []) for ip in ip_addresses_by_spec_net_name[iface.name]
+                    )
+                ),
+            )
 
 
 def lookup_primary_network(vm: BaseVirtualMachine) -> Network:

--- a/libs/vm/oper.py
+++ b/libs/vm/oper.py
@@ -1,0 +1,21 @@
+from libs.net.vmspec import wait_for_ifaces_status
+from libs.vm.vm import BaseVirtualMachine
+
+
+def run_vm(
+    vm: BaseVirtualMachine,
+    ip_addresses_by_spec_net_name: dict[str, list[str]],
+) -> BaseVirtualMachine:
+    """Start a VM, wait for agent connection, and verify interface IP addresses.
+
+    Args:
+        vm: The virtual machine to start.
+        ip_addresses_by_spec_net_name: Mapping of spec network name to expected IP addresses.
+
+    Returns:
+        The same VM, running with all interfaces reporting expected IPs.
+    """
+    vm.start(wait=True)
+    vm.wait_for_agent_connected()
+    wait_for_ifaces_status(vm=vm, ip_addresses_by_spec_net_name=ip_addresses_by_spec_net_name)
+    return vm

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -75,6 +75,8 @@ class Interface:
     bridge: dict[Any, Any] | None = None
     sriov: dict[Any, Any] | None = None
     binding: NetBinding | None = None
+    state: str | None = None
+    macAddress: str | None = None  # noqa: N815
 
 
 @dataclass

--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -48,6 +48,7 @@ class CPU:
 @dataclass
 class Memory:
     guest: str
+    maxGuest: str | None = None  # noqa: N815
 
 
 @dataclass

--- a/libs/vm/vm.py
+++ b/libs/vm/vm.py
@@ -8,10 +8,11 @@ import yaml
 from dacite import from_dict
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.node import Node
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.virtual_machine import VirtualMachine, VirtualMachineInstance
 from pytest_testconfig import config as py_config
 
-from libs.vm.spec import CloudInitNoCloud, ContainerDisk, Disk, SpecDisk, VMSpec, Volume
+from libs.vm.spec import CloudInitNoCloud, ContainerDisk, Disk, Memory, SpecDisk, VMISpec, VMSpec, Volume
 from tests.network.libs import cloudinit
 from utilities import infra
 from utilities.constants import CLOUD_INIT_DISK_NAME
@@ -75,6 +76,26 @@ class BaseVirtualMachine(VirtualMachine):
             condition=VirtualMachineInstance.Condition.Type.AGENT_CONNECTED,
             status=VirtualMachineInstance.Condition.Status.TRUE,
         )
+
+    def set_guest_memory(self, memory_guest: str) -> None:
+        """Set the guest memory and update the VM spec on the cluster.
+
+        On a running VM this triggers an automatic live migration.
+
+        Args:
+            memory_guest: New guest memory value (e.g. "5Gi").
+        """
+        if self._spec.template.spec.domain.memory:
+            self._spec.template.spec.domain.memory.guest = memory_guest
+        else:
+            self._spec.template.spec.domain.memory = Memory(guest=memory_guest)
+        ResourceEditor(
+            patches={self: {"spec": {"template": {"spec": {"domain": {"memory": {"guest": memory_guest}}}}}}}
+        ).update()
+
+    @property
+    def template_spec(self) -> VMISpec:
+        return self._spec.template.spec
 
     @property
     def cloud_init_network_data(self) -> cloudinit.NetworkData:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
   "pytest-dependency>=0.6.0",
   "pytest-jira>=0.3.24",
   "pytest-order>=1.3.0",
+  "pytest-subtests>=0.13.1",
   "pytest-progress>=1.3.0",
   "pytest-testconfig>=0.2.0",
   "python-benedict>=0.34.0",

--- a/tests/network/libs/connectivity.py
+++ b/tests/network/libs/connectivity.py
@@ -1,0 +1,37 @@
+from timeout_sampler import TimeoutExpiredError, retry
+
+from libs.net.traffic_generator import IPERF_SERVER_PORT, Client, Server
+from libs.vm.vm import BaseVirtualMachine
+
+
+@retry(wait_timeout=60, sleep=5, exceptions_dict={})
+def poll_tcp_connectivity(
+    client_vm: BaseVirtualMachine,
+    server_vm: BaseVirtualMachine,
+    server_ip: str,
+    client_bind_dev: str | None = None,
+    server_bind_dev: str | None = None,
+    expect_connectivity: bool = True,
+) -> bool:
+    """Poll TCP connectivity (or its absence) between two VMs, retrying until the expected state is reached.
+
+    Args:
+        client_vm: VM initiating the TCP connection.
+        server_vm: VM running the iperf3 server.
+        server_ip: IP address the server binds to.
+        client_bind_dev: Guest network device name to force the client out (e.g. "eth1").
+            Bypasses ECMP routing when both secondary interfaces share the same subnet.
+        server_bind_dev: Guest network device name to force the server responses out (e.g. "eth1").
+            Bypasses ECMP routing on the server VM when it has multiple secondary interfaces.
+        expect_connectivity: When True polls until connectivity exists; when False polls until it does not.
+
+    Returns:
+        True when the observed reachability matches expect_connectivity.
+    """
+    try:
+        with Server(vm=server_vm, port=IPERF_SERVER_PORT, bind_ip=server_ip, bind_dev=server_bind_dev):
+            with Client(vm=client_vm, server_ip=server_ip, server_port=IPERF_SERVER_PORT, bind_dev=client_bind_dev):
+                reachable = True
+    except TimeoutExpiredError:
+        reachable = False
+    return reachable if expect_connectivity else not reachable

--- a/tests/network/sriov/libsriov.py
+++ b/tests/network/sriov/libsriov.py
@@ -1,0 +1,66 @@
+"""SR-IOV library constants and utilities."""
+
+from libs.net.vmspec import add_volume_disk
+from libs.vm.factory import base_vmspec, fedora_vm
+from libs.vm.spec import CloudInitNoCloud, Interface, Memory, Multus, Network
+from libs.vm.vm import BaseVirtualMachine, cloudinitdisk_storage
+from tests.network.libs import cloudinit
+from tests.network.libs.cloudinit import MatchSelector
+
+VM_SRIOV_IFACE_NAME = "sriov1"
+
+
+def base_sriov_vm(
+    namespace: str,
+    name: str,
+    sriov_network_name: str,
+    sriov_mac: str,
+    addresses: list[str],
+    memory_guest: str = "1Gi",
+    memory_max_guest: str | None = None,
+) -> BaseVirtualMachine:
+    """Create a Fedora VM with an SR-IOV secondary interface using BaseVirtualMachine.
+
+    The SR-IOV VF is matched by MAC address and renamed to sriov1 via
+    cloud-init set-name.
+
+    Args:
+        namespace: Namespace to deploy the VM in.
+        name: VM name prefix (a unique suffix is appended automatically).
+        sriov_network_name: Name of the SR-IOV NetworkAttachmentDefinition.
+        sriov_mac: MAC address to assign to the SR-IOV interface.
+        addresses: CIDR addresses to assign to the SR-IOV interface
+            (e.g. ["172.16.0.1/24", "fd00::1/64"]).
+        memory_guest: Initial guest memory (e.g. "1Gi"). Defaults to "1Gi".
+        memory_max_guest: Maximum guest memory for hot-plug. None disables hot-plug.
+
+    Returns:
+        BaseVirtualMachine configured with an SR-IOV secondary interface.
+    """
+    spec = base_vmspec()
+    spec.template.spec.domain.memory = Memory(guest=memory_guest, maxGuest=memory_max_guest)
+    spec.template.spec.domain.devices.interfaces = [  # type: ignore[union-attr]
+        Interface(name=sriov_network_name, sriov={}, macAddress=sriov_mac),
+    ]
+    spec.template.spec.networks = [
+        Network(name=sriov_network_name, multus=Multus(networkName=f"{namespace}/{sriov_network_name}")),
+    ]
+
+    ethernets: dict[str, cloudinit.EthernetDevice] = {}
+    ethernets["sriov"] = cloudinit.EthernetDevice(
+        addresses=addresses,
+        match=MatchSelector(macaddress=sriov_mac),
+        set_name=VM_SRIOV_IFACE_NAME,
+    )
+    disk, volume = cloudinitdisk_storage(
+        data=CloudInitNoCloud(
+            networkData=cloudinit.asyaml(no_cloud=cloudinit.NetworkData(ethernets=ethernets)),
+            userData=cloudinit.format_cloud_config(userdata=cloudinit.UserData(users=[])),
+        )
+    )
+    spec.template.spec = add_volume_disk(vmi_spec=spec.template.spec, volume=volume, disk=disk)
+    return fedora_vm(namespace=namespace, name=name, spec=spec)
+
+
+def vm_sriov_mac(mac_suffix_index: int) -> str:
+    return f"02:00:b5:b5:b5:{mac_suffix_index:02x}"

--- a/tests/network/sriov/memory_hotplug/conftest.py
+++ b/tests/network/sriov/memory_hotplug/conftest.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from libs.net.ip import random_cidr_addresses_by_family
+from libs.vm.oper import run_vm
+from tests.network.sriov.libsriov import base_sriov_vm, vm_sriov_mac
+
+if TYPE_CHECKING:
+    from ocp_resources.namespace import Namespace
+    from ocp_resources.sriov_network import SriovNetwork
+
+    from libs.vm.vm import BaseVirtualMachine
+
+_NET_SEED: Final[int] = 0
+_HOTPLUG_VM_HOST_ADDRESS: Final[int] = 10
+_REF_VM_HOST_ADDRESS: Final[int] = 11
+_INITIAL_MEMORY: Final[str] = "1Gi"
+_MAX_GUEST_MEMORY: Final[str] = "4Gi"
+_SRIOV_CLOUD_INIT_PROFILE: Final[str] = "sriov"
+
+
+@pytest.fixture(scope="class")
+def sriov_vm_with_max_guest(
+    index_number: Generator[int],
+    namespace: Namespace,
+    sriov_network: SriovNetwork,
+) -> Generator[BaseVirtualMachine]:
+    sriov_iface_addresses = random_cidr_addresses_by_family(net_seed=_NET_SEED, host_address=_HOTPLUG_VM_HOST_ADDRESS)
+    with base_sriov_vm(
+        namespace=namespace.name,
+        name="sriov-memory-hotplug-vm",
+        sriov_network_name=sriov_network.name,
+        sriov_mac=vm_sriov_mac(mac_suffix_index=next(index_number)),
+        addresses=sriov_iface_addresses,
+        memory_guest=_INITIAL_MEMORY,
+        memory_max_guest=_MAX_GUEST_MEMORY,
+    ) as vm:
+        addresses = vm.cloud_init_network_data.ethernets[_SRIOV_CLOUD_INIT_PROFILE].addresses or []
+        run_vm(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                sriov_network.name: [str(ipaddress.ip_interface(addr).ip) for addr in addresses]
+            },
+        )
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def sriov_ref_vm(
+    index_number: Generator[int],
+    namespace: Namespace,
+    sriov_network: SriovNetwork,
+) -> Generator[BaseVirtualMachine]:
+    sriov_iface_addresses = random_cidr_addresses_by_family(net_seed=_NET_SEED, host_address=_REF_VM_HOST_ADDRESS)
+    with base_sriov_vm(
+        namespace=namespace.name,
+        name="sriov-ref-vm",
+        sriov_network_name=sriov_network.name,
+        sriov_mac=vm_sriov_mac(mac_suffix_index=next(index_number)),
+        addresses=sriov_iface_addresses,
+        memory_guest=_INITIAL_MEMORY,
+    ) as vm:
+        addresses = vm.cloud_init_network_data.ethernets[_SRIOV_CLOUD_INIT_PROFILE].addresses or []
+        run_vm(
+            vm=vm,
+            ip_addresses_by_spec_net_name={
+                sriov_network.name: [str(ipaddress.ip_interface(addr).ip) for addr in addresses]
+            },
+        )
+        yield vm

--- a/tests/network/sriov/memory_hotplug/lib_helpers.py
+++ b/tests/network/sriov/memory_hotplug/lib_helpers.py
@@ -3,25 +3,45 @@ from timeout_sampler import retry
 
 from libs.vm.vm import BaseVirtualMachine
 from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC
+from utilities.infra import is_jira_open
 
 
 def hotplug_memory_and_wait(vm: BaseVirtualMachine, memory_guest: str) -> None:
     """Hot-plug memory on a VM and wait for the guest OS to report the new amount.
 
-    Sets the new guest memory value on the VM, then polls the VMI status
-    guestCurrent field until it reaches the expected value — confirming the
-    live migration triggered by the hot-plug has completed and the guest OS
-    has received the memory.
+    Sets the new guest memory value on the VM, then polls VMI status guestCurrent.
+    While CNV-93556 is open (guestCurrent not updated after memory hotplug migration), falls
+    back to reading /proc/meminfo via console as the authoritative memory check.
 
     Args:
         vm: The virtual machine to hot-plug memory on.
         memory_guest: New guest memory value (e.g. "2Gi").
     """
     vm.set_guest_memory(memory_guest=memory_guest)
-    _wait_for_guest_memory_in_vmi_status(vm=vm, memory_guest=memory_guest)
+    if is_jira_open(jira_id="CNV-93556"):
+        _wait_for_guest_memory_in_proc_meminfo(vm=vm, memory_guest=memory_guest)
+    else:
+        _wait_for_guest_memory_in_vmi_status(vm=vm, memory_guest=memory_guest)
 
 
 @retry(wait_timeout=TIMEOUT_5MIN, sleep=TIMEOUT_5SEC)
 def _wait_for_guest_memory_in_vmi_status(vm: BaseVirtualMachine, memory_guest: str) -> bool:
     current = vm.vmi.instance.status.memory.guestCurrent
     return bool(current) and parse_quantity(str(current)) == parse_quantity(memory_guest)
+
+
+@retry(wait_timeout=TIMEOUT_5MIN, sleep=30)
+def _wait_for_guest_memory_in_proc_meminfo(vm: BaseVirtualMachine, memory_guest: str) -> bool:
+    """Read MemTotal from /proc/meminfo via VM console.
+
+    Args:
+        vm: The virtual machine to check memory on.
+        memory_guest: Expected guest memory value (e.g. "2Gi").
+    """
+    expected_kb = int(parse_quantity(memory_guest)) // 1024
+    threshold = expected_kb * 95 // 100
+    vm.console(
+        commands=[f"awk '/MemTotal/{{exit ($2<{threshold})}}' /proc/meminfo"],
+        timeout=30,
+    )
+    return True

--- a/tests/network/sriov/memory_hotplug/lib_helpers.py
+++ b/tests/network/sriov/memory_hotplug/lib_helpers.py
@@ -1,0 +1,27 @@
+from kubernetes.utils.quantity import parse_quantity
+from timeout_sampler import retry
+
+from libs.vm.vm import BaseVirtualMachine
+from utilities.constants import TIMEOUT_5MIN, TIMEOUT_5SEC
+
+
+def hotplug_memory_and_wait(vm: BaseVirtualMachine, memory_guest: str) -> None:
+    """Hot-plug memory on a VM and wait for the guest OS to report the new amount.
+
+    Sets the new guest memory value on the VM, then polls the VMI status
+    guestCurrent field until it reaches the expected value — confirming the
+    live migration triggered by the hot-plug has completed and the guest OS
+    has received the memory.
+
+    Args:
+        vm: The virtual machine to hot-plug memory on.
+        memory_guest: New guest memory value (e.g. "2Gi").
+    """
+    vm.set_guest_memory(memory_guest=memory_guest)
+    _wait_for_guest_memory_in_vmi_status(vm=vm, memory_guest=memory_guest)
+
+
+@retry(wait_timeout=TIMEOUT_5MIN, sleep=TIMEOUT_5SEC)
+def _wait_for_guest_memory_in_vmi_status(vm: BaseVirtualMachine, memory_guest: str) -> bool:
+    current = vm.vmi.instance.status.memory.guestCurrent
+    return bool(current) and parse_quantity(str(current)) == parse_quantity(memory_guest)

--- a/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
+++ b/tests/network/sriov/memory_hotplug/test_sriov_memory_hotplug.py
@@ -1,0 +1,100 @@
+"""
+SR-IOV VM memory hot-plug tests.
+
+Jira: https://redhat.atlassian.net/browse/CNV-69778 # <skip-jira-utils-check>
+"""
+
+from typing import Final
+
+import pytest
+
+from libs.net.ip import filter_link_local_addresses
+from libs.net.vmspec import lookup_iface_status
+from tests.network.libs.connectivity import poll_tcp_connectivity
+from tests.network.sriov.memory_hotplug.lib_helpers import hotplug_memory_and_wait
+from utilities.constants import TIMEOUT_2MIN
+
+HOTPLUG_MEMORY_SIZE: Final[str] = "3Gi"
+
+
+pytestmark = [pytest.mark.special_infra, pytest.mark.sriov]
+
+
+@pytest.mark.usefixtures("sriov_ref_vm")
+@pytest.mark.incremental
+class TestSriovMemoryHotplug:
+    """
+    Tests for SR-IOV VM memory hot-plug.
+
+    Preconditions:
+        - Running under-test VM with SR-IOV interface, 1Gi initial
+          memory, and 4Gi maxGuest configured
+        - Running reference VM with SR-IOV interface on the same
+          SR-IOV network
+    """
+
+    @pytest.mark.polarion("CNV-16278")
+    def test_vmi_status(
+        self,
+        sriov_vm_with_max_guest,
+        sriov_network,
+    ):
+        """
+        Test that after memory hot-plug on SR-IOV VM, the VMI status reflects the
+        new memory and the SR-IOV interface is present in the VMI status.
+
+        Preconditions:
+            - A running under-test VM with an SR-IOV interface, 1Gi initial
+              memory, and 4Gi maxGuest configured
+
+        Steps:
+            1. Hot-plug memory to 3Gi on the under-test VM
+
+        Expected:
+            - VMI status of the under-test VM shows actual guest memory
+              increased to 3Gi
+            - SR-IOV interface is present in the VMI status of the under-test
+              VM with guest-agent and domain as an info source
+        """
+        hotplug_memory_and_wait(vm=sriov_vm_with_max_guest, memory_guest=HOTPLUG_MEMORY_SIZE)
+        lookup_iface_status(
+            vm=sriov_vm_with_max_guest,
+            iface_name=sriov_network.name,
+            timeout=TIMEOUT_2MIN,
+            predicate=lambda iface: all(source in iface["infoSource"] for source in ("domain", "guest-agent")),
+        )
+
+    @pytest.mark.polarion("CNV-16279")
+    def test_connectivity(
+        self,
+        subtests,
+        sriov_vm_with_max_guest,
+        sriov_ref_vm,
+        sriov_network,
+    ):
+        """
+        Test that SR-IOV connectivity is preserved after memory hot-plug.
+
+        Preconditions:
+            - Under-test VM after memory hot-plug with SR-IOV interface present
+            - A running reference VM with an SR-IOV interface on the same
+              SR-IOV network
+
+        Steps:
+            1. Poll TCP connection from the under-test VM to the reference VM over the SR-IOV interface
+
+        Expected:
+            - TCP connectivity between the under-test VM and the reference VM
+              over the SR-IOV interface is eventually preserved after memory hotplug
+        """
+        ref_iface = lookup_iface_status(vm=sriov_ref_vm, iface_name=sriov_network.name)
+        under_test_iface = lookup_iface_status(vm=sriov_vm_with_max_guest, iface_name=sriov_network.name)
+        for server_ip in filter_link_local_addresses(ip_addresses=ref_iface.ipAddresses):
+            with subtests.test(msg=f"IPv{server_ip.version}: {server_ip}"):
+                poll_tcp_connectivity(
+                    client_vm=sriov_vm_with_max_guest,
+                    server_vm=sriov_ref_vm,
+                    server_ip=str(server_ip),
+                    client_bind_dev=under_test_iface.interfaceName,
+                    server_bind_dev=ref_iface.interfaceName,
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -755,6 +764,7 @@ dependencies = [
     { name = "pytest-jira" },
     { name = "pytest-order" },
     { name = "pytest-progress" },
+    { name = "pytest-subtests" },
     { name = "pytest-testconfig" },
     { name = "python-benedict" },
     { name = "python-dotenv" },
@@ -810,6 +820,7 @@ requires-dist = [
     { name = "pytest-jira", specifier = ">=0.3.24" },
     { name = "pytest-order", specifier = ">=1.3.0" },
     { name = "pytest-progress", specifier = ">=1.3.0" },
+    { name = "pytest-subtests", specifier = ">=0.13.1" },
     { name = "pytest-testconfig", specifier = ">=0.2.0" },
     { name = "python-benedict", specifier = ">=0.34.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
@@ -1241,6 +1252,19 @@ dependencies = [
     { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/af/285d33ac0630610eaf0bdba431ac7e3d3f8332e1c0244db360a7193c6541/pytest_progress-1.3.0.tar.gz", hash = "sha256:b2a6cd0b0cd8b50b19f56777402835e546dc8404eb7fa77ac2ace9dc719ec50e", size = 4736, upload-time = "2024-06-18T09:30:00.051Z" }
+
+[[package]]
+name = "pytest-subtests"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/d9/20097971a8d315e011e055d512fa120fd6be3bdb8f4b3aa3e3c6bf77bebc/pytest_subtests-0.15.0.tar.gz", hash = "sha256:cb495bde05551b784b8f0b8adfaa27edb4131469a27c339b80fd8d6ba33f887c", size = 18525, upload-time = "2025-10-20T16:26:18.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/64/bba465299b37448b4c1b84c7a04178399ac22d47b3dc5db1874fe55a2bd3/pytest_subtests-0.15.0-py3-none-any.whl", hash = "sha256:da2d0ce348e1f8d831d5a40d81e3aeac439fec50bd5251cbb7791402696a9493", size = 9185, upload-time = "2025-10-20T16:26:17.239Z" },
+]
 
 [[package]]
 name = "pytest-testconfig"


### PR DESCRIPTION
##### What this PR does / why we need it:
Manual cherry-pick to 4.19: net, sriov: memory hotplug tests (https://github.com/RedHatQE/openshift-virtualization-tests/pull/5349)

##### Which issue(s) this PR fixes:
Auto-cherry-pick failed due to missing helpers, wrong imports and missing subtests package

##### Special notes for reviewer:
Added workaround of the new virt [bug](https://redhat.atlassian.net/browse/CNV-93556) since we need to verify the 4.19 network [bug](https://redhat.atlassian.net/browse/CNV-69778) fix

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-89773
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
