### PR TITLE
Remove redundant upstream image registry validation tests

### DIFF
--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -1,8 +1,6 @@
 import pytest
 
 from tests.install_upgrade_operators.deployment.utils import (
-    assert_cnv_deployment_container_env_image_not_in_upstream,
-    assert_cnv_deployment_container_image_not_in_upstream,
     validate_liveness_probe_fields,
     validate_request_fields,
 )
@@ -92,11 +90,3 @@ def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
         if list(filter(deployment.name.startswith, ALL_CNV_DEPLOYMENTS)) == []
     ]
     assert not new_deployment, f"New cnv deployment: {new_deployment}, has been added."
-
-
-@pytest.mark.gating
-@pytest.mark.conformance
-@pytest.mark.polarion("CNV-8264")
-def test_cnv_deployment_container_image(cnv_deployment_by_name):
-    assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)
-    assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment=cnv_deployment_by_name)

--- a/tests/install_upgrade_operators/deployment/utils.py
+++ b/tests/install_upgrade_operators/deployment/utils.py
@@ -1,10 +1,5 @@
 import re
 
-from ocp_resources.resource import Resource
-
-from tests.install_upgrade_operators.utils import (
-    get_resource_container_env_image_mismatch,
-)
 from utilities.exceptions import ResourceMismatch
 
 
@@ -80,32 +75,4 @@ def validate_request_fields(deployment, cpu_min_value):
         raise ResourceMismatch(
             f"For deployment {deployment.name} mismatch in cpu values found: {invalid_cpus}, "
             f"expected cpu values < {cpu_min_value}"
-        )
-
-
-def assert_cnv_deployment_container_image_not_in_upstream(cnv_deployment):
-    cnv_deployments_with_upstream_image_reference = {
-        container["name"]: container["image"]
-        for container in cnv_deployment.instance.spec.template.spec.containers
-        if not container["image"].startswith(Resource.ApiGroup.IMAGE_REGISTRY)
-    }
-
-    if cnv_deployments_with_upstream_image_reference:
-        raise ResourceMismatch(
-            f"For following deployments upstream image references "
-            f"found: {cnv_deployments_with_upstream_image_reference}"
-        )
-
-
-def assert_cnv_deployment_container_env_image_not_in_upstream(cnv_deployment):
-    cnv_deployments_env_with_upstream_image_reference = {}
-    for container in cnv_deployment.instance.spec.template.spec.containers:
-        resource_env_image_mismatch = get_resource_container_env_image_mismatch(container=container)
-        if resource_env_image_mismatch:
-            cnv_deployments_env_with_upstream_image_reference[container["name"]] = resource_env_image_mismatch
-
-    if cnv_deployments_env_with_upstream_image_reference:
-        raise ResourceMismatch(
-            f"For following deployments upstream image references "
-            f"found: {cnv_deployments_env_with_upstream_image_reference}"
         )

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -4,8 +4,6 @@ import pytest
 from ocp_resources.job import Job
 
 from tests.install_upgrade_operators.pod_validation.utils import (
-    assert_cnv_pod_container_env_image_not_in_upstream,
-    assert_cnv_pod_container_image_not_in_upstream,
     validate_cnv_pods_priority_class_name_exists,
     validate_cnv_pods_resource_request,
     validate_priority_class_value,
@@ -67,9 +65,3 @@ def test_pods_resource_request(
         cnv_pods=cnv_pods_by_type,
         resource=pod_resource_validation_matrix__function__,
     )
-
-
-@pytest.mark.polarion("CNV-8267")
-def test_cnv_pod_container_image(cnv_pods_by_type):
-    assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)
-    assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)

--- a/tests/install_upgrade_operators/pod_validation/utils.py
+++ b/tests/install_upgrade_operators/pod_validation/utils.py
@@ -1,13 +1,6 @@
 import logging
 import re
 
