### PR TITLE
[IUO] Add multiarch golden image automation tests

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -1,19 +1,25 @@
 import pytest
+from ocp_resources.data_import_cron import DataImportCron
+from ocp_resources.data_source import DataSource
 from ocp_resources.image_stream import ImageStream
 from ocp_resources.pod import Pod
 from ocp_utilities.infra import get_pods_by_name_prefix
 
-from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME
+from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME, ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
+    COMMON_TEMPLATE,
     CUSTOM_TEMPLATE,
     HCO_CR_DATA_IMPORT_SCHEDULE_KEY,
     get_modifed_common_template_names,
     get_random_minutes_hours_fields_from_data_import_schedule,
     get_templates_by_type_from_hco_status,
+    get_templates_resources_names_dict,
 )
+from utilities.constants.cluster import KUBERNETES_ARCH_LABEL
 from utilities.constants.components import HCO_OPERATOR
 from utilities.constants.hco import (
     COMMON_TEMPLATES_KEY_NAME,
+    FEATURE_GATES,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
 )
 from utilities.hco import disable_common_boot_image_import_hco_spec
@@ -115,6 +121,53 @@ def ssp_spec_templates_scope_function(ssp_resource_scope_function):
 @pytest.fixture(scope="session")
 def common_templates_scope_session(hyperconverged_status_scope_session):
     return hyperconverged_status_scope_session[SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME]
+
+
+@pytest.fixture(scope="session")
+def worker_architectures(schedulable_nodes):
+    return {node.labels[KUBERNETES_ARCH_LABEL] for node in schedulable_nodes}
+
+
+@pytest.fixture(scope="class")
+def default_common_template_hco_status(hyperconverged_status_templates_scope_class):
+    return get_templates_by_type_from_hco_status(
+        hco_status_templates=hyperconverged_status_templates_scope_class, template_type=COMMON_TEMPLATE
+    )
+
+
+@pytest.fixture(scope="class")
+def default_common_templates_related_resources(
+    worker_architectures,
+    default_common_template_hco_status,
+    hyperconverged_resource_scope_class,
+):
+    """Return expected golden image resource names for the current cluster state.
+
+    When enableMultiArchBootImageImport is enabled:
+        - DataImportCrons: arch-specific only (base names are replaced)
+        - DataSources: both arch-specific and agnostic pointers
+        - ImageStreams: always base names
+    When disabled: all base names.
+    """
+    base_resources = get_templates_resources_names_dict(templates=default_common_template_hco_status)
+
+    feature_gate_enabled = hyperconverged_resource_scope_class.instance.spec.get(FEATURE_GATES, {}).get(
+        ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT, False
+    )
+
+    if not feature_gate_enabled:
+        return base_resources
+
+    result = {}
+    for kind, base_names in base_resources.items():
+        arch_names = {f"{name}-{arch}" for name in base_names for arch in worker_architectures}
+        if kind == DataImportCron.kind:
+            result[kind] = arch_names
+        elif kind == DataSource.kind:
+            result[kind] = base_names | arch_names
+        else:
+            result[kind] = base_names
+    return result
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -129,11 +129,15 @@ def workers_architectures(workers):
 
 
 @pytest.fixture(scope="class")
