### PR TITLE
Skip test_cnv_deployment_container_image for hco-operator due to CNV-92888/CNV-92889

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -209,6 +209,11 @@ def hco_spec_scope_module(hyperconverged_resource_scope_module):
     return hyperconverged_resource_scope_module.instance.to_dict()["spec"]
 
 
+@pytest.fixture(scope="session")
+def hco_current_version(admin_client, hco_namespace):
+    return get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)
+
+
 @pytest.fixture(scope="class")
 def hco_version_scope_class(admin_client, hco_namespace):
     return get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -29,6 +29,7 @@ from tests.install_upgrade_operators.utils import (
 )
 from utilities.constants.architecture import MULTIARCH
 from utilities.constants.components import (
+    HCO_OPERATOR,
     HOSTPATH_PROVISIONER_CSI,
     HPP_POOL,
 )
@@ -209,9 +210,23 @@ def hco_spec_scope_module(hyperconverged_resource_scope_module):
     return hyperconverged_resource_scope_module.instance.to_dict()["spec"]
 
 
-@pytest.fixture(scope="session")
-def hco_current_version(admin_client, hco_namespace):
-    return get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)
+@pytest.fixture()
+def xfail_if_sriov_conforma_jira_open_and_hco_operator(admin_client, hco_namespace, request):
+    try:
+        is_hco_operator = request.getfixturevalue("cnv_deployment_by_name").name == HCO_OPERATOR
+    except pytest.FixtureLookupError:
+        is_hco_operator = any(pod.name.startswith(HCO_OPERATOR) for pod in request.getfixturevalue("cnv_pods_by_type"))
+    if not is_hco_operator:
+        return
+    hco_version = get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)
+    if hco_version.startswith("4.23") and is_jira_open(jira_id="CNV-92888"):
+        pytest.xfail(
+            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
+        )
+    if hco_version.startswith("5.0") and is_jira_open(jira_id="CNV-92889"):
+        pytest.xfail(
+            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
+        )
 
 
 @pytest.fixture(scope="class")

--- a/tests/install_upgrade_operators/deployment/conftest.py
+++ b/tests/install_upgrade_operators/deployment/conftest.py
@@ -1,12 +1,10 @@
 import pytest
 
 from utilities.constants.components import (
-    HCO_OPERATOR,
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
 )
 from utilities.infra import get_deployment_by_name, get_deployments
-from utilities.jira import is_jira_open
 
 
 @pytest.fixture()
@@ -27,20 +25,6 @@ def cnv_deployments_excluding_hpp_pool(admin_client, hco_namespace):
         for deployment in get_deployments(admin_client=admin_client, namespace=hco_namespace.name)
         if not deployment.name.startswith(HPP_POOL)
     ]
-
-
-@pytest.fixture()
-def xfail_if_sriov_conforma_jira_open_and_hco_operator(hco_current_version, cnv_deployment_by_name):
-    if cnv_deployment_by_name.name != HCO_OPERATOR:
-        return
-    if hco_current_version.startswith("4.23") and is_jira_open(jira_id="CNV-92888"):
-        pytest.xfail(
-            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
-        )
-    if hco_current_version.startswith("5.0") and is_jira_open(jira_id="CNV-92889"):
-        pytest.xfail(
-            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
-        )
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/deployment/conftest.py
+++ b/tests/install_upgrade_operators/deployment/conftest.py
@@ -35,29 +35,17 @@ def hco_current_version(admin_client, hco_namespace):
     return get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)
 
 
-@pytest.fixture(scope="session")
-def jira_92888_open():
-    return is_jira_open(jira_id="CNV-92888")
-
-
-@pytest.fixture(scope="session")
-def jira_92889_open():
-    return is_jira_open(jira_id="CNV-92889")
-
-
 @pytest.fixture()
-def skip_if_sriov_conforma_jira_open_and_hco_operator(
-    hco_current_version, jira_92888_open, jira_92889_open, cnv_deployment_by_name
-):
+def xfail_if_sriov_conforma_jira_open_and_hco_operator(hco_current_version, cnv_deployment_by_name):
     if cnv_deployment_by_name.name != HCO_OPERATOR:
         return