-from ocp_resources.resource import Resource
-
-from tests.install_upgrade_operators.utils import (
-    get_resource_container_env_image_mismatch,
-)
-from utilities.exceptions import ResourceMismatch
-
 VALID_PRIORITY_CLASS = [
     "openshift-user-critical",
     "system-cluster-critical",
@@ -81,38 +74,3 @@ def validate_cnv_pods_resource_request(cnv_pods, resource):
         assert not cpu_error, f"For following pods invalid cpu values found: {cpu_error}"
     else:
         raise AssertionError(f"Invalid resource: {resource}")
-
-
-def assert_cnv_pod_container_env_image_not_in_upstream(cnv_pods_by_type):
-    cnv_pods_env_with_upstream_image_reference = {}
-    for pod in cnv_pods_by_type:
-        cnv_pods_env_with_upstream_image_reference[pod.name] = {}
-        for container in pod.instance.spec.containers:
-            pod_env_image_mismatch = get_resource_container_env_image_mismatch(container=container)
-            if pod_env_image_mismatch:
-                cnv_pods_env_with_upstream_image_reference[pod.name][container["name"]] = pod_env_image_mismatch
-    validate_image_values(pod_image_dict=cnv_pods_env_with_upstream_image_reference)
-
-
-def assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type):
-    cnv_pods_with_upstream_image_reference = {
-        pod.name: {
-            container["name"]: container["image"]
-            for container in pod.instance.spec.containers
-            if not container["image"].startswith(Resource.ApiGroup.IMAGE_REGISTRY)
-        }
-        for pod in cnv_pods_by_type
-    }
-    validate_image_values(pod_image_dict=cnv_pods_with_upstream_image_reference)
-
-
-def validate_image_values(pod_image_dict):
-    cnv_pods_with_upstream_image_reference = filter_dict_remove_keys_with_empty_value(input_dictionary=pod_image_dict)
-    if cnv_pods_with_upstream_image_reference:
-        raise ResourceMismatch(
-            f"For following pods found upstream image references: {cnv_pods_with_upstream_image_reference}"
-        )
-
-
-def filter_dict_remove_keys_with_empty_value(input_dictionary):
-    return {key: value for key, value in input_dictionary.items() if value}

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -1,7 +1,6 @@
 import importlib
 import inspect
 import logging
-import re
 from typing import Any
 
 from benedict import benedict
@@ -192,19 +191,6 @@ def get_function_name(function_name):
         str: name of the function
     """
     return inspect.getsource(function_name).split("(")[0].split(" ")[-1]
-
-
-def get_resource_container_env_image_mismatch(container):
-    return [
-        env_dict
-        for env_dict in container.get("env", [])
-        if "image" in env_dict["name"].lower()
-        and env_dict.get("value")
-        and not re.match(
-            rf"NOT_AVAILABLE|{Resource.ApiGroup.IMAGE_REGISTRY}",
-            env_dict.get("value"),
-        )
-    ]
 
 
 def get_ocp_resource_module_name(related_object_kind, list_submodules):


### PR DESCRIPTION
##### What this PR does / why we need it:

Removes `test_cnv_deployment_container_image` (CNV-8264) and `test_cnv_pod_container_image` (CNV-8267) which validate that CNV container images and env vars reference `registry.redhat.io` instead of upstream registries.

These tests are now redundant because the Konflux security pipeline already performs this validation via the `Related images references are from allowed registries` check. This was confirmed by CI & Release engineering.

The immediate trigger is [CNV-93093](https://redhat.atlassian.net/browse/CNV-93093), where `test_cnv_deployment_container_image` fails in 4.23/5.0 gating because [VMER-895](https://redhat.atlassian.net/browse/VMER-895) added the `network-resources-injector` image to the HCO bundle referencing a Konflux `quay.io` path instead of `registry.redhat.io`.

**Changes:**
- Remove `test_cnv_deployment_container_image` (CNV-8264) and `test_cnv_pod_container_image` (CNV-8267)
- Remove supporting utility functions that become dead code: `assert_cnv_deployment_container_image_not_in_upstream`, `assert_cnv_deployment_container_env_image_not_in_upstream`, `assert_cnv_pod_container_image_not_in_upstream`, `assert_cnv_pod_container_env_image_not_in_upstream`, `validate_image_values`, `filter_dict_remove_keys_with_empty_value`, `get_resource_container_env_image_mismatch`
- Clean up unused imports across all affected files

**What stays:**
- `test_immutable_image_using_sha` (CNV-4751) — different concern (SHA256 digest immutability)
- All other deployment/pod validation tests (liveness probe, request params, priority class, resource requests)
- Konflux IDMS/mirror utilities used by upgrade tests

##### Which issue(s) this PR fixes:

https://redhat.atlassian.net/browse/CNV-93093

##### Special notes for reviewer:

The Konflux security pipeline check "Related images references are from allowed registries" covers the same validation these tests performed. This was confirmed by CI & Release engineering. See the [Konflux pipeline run](https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/hco-bundle-registry/pipelineruns/managed-7flv2/security) for reference.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-93093