### PR TITLE
refactor(storage): migrate hotplug and live migration tests VM from quay to golden image

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -28,7 +28,6 @@ from utilities.storage import (
 )
 from utilities.virt import (
     VirtualMachineForTests,
-    fedora_vm_body,
     migrate_vm_and_verify,
     running_vm,
 )
@@ -122,14 +121,24 @@ def param_substring_scope_class(storage_class_name_scope_class):
 
 
 @pytest.fixture(scope="class")
-def fedora_vm_for_hotplug_scope_class(unprivileged_client, namespace, param_substring_scope_class, cpu_for_migration):
-    name = f"fedora-hotplug-{param_substring_scope_class}"
-
+def fedora_vm_for_hotplug_scope_class(
+    unprivileged_client,
+    namespace,
+    param_substring_scope_class,
+    fedora_data_source_scope_module,
+    storage_class_name_scope_class,
+    cpu_for_migration,
+):
     with VirtualMachineForTests(
-        client=unprivileged_client,
-        name=name,
+        name=f"fedora-hotplug-{param_substring_scope_class}",
         namespace=namespace.name,
-        body=fedora_vm_body(name=name),
+        client=unprivileged_client,
+        vm_instance_type_infer=True,
+        vm_preference_infer=True,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=fedora_data_source_scope_module,
+            storage_class=storage_class_name_scope_class,
+        ),
         cpu_model=cpu_for_migration,
     ) as vm:
         running_vm(vm=vm)


### PR DESCRIPTION
##### What this PR does / why we need it:

Migrates the `fedora_vm_for_hotplug_scope_class` fixture from `fedora_vm_body()` + quay.io registry to golden image DataSource,  Tests now use only on-cluster golden images, making them suitable for disconnected/self-validation runs and more stable 

No functional changes — `TestHotPlugWithPersist` and `TestHotPlugWithSerialPersist`  and other affected tests, retain the same  behavior and assertions.

##### Which issue(s) this PR fixes:

Part of CNV-88910 (split from #5597)

##### Special notes for reviewer:

This is a pure infrastructure migration — no test behavior changed,  a  4-disk conformance expansion will follow in a separate PR, that going to use this infra change 

##### jira-ticket:

CNV-88910


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated hotplug test VM setup to use explicit instance type and OS preference settings.
  * Hotplug tests now select Fedora data and storage configuration explicitly for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->