### PR TITLE
[net, MultiNetworkPolicy 4.22] Reference the correct bug ID

### DIFF
--- a/tests/network/flat_overlay/conftest.py
+++ b/tests/network/flat_overlay/conftest.py
@@ -57,7 +57,7 @@ def multi_network_policy_enabled(admin_client, network_operator):
             resource_name="network",
             expected_conditions=DEFAULT_RESOURCE_CONDITIONS,
         )
-        if is_jira_open(jira_id="OCPBUGS-97944"):
+        if is_jira_open(jira_id="OCPBUGS-92080"):
             restart_ovnkube_node_daemonset()
         yield
     wait_for_consistent_resource_conditions(


### PR DESCRIPTION
A dedicated 4.22 tracker (OCPBUGS-97944) is unnecessary, because OCP bugs are tracking all the affected versions in one ticket. This ticket is now closed, and all versions of it are tracked in the original OCPBUGS-92080, and this is the one that should be watched.