-    if hco_current_version.startswith("4.23") and jira_92888_open:
-        pytest.skip(
-            "Skipping hco-operator image check: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
+    if hco_current_version.startswith("4.23") and is_jira_open(jira_id="CNV-92888"):
+        pytest.xfail(
+            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
         )
-    if hco_current_version.startswith("5.0") and jira_92889_open:
-        pytest.skip(
-            "Skipping hco-operator image check: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
+    if hco_current_version.startswith("5.0") and is_jira_open(jira_id="CNV-92889"):
+        pytest.xfail(
+            "hco-operator image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
         )
 
 

--- a/tests/install_upgrade_operators/deployment/conftest.py
+++ b/tests/install_upgrade_operators/deployment/conftest.py
@@ -5,7 +5,6 @@ from utilities.constants.components import (
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
 )
-from utilities.hco import get_hco_version
 from utilities.infra import get_deployment_by_name, get_deployments
 from utilities.jira import is_jira_open
 
@@ -28,11 +27,6 @@ def cnv_deployments_excluding_hpp_pool(admin_client, hco_namespace):
         for deployment in get_deployments(admin_client=admin_client, namespace=hco_namespace.name)
         if not deployment.name.startswith(HPP_POOL)
     ]
-
-
-@pytest.fixture(scope="session")
-def hco_current_version(admin_client, hco_namespace):
-    return get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/deployment/conftest.py
+++ b/tests/install_upgrade_operators/deployment/conftest.py
@@ -1,10 +1,13 @@
 import pytest
 
 from utilities.constants.components import (
+    HCO_OPERATOR,
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
 )
+from utilities.hco import get_hco_version
 from utilities.infra import get_deployment_by_name, get_deployments
+from utilities.jira import is_jira_open
 
 
 @pytest.fixture()
@@ -25,6 +28,37 @@ def cnv_deployments_excluding_hpp_pool(admin_client, hco_namespace):
         for deployment in get_deployments(admin_client=admin_client, namespace=hco_namespace.name)
         if not deployment.name.startswith(HPP_POOL)
     ]
+
+
+@pytest.fixture(scope="session")
+def hco_current_version(admin_client, hco_namespace):
+    return get_hco_version(client=admin_client, hco_ns_name=hco_namespace.name)
+
+
+@pytest.fixture(scope="session")
+def jira_92888_open():
+    return is_jira_open(jira_id="CNV-92888")
+
+
+@pytest.fixture(scope="session")
+def jira_92889_open():
+    return is_jira_open(jira_id="CNV-92889")
+
+
+@pytest.fixture()
+def skip_if_sriov_conforma_jira_open_and_hco_operator(
+    hco_current_version, jira_92888_open, jira_92889_open, cnv_deployment_by_name
+):
+    if cnv_deployment_by_name.name != HCO_OPERATOR:
+        return
+    if hco_current_version.startswith("4.23") and jira_92888_open:
+        pytest.skip(
+            "Skipping hco-operator image check: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
+        )
+    if hco_current_version.startswith("5.0") and jira_92889_open:
+        pytest.skip(
+            "Skipping hco-operator image check: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
+        )
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -94,6 +94,7 @@ def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
     assert not new_deployment, f"New cnv deployment: {new_deployment}, has been added."
 
 
+@pytest.mark.usefixtures("skip_if_sriov_conforma_jira_open_and_hco_operator")
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-8264")

--- a/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
+++ b/tests/install_upgrade_operators/deployment/test_hco_deployment_params.py
@@ -94,7 +94,7 @@ def test_no_new_cnv_deployments_added(cnv_deployments_excluding_hpp_pool):
     assert not new_deployment, f"New cnv deployment: {new_deployment}, has been added."
 
 
-@pytest.mark.usefixtures("skip_if_sriov_conforma_jira_open_and_hco_operator")
+@pytest.mark.usefixtures("xfail_if_sriov_conforma_jira_open_and_hco_operator")
 @pytest.mark.gating
 @pytest.mark.conformance
 @pytest.mark.polarion("CNV-8264")

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -12,12 +12,10 @@ from tests.install_upgrade_operators.pod_validation.utils import (
 )
 from utilities.constants.components import (
     ALL_CNV_PODS,
-    HCO_OPERATOR,
     HOSTPATH_PROVISIONER_CSI,
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
 )
-from utilities.jira import is_jira_open
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
@@ -33,20 +31,6 @@ def cnv_jobs(admin_client, hco_namespace):
 def xfail_if_jira_76659_open_and_migration_controller_pod(jira_76659_open, cnv_pods_by_type):
     if any(pod.name.startswith(KUBEVIRT_MIGRATION_CONTROLLER) for pod in cnv_pods_by_type) and jira_76659_open:
         pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} pod has no priority class name due to CNV-76659 bug")
-
-
-@pytest.fixture()
-def xfail_if_sriov_conforma_jira_open_and_hco_operator_pod(hco_current_version, cnv_pods_by_type):
-    if not any(pod.name.startswith(HCO_OPERATOR) for pod in cnv_pods_by_type):
-        return
-    if hco_current_version.startswith("4.23") and is_jira_open(jira_id="CNV-92888"):
-        pytest.xfail(
-            "hco-operator pod image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
-        )
-    if hco_current_version.startswith("5.0") and is_jira_open(jira_id="CNV-92889"):
-        pytest.xfail(
-            "hco-operator pod image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
-        )
 
 
 @pytest.mark.skip_must_gather_collection
