### PR TITLE
Set DataVolume architecture on multi-arch clusters

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -36,6 +36,7 @@ import utilities.virt as virt_util
 from utilities import console
 from utilities.artifactory import get_test_artifact_server_url
 from utilities.constants import Images
+from utilities.constants.architecture import MULTIARCH
 from utilities.constants.components import HPP_POOL
 from utilities.constants.images import OS_FLAVOR_WINDOWS
 from utilities.constants.networking import POD_CONTAINER_SPEC
@@ -137,7 +138,13 @@ def construct_datavolume_source_dict(
             validate_file_exists_in_url(url=url)
         source_spec: dict[str, Any] = {"http": {"url": url}}
     elif source == "registry":
-        source_spec = {"registry": {"url": url}}
+        registry_spec: dict[str, Any] = {"url": url}
+        # For multi-arch cluster and single --cpu-arch=ARCH, explicitly set the registry platform architecture
+        # For --cpu-arch=ARCH1,ARCH2, py_config["cpu_arch"] is never set
+        cpu_arch = py_config.get("cpu_arch")
+        if cpu_arch and py_config.get("cluster_type") == MULTIARCH:
+            registry_spec["platform"] = {"architecture": cpu_arch}
+        source_spec = {"registry": registry_spec}
     elif source == "pvc":
         pvc_spec: dict[str, Any] = {"name": source_pvc_name}
         if source_pvc_namespace is not None:

--- a/utilities/unittests/test_storage.py
+++ b/utilities/unittests/test_storage.py
@@ -107,6 +107,28 @@ class TestConstructDatavolumeSourceDictRegistry:
             }
         }
 
+    @patch.dict("utilities.storage.py_config", {"cpu_arch": "arm64", "cluster_type": "multiarch"})
+    def test_registry_source_multiarch_with_cpu_arch(self):
+        result = construct_datavolume_source_dict(source="registry", url="docker://registry.example.com/image:latest")
+        assert result == {
+            "registry": {
+                "url": "docker://registry.example.com/image:latest",
+                "platform": {"architecture": "arm64"},
+            }
+        }
+
+    @patch.dict("utilities.storage.py_config", {"cpu_arch": "arm64", "cluster_type": "standard"})
+    def test_registry_source_non_multiarch_no_platform(self):
+        result = construct_datavolume_source_dict(source="registry", url="docker://registry.example.com/image:latest")
+        assert result == {"registry": {"url": "docker://registry.example.com/image:latest"}}
+        assert "platform" not in result["registry"]
+
+    @patch.dict("utilities.storage.py_config", {"cluster_type": "multiarch"})
+    def test_registry_source_multiarch_no_cpu_arch_no_platform(self):
+        result = construct_datavolume_source_dict(source="registry", url="docker://registry.example.com/image:latest")
+        assert result == {"registry": {"url": "docker://registry.example.com/image:latest"}}
+        assert "platform" not in result["registry"]
+
 
 class TestConstructDatavolumeSourceDictPvc:
     def test_pvc_source_with_namespace(self):


### PR DESCRIPTION
##### What this PR does / why we need it:
- When running with `--cpu-arch=ARCH` on a multi-arch cluster, set `DV.spec.source.registry.platform.architecture`.
- Unit tests added

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:
Jira: https://redhat.atlassian.net/browse/CNV-92234

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry-based data volume configuration for multi-architecture clusters.
  * Registry sources now respect the configured CPU architecture when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->