### PR TITLE
CherryPicked: [cnv-4.19] Remove hotplug cases for arm64 as not support yet (#2336)

### DIFF
--- a/tests/virt/cluster/aaq/test_arq.py
+++ b/tests/virt/cluster/aaq/test_arq.py
@@ -200,7 +200,6 @@ class TestARQSupportCPUHotplug:
         wait_when_pod_in_gated_state(pod=hotplugged_target_pod)
 
 
-@pytest.mark.arm64
 class TestARQSupportMemoryHotplug:
     @pytest.mark.parametrize(
         "hotplugged_resource",


### PR DESCRIPTION
## Summary
- Cherry-pick of #2336 (commit c018dd11) to cnv-4.19
- Removes `@pytest.mark.arm64` from `TestARQSupportMemoryHotplug` — memory hotplug is x86_64-only, KubeVirt admission webhook rejects it on ARM64 with 422
- Fixes 2 failures in [test-pytest-cnv-4.19-virt-cluster-gating-arm64 #10](https://jenkins/job/test-pytest-cnv-4.19-virt-cluster-gating-arm64/10/testReport)

## Test plan
- [x] Already verified on main and cnv-4.20 via #2336

🤖 Generated with [Claude Code](https://claude.com/claude-code)