@@ -85,7 +69,7 @@ def test_pods_resource_request(
     )
 
 
-@pytest.mark.usefixtures("xfail_if_sriov_conforma_jira_open_and_hco_operator_pod")
+@pytest.mark.usefixtures("xfail_if_sriov_conforma_jira_open_and_hco_operator")
 @pytest.mark.polarion("CNV-8267")
 def test_cnv_pod_container_image(cnv_pods_by_type):
     assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)

--- a/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
+++ b/tests/install_upgrade_operators/pod_validation/test_pod_spec.py
@@ -12,10 +12,12 @@ from tests.install_upgrade_operators.pod_validation.utils import (
 )
 from utilities.constants.components import (
     ALL_CNV_PODS,
+    HCO_OPERATOR,
     HOSTPATH_PROVISIONER_CSI,
     HPP_POOL,
     KUBEVIRT_MIGRATION_CONTROLLER,
 )
+from utilities.jira import is_jira_open
 
 pytestmark = [pytest.mark.sno, pytest.mark.arm64, pytest.mark.s390x]
 
@@ -31,6 +33,20 @@ def cnv_jobs(admin_client, hco_namespace):
 def xfail_if_jira_76659_open_and_migration_controller_pod(jira_76659_open, cnv_pods_by_type):
     if any(pod.name.startswith(KUBEVIRT_MIGRATION_CONTROLLER) for pod in cnv_pods_by_type) and jira_76659_open:
         pytest.xfail(f"{KUBEVIRT_MIGRATION_CONTROLLER} pod has no priority class name due to CNV-76659 bug")
+
+
+@pytest.fixture()
+def xfail_if_sriov_conforma_jira_open_and_hco_operator_pod(hco_current_version, cnv_pods_by_type):
+    if not any(pod.name.startswith(HCO_OPERATOR) for pod in cnv_pods_by_type):
+        return
+    if hco_current_version.startswith("4.23") and is_jira_open(jira_id="CNV-92888"):
+        pytest.xfail(
+            "hco-operator pod image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92888)"
+        )
+    if hco_current_version.startswith("5.0") and is_jira_open(jira_id="CNV-92889"):
+        pytest.xfail(
+            "hco-operator pod image check xfailed: nightly sriov-dp-admission-controller triggers upstream registry violation (CNV-92889)"
+        )
 
 
 @pytest.mark.skip_must_gather_collection
@@ -69,6 +85,7 @@ def test_pods_resource_request(
     )
 
 
+@pytest.mark.usefixtures("xfail_if_sriov_conforma_jira_open_and_hco_operator_pod")
 @pytest.mark.polarion("CNV-8267")
 def test_cnv_pod_container_image(cnv_pods_by_type):
     assert_cnv_pod_container_image_not_in_upstream(cnv_pods_by_type=cnv_pods_by_type)


### PR DESCRIPTION
##### What this PR does / why we need it:
`test_cnv_deployment_container_image[#hco-operator#]` and
`test_cnv_pod_container_image[#hco-operator#]` are failing because the nightly
`sriov-dp-admission-controller` image (required by VMER-895) references a
non-production registry (`quay.io/openshift-virtualization/konflux-builds/`),
triggering the upstream image check. This is a confirmed product bug tracked in
CNV-92888 (v4.23) and CNV-92889 (v5.0).

The fix adds a single `xfail_if_sriov_conforma_jira_open_and_hco_operator`
fixture in `install_upgrade_operators/conftest.py` that xfails the `hco-operator`
parametrization in both tests while the corresponding Jira is open. Each pipeline
unblocks independently when its bug is resolved.

The fixture uses `request.getfixturevalue` to adapt to both deployment and pod
test contexts, avoiding duplication.

##### Which issue(s) this PR fixes:
CNV-92888, CNV-92889

##### Special notes for reviewer:
- This is NOT a quarantine — `@pytest.mark.xfail` with `QUARANTINED` is not used here.
- Only the `hco-operator` parametrization is xfailed; all other deployments/pods in the matrix are unaffected.
- A single shared fixture in `install_upgrade_operators/conftest.py` handles both `test_cnv_deployment_container_image` and `test_cnv_pod_container_image`.
- `get_hco_version()` and `is_jira_open()` are called inline (no dedicated session fixtures), only when the `hco-operator` parametrization is active.

##### jira-ticket:
CNV-92888, CNV-92889