### PR TITLE
[Storage] Parametrize hotplug tests for multi-disk conformance & add persist_survives_reboot test + STD

### DIFF
--- a/tests/storage/constants.py
+++ b/tests/storage/constants.py
@@ -24,6 +24,9 @@ QUAY_FEDORA_CONTAINER_IMAGE = f"docker://{Images.Fedora.FEDORA_CONTAINER_IMAGE}"
 TEST_FILE_NAME = "test-file.txt"
 TEST_FILE_CONTENT = "test-content"
 
+NUM_HOTPLUG_DISKS = 3
+BLANK_DV_SIZE = "1Gi"
+
 STORAGE_CLASS_A = "storage_class_a"
 STORAGE_CLASS_B = "storage_class_b"
 

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -223,6 +223,20 @@ class TestHotPlugWithPersist:
 @pytest.mark.gating
 @pytest.mark.usefixtures("hotplug_volume_scope_class")
 class TestHotPlugWithSerialPersist:
+    """
+    Test hotplug volume persistence with serial identification, migration, and reboot survival.
+
+    Jira: https://issues.redhat.com/browse/CNV-88910  # <skip-jira-utils-check>
+
+    Parametrize:
+        - 1-disk [Markers: gating, sno, s390x]: one blank DV hotplugged and persisted to the VM spec
+        - 3-hotplugged [Markers: conformance, tier3]: three blank DVs hotplugged and persisted to the VM spec
+
+    Preconditions:
+        - Running Fedora VM
+        - N blank DataVolumes hotplugged to the VM with persistence enabled and a unique serial per disk
+    """
+
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-6425")
     @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
@@ -232,6 +246,19 @@ class TestHotPlugWithSerialPersist:
         blank_disk_dv_multi_storage_scope_class,
         fedora_vm_for_hotplug_scope_class,
     ):
+        """
+        Verify that persisted hotplugged disks are visible with correct serials and converted to regular disks.
+
+        Preconditions:
+            - Running Fedora VM with hotplugged disks persisted to the VM spec
+
+        Steps:
+            1. Verify all disk serials are visible inside the guest
+            2. Verify none of the volumes still carry a hotplug marker
+
+        Expected:
+            - All disk serials are visible and all hotplugged volumes are converted to regular disks
+        """
         wait_for_vm_volume_ready(
             vm=fedora_vm_for_hotplug_scope_class, volume_name=blank_disk_dv_multi_storage_scope_class.name
         )
@@ -247,10 +274,50 @@ class TestHotPlugWithSerialPersist:
         blank_disk_dv_multi_storage_scope_class: DataVolume,
         fedora_vm_for_hotplug_scope_class: VirtualMachineForTests,
     ):
+        """
+        Verify that disk serials remain visible after live migrating a VM with persisted hotplugged disks.
+
+        Preconditions:
+            - Running Fedora VM with hotplugged disks persisted to the VM spec
+            - All hotplugged DataVolumes support RWX access mode (required for live migration)
+
+        Steps:
+            1. Live migrate the VM
+            2. Verify each persisted volume is ready after migration
+            3. Verify all disk serials are visible inside the guest
+
+        Expected:
+            - All hotplugged volumes are ready and their disk serials are visible after migration
+        """
         if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
             migrate_vm_and_verify(
                 vm=fedora_vm_for_hotplug_scope_class, client=admin_client, check_ssh_connectivity=True
             )
+
+
+class TestHotPlugPersistAfterReboot:
+    """STD placeholder — implementation in the next commit."""
+
+    __test__ = False
+
+    @pytest.mark.polarion("CNV-16331")
+    def test_hotplug_volume_with_serial_and_persist_after_reboot(self):
+        """
+        Test that hotplugged persistent disks survive VM reboot.
+
+        Jira: https://issues.redhat.com/browse/CNV-92782  # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running Fedora VM with hotplugged disks persisted to VM spec
+
+        Steps:
+            1. Restart the VM and wait for it to reach Running state
+            2. Verify each hotplugged volume is ready on the VM
+            3. Verify all disk serials are visible inside the guest
+
+        Expected:
+            - All hotplugged volumes are ready and their disk serials are visible after reboot
+        """
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import shlex
+from contextlib import ExitStack
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,7 +14,8 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
 