-def base_common_templates_related_resources(hyperconverged_status_templates_scope_class):
-    templates = get_templates_by_type_from_hco_status(
+def common_templates_from_hco_status_scope_class(hyperconverged_status_templates_scope_class):
+    return get_templates_by_type_from_hco_status(
         hco_status_templates=hyperconverged_status_templates_scope_class, template_type=COMMON_TEMPLATE
     )
-    return get_templates_resources_names_dict(templates=templates)
+
+
+@pytest.fixture(scope="class")
+def base_common_templates_related_resources(common_templates_from_hco_status_scope_class):
+    return get_templates_resources_names_dict(templates=common_templates_from_hco_status_scope_class)
 
 
 @pytest.fixture(scope="class")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -148,6 +148,9 @@ def expected_common_templates_related_resources(
 ):
     """Return expected golden image resource names for the current cluster state.
 
+    Relies on the class-level feature-gate fixture (applied via @pytest.mark.usefixtures
+    on the test class) being resolved before this fixture reads the HCO spec.
+
     When enableMultiArchBootImageImport is enabled:
         - DataImportCrons: arch-specific only (base names are replaced)
         - DataSources: both arch-specific and agnostic pointers

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -124,21 +124,22 @@ def common_templates_scope_session(hyperconverged_status_scope_session):
 
 
 @pytest.fixture(scope="session")
-def worker_architectures(schedulable_nodes):
-    return {node.labels[KUBERNETES_ARCH_LABEL] for node in schedulable_nodes}
+def workers_architectures(workers):
+    return {worker.labels[KUBERNETES_ARCH_LABEL] for worker in workers}
 
 
 @pytest.fixture(scope="class")
-def default_common_template_hco_status(hyperconverged_status_templates_scope_class):
-    return get_templates_by_type_from_hco_status(
+def base_common_templates_related_resources(hyperconverged_status_templates_scope_class):
+    templates = get_templates_by_type_from_hco_status(
         hco_status_templates=hyperconverged_status_templates_scope_class, template_type=COMMON_TEMPLATE
     )
+    return get_templates_resources_names_dict(templates=templates)
 
 
 @pytest.fixture(scope="class")
-def default_common_templates_related_resources(
-    worker_architectures,
-    default_common_template_hco_status,
+def expected_common_templates_related_resources(
+    workers_architectures,
+    base_common_templates_related_resources,
     hyperconverged_resource_scope_class,
 ):
     """Return expected golden image resource names for the current cluster state.
@@ -149,25 +150,24 @@ def default_common_templates_related_resources(
         - ImageStreams: always base names
     When disabled: all base names.
     """
-    base_resources = get_templates_resources_names_dict(templates=default_common_template_hco_status)
-
     feature_gate_enabled = hyperconverged_resource_scope_class.instance.spec.get(FEATURE_GATES, {}).get(
         ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT, False
     )
 
     if not feature_gate_enabled:
-        return base_resources
+        return base_common_templates_related_resources
 
-    result = {}
-    for kind, base_names in base_resources.items():
-        arch_names = {f"{name}-{arch}" for name in base_names for arch in worker_architectures}
+    expected_resources = {}
+    for kind, base_names in base_common_templates_related_resources.items():
+        arch_names = {f"{name}-{arch}" for name in base_names for arch in workers_architectures}
+        # only DataImportCrons are replaced, DataSources are kept as pointers
         if kind == DataImportCron.kind:
-            result[kind] = arch_names
+            expected_resources[kind] = arch_names
         elif kind == DataSource.kind:
-            result[kind] = base_names | arch_names
+            expected_resources[kind] = base_names | arch_names
         else:
-            result[kind] = base_names
-    return result
+            expected_resources[kind] = base_names
+    return expected_resources
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -162,7 +162,7 @@ def expected_common_templates_related_resources(
     )
 
     if not feature_gate_enabled:
-        return base_common_templates_related_resources
+        return {kind: set(names) for kind, names in base_common_templates_related_resources.items()}
 
     expected_resources = {}
     for kind, base_names in base_common_templates_related_resources.items():

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -10,7 +10,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     COMMON_TEMPLATE,
     CUSTOM_TEMPLATE,
     HCO_CR_DATA_IMPORT_SCHEDULE_KEY,
-    get_modifed_common_template_names,
+    get_modified_common_template_names,
     get_random_minutes_hours_fields_from_data_import_schedule,
     get_templates_by_type_from_hco_status,
     get_templates_resources_names_dict,
@@ -108,7 +108,7 @@ def default_custom_templates_scope_session(
 
 @pytest.fixture(scope="session")
 def modified_common_templates_scope_session(hyperconverged_resource_scope_session):
-    return get_modifed_common_template_names(hyperconverged=hyperconverged_resource_scope_session)
+    return get_modified_common_template_names(hyperconverged=hyperconverged_resource_scope_session)
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
@@ -1,0 +1,117 @@
+import logging
+
+import pytest
+from ocp_resources.cdi import CDI
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.network_addons_config import NetworkAddonsConfig
+from ocp_resources.ssp import SSP
+
+from tests.install_upgrade_operators.constants import ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT
+from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
+    CUSTOM_MULTIARCH_DATASOURCE_NAME,
+    get_control_plane_architecture,
+    get_no_arch_annotation_template,
+    get_unsupported_arch_template,
+)
+from utilities.constants.cluster import KUBERNETES_ARCH_LABEL
+from utilities.constants.hco import FEATURE_GATES
+from utilities.hco import (
+    ResourceEditorValidateHCOReconcile,
+    update_hco_templates_spec,
+)
+from utilities.storage import verify_boot_sources_reimported
+
+LOGGER = logging.getLogger(__name__)
+
+_MULTIARCH_MANAGED_CRS = [SSP, KubeVirt, CDI]
+
+
+@pytest.fixture(scope="class")
+def disabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperconverged_resource_scope_class):
+    with ResourceEditorValidateHCOReconcile(
+        patches={
+            hyperconverged_resource_scope_class: {"spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: False}}}
+        },
+        list_resource_reconcile=_MULTIARCH_MANAGED_CRS,
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+    verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name)
+
+
+@pytest.fixture(scope="class")
+def enabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperconverged_resource_scope_class):
+    feature_gates = hyperconverged_resource_scope_class.instance.spec.get(FEATURE_GATES, {})
+    if feature_gates.get(ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT):
+        LOGGER.warning("Multiarch feature gate is already enabled")
+        yield
+    else:
+        with ResourceEditorValidateHCOReconcile(
+            patches={
+                hyperconverged_resource_scope_class: {
+                    "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: True}}
+                }
+            },
+            list_resource_reconcile=_MULTIARCH_MANAGED_CRS,
+            wait_for_reconcile_post_update=True,
+        ):
+            yield
+        verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name)
+
+
+@pytest.fixture(scope="class")
+def control_plane_architecture(control_plane_nodes):
+    return get_control_plane_architecture(control_plane_nodes=control_plane_nodes)
+
+
+@pytest.fixture()
+def single_arch_node_placement(worker_architectures, hyperconverged_resource_scope_function):
+    single_arch = sorted(worker_architectures)[0]
+    LOGGER.info(f"Restricting workloads nodePlacement to single architecture: {single_arch}")
+    placement = {"nodePlacement": {"nodeSelector": {KUBERNETES_ARCH_LABEL: single_arch}}}
+    with ResourceEditorValidateHCOReconcile(
+        patches={hyperconverged_resource_scope_function: {"spec": {"workloads": placement}}},
+        list_resource_reconcile=[SSP, KubeVirt, CDI, NetworkAddonsConfig],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+
+
+@pytest.fixture()
+def hco_with_custom_unsupported_arch_template(
+    admin_client,
+    hco_namespace,
+    golden_images_namespace,
+    hyperconverged_resource_scope_function,
+    hyperconverged_status_templates_scope_function,
+):
+    yield from update_hco_templates_spec(
+        admin_client=admin_client,
+        hco_namespace=hco_namespace,
+        hyperconverged_resource=hyperconverged_resource_scope_function,
+        updated_template=get_unsupported_arch_template(
+            common_templates=hyperconverged_status_templates_scope_function,
+        ),
+        custom_datasource_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+        golden_images_namespace=golden_images_namespace,
+    )
+
+
+@pytest.fixture()
+def hco_with_custom_no_arch_annotation_template(
+    admin_client,
+    hco_namespace,
+    golden_images_namespace,
+    hyperconverged_resource_scope_function,
+    hyperconverged_status_templates_scope_function,
+):
+    yield from update_hco_templates_spec(
+        admin_client=admin_client,
+        hco_namespace=hco_namespace,
+        hyperconverged_resource=hyperconverged_resource_scope_function,
+        updated_template=get_no_arch_annotation_template(
+            common_templates=hyperconverged_status_templates_scope_function,
+        ),
+        custom_datasource_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+        golden_images_namespace=golden_images_namespace,
+    )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
@@ -6,7 +6,11 @@ from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.network_addons_config import NetworkAddonsConfig
 from ocp_resources.ssp import SSP
 
-from tests.install_upgrade_operators.constants import ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT
+from tests.install_upgrade_operators.constants import (
+    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
+    FG_DISABLED,
+    FG_ENABLED,
+)
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
     CUSTOM_MULTIARCH_DATASOURCE_NAME,
 )
@@ -25,7 +29,9 @@ def disabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
         patches={
-            hyperconverged_resource_scope_class: {"spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: False}}}
+            hyperconverged_resource_scope_class: {
+                "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_DISABLED}}
+            }
         },
         list_resource_reconcile=_MULTIARCH_MANAGED_CRS,
         wait_for_reconcile_post_update=True,
@@ -44,7 +50,7 @@ def enabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_c
             admin_client=admin_client,
             patches={
                 hyperconverged_resource_scope_class: {
-                    "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: True}}
+                    "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_ENABLED}}
                 }
             },
             list_resource_reconcile=_MULTIARCH_MANAGED_CRS,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
@@ -9,15 +9,10 @@ from ocp_resources.ssp import SSP
 from tests.install_upgrade_operators.constants import ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
     CUSTOM_MULTIARCH_DATASOURCE_NAME,
-    get_no_arch_annotation_template,
-    get_unsupported_arch_template,
 )
 from utilities.constants.cluster import KUBERNETES_ARCH_LABEL
 from utilities.constants.hco import FEATURE_GATES
-from utilities.hco import (
-    ResourceEditorValidateHCOReconcile,
-    update_hco_templates_spec,
-)
+from utilities.hco import ResourceEditorValidateHCOReconcile, update_hco_templates_spec
 from utilities.virt import get_hyperconverged_kubevirt
 
 LOGGER = logging.getLogger(__name__)
@@ -26,7 +21,7 @@ _MULTIARCH_MANAGED_CRS = [SSP, KubeVirt, CDI]
 
 
 @pytest.fixture(scope="class")
-def disabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperconverged_resource_scope_class):
+def disabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_class):
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
         patches={
@@ -39,7 +34,7 @@ def disabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyper
 
 
 @pytest.fixture(scope="class")
-def enabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperconverged_resource_scope_class):
+def enabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_class):
     feature_gates = hyperconverged_resource_scope_class.instance.spec.get(FEATURE_GATES, {})
     if feature_gates.get(ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT):
         LOGGER.info("Multiarch feature gate is already enabled")
@@ -60,6 +55,9 @@ def enabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperc
 
 @pytest.fixture(scope="class")
 def kubevirt_default_architecture(admin_client, hco_namespace):
+    # TODO: Migrate to HCO CR once defaultArchitecture is exposed there.
+    # Currently only available on KubeVirt CR status. See:
+    # https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4329
     return get_hyperconverged_kubevirt(
         admin_client=admin_client,
         hco_namespace=hco_namespace,
@@ -68,7 +66,7 @@ def kubevirt_default_architecture(admin_client, hco_namespace):
 
 @pytest.fixture()
 def single_arch_node_placement(admin_client, workers_architectures, hyperconverged_resource_scope_function):
-    single_arch = sorted(workers_architectures)[0]
+    single_arch = min(workers_architectures)
     LOGGER.info(f"Restricting workloads nodePlacement to single architecture: {single_arch}")
     placement = {"nodePlacement": {"nodeSelector": {KUBERNETES_ARCH_LABEL: single_arch}}}
     with ResourceEditorValidateHCOReconcile(
@@ -81,7 +79,8 @@ def single_arch_node_placement(admin_client, workers_architectures, hyperconverg
 
 
 @pytest.fixture()
-def hco_with_custom_unsupported_arch_template(
+def hco_with_custom_template(
+    request,
     admin_client,
     hco_namespace,
     golden_images_namespace,
@@ -92,29 +91,7 @@ def hco_with_custom_unsupported_arch_template(
         admin_client=admin_client,
         hco_namespace=hco_namespace,
         hyperconverged_resource=hyperconverged_resource_scope_function,
-        updated_template=get_unsupported_arch_template(
-            common_templates=hyperconverged_status_templates_scope_function,
-        ),
-        custom_datasource_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
-        golden_images_namespace=golden_images_namespace,
-    )
-
-
-@pytest.fixture()
-def hco_with_custom_no_arch_annotation_template(
-    admin_client,
-    hco_namespace,
-    golden_images_namespace,
-    hyperconverged_resource_scope_function,
-    hyperconverged_status_templates_scope_function,
-):
-    yield from update_hco_templates_spec(
-        admin_client=admin_client,
-        hco_namespace=hco_namespace,
-        hyperconverged_resource=hyperconverged_resource_scope_function,
-        updated_template=get_no_arch_annotation_template(
-            common_templates=hyperconverged_status_templates_scope_function,
-        ),
+        updated_template=request.param(common_templates=hyperconverged_status_templates_scope_function),
         custom_datasource_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
         golden_images_namespace=golden_images_namespace,
     )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
@@ -42,7 +42,7 @@ def disabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyper
 def enabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperconverged_resource_scope_class):
     feature_gates = hyperconverged_resource_scope_class.instance.spec.get(FEATURE_GATES, {})
     if feature_gates.get(ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT):
-        LOGGER.warning("Multiarch feature gate is already enabled")
+        LOGGER.info("Multiarch feature gate is already enabled")
         yield
     else:
         with ResourceEditorValidateHCOReconcile(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
@@ -13,6 +13,7 @@ from tests.install_upgrade_operators.constants import (
 )
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
     CUSTOM_MULTIARCH_DATASOURCE_NAME,
+    MULTIARCH_MANAGED_CRS,
 )
 from utilities.constants.cluster import KUBERNETES_ARCH_LABEL
 from utilities.constants.hco import FEATURE_GATES
@@ -20,8 +21,6 @@ from utilities.hco import ResourceEditorValidateHCOReconcile, update_hco_templat
 from utilities.virt import get_hyperconverged_kubevirt
 
 LOGGER = logging.getLogger(__name__)
-
-_MULTIARCH_MANAGED_CRS = [SSP, KubeVirt, CDI]
 
 
 @pytest.fixture(scope="class")
@@ -33,7 +32,7 @@ def disabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_
                 "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_DISABLED}}
             }
         },
-        list_resource_reconcile=_MULTIARCH_MANAGED_CRS,
+        list_resource_reconcile=MULTIARCH_MANAGED_CRS,
         wait_for_reconcile_post_update=True,
     ):
         yield
@@ -53,7 +52,7 @@ def enabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_c
                     "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_ENABLED}}
                 }
             },
-            list_resource_reconcile=_MULTIARCH_MANAGED_CRS,
+            list_resource_reconcile=MULTIARCH_MANAGED_CRS,
             wait_for_reconcile_post_update=True,
         ):
             yield

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
@@ -9,7 +9,6 @@ from ocp_resources.ssp import SSP
 from tests.install_upgrade_operators.constants import ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
     CUSTOM_MULTIARCH_DATASOURCE_NAME,
-    get_control_plane_architecture,
     get_no_arch_annotation_template,
     get_unsupported_arch_template,
 )
@@ -19,7 +18,7 @@ from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     update_hco_templates_spec,
 )
-from utilities.storage import verify_boot_sources_reimported
+from utilities.virt import get_hyperconverged_kubevirt
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +28,7 @@ _MULTIARCH_MANAGED_CRS = [SSP, KubeVirt, CDI]
 @pytest.fixture(scope="class")
 def disabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperconverged_resource_scope_class):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {"spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: False}}}
         },
@@ -36,7 +36,6 @@ def disabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyper
         wait_for_reconcile_post_update=True,
     ):
         yield
-    verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name)
 
 
 @pytest.fixture(scope="class")
@@ -47,6 +46,7 @@ def enabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperc
         yield
     else:
         with ResourceEditorValidateHCOReconcile(
+            admin_client=admin_client,
             patches={
                 hyperconverged_resource_scope_class: {
                     "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: True}}
@@ -56,20 +56,23 @@ def enabled_multiarch_feature_gate(admin_client, golden_images_namespace, hyperc
             wait_for_reconcile_post_update=True,
         ):
             yield
-        verify_boot_sources_reimported(admin_client=admin_client, namespace=golden_images_namespace.name)
 
 
 @pytest.fixture(scope="class")
-def control_plane_architecture(control_plane_nodes):
-    return get_control_plane_architecture(control_plane_nodes=control_plane_nodes)
+def kubevirt_default_architecture(admin_client, hco_namespace):
+    return get_hyperconverged_kubevirt(
+        admin_client=admin_client,
+        hco_namespace=hco_namespace,
+    ).instance.status.defaultArchitecture
 
 
 @pytest.fixture()
-def single_arch_node_placement(worker_architectures, hyperconverged_resource_scope_function):
-    single_arch = sorted(worker_architectures)[0]
+def single_arch_node_placement(admin_client, workers_architectures, hyperconverged_resource_scope_function):
+    single_arch = sorted(workers_architectures)[0]
     LOGGER.info(f"Restricting workloads nodePlacement to single architecture: {single_arch}")
     placement = {"nodePlacement": {"nodeSelector": {KUBERNETES_ARCH_LABEL: single_arch}}}
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {"workloads": placement}}},
         list_resource_reconcile=[SSP, KubeVirt, CDI, NetworkAddonsConfig],
         wait_for_reconcile_post_update=True,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -8,17 +8,32 @@ Preconditions:
     - Multi-architecture cluster with AMD64 and ARM64 worker nodes
     - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     - Prometheus is installed and running
-
-Markers:
-    - multiarch
-    - post_upgrade
 """
 
+import logging
+
 import pytest
+from ocp_resources.data_import_cron import DataImportCron
+from ocp_resources.data_source import DataSource
 
-pytestmark = [pytest.mark.multiarch]
+from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
+    CUSTOM_MULTIARCH_DATASOURCE_NAME,
+    CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME,
+    CUSTOM_UNSUPPORTED_ARCH_CRON_NAME,
+    KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY,
+    KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_SUPPORTED_ARCHITECTURES_QUERY,
+    KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED,
+)
+from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import verify_resource_in_ns
+from utilities.jira import is_jira_open
+from utilities.monitoring import validate_metrics_value
+
+LOGGER = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.multiarch
 
 
+@pytest.mark.usefixtures("disabled_multiarch_feature_gate")
 class TestDisabledMultiarchGoldenImagesSupport:
     """
     Tests for boot source state and misconfiguration metrics when
@@ -29,29 +44,48 @@ class TestDisabledMultiarchGoldenImagesSupport:
         - "enableMultiArchBootImageImport" feature gate disabled in HCO CR
     """
 
-    __test__ = False
-
     @pytest.mark.polarion("CNV-15977")
-    def test_only_architecture_agnostic_golden_image_resources_exist(self):
+    def test_only_architecture_agnostic_golden_image_resources_exist(
+        self,
+        admin_client,
+        golden_images_namespace,
+        worker_architectures,
+        subtests,
+    ):
         """
         Test that only architecture-agnostic golden image resources exist
         after disabling multi-architecture golden images support.
 
-        Parametrize:
-            - resource_type:
-                - DataImportCron
-                - DataSource
-
         Steps:
-            1. List resources of the parametrized type in the golden images namespace.
-            2. Verify arch-suffix resources are not present.
+            1. List DataImportCrons and DataSources in the golden images namespace.
+            2. Verify no resources have architecture suffix.
 
         Expected:
-            - No resources exist with architecture suffix.
+            - No DataImportCron or DataSource resources exist with architecture suffix.
         """
+        for resource_type in (DataImportCron, DataSource):
+            if resource_type is DataSource and is_jira_open("CNV-68996"):
+                LOGGER.warning("CNV-68996: arch-specific DataSources not cleaned up after disabling multiarch")
+                continue
+            with subtests.test(msg=resource_type.kind):
+                resources = list(resource_type.get(client=admin_client, namespace=golden_images_namespace.name))
+                arch_specific = [
+                    resource.name
+                    for resource in resources
+                    if any(resource.name.endswith(f"-{arch}") for arch in worker_architectures)
+                ]
+                assert not arch_specific, (
+                    f"Architecture-specific {resource_type.kind} resources found when multiarch is disabled: "
+                    f"{arch_specific}"
+                )
 
     @pytest.mark.polarion("CNV-15978")
-    def test_architecture_agnostic_data_sources_rollback(self):
+    def test_architecture_agnostic_data_sources_rollback(
+        self,
+        admin_client,
+        golden_images_namespace,
+        default_common_templates_related_resources,
+    ):
         """
         Test that architecture-agnostic (pointer) DataSources remain available after
         disabling multi-architecture golden images support, and pointing to a pvc/snapshot source.
@@ -63,9 +97,26 @@ class TestDisabledMultiarchGoldenImagesSupport:
         Expected:
             - Architecture-agnostic DataSources reference a pvc/snapshot source.
         """
+        verify_resource_in_ns(
+            expected_resource_names=default_common_templates_related_resources[DataSource.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=DataSource,
+            ready_condition=DataSource.Condition.READY,
+        )
+        for ds_name in default_common_templates_related_resources[DataSource.kind]:
+            data_source = DataSource(
+                name=ds_name,
+                namespace=golden_images_namespace.name,
+                client=admin_client,
+            )
+            source = data_source.instance.spec.source
+            assert source.get("pvc") or source.get("snapshot"), (
+                f"DataSource {ds_name} does not reference a pvc/snapshot source: {source}"
+            )
 
     @pytest.mark.polarion("CNV-15979")
-    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric(self):
+    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric(self, prometheus):
         """
         Test that the metric is indicating that multi-arch
         golden images support is disabled on a multiarch cluster.
@@ -76,12 +127,21 @@ class TestDisabledMultiarchGoldenImagesSupport:
         Expected:
             - Metric value is 0.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED,
+            expected_value="0",
+        )
 
+    @pytest.mark.usefixtures("single_arch_node_placement")
     @pytest.mark.polarion("CNV-15980")
-    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric_single_arch_node_placement(self):
+    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric_single_arch_node_placement(
+        self,
+        prometheus,
+    ):
         """
-        Test that the metric is indicating that multi-arch support is enabled
-        when nodePlacement restricts workloads to a single architecture.
+        Test that the metric is not emitted when nodePlacement restricts
+        workloads to a single architecture.
 
         Preconditions:
             - nodePlacement restricts workloads to a single architecture in HCO CR.
@@ -90,10 +150,16 @@ class TestDisabledMultiarchGoldenImagesSupport:
             1. Query the metric.
 
         Expected:
-            - Metric value is 1.
+            - Metric is not emitted.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED,
+            expected_value=0,
+        )
 
 
+@pytest.mark.usefixtures("enabled_multiarch_feature_gate")
 class TestEnabledMultiarchGoldenImagesSupport:
     """
     Tests for architecture-specific golden image boot sources availability
@@ -103,8 +169,21 @@ class TestEnabledMultiarchGoldenImagesSupport:
         - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     """
 
-    @pytest.mark.polarion("CNV-15981")
-    def test_architecture_specific_golden_image_resources(self):
+    @pytest.mark.parametrize(
+        "resource_type, expected_condition",
+        [
+            pytest.param(DataImportCron, DataImportCron.Condition.UP_TO_DATE, marks=pytest.mark.polarion("CNV-15981")),
+            pytest.param(DataSource, DataSource.Condition.READY, marks=pytest.mark.polarion("CNV-15982")),
+        ],
+    )
+    def test_architecture_specific_golden_image_resources(
+        self,
+        admin_client,
+        golden_images_namespace,
+        default_common_templates_related_resources,
+        resource_type,
+        expected_condition,
+    ):
         """
         Test that architecture-specific golden image resources are created
         for each common DataImportCronTemplate and each supported cluster architecture.
@@ -122,9 +201,22 @@ class TestEnabledMultiarchGoldenImagesSupport:
             - Architecture-specific golden image resources exist for each supported
               architecture matching the workers architectures and in expected condition.
         """
+        verify_resource_in_ns(
+            expected_resource_names=default_common_templates_related_resources[resource_type.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=resource_type,
+            ready_condition=expected_condition,
+        )
 
-    @pytest.mark.polarion("CNV-15982")
-    def test_architecture_agnostic_data_sources(self):
+    @pytest.mark.polarion("CNV-16020")
+    def test_architecture_agnostic_data_sources(
+        self,
+        admin_client,
+        golden_images_namespace,
+        default_common_template_hco_status,
+        control_plane_architecture,
+    ):
         """
         Test that architecture-agnostic (pointer) DataSources are referencing
         the default architecture-specific DataSource.
@@ -137,8 +229,29 @@ class TestEnabledMultiarchGoldenImagesSupport:
             - DataSources in ready condition and referencing the control-plane
               architecture-specific DataSource.
         """
+        base_ds_names = {template["spec"]["managedDataSource"] for template in default_common_template_hco_status}
+        verify_resource_in_ns(
+            expected_resource_names=base_ds_names,
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=DataSource,
+            ready_condition=DataSource.Condition.READY,
+        )
+        for ds_name in base_ds_names:
+            data_source = DataSource(
+                name=ds_name,
+                namespace=golden_images_namespace.name,
+                client=admin_client,
+            )
+            expected_arch_ds_prefix = f"{ds_name}-{control_plane_architecture}"
+            assert data_source.source.name.startswith(expected_arch_ds_prefix), (
+                f"DataSource {ds_name} does not reference a control-plane "
+                f"architecture-specific DataSource (expected prefix: {expected_arch_ds_prefix}). "
+                f"Actual source: {data_source.source.name}"
+            )
 
 
+@pytest.mark.usefixtures("enabled_multiarch_feature_gate")
 class TestMultiarchGoldenImageAnnotationMetrics:
     """
     Tests for misconfiguration metrics on golden image annotation issues
@@ -148,8 +261,12 @@ class TestMultiarchGoldenImageAnnotationMetrics:
         - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     """
 
+    @pytest.mark.usefixtures("hco_with_custom_unsupported_arch_template")
     @pytest.mark.polarion("CNV-15983")
-    def test_kubevirt_hco_dataimportcrontemplate_with_supported_architectures_metric(self):
+    def test_kubevirt_hco_dataimportcrontemplate_with_supported_architectures_metric(
+        self,
+        prometheus,
+    ):
         """
         [NEGATIVE] Test that a misconfiguration metric is reported when a golden
         image is annotated with an architecture not supported by the cluster.
@@ -164,9 +281,21 @@ class TestMultiarchGoldenImageAnnotationMetrics:
         Expected:
             - Metric value is 0.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_SUPPORTED_ARCHITECTURES_QUERY.format(
+                cron_name=CUSTOM_UNSUPPORTED_ARCH_CRON_NAME,
+                ds_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+            ),
+            expected_value="0",
+        )
 
+    @pytest.mark.usefixtures("hco_with_custom_no_arch_annotation_template")
     @pytest.mark.polarion("CNV-15984")
-    def test_kubevirt_hco_dataimportcrontemplate_with_architecture_annotation_metric(self):
+    def test_kubevirt_hco_dataimportcrontemplate_with_architecture_annotation_metric(
+        self,
+        prometheus,
+    ):
         """
         [NEGATIVE] Test that a misconfiguration metric is reported when a golden
         image lacks an architecture annotation on a multi-architecture cluster.
@@ -181,3 +310,11 @@ class TestMultiarchGoldenImageAnnotationMetrics:
         Expected:
             - Metric value is 0.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY.format(
+                cron_name=CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME,
+                ds_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+            ),
+            expected_value="0",
+        )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -201,7 +201,7 @@ class TestEnabledMultiarchGoldenImagesSupport:
 
         Expected:
             - Architecture-specific golden image resources exist for each supported
-              architecture matching the workers architectures and in expected condition.
+              architecture matching the workers architectures and in ready condition.
         """
         verify_resource_in_ns(
             expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
@@ -229,8 +229,7 @@ class TestEnabledMultiarchGoldenImagesSupport:
             2. Get Kubevirt default architecture.
 
         Expected:
-            - DataSources in ready condition and referencing the Kubevirt default
-              architecture-specific DataSource.
+            - DataSource is referencing architecture-specific DataSource matching the Kubevirt default architecture.
         """
         for ds_name in base_common_templates_related_resources[DataSource.kind]:
             with subtests.test(msg=ds_name):

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -6,7 +6,6 @@ https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
 
 Preconditions:
     - Multi-architecture cluster with AMD64 and ARM64 worker nodes
-    - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     - Prometheus is installed and running
 """
 
@@ -23,6 +22,8 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiar
     KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY,
     KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_SUPPORTED_ARCHITECTURES_QUERY,
     KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED,
+    get_no_arch_annotation_template,
+    get_unsupported_arch_template,
 )
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import verify_resource_in_ns
 from utilities.jira import is_jira_open
@@ -30,7 +31,7 @@ from utilities.monitoring import validate_metrics_value
 
 LOGGER = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.multiarch
+pytestmark = [pytest.mark.multiarch, pytest.mark.post_upgrade]
 
 
 @pytest.mark.usefixtures("disabled_multiarch_feature_gate")
@@ -45,7 +46,7 @@ class TestDisabledMultiarchGoldenImagesSupport:
     """
 
     @pytest.mark.polarion("CNV-15977")
-    def test_only_architecture_agnostic_golden_image_resources_exist(
+    def test_no_architecture_specific_golden_image_resources_exist(
         self,
         admin_client,
         golden_images_namespace,
@@ -53,7 +54,7 @@ class TestDisabledMultiarchGoldenImagesSupport:
         subtests,
     ):
         """
-        Test that only architecture-agnostic golden image resources exist
+        Test that no architecture-specific golden image resources exist
         after disabling multi-architecture golden images support.
 
         Steps:
@@ -88,7 +89,7 @@ class TestDisabledMultiarchGoldenImagesSupport:
         subtests,
     ):
         """
-        Test that architecture-agnostic (pointer) DataSources remain available after
+        Test that architecture-agnostic DataSources remain available after
         disabling multi-architecture golden images support, and pointing to a pvc/snapshot source.
 
         Steps:
@@ -201,7 +202,8 @@ class TestEnabledMultiarchGoldenImagesSupport:
 
         Expected:
             - Architecture-specific golden image resources exist for each supported
-              architecture matching the workers architectures and in ready condition.
+              architecture matching the workers architectures and in the expected condition.
+              DataSources include both architecture-agnostic pointers and arch-specific names.
         """
         verify_resource_in_ns(
             expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
@@ -256,10 +258,15 @@ class TestMultiarchGoldenImageAnnotationMetrics:
         - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     """
 
-    @pytest.mark.usefixtures("hco_with_custom_unsupported_arch_template")
+    @pytest.mark.parametrize(
+        "hco_with_custom_template",
+        [pytest.param(get_unsupported_arch_template, id="unsupported_arch")],
+        indirect=True,
+    )
     @pytest.mark.polarion("CNV-15983")
     def test_kubevirt_hco_dataimportcrontemplate_with_supported_architectures_metric(
         self,
+        hco_with_custom_template,
         prometheus,
     ):
         """
@@ -285,10 +292,15 @@ class TestMultiarchGoldenImageAnnotationMetrics:
             expected_value="0",
         )
 
-    @pytest.mark.usefixtures("hco_with_custom_no_arch_annotation_template")
+    @pytest.mark.parametrize(
+        "hco_with_custom_template",
+        [pytest.param(get_no_arch_annotation_template, id="no_arch_annotation")],
+        indirect=True,
+    )
     @pytest.mark.polarion("CNV-15984")
     def test_kubevirt_hco_dataimportcrontemplate_with_architecture_annotation_metric(
         self,
+        hco_with_custom_template,
         prometheus,
     ):
         """

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -128,7 +128,8 @@ class TestDisabledMultiarchGoldenImagesSupport:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0.
+            - Metric value is 0. This metric is the underlying signal for the
+              corresponding alert.
         """
         validate_metrics_value(
             prometheus=prometheus,
@@ -153,7 +154,8 @@ class TestDisabledMultiarchGoldenImagesSupport:
             1. Query the metric.
 
         Expected:
-            - Metric is not emitted.
+            - Metric is not emitted. This metric is the underlying signal for the
+              corresponding alert.
         """
         validate_metrics_value(
             prometheus=prometheus,
@@ -233,18 +235,28 @@ class TestEnabledMultiarchGoldenImagesSupport:
         Expected:
             - DataSource is referencing architecture-specific DataSource matching the Kubevirt default architecture.
         """
+        verify_resource_in_ns(
+            expected_resource_names=base_common_templates_related_resources[DataSource.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=DataSource,
+            ready_condition=DataSource.Condition.READY,
+        )
         for ds_name in base_common_templates_related_resources[DataSource.kind]:
+            expected_arch_ds = f"{ds_name}-{kubevirt_default_architecture}"
             with subtests.test(msg=ds_name):
                 data_source = DataSource(
                     name=ds_name,
                     namespace=golden_images_namespace.name,
                     client=admin_client,
                 )
-                expected_arch_ds_prefix = f"{ds_name}-{kubevirt_default_architecture}"
-                assert data_source.source.name.startswith(expected_arch_ds_prefix), (
+                assert (source := data_source.instance.spec.source.get("dataSource")), (
+                    f"DataSource {ds_name} does not reference an architecture-specific DataSource."
+                )
+                assert source.name == expected_arch_ds, (
                     f"DataSource {ds_name} does not reference a Kubevirt default "
-                    f"architecture-specific DataSource (expected prefix: {expected_arch_ds_prefix}). "
-                    f"Actual source: {data_source.source.name}"
+                    f"architecture-specific DataSource (expected: {expected_arch_ds}). "
+                    f"Actual source: {source.name}"
                 )
 
 
@@ -281,7 +293,8 @@ class TestMultiarchGoldenImageAnnotationMetrics:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0.
+            - Metric value is 0. This metric is the underlying signal for the
+              corresponding alert.
         """
         validate_metrics_value(
             prometheus=prometheus,
@@ -315,7 +328,8 @@ class TestMultiarchGoldenImageAnnotationMetrics:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0.
+            - Metric value is 0. This metric is the underlying signal for the
+              corresponding alert.
         """
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -9,8 +9,6 @@ Preconditions:
     - Prometheus is installed and running
 """
 
-import logging
-
 import pytest
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.data_source import DataSource
@@ -26,10 +24,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiar
     get_unsupported_arch_template,
 )
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import verify_resource_in_ns
-from utilities.jira import is_jira_open
 from utilities.monitoring import validate_metrics_value
-
-LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.multiarch, pytest.mark.post_upgrade]
 
@@ -46,39 +41,50 @@ class TestDisabledMultiarchGoldenImagesSupport:
     """
 
     @pytest.mark.polarion("CNV-15977")
+    @pytest.mark.parametrize(
+        "resource_type",
+        [
+            pytest.param(DataImportCron, id="DataImportCron"),
+            pytest.param(
+                DataSource,
+                id="DataSource",
+                marks=pytest.mark.jira("CNV-68996", run=False),
+            ),
+        ],
+    )
     def test_no_architecture_specific_golden_image_resources_exist(
         self,
         admin_client,
         golden_images_namespace,
         base_common_templates_related_resources,
-        subtests,
+        resource_type,
     ):
         """
         Test that no architecture-specific golden image resources exist
         after disabling multi-architecture golden images support.
 
+        Parametrize:
+            - resource_type:
+                - DataImportCron
+                - DataSource [Markers: jira(CNV-94361)]
+
         Steps:
-            1. List DataImportCrons and DataSources in the golden images namespace.
+            1. List parametrized resources in the golden images namespace.
             2. Verify no architecture-specific resources exist.
 
         Expected:
-            - No architecture-specific DataImportCron or DataSource resources exist.
+            - No architecture-specific resources of the parametrized type exist.
         """
-        for resource_type in (DataImportCron, DataSource):
-            if resource_type is DataSource and is_jira_open("CNV-94361"):
-                LOGGER.warning("CNV-94361: arch-specific DataSources not cleaned up after disabling multiarch")
-                continue
-            base_names = base_common_templates_related_resources[resource_type.kind]
-            with subtests.test(msg=resource_type.kind):
-                arch_specific_resources = [
-                    resource.name
-                    for resource in resource_type.get(client=admin_client, namespace=golden_images_namespace.name)
-                    if any(resource.name.startswith(f"{base_name}-") for base_name in base_names)
-                ]
-                assert not arch_specific_resources, (
-                    f"Architecture-specific {resource_type.kind} resources found when multiarch is disabled: "
-                    f"{arch_specific_resources}"
-                )
+        base_names = base_common_templates_related_resources[resource_type.kind]
+        arch_specific_resources = [
+            resource.name
+            for resource in resource_type.get(client=admin_client, namespace=golden_images_namespace.name)
+            if any(resource.name.startswith(f"{base_name}-") for base_name in base_names)
+        ]
+        assert not arch_specific_resources, (
+            f"Architecture-specific {resource_type.kind} resources found when multiarch is disabled: "
+            f"{arch_specific_resources}"
+        )
 
     @pytest.mark.polarion("CNV-15978")
     def test_architecture_agnostic_data_sources_rollback(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -90,11 +90,12 @@ class TestDisabledMultiarchGoldenImagesSupport:
     ):
         """
         Test that architecture-agnostic DataSources remain available after
-        disabling multi-architecture golden images support, and pointing to a pvc/snapshot source.
+        disabling multi-architecture golden images support, and point to a pvc/snapshot source.
 
         Steps:
             1. Get architecture-agnostic DataSources from golden images namespace.
             2. Wait for them to be in ready condition.
+            3. Check the source reference of each DataSource.
 
         Expected:
             - Architecture-agnostic DataSources reference a pvc/snapshot source.
@@ -205,7 +206,8 @@ class TestEnabledMultiarchGoldenImagesSupport:
         Expected:
             - Architecture-specific golden image resources exist for each supported
               architecture matching the workers architectures and in the expected condition.
-              DataSources include both architecture-agnostic pointers and arch-specific names.
+              For DataImportCrons, only arch-specific names are expected (base names are replaced).
+              For DataSources, both architecture-agnostic pointers and arch-specific names are expected.
         """
         verify_resource_in_ns(
             expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
@@ -282,8 +284,8 @@ class TestMultiarchGoldenImageAnnotationMetrics:
         prometheus,
     ):
         """
-        [NEGATIVE] Test that a misconfiguration metric is reported when a golden
-        image is annotated with an architecture not supported by the cluster.
+        [NEGATIVE] Test that a misconfiguration metric indicates an unsupported
+        architecture annotation on a golden image.
 
         Preconditions:
             - HCO CR is patched with a custom DataImportCronTemplate annotated
@@ -293,8 +295,8 @@ class TestMultiarchGoldenImageAnnotationMetrics:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0. This metric is the underlying signal for the
-              corresponding alert.
+            - Metric is emitted with value 0, indicating the misconfiguration is
+              detected. This metric is the underlying signal for the corresponding alert.
         """
         validate_metrics_value(
             prometheus=prometheus,
@@ -317,19 +319,19 @@ class TestMultiarchGoldenImageAnnotationMetrics:
         prometheus,
     ):
         """
-        [NEGATIVE] Test that a misconfiguration metric is reported when a golden
-        image lacks an architecture annotation on a multi-architecture cluster.
+        [NEGATIVE] Test that a misconfiguration metric indicates a missing
+        architecture annotation on a golden image.
 
         Preconditions:
-            - HCO CR is patched with a custom DataImportCronTemplate annotated without
+            - HCO CR is patched with a custom DataImportCronTemplate without
               architecture annotation.
 
         Steps:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0. This metric is the underlying signal for the
-              corresponding alert.
+            - Metric is emitted with value 0, indicating the misconfiguration is
+              detected. This metric is the underlying signal for the corresponding alert.
         """
         validate_metrics_value(
             prometheus=prometheus,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -44,37 +44,40 @@ class TestDisabledMultiarchGoldenImagesSupport:
     @pytest.mark.parametrize(
         "resource_type",
         [
-            pytest.param(DataImportCron, id="DataImportCron"),
-            pytest.param(
-                DataSource,
-                id="DataSource",
-                marks=pytest.mark.jira("CNV-68996", run=False),
-            ),
+            pytest.param(DataImportCron),
+            pytest.param(DataSource, marks=pytest.mark.jira("CNV-68996", run=False)),
         ],
     )
-    def test_no_architecture_specific_golden_image_resources_exist(
+    def test_only_base_golden_image_resources_exist(
         self,
         admin_client,
         golden_images_namespace,
         base_common_templates_related_resources,
+        expected_common_templates_related_resources,
         resource_type,
     ):
         """
-        Test that no architecture-specific golden image resources exist
+        Test that only base golden image resources exist
         after disabling multi-architecture golden images support.
 
         Parametrize:
             - resource_type:
                 - DataImportCron
-                - DataSource [Markers: jira(CNV-94361)]
+                - DataSource [Markers: jira(CNV-68996)]
 
         Steps:
-            1. List parametrized resources in the golden images namespace.
+            1. Verify expected base resources exist in the golden images namespace.
             2. Verify no architecture-specific resources exist.
 
         Expected:
-            - No architecture-specific resources of the parametrized type exist.
+            - Only base resources of the parametrized type exist.
         """
+        verify_resource_in_ns(
+            expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=resource_type,
+        )
         base_names = base_common_templates_related_resources[resource_type.kind]
         arch_specific_resources = [
             resource.name

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -49,7 +49,7 @@ class TestDisabledMultiarchGoldenImagesSupport:
         self,
         admin_client,
         golden_images_namespace,
-        worker_architectures,
+        base_common_templates_related_resources,
         subtests,
     ):
         """
@@ -58,25 +58,25 @@ class TestDisabledMultiarchGoldenImagesSupport:
 
         Steps:
             1. List DataImportCrons and DataSources in the golden images namespace.
-            2. Verify no resources have architecture suffix.
+            2. Verify no architecture-specific resources exist.
 
         Expected:
-            - No DataImportCron or DataSource resources exist with architecture suffix.
+            - No architecture-specific DataImportCron or DataSource resources exist.
         """
         for resource_type in (DataImportCron, DataSource):
-            if resource_type is DataSource and is_jira_open("CNV-68996"):
-                LOGGER.warning("CNV-68996: arch-specific DataSources not cleaned up after disabling multiarch")
+            if resource_type is DataSource and is_jira_open("CNV-94361"):
+                LOGGER.warning("CNV-94361: arch-specific DataSources not cleaned up after disabling multiarch")
                 continue
+            base_names = base_common_templates_related_resources[resource_type.kind]
             with subtests.test(msg=resource_type.kind):
-                resources = list(resource_type.get(client=admin_client, namespace=golden_images_namespace.name))
-                arch_specific = [
+                arch_specific_resources = [
                     resource.name
-                    for resource in resources
-                    if any(resource.name.endswith(f"-{arch}") for arch in worker_architectures)
+                    for resource in resource_type.get(client=admin_client, namespace=golden_images_namespace.name)
+                    if any(resource.name.startswith(f"{base_name}-") for base_name in base_names)
                 ]
-                assert not arch_specific, (
+                assert not arch_specific_resources, (
                     f"Architecture-specific {resource_type.kind} resources found when multiarch is disabled: "
-                    f"{arch_specific}"
+                    f"{arch_specific_resources}"
                 )
 
     @pytest.mark.polarion("CNV-15978")
@@ -84,7 +84,8 @@ class TestDisabledMultiarchGoldenImagesSupport:
         self,
         admin_client,
         golden_images_namespace,
-        default_common_templates_related_resources,
+        expected_common_templates_related_resources,
+        subtests,
     ):
         """
         Test that architecture-agnostic (pointer) DataSources remain available after
@@ -98,22 +99,23 @@ class TestDisabledMultiarchGoldenImagesSupport:
             - Architecture-agnostic DataSources reference a pvc/snapshot source.
         """
         verify_resource_in_ns(
-            expected_resource_names=default_common_templates_related_resources[DataSource.kind],
+            expected_resource_names=expected_common_templates_related_resources[DataSource.kind],
             namespace=golden_images_namespace.name,
             client=admin_client,
             resource_type=DataSource,
             ready_condition=DataSource.Condition.READY,
         )
-        for ds_name in default_common_templates_related_resources[DataSource.kind]:
-            data_source = DataSource(
-                name=ds_name,
-                namespace=golden_images_namespace.name,
-                client=admin_client,
-            )
-            source = data_source.instance.spec.source
-            assert source.get("pvc") or source.get("snapshot"), (
-                f"DataSource {ds_name} does not reference a pvc/snapshot source: {source}"
-            )
+        for ds_name in expected_common_templates_related_resources[DataSource.kind]:
+            with subtests.test(msg=ds_name):
+                data_source = DataSource(
+                    name=ds_name,
+                    namespace=golden_images_namespace.name,
+                    client=admin_client,
+                )
+                source = data_source.instance.spec.source
+                assert source.get("pvc") or source.get("snapshot"), (
+                    f"DataSource {ds_name} does not reference a pvc/snapshot source: {source}"
+                )
 
     @pytest.mark.polarion("CNV-15979")
     def test_kubevirt_hco_multi_arch_boot_images_enabled_metric(self, prometheus):
@@ -180,7 +182,7 @@ class TestEnabledMultiarchGoldenImagesSupport:
         self,
         admin_client,
         golden_images_namespace,
-        default_common_templates_related_resources,
+        expected_common_templates_related_resources,
         resource_type,
         expected_condition,
     ):
@@ -202,7 +204,7 @@ class TestEnabledMultiarchGoldenImagesSupport:
               architecture matching the workers architectures and in expected condition.
         """
         verify_resource_in_ns(
-            expected_resource_names=default_common_templates_related_resources[resource_type.kind],
+            expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
             namespace=golden_images_namespace.name,
             client=admin_client,
             resource_type=resource_type,
@@ -214,8 +216,9 @@ class TestEnabledMultiarchGoldenImagesSupport:
         self,
         admin_client,
         golden_images_namespace,
-        default_common_template_hco_status,
-        control_plane_architecture,
+        base_common_templates_related_resources,
+        kubevirt_default_architecture,
+        subtests,
     ):
         """
         Test that architecture-agnostic (pointer) DataSources are referencing
@@ -223,32 +226,25 @@ class TestEnabledMultiarchGoldenImagesSupport:
 
         Steps:
             1. Get architecture-agnostic DataSources from golden images namespace.
-            2. Get control-plane architecture.
+            2. Get Kubevirt default architecture.
 
         Expected:
-            - DataSources in ready condition and referencing the control-plane
+            - DataSources in ready condition and referencing the Kubevirt default
               architecture-specific DataSource.
         """
-        base_ds_names = {template["spec"]["managedDataSource"] for template in default_common_template_hco_status}
-        verify_resource_in_ns(
-            expected_resource_names=base_ds_names,
-            namespace=golden_images_namespace.name,
-            client=admin_client,
-            resource_type=DataSource,
-            ready_condition=DataSource.Condition.READY,
-        )
-        for ds_name in base_ds_names:
-            data_source = DataSource(
-                name=ds_name,
-                namespace=golden_images_namespace.name,
-                client=admin_client,
-            )
-            expected_arch_ds_prefix = f"{ds_name}-{control_plane_architecture}"
-            assert data_source.source.name.startswith(expected_arch_ds_prefix), (
-                f"DataSource {ds_name} does not reference a control-plane "
-                f"architecture-specific DataSource (expected prefix: {expected_arch_ds_prefix}). "
-                f"Actual source: {data_source.source.name}"
-            )
+        for ds_name in base_common_templates_related_resources[DataSource.kind]:
+            with subtests.test(msg=ds_name):
+                data_source = DataSource(
+                    name=ds_name,
+                    namespace=golden_images_namespace.name,
+                    client=admin_client,
+                )
+                expected_arch_ds_prefix = f"{ds_name}-{kubevirt_default_architecture}"
+                assert data_source.source.name.startswith(expected_arch_ds_prefix), (
+                    f"DataSource {ds_name} does not reference a Kubevirt default "
+                    f"architecture-specific DataSource (expected prefix: {expected_arch_ds_prefix}). "
+                    f"Actual source: {data_source.source.name}"
+                )
 
 
 @pytest.mark.usefixtures("enabled_multiarch_feature_gate")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
@@ -1,0 +1,86 @@
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+from utilities.constants.cluster import KUBERNETES_ARCH_LABEL
+
+if TYPE_CHECKING:
+    from ocp_resources.node import Node
+
+KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED = "kubevirt_hco_multi_arch_boot_images_enabled"
+MULTIARCH_DICT_ANNOTATION = "ssp.kubevirt.io/dict.architectures"
+
+CUSTOM_MULTIARCH_DATASOURCE_NAME = "custom-multiarch-datasource"
+CUSTOM_UNSUPPORTED_ARCH_CRON_NAME = "custom-unsupported-arch-cron"
+CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME = "custom-no-arch-annotation-cron"
+
+KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_SUPPORTED_ARCHITECTURES_QUERY = (
+    "kubevirt_hco_dataimportcrontemplate_with_supported_architectures"
+    "{{data_import_cron_name='{cron_name}', managed_data_source_name='{ds_name}'}}"
+)
+KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY = (
+    "kubevirt_hco_dataimportcrontemplate_with_architecture_annotation"
+    "{{data_import_cron_name='{cron_name}', managed_data_source_name='{ds_name}'}}"
+)
+
+
+def get_control_plane_architecture(control_plane_nodes: list[Node]) -> str:
+    """Return the architecture of the first control plane node.
+
+    Assumes all control plane nodes share the same architecture.
+
+    Args:
+        control_plane_nodes: List of control plane Node objects.
+
+    Returns:
+        str: Architecture label value (e.g. "amd64", "arm64").
+    """
+    return control_plane_nodes[0].labels[KUBERNETES_ARCH_LABEL]
+
+
+def get_modified_data_import_cron_template(
+    common_templates: list[dict[str, Any]],
+    name: str,
+    managed_data_source: str,
+    annotations: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Create a custom DataImportCronTemplate based on the first common template.
+
+    Args:
+        common_templates: List of common templates from HCO status.
+        name: Name for the custom template.
+        managed_data_source: DataSource name this template manages.
+        annotations: Optional annotations to merge into the template metadata.
+
+    Returns:
+        dict[str, Any]: A deep copy of the first common template with customized name,
+            managed data source, status removed, and optional annotations.
+    """
+    template = deepcopy(common_templates[0])
+    del template["status"]
+    template["metadata"]["name"] = name
+    template["spec"]["managedDataSource"] = managed_data_source
+    if annotations is not None:
+        template["metadata"].setdefault("annotations", {}).update(annotations)
+    return template
+
+
+def get_unsupported_arch_template(common_templates: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return a custom template annotated with an architecture not supported by any cluster."""
+    return get_modified_data_import_cron_template(
+        common_templates=common_templates,
+        name=CUSTOM_UNSUPPORTED_ARCH_CRON_NAME,
+        managed_data_source=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+        annotations={MULTIARCH_DICT_ANNOTATION: "arm42"},
+    )
+
+
+def get_no_arch_annotation_template(common_templates: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return a custom template with the architecture annotation removed."""
+    template = get_modified_data_import_cron_template(
+        common_templates=common_templates,
+        name=CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME,
+        managed_data_source=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+    )
+    # annotations is optional in Kubernetes metadata
+    template["metadata"].get("annotations", {}).pop(MULTIARCH_DICT_ANNOTATION, None)
+    return template

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
@@ -1,10 +1,5 @@
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
-
-from utilities.constants.cluster import KUBERNETES_ARCH_LABEL
-
-if TYPE_CHECKING:
-    from ocp_resources.node import Node
+from typing import Any
 
 KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED = "kubevirt_hco_multi_arch_boot_images_enabled"
 MULTIARCH_DICT_ANNOTATION = "ssp.kubevirt.io/dict.architectures"
@@ -21,20 +16,6 @@ KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY = (
     "kubevirt_hco_dataimportcrontemplate_with_architecture_annotation"
     "{{data_import_cron_name='{cron_name}', managed_data_source_name='{ds_name}'}}"
 )
-
-
-def get_control_plane_architecture(control_plane_nodes: list[Node]) -> str:
-    """Return the architecture of the first control plane node.
-
-    Assumes all control plane nodes share the same architecture.
-
-    Args:
-        control_plane_nodes: List of control plane Node objects.
-
-    Returns:
-        str: Architecture label value (e.g. "amd64", "arm64").
-    """
-    return control_plane_nodes[0].labels[KUBERNETES_ARCH_LABEL]
 
 
 def get_modified_data_import_cron_template(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED = "kubevirt_hco_multi_arch_boot_images_enabled"
 MULTIARCH_DICT_ANNOTATION = "ssp.kubevirt.io/dict.architectures"

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
@@ -51,7 +51,7 @@ def get_modified_data_import_cron_template(
 
 
 def get_unsupported_arch_template(common_templates: list[dict[str, Any]]) -> dict[str, Any]:
-    """Return a custom template annotated with an architecture not supported by any cluster."""
+    """Return a custom template annotated with an architecture unsupported by the cluster."""
     return get_modified_data_import_cron_template(
         common_templates=common_templates,
         name=CUSTOM_UNSUPPORTED_ARCH_CRON_NAME,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
@@ -6,8 +6,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any
 
+from ocp_resources.cdi import CDI
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.ssp import SSP
+
 KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED = "kubevirt_hco_multi_arch_boot_images_enabled"
 MULTIARCH_DICT_ANNOTATION = "ssp.kubevirt.io/dict.architectures"
+MULTIARCH_MANAGED_CRS = [SSP, KubeVirt, CDI]
 
 CUSTOM_MULTIARCH_DATASOURCE_NAME = "custom-multiarch-datasource"
 CUSTOM_UNSUPPORTED_ARCH_CRON_NAME = "custom-unsupported-arch-cron"

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -11,13 +11,10 @@ from ocp_resources.ssp import SSP
 from ocp_resources.volume_snapshot import VolumeSnapshot
 
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
-    COMMON_TEMPLATE,
-    get_templates_by_type_from_hco_status,
+    verify_resource_in_ns,
+    verify_resource_not_in_ns,
 )
-from utilities.constants.timeouts import (
-    TIMEOUT_3MIN,
-    TIMEOUT_10MIN,
-)
+from utilities.constants.timeouts import TIMEOUT_3MIN, TIMEOUT_10MIN
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     wait_for_hco_conditions,
@@ -29,42 +26,6 @@ LOGGER = logging.getLogger(__name__)
 COMMON_BOOT_IMAGE_NAMESPACE_STR = "commonBootImageNamespace"
 
 pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
-
-
-def get_templates_resources_names_dict(templates):
-    resource_dict = {}
-    for template in templates:
-        image_stream_name = template["spec"]["template"]["spec"]["source"]["registry"].get("imageStream")
-        if image_stream_name:
-            resource_dict.setdefault(ImageStream.kind, set()).add(image_stream_name)
-        resource_dict.setdefault(DataImportCron.kind, set()).add(template["metadata"]["name"])
-        resource_dict.setdefault(DataSource.kind, set()).add(template["spec"]["managedDataSource"])
-    return resource_dict
-
-
-def verify_resource_not_in_ns(resource_type, namespace, client):
-    resources = resource_type.get(client=client, namespace=namespace)
-    resources_names = {resource.name for resource in resources}
-    assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
-
-
-def verify_resource_in_ns(expected_resource_names, namespace, client, resource_type, ready_condition=None):
-    """
-    Verify that resources exist in expected_namespace and in ready status.
-    """
-    resources = list(resource_type.get(client=client, namespace=namespace))
-    resources_names = {resource.name for resource in resources}
-    missing_resources_names = expected_resource_names - resources_names
-    assert not missing_resources_names, f"Missing {resource_type.kind} in {namespace}: {missing_resources_names}"
-
-    if ready_condition:
-        LOGGER.info(f"Verify that {expected_resource_names} are in {ready_condition} condition")
-        for resource in resources:
-            resource.wait_for_condition(
-                condition=ready_condition,
-                status=resource.Condition.Status.TRUE,
-                timeout=TIMEOUT_10MIN,
-            )
 
 
 def verify_common_template_namespace_updated(common_templates, namespace_name):
@@ -81,18 +42,6 @@ def verify_common_template_namespace_updated(common_templates, namespace_name):
 @pytest.fixture(scope="module")
 def custom_golden_images_namespace(admin_client):
     yield from create_ns(admin_client=admin_client, name="custom-golden-images-namespace")
-
-
-@pytest.fixture(scope="class")
-def default_common_template_hco_status(hyperconverged_status_templates_scope_class):
-    return get_templates_by_type_from_hco_status(
-        hco_status_templates=hyperconverged_status_templates_scope_class, template_type=COMMON_TEMPLATE
-    )
-
-
-@pytest.fixture(scope="class")
-def default_common_templates_related_resources(default_common_template_hco_status):
-    return get_templates_resources_names_dict(templates=default_common_template_hco_status)
 
 
 @pytest.fixture(scope="class")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -14,6 +14,7 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     verify_resource_in_ns,
     verify_resource_not_in_ns,
 )
+from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_3MIN, TIMEOUT_10MIN
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
@@ -120,7 +121,18 @@ class TestDefaultCommonTemplates:
         [
             pytest.param(ImageStream, None, marks=pytest.mark.polarion("CNV-11474")),
             pytest.param(DataImportCron, "UpToDate", marks=pytest.mark.polarion("CNV-11475")),
-            pytest.param(DataSource, DataSource.Condition.READY, marks=pytest.mark.polarion("CNV-11476")),
+            pytest.param(
+                DataSource,
+                DataSource.Condition.READY,
+                marks=(
+                    pytest.mark.polarion("CNV-11476"),
+                    pytest.mark.xfail(
+                        reason=f"{QUARANTINED}: Base-name pointer DataSources not created in custom namespace "
+                        f"on multiarch clusters; tracked in CNV-86247",
+                        run=False,
+                    ),
+                ),
+            ),
         ],
     )
     def test_resources_in_custom_ns(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -16,7 +16,6 @@ from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils i
     verify_resource_not_in_ns,
 )
 from utilities.constants.architecture import MULTIARCH
-from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_3MIN, TIMEOUT_10MIN
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
@@ -128,12 +127,7 @@ class TestDefaultCommonTemplates:
                 DataSource.Condition.READY,
                 marks=(
                     pytest.mark.polarion("CNV-11476"),
-                    pytest.mark.xfail(
-                        condition=py_config["cluster_type"] == MULTIARCH,
-                        reason=f"{QUARANTINED}: Base-name pointer DataSources not created in custom namespace "
-                        f"on multiarch clusters; tracked in CNV-94361",
-                        run=False,
-                    ),
+                    *((pytest.mark.jira("CNV-94362", run=False),) if py_config["cluster_type"] == MULTIARCH else ()),
                 ),
             ),
         ],

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -9,11 +9,13 @@ from ocp_resources.image_stream import ImageStream
 from ocp_resources.resource import Resource
 from ocp_resources.ssp import SSP
 from ocp_resources.volume_snapshot import VolumeSnapshot
+from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
     verify_resource_in_ns,
     verify_resource_not_in_ns,
 )
+from utilities.constants.architecture import MULTIARCH
 from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_3MIN, TIMEOUT_10MIN
 from utilities.hco import (
@@ -101,7 +103,7 @@ class TestDefaultCommonTemplates:
     @pytest.mark.parametrize(
         "common_templates",
         [
-            pytest.param("default_common_template_hco_status", marks=pytest.mark.polarion("CNV-11473")),
+            pytest.param("hyperconverged_status_templates_scope_function", marks=pytest.mark.polarion("CNV-11473")),
             pytest.param("ssp_spec_templates_scope_function", marks=pytest.mark.polarion("CNV-11677")),
         ],
     )
@@ -127,8 +129,9 @@ class TestDefaultCommonTemplates:
                 marks=(
                     pytest.mark.polarion("CNV-11476"),
                     pytest.mark.xfail(
+                        condition=py_config["cluster_type"] == MULTIARCH,
                         reason=f"{QUARANTINED}: Base-name pointer DataSources not created in custom namespace "
-                        f"on multiarch clusters; tracked in CNV-86247",
+                        f"on multiarch clusters; tracked in CNV-94361",
                         run=False,
                     ),
                 ),
@@ -139,12 +142,12 @@ class TestDefaultCommonTemplates:
         self,
         admin_client,
         custom_golden_images_namespace,
-        default_common_templates_related_resources,
+        expected_common_templates_related_resources,
         resource_type,
         ready_condition,
     ):
         verify_resource_in_ns(
-            expected_resource_names=default_common_templates_related_resources[resource_type.kind],
+            expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
             namespace=custom_golden_images_namespace.name,
             client=admin_client,
             resource_type=resource_type,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -12,6 +12,7 @@ from ocp_resources.volume_snapshot import VolumeSnapshot
 from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
+    verify_common_template_namespace_updated,
     verify_resource_in_ns,
     verify_resource_not_in_ns,
 )
@@ -28,17 +29,6 @@ LOGGER = logging.getLogger(__name__)
 COMMON_BOOT_IMAGE_NAMESPACE_STR = "commonBootImageNamespace"
 
 pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
-
-
-def verify_common_template_namespace_updated(common_templates, namespace_name):
-    non_updated_templates = []
-    for template in common_templates:
-        if template["metadata"].get("namespace") != namespace_name:
-            non_updated_templates.append(
-                f"{template['metadata']['name']} expected namespace: {namespace_name} "
-                f"actual: {template['metadata'].get('namespace')}\n"
-            )
-    assert not non_updated_templates, non_updated_templates
 
 
 @pytest.fixture(scope="module")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -103,7 +103,7 @@ class TestDefaultCommonTemplates:
     @pytest.mark.parametrize(
         "common_templates",
         [
-            pytest.param("hyperconverged_status_templates_scope_function", marks=pytest.mark.polarion("CNV-11473")),
+            pytest.param("common_templates_from_hco_status_scope_class", marks=pytest.mark.polarion("CNV-11473")),
             pytest.param("ssp_spec_templates_scope_function", marks=pytest.mark.polarion("CNV-11677")),
         ],
     )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -122,7 +122,7 @@ class TestDefaultCommonTemplates:
         "resource_type, ready_condition",
         [
             pytest.param(ImageStream, None, marks=pytest.mark.polarion("CNV-11474")),
-            pytest.param(DataImportCron, "UpToDate", marks=pytest.mark.polarion("CNV-11475")),
+            pytest.param(DataImportCron, DataImportCron.Condition.UP_TO_DATE, marks=pytest.mark.polarion("CNV-11475")),
             pytest.param(
                 DataSource,
                 DataSource.Condition.READY,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -10,7 +10,7 @@ from ocp_resources.ssp import SSP
 
 from tests.install_upgrade_operators.constants import KEY_PATH_SEPARATOR
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
-    get_data_import_cron_by_name,
+    get_data_import_crons_by_prefix,
     get_modifed_common_template_names,
     get_template_dict_by_name,
 )
@@ -212,19 +212,23 @@ class TestModifyCommonTemplateSpec:
             if ssp_error:
                 errors.append(f"Mismatch for template in ssp.spec: {template_name}: {''.join(ssp_error)}.\n")
 
-            data_import_cron_error = validate_template_change(
-                template_dict=benedict(
-                    get_data_import_cron_by_name(
-                        cron_name=template_name, namespace=golden_images_namespace.name, admin_client=admin_client
-                    ).instance.to_dict(),
-                    keypath_separator=KEY_PATH_SEPARATOR,
-                ),
-                expected_dict=expected_value,
-            )
-            if data_import_cron_error:
-                errors.append(
-                    f"Mismatch for template: {template_name} in dataimportcron.spec: {''.join(data_import_cron_error)}."
+            for data_import_cron in get_data_import_crons_by_prefix(
+                cron_prefix=template_name,
+                namespace=golden_images_namespace.name,
+                admin_client=admin_client,
+            ):
+                data_import_cron_error = validate_template_change(
+                    template_dict=benedict(
+                        data_import_cron.instance.to_dict(),
+                        keypath_separator=KEY_PATH_SEPARATOR,
+                    ),
+                    expected_dict=expected_value,
                 )
+                if data_import_cron_error:
+                    errors.append(
+                        f"Mismatch for {data_import_cron.name} in dataimportcron.spec: "
+                        f"{''.join(data_import_cron_error)}."
+                    )
         assert not errors, "".join(errors)
 
 
@@ -293,8 +297,10 @@ class TestCommonTemplatesEnableDisable:
                 )
 
             with pytest.raises(ResourceNotFoundError):
-                get_data_import_cron_by_name(
-                    cron_name=template_name, namespace=golden_images_namespace.name, admin_client=admin_client
+                get_data_import_crons_by_prefix(
+                    cron_prefix=template_name,
+                    namespace=golden_images_namespace.name,
+                    admin_client=admin_client,
                 )
         assert not errors, (
             f"Enabling/Disabling common templates via HCO failed with following reasons: {' '.join(errors)}"

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -11,7 +11,7 @@ from ocp_resources.ssp import SSP
 from tests.install_upgrade_operators.constants import KEY_PATH_SEPARATOR
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
     get_data_import_crons_by_prefix,
-    get_modifed_common_template_names,
+    get_modified_common_template_names,
     get_template_dict_by_name,
 )
 from utilities.constants.hco import (
@@ -112,7 +112,9 @@ def updated_common_template(
     ):
         yield updated_templates
 
-    modified_common_templates = get_modifed_common_template_names(hyperconverged=hyperconverged_resource_scope_function)
+    modified_common_templates = get_modified_common_template_names(
+        hyperconverged=hyperconverged_resource_scope_function
+    )
     assert not modified_common_templates, f"Following templates were not reverted back: {modified_common_templates}"
 
 

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -1,9 +1,13 @@
 import logging
 import re
+from typing import Any
 
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.data_import_cron import DataImportCron
+from ocp_resources.data_source import DataSource
+from ocp_resources.image_stream import ImageStream
+from ocp_resources.resource import Resource
 
 from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME
 from utilities.constants.hco import SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME
@@ -11,6 +15,7 @@ from utilities.constants.storage import (
     OUTDATED,
     WILDCARD_CRON_EXPRESSION,
 )
+from utilities.constants.timeouts import TIMEOUT_10MIN
 
 HCO_CR_DATA_IMPORT_SCHEDULE_KEY = "dataImportSchedule"
 RE_NAMED_GROUP_MINUTES = "minutes"
@@ -104,3 +109,51 @@ def get_template_dict_by_name(template_name, templates):
     for template in templates:
         if template["metadata"]["name"] == template_name:
             return template
+
+
+def get_templates_resources_names_dict(templates: list[dict[str, Any]]) -> dict[str, set[str]]:
+    """Extract resource names from HCO DataImportCronTemplates, grouped by kind.
+
+    Returns:
+        dict[str, set[str]]: Mapping of resource kind to set of names.
+            Keys: DataImportCron.kind and DataSource.kind are always present;
+                  ImageStream.kind is present only when templates contain an image stream.
+    """
+    resource_dict: dict[str, set[str]] = {}
+    for template in templates:
+        image_stream_name = template["spec"]["template"]["spec"]["source"]["registry"].get("imageStream")
+        if image_stream_name:
+            resource_dict.setdefault(ImageStream.kind, set()).add(image_stream_name)
+        resource_dict.setdefault(DataImportCron.kind, set()).add(template["metadata"]["name"])
+        resource_dict.setdefault(DataSource.kind, set()).add(template["spec"]["managedDataSource"])
+    return resource_dict
+
+
+def verify_resource_not_in_ns(resource_type: type[Resource], namespace: str, client: DynamicClient) -> None:
+    resources = resource_type.get(client=client, namespace=namespace)
+    resources_names = {resource.name for resource in resources}
+    assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
+
+
+def verify_resource_in_ns(
+    expected_resource_names: set[str],
+    namespace: str,
+    client: DynamicClient,
+    resource_type: type[Resource],
+    ready_condition: str | None = None,
+) -> None:
+    """Verify that resources exist in namespace and optionally in ready condition."""
+    resources = list(resource_type.get(client=client, namespace=namespace))
+    resources_names = {resource.name for resource in resources}
+    missing_resources_names = expected_resource_names - resources_names
+    assert not missing_resources_names, f"Missing {resource_type.kind} in {namespace}: {missing_resources_names}"
+
+    if ready_condition:
+        LOGGER.info(f"Verify that {expected_resource_names} are in {ready_condition} condition")
+        for resource in resources:
+            if resource.name in expected_resource_names:
+                resource.wait_for_condition(
+                    condition=ready_condition,
+                    status=resource.Condition.Status.TRUE,
+                    timeout=TIMEOUT_10MIN,
+                )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -98,11 +98,35 @@ def get_templates_by_type_from_hco_status(hco_status_templates, template_type=CO
     ]
 
 
-def get_data_import_cron_by_name(namespace: str, cron_name: str, admin_client: DynamicClient) -> DataImportCron:
-    data_import_cron = DataImportCron(name=cron_name, namespace=namespace, client=admin_client)
-    if data_import_cron.exists:
-        return data_import_cron
-    raise ResourceNotFoundError(f"DataImportCron: {data_import_cron} not found in namespace: {namespace}")
+def get_data_import_crons_by_prefix(
+    namespace: str,
+    cron_prefix: str,
+    admin_client: DynamicClient,
+) -> list[DataImportCron]:
+    """Return all DataImportCrons matching a template base name prefix.
+
+    Matches exact name or name with architecture suffix (e.g. prefix "fedora"
+    matches "fedora", "fedora-amd64", "fedora-arm64").
+
+    Args:
+        namespace: Namespace to search in.
+        cron_prefix: HCO template base name to match against.
+        admin_client: Kubernetes client.
+
+    Returns:
+        List of matching DataImportCron resources.
+
+    Raises:
+        ResourceNotFoundError: If no matching DataImportCrons are found.
+    """
+    matching = [
+        dic
+        for dic in DataImportCron.get(client=admin_client, namespace=namespace)
+        if dic.name == cron_prefix or dic.name.startswith(f"{cron_prefix}-")
+    ]
+    if not matching:
+        raise ResourceNotFoundError(f"No DataImportCron with prefix '{cron_prefix}' found in namespace: {namespace}")
+    return matching
 
 
 def get_template_dict_by_name(template_name, templates):

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -120,9 +120,9 @@ def get_data_import_crons_by_prefix(
         ResourceNotFoundError: If no matching DataImportCrons are found.
     """
     matching = [
-        dic
-        for dic in DataImportCron.get(client=admin_client, namespace=namespace)
-        if dic.name == cron_prefix or dic.name.startswith(f"{cron_prefix}-")
+        data_import_cron
+        for data_import_cron in DataImportCron.get(client=admin_client, namespace=namespace)
+        if data_import_cron.name == cron_prefix or data_import_cron.name.startswith(f"{cron_prefix}-")
     ]
     if not matching:
         raise ResourceNotFoundError(f"No DataImportCron with prefix '{cron_prefix}' found in namespace: {namespace}")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -154,6 +154,16 @@ def get_templates_resources_names_dict(templates: list[dict[str, Any]]) -> dict[
 
 
 def verify_resource_not_in_ns(resource_type: type[Resource], namespace: str, client: DynamicClient) -> None:
+    """Assert that no resources of the given type exist in the namespace.
+
+    Args:
+        resource_type: OCP resource class to query.
+        namespace: Namespace to check.
+        client: OpenShift client.
+
+    Raises:
+        AssertionError: If any resources of the given type exist.
+    """
     resources = resource_type.get(client=client, namespace=namespace)
     resources_names = {resource.name for resource in resources}
     assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
@@ -166,7 +176,20 @@ def verify_resource_in_ns(
     resource_type: type[Resource],
     ready_condition: str | None = None,
 ) -> None:
-    """Verify that resources exist in namespace and optionally in ready condition."""
+    """Assert that expected resources exist in the namespace and optionally wait for readiness.
+
+    Args:
+        expected_resource_names: Set of resource names that must be present.
+        namespace: Namespace to check.
+        client: OpenShift client.
+        resource_type: OCP resource class to query.
+        ready_condition: If provided, waits up to 10 minutes for each expected
+            resource to reach this condition with status True.
+
+    Raises:
+        AssertionError: If any expected resources are missing.
+        TimeoutExpiredError: If a resource does not reach the ready condition in time.
+    """
     resources = list(resource_type.get(client=client, namespace=namespace))
     resources_names = {resource.name for resource in resources}
     missing_resources_names = expected_resource_names - resources_names

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -178,6 +178,10 @@ def verify_resource_in_ns(
 ) -> None:
     """Assert that expected resources exist in the namespace and optionally wait for readiness.
 
+    DataSources use a subset check (expected ⊆ actual) because they retain
+    architecture-agnostic pointers alongside arch-specific entries.
+    All other resource types use an exact-match check (expected == actual).
+
     Args:
         expected_resource_names: Set of resource names that must be present.
         namespace: Namespace to check.
@@ -187,13 +191,18 @@ def verify_resource_in_ns(
             resource to reach this condition with status True.
 
     Raises:
-        AssertionError: If any expected resources are missing.
+        AssertionError: If any expected resources are missing, or if unexpected
+            resources exist (for non-DataSource types).
         TimeoutExpiredError: If a resource does not reach the ready condition in time.
     """
     resources = list(resource_type.get(client=client, namespace=namespace))
     resources_names = {resource.name for resource in resources}
     missing_resources_names = expected_resource_names - resources_names
     assert not missing_resources_names, f"Missing {resource_type.kind} in {namespace}: {missing_resources_names}"
+
+    if resource_type is not DataSource:
+        extra_resources_names = resources_names - expected_resource_names
+        assert not extra_resources_names, f"Unexpected {resource_type.kind} in {namespace}: {extra_resources_names}"
 
     if ready_condition:
         LOGGER.info(f"Verify that {expected_resource_names} are in {ready_condition} condition")

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -79,7 +79,7 @@ def get_random_minutes_hours_fields_from_data_import_schedule(target_string):
     return re_result.group(RE_NAMED_GROUP_MINUTES), re_result.group(RE_NAMED_GROUP_HOURS)
 
 
-def get_modifed_common_template_names(hyperconverged):
+def get_modified_common_template_names(hyperconverged):
     return [
         template["metadata"]["name"]
         for template in get_templates_by_type_from_hco_status(
@@ -129,10 +129,31 @@ def get_data_import_crons_by_prefix(
     return matching
 
 
-def get_template_dict_by_name(template_name, templates):
+def verify_common_template_namespace_updated(common_templates: list[dict[str, Any]], namespace_name: str) -> None:
+    """Assert that all templates have the expected namespace in their metadata.
+
+    Args:
+        common_templates: List of common templates from HCO status.
+        namespace_name: Expected namespace name.
+
+    Raises:
+        AssertionError: If any template has a different namespace.
+    """
+    non_updated_templates = []
+    for template in common_templates:
+        if template["metadata"].get("namespace") != namespace_name:
+            non_updated_templates.append(
+                f"{template['metadata']['name']} expected namespace: {namespace_name} "
+                f"actual: {template['metadata'].get('namespace')}\n"
+            )
+    assert not non_updated_templates, non_updated_templates
+
+
+def get_template_dict_by_name(template_name: str, templates: list[dict[str, Any]]) -> dict[str, Any] | None:
     for template in templates:
         if template["metadata"]["name"] == template_name:
             return template
+    return None
 
 
 def get_templates_resources_names_dict(templates: list[dict[str, Any]]) -> dict[str, set[str]]:

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -550,16 +550,9 @@ def update_hco_templates_spec(
     custom_datasource_name=None,
     golden_images_namespace=None,
 ):
-    existing_spec_templates = list(
-        hyperconverged_resource.instance.to_dict()["spec"].get(SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME, [])
-    )
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
-        patches={
-            hyperconverged_resource: {
-                "spec": {SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME: existing_spec_templates + [updated_template]}
-            }
-        },
+        patches={hyperconverged_resource: {"spec": {SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME: [updated_template]}}},
         list_resource_reconcile=[SSP, CDI],
         wait_for_reconcile_post_update=True,
     ):

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -550,9 +550,16 @@ def update_hco_templates_spec(
     custom_datasource_name=None,
     golden_images_namespace=None,
 ):
+    existing_spec_templates = list(
+        hyperconverged_resource.instance.to_dict()["spec"].get(SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME, [])
+    )
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
-        patches={hyperconverged_resource: {"spec": {SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME: [updated_template]}}},
+        patches={
+            hyperconverged_resource: {
+                "spec": {SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME: existing_spec_templates + [updated_template]}
+            }
+        },
         list_resource_reconcile=[SSP, CDI],
         wait_for_reconcile_post_update=True,
     ):


### PR DESCRIPTION
##### What this PR does / why we need it:

  Adds automated tests for multi-architecture golden image boot source support (multiarch feature gate).

  **New tests (tests/.../multiarch/):**
  - CNV-15977: Verify only architecture-agnostic resources exist when multiarch is disabled
  - CNV-15978: Verify DataSource rollback to pvc/snapshot sources after disabling multiarch
  - CNV-15979, CNV-15980: Verify `kubevirt_hco_multi_arch_boot_images_enabled` metric (disabled, single-arch placement)
  - CNV-15981, CNV-15982: Verify arch-specific DataImportCrons (UpToDate) and DataSources (Ready) when enabled
  - CNV-16020: Verify agnostic DataSources point to the default architecture-specific DataSource
  - CNV-15983, CNV-15984: [NEGATIVE] Verify misconfiguration metrics for unsupported/missing arch annotations

  **Shared fixture/utility changes:**
  - Added `expected_common_templates_related_resources` fixture that dynamically computes expected resource names based on multiarch feature gate state
  - Added `base_common_templates_related_resources` fixture for base (agnostic) template resource names
  - Promoted `verify_resource_not_in_ns` and `verify_resource_in_ns` to shared utils for reuse across custom-namespace tests
  - Added `workers_architectures` session fixture

  **Existing test adaptations:**
  - `test_custom_golden_images_namespace.py`: Adapted `test_resources_in_custom_ns` to use dynamic expected resources; added conditional xfail for CNV-94361 (base-name DataSources missing
  in custom namespace on multiarch clusters)
  - `test_modify_common_templates.py`: Adapted DataImportCron lookup to match arch-suffixed names via `get_data_import_crons_by_prefix`

  ##### Which issue(s) this PR fixes:
CNV-78181
  ##### Special notes for reviewer:
  - CNV-94361 quarantine uses conditional `xfail` (not `jira` marker) because it only affects multiarch clusters — `pytest.mark.jira` doesn't support a `condition` parameter
  - `kubevirt_default_architecture` reads from KubeVirt CR status (not HCO) because HCO sets this field on the KubeVirt CR during reconciliation, it is not exposed on the HCO CR itself
  (ref: https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4329)

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-78181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded upgrade validation for multi-architecture golden-image workflows.
  * Added coverage for enabling and disabling architecture-specific image imports, resource readiness, cleanup, and rollback behavior.
  * Improved validation of custom templates, unsupported architectures, missing architecture metadata, and single-architecture worker placement.
  * Enhanced checks for multiple matching image-import resources, default architecture handling, and monitoring metrics.
  * Consolidated resource verification and template validation across related golden-image tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->