### PR TITLE
fix: resolve Version Explorer URL for --upgrade_custom runs

### DIFF
--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -416,7 +416,12 @@ def get_artifactory_server_url(cluster_host_url, session):
 
 
 def get_cnv_version_explorer_url(pytest_config):
-    if pytest_config.getoption("install") or pytest_config.getoption("upgrade") in ("eus", "cnv"):
+    needs_url = (
+        pytest_config.getoption("install")
+        or pytest_config.getoption("upgrade") in ("eus", "cnv")
+        or pytest_config.getoption("upgrade_custom") in ("cnv", "ocp")
+    )
+    if needs_url:
         LOGGER.info("Checking for cnv version explorer url:")
         version_explorer_url = os.environ.get("CNV_VERSION_EXPLORER_URL")
         if not version_explorer_url:

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -1264,11 +1264,45 @@ class TestGetCnvVersionExplorerUrl:
     def test_get_cnv_version_explorer_url_no_relevant_flags(self):
         """Test no action when no relevant flags are set"""
         mock_config = MagicMock()
-        mock_config.getoption.side_effect = lambda option: {"install": False, "upgrade": "regular"}.get(option, False)
+        mock_config.getoption.side_effect = lambda option: {
+            "install": False,
+            "upgrade": None,
+            "upgrade_custom": None,
+        }.get(option)
 
         result = get_cnv_version_explorer_url(mock_config)
 
         assert result is None
+
+    @patch("utilities.pytest_utils.os.environ", {"CNV_VERSION_EXPLORER_URL": "https://version-explorer.com"})
+    @patch("utilities.pytest_utils.LOGGER")
+    def test_get_cnv_version_explorer_url_upgrade_custom_cnv(self, mock_logger):
+        """Test getting CNV version explorer URL with --upgrade_custom=cnv"""
+        mock_config = MagicMock()
+        mock_config.getoption.side_effect = lambda option: {
+            "install": False,
+            "upgrade": None,
+            "upgrade_custom": "cnv",
+        }.get(option)
+
+        result = get_cnv_version_explorer_url(mock_config)
+
+        assert result == "https://version-explorer.com"
+
+    @patch("utilities.pytest_utils.os.environ", {"CNV_VERSION_EXPLORER_URL": "https://version-explorer.com"})
+    @patch("utilities.pytest_utils.LOGGER")
+    def test_get_cnv_version_explorer_url_upgrade_custom_ocp(self, mock_logger):
+        """Test getting CNV version explorer URL with --upgrade_custom=ocp"""
+        mock_config = MagicMock()
+        mock_config.getoption.side_effect = lambda option: {
+            "install": False,
+            "upgrade": None,
+            "upgrade_custom": "ocp",
+        }.get(option)
+
+        result = get_cnv_version_explorer_url(mock_config)
+
+        assert result == "https://version-explorer.com"
 
 
 class TestGetTestsClusterMarkers:


### PR DESCRIPTION
##### What this PR does / why we need it:
`get_cnv_version_explorer_url` only checked `--upgrade` (`"eus"`/`"cnv"`) and `--install` flags, but `Upgrade-Virt-Custom-4.X-Triggered` jobs pass `--upgrade_custom=cnv` instead. The function returned `None`, causing all Virt-Custom upgrade pipelines to crash with:

```
MissingSchema: Invalid URL 'None/GetBuildByIIB?iib_number=...'
```

This adds `--upgrade_custom` to the URL resolution condition, covering both `"cnv"` and `"ocp"` values.

##### Which issue(s) this PR fixes:
Fixes: [VMEDO-462](https://redhat.atlassian.net/browse/VMEDO-462)

##### Special notes for reviewer:
Root cause: `conftest.py` defines `--upgrade` and `--upgrade_custom` as separate pytest options. The Jenkins `upgrade.groovy` sets `upgradeType = '--upgrade_custom'` when `params.CUSTOM_UPGRADE` is true (all Virt-Custom lanes). But `get_cnv_version_explorer_url` never checked `upgrade_custom`, so it returned `None` silently instead of the Version Explorer URL.

Unit tests added for both `--upgrade_custom=cnv` and `--upgrade_custom=ocp` scenarios.

##### jira-ticket:
VMEDO-462

##### Test plan:
- [x] All 6 `TestGetCnvVersionExplorerUrl` unit tests pass
- [x] Pre-commit linting passes
- [ ] Trigger dry-run of `Upgrade-Virt-Custom-4.21-Triggered` with this branch to verify URL resolution

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CNV Version Explorer URL validation now works correctly for custom upgrades involving CNV or OCP.
  * Users receive the configured explorer URL when required for these upgrade types.

* **Tests**
  * Expanded coverage for custom upgrade scenarios and cases where no relevant upgrade option is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->