-from tests.storage.utils import assert_disk_bus
+from tests.storage.constants import BLANK_DV_SIZE, NUM_HOTPLUG_DISKS
+from tests.storage.utils import assert_disk_bus, expected_hotplug_serials
 from tests.utils import create_windows2022_vm_with_data_volume_template
 from utilities.constants.storage import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.constants.virt import WIN_2K22
@@ -29,6 +31,7 @@ from utilities.storage import (
 from utilities.virt import (
     VirtualMachineForTests,
     migrate_vm_and_verify,
+    restart_vm_wait_for_running_vm,
     running_vm,
 )
 
@@ -156,11 +159,75 @@ def blank_disk_dv_multi_storage_scope_class(
         source="blank",
         dv_name=f"blank-dv-{param_substring_scope_class}",
         namespace=namespace.name,
-        size="1Gi",
+        size=BLANK_DV_SIZE,
         storage_class=storage_class_name_scope_class,
         consume_wffc=False,
     ) as dv:
         yield dv
+
+
+@pytest.fixture(scope="class")
+def blank_dvs_multi_storage_for_hotplug_scope_class(
+    request, unprivileged_client, namespace, param_substring_scope_class, storage_class_name_scope_class
+):
+    """Yields a list of blank DataVolumes sized for hotplug testing.
+
+    Yields:
+        list[DataVolume]: Blank DVs whose count is driven by the indirect ``request.param``.
+    """
+    with ExitStack() as stack:
+        dvs = []
+        for idx in range(request.param):
+            dv = stack.enter_context(
+                cm=create_dv(
+                    source="blank",
+                    dv_name=f"blank-dv-hotplug-{param_substring_scope_class}-{idx}",
+                    client=unprivileged_client,
+                    namespace=namespace.name,
+                    size=BLANK_DV_SIZE,
+                    storage_class=storage_class_name_scope_class,
+                    consume_wffc=False,
+                )
+            )
+            dvs.append(dv)
+        yield dvs
+
+
+@pytest.fixture(scope="class")
+def hotplugged_dvs_scope_class(
+    request, blank_dvs_multi_storage_for_hotplug_scope_class, fedora_vm_for_hotplug_scope_class
+):
+    """Hotplugs all blank DVs to the VM and waits for each volume to become ready.
+
+    Args passed via ``request.param`` (dict):
+        persist: Whether to persist the hotplugged volume to the VM spec.
+        serial: Optional serial string to assign to each hotplugged disk.
+
+    Yields:
+        list[DataVolume]: The hotplugged DVs after they become ready on the VM.
+    """
+    hotplug_opts = request.param
+    serial_base = hotplug_opts.get("serial")
+    num_dvs = len(blank_dvs_multi_storage_for_hotplug_scope_class)
+    with ExitStack() as stack:
+        for idx, dv in enumerate(blank_dvs_multi_storage_for_hotplug_scope_class):
+            disk_serial = (f"{serial_base}-{idx}" if num_dvs > 1 else serial_base) if serial_base else None
+            status, out, err = stack.enter_context(
+                cm=virtctl_volume(
+                    action="add",
+                    namespace=fedora_vm_for_hotplug_scope_class.namespace,
+                    vm_name=fedora_vm_for_hotplug_scope_class.name,
+                    volume_name=dv.name,
+                    persist=hotplug_opts.get("persist"),
+                    serial=disk_serial,
+                )
+            )
+            assert status, f"Failed to add volume {dv.name} to VM, out: {out}, err: {err}."
+            wait_for_vm_volume_ready(
+                vm=fedora_vm_for_hotplug_scope_class,
+                volume_name=dv.name,
+            )
+        yield blank_dvs_multi_storage_for_hotplug_scope_class
 
 
 @pytest.mark.parametrize(
@@ -213,15 +280,25 @@ class TestHotPlugWithPersist:
 
 
 @pytest.mark.parametrize(
-    "hotplug_volume_scope_class",
+    ("blank_dvs_multi_storage_for_hotplug_scope_class", "hotplugged_dvs_scope_class"),
     [
-        pytest.param({"persist": True, "serial": HOTPLUG_DISK_SERIAL}),
+        pytest.param(
+            1,
+            {"persist": True, "serial": HOTPLUG_DISK_SERIAL},
+            marks=[pytest.mark.gating, pytest.mark.sno, pytest.mark.s390x],
+            id="1-disk",
+        ),
+        pytest.param(
+            NUM_HOTPLUG_DISKS,
+            {"persist": True, "serial": HOTPLUG_DISK_SERIAL},
+            marks=[pytest.mark.conformance, pytest.mark.tier3],
+            id="3-hotplugged",
+        ),
     ],
     indirect=True,
+    scope="class",
 )
-@pytest.mark.conformance
-@pytest.mark.gating
-@pytest.mark.usefixtures("hotplug_volume_scope_class")
+@pytest.mark.usefixtures("hotplugged_dvs_scope_class")
 class TestHotPlugWithSerialPersist:
     """
     Test hotplug volume persistence with serial identification, migration, and reboot survival.
@@ -237,14 +314,12 @@ class TestHotPlugWithSerialPersist:
         - N blank DataVolumes hotplugged to the VM with persistence enabled and a unique serial per disk
     """
 
-    @pytest.mark.sno
     @pytest.mark.polarion("CNV-6425")
-    @pytest.mark.dependency(name="test_hotplug_volume_with_persist")
-    @pytest.mark.s390x
+    @pytest.mark.dependency(name="test_hotplug_volume_with_serial_and_persist", scope="class")
     def test_hotplug_volume_with_serial_and_persist(
         self,
-        blank_disk_dv_multi_storage_scope_class,
-        fedora_vm_for_hotplug_scope_class,
+        hotplugged_dvs_scope_class: list[DataVolume],
+        fedora_vm_for_hotplug_scope_class: VirtualMachineForTests,
     ):
         """
         Verify that persisted hotplugged disks are visible with correct serials and converted to regular disks.
@@ -259,19 +334,19 @@ class TestHotPlugWithSerialPersist:
         Expected:
             - All disk serials are visible and all hotplugged volumes are converted to regular disks
         """
-        wait_for_vm_volume_ready(
-            vm=fedora_vm_for_hotplug_scope_class, volume_name=blank_disk_dv_multi_storage_scope_class.name
+        assert_disk_serial(
+            vm=fedora_vm_for_hotplug_scope_class,
+            serials=expected_hotplug_serials(count=len(hotplugged_dvs_scope_class), serial=HOTPLUG_DISK_SERIAL),
         )
-        assert_disk_serial(vm=fedora_vm_for_hotplug_scope_class)
         assert_hotplugvolume_nonexist(vm=fedora_vm_for_hotplug_scope_class)
 
     @pytest.mark.polarion("CNV-6425b")
-    @pytest.mark.dependency(depends=["test_hotplug_volume_with_persist"])
-    @pytest.mark.s390x
+    # Depends on the base persist test: migration only makes sense once hotplug + persist is confirmed working.
+    @pytest.mark.dependency(depends=["test_hotplug_volume_with_serial_and_persist"], scope="class")
     def test_hotplug_volume_with_serial_and_persist_migrate(
         self,
         admin_client: DynamicClient,
-        blank_disk_dv_multi_storage_scope_class: DataVolume,
+        hotplugged_dvs_scope_class: list[DataVolume],
         fedora_vm_for_hotplug_scope_class: VirtualMachineForTests,
     ):
         """
@@ -289,19 +364,30 @@ class TestHotPlugWithSerialPersist:
         Expected:
             - All hotplugged volumes are ready and their disk serials are visible after migration
         """
-        if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
+        if all(is_dv_migratable(dv=dv) for dv in hotplugged_dvs_scope_class):
             migrate_vm_and_verify(
                 vm=fedora_vm_for_hotplug_scope_class, client=admin_client, check_ssh_connectivity=True
             )
-
-
-class TestHotPlugPersistAfterReboot:
-    """STD placeholder — implementation in the next commit."""
-
-    __test__ = False
+            for data_volume in hotplugged_dvs_scope_class:
+                wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class, volume_name=data_volume.name)
+            assert_disk_serial(
+                vm=fedora_vm_for_hotplug_scope_class,
+                serials=expected_hotplug_serials(count=len(hotplugged_dvs_scope_class), serial=HOTPLUG_DISK_SERIAL),
+            )
+        else:
+            LOGGER.warning(
+                f"Skipping migration for VM {fedora_vm_for_hotplug_scope_class.name}: "
+                "not all hotplugged DVs support RWX access mode"
+            )
 
     @pytest.mark.polarion("CNV-16331")
-    def test_hotplug_volume_with_serial_and_persist_after_reboot(self):
+    # Depends on the base persist test to avoid validating reboot behavior on top of a broken persistence step.
+    @pytest.mark.dependency(depends=["test_hotplug_volume_with_serial_and_persist"], scope="class")
+    def test_hotplug_volume_with_serial_and_persist_after_reboot(
+        self,
+        hotplugged_dvs_scope_class: list[DataVolume],
+        fedora_vm_for_hotplug_scope_class: VirtualMachineForTests,
+    ):
         """
         Test that hotplugged persistent disks survive VM reboot.
 
@@ -318,6 +404,13 @@ class TestHotPlugPersistAfterReboot:
         Expected:
             - All hotplugged volumes are ready and their disk serials are visible after reboot
         """
+        restart_vm_wait_for_running_vm(vm=fedora_vm_for_hotplug_scope_class, check_ssh_connectivity=True)
+        for dv in hotplugged_dvs_scope_class:
+            wait_for_vm_volume_ready(vm=fedora_vm_for_hotplug_scope_class, volume_name=dv.name)
+        assert_disk_serial(
+            vm=fedora_vm_for_hotplug_scope_class,
+            serials=expected_hotplug_serials(count=len(hotplugged_dvs_scope_class), serial=HOTPLUG_DISK_SERIAL),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -410,6 +410,24 @@ def create_windows_directory(windows_vm: VirtualMachineForTests, directory_path:
     )
 
 
+def expected_hotplug_serials(count: int, serial: str) -> list[str]:
+    """Build the expected serial list for hotplugged disks.
+
+    Single-disk uses the bare serial; multi-disk appends an index suffix to distinguish disks,
+    matching the indexed assignment done in the hotplugged_dvs_scope_class fixture.
+
+    Args:
+        count: Number of hotplugged disks.
+        serial: Base serial string.
+
+    Returns:
+        List of expected serial strings.
+    """
+    if count == 1:
+        return [serial]
+    return [f"{serial}-{idx}" for idx in range(count)]
+
+
 def assert_disk_bus(vm: VirtualMachineForTests, volume: DataVolume, expected_bus: str) -> None:
     """Assert that a hotplugged volume has the expected disk bus type.
 

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -800,18 +800,37 @@ def run_command_on_vm_and_check_output(
     )
 
 
-def assert_disk_serial(vm, command=_DEFAULT_DISK_SERIAL_COMMAND):
-    assert (
-        HOTPLUG_DISK_SERIAL
-        in run_ssh_commands(host=vm.ssh_exec, commands=command, wait_timeout=TIMEOUT_2MIN, sleep=TIMEOUT_5SEC)[0]
-    ), f"hotplug disk serial id {HOTPLUG_DISK_SERIAL} is not in VM"
+def assert_disk_serial(
+    vm: virt_util.VirtualMachineForTests,
+    serials: list[str] | None = None,
+    command: list[str] = _DEFAULT_DISK_SERIAL_COMMAND,
+) -> None:
+    """Assert that hotplug disk serial(s) are visible inside the VM.
+
+    Args:
+        vm: Virtual machine instance to inspect.
+        serials: Serial strings to verify. Defaults to [HOTPLUG_DISK_SERIAL].
+        command: Shell command whose output is searched for the serial strings.
+    """
+    if serials is None:
+        serials = [HOTPLUG_DISK_SERIAL]
+    output = run_ssh_commands(host=vm.ssh_exec, commands=command, wait_timeout=TIMEOUT_2MIN, sleep=TIMEOUT_5SEC)[0]
+    missing = [serial for serial in serials if serial not in output]
+    assert not missing, f"Disk serial(s) {missing} not found in VM, output: {output}"
 
 
-def assert_hotplugvolume_nonexist(vm):
-    volume_status = vm.vmi.instance.status.volumeStatus[0]
-    assert HOTPLUG_VOLUME not in volume_status, (
-        f"{HOTPLUG_VOLUME} in {volume_status}, hotplug disk should become a regular disk for VM"
-    )
+def assert_hotplugvolume_nonexist(vm: virt_util.VirtualMachineForTests) -> None:
+    """Assert no volume in the VM still carries a hotplugVolume marker.
+
+    After a hotplugged disk is persisted the marker must be removed from every
+    volumeStatus entry; a leftover indicates the disk was not fully converted
+    to a regular disk.
+
+    Args:
+        vm: Virtual machine instance to inspect.
+    """
+    hotplug_statuses = [status for status in vm.vmi.instance.status.volumeStatus if HOTPLUG_VOLUME in status]
+    assert not hotplug_statuses, f"Hotplug disk was not converted to a regular disk in {hotplug_statuses}"
 
 
 def wait_for_vm_volume_ready(


### PR DESCRIPTION
##### What this PR does / why we need it:

Adds multi-disk hotplug conformance coverage (cloud provider GA requirement) by parametrizing the existing `TestHotPlugWithSerialPersist` class into two variants:

| Variant | Disks | Markers |
|---|---|---|
| `1-disk` | 1 (existing behavior) | `gating`, `sno`, `s390x` |
| `3-hotplugged` | 4 total (1 root + 3 hotplugged) | `conformance`, `tier3` |

Also adds `test_hotplug_volume_with_serial_and_persist_after_reboot` (CNV-16331) to verify that persisted hotplugged disks survive a VM reboot.

The PR has two commits following the STD-first workflow: an STD placeholder first, then the implementation.

##### Which issue(s) this PR fixes:
CNV-88910, CNV-92782

##### Special notes for reviewer:

- **Two-commit structure**: commit 1 is the STD (docstrings + placeholder for the new reboot test, no implementation); commit 2 is the full implementation
- 1-disk gating behavior is unchanged — same serial, same markers
- Each hotplugged disk gets a unique indexed serial (`HOTPLUG_DISK_SERIAL-0`, `-1`, ...) so guest-side verification can identify disks individually; single-disk case uses the bare serial
- No unit tests for `assert_disk_serial` / `assert_hotplugvolume_nonexist` — `utilities/storage.py` is coverage-omitted; behavior covered by integration tests
- CNV-92782 unplug case (`removevolume --persist`) will be covered in another case followed in CNV-92782
- Verified on cluster:OCS & cloud (GCP) all 6 gating + 6 conformance tests passed ✅

##### jira-ticket:
CNV-92782