### PR TITLE
[Storage] Add conformance marker and STD docstrings for clone tests

### DIFF
--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -228,6 +228,7 @@ def test_successful_snapshot_clone(
 
 
 @pytest.mark.gating
+@pytest.mark.conformance
 @pytest.mark.polarion("CNV-5607")
 @pytest.mark.s390x
 def test_clone_from_fs_to_block_using_dv_template(
@@ -237,6 +238,18 @@ def test_clone_from_fs_to_block_using_dv_template(
     fedora_dv_with_filesystem_volume_mode,
     storage_class_with_block_volume_mode,
 ):
+    """Test cloning a DV from filesystem to block volume mode via DV template.
+
+    Preconditions:
+        - Fedora DataVolume with filesystem volume mode
+        - Storage class supporting block volume mode
+
+    Steps:
+        1. Create a VM using a clone DataVolume template that clones the filesystem DV to block
+
+    Expected:
+        - VM is created successfully with the cloned block DV
+    """
     create_vm_from_clone_dv_template(
         vm_name="vm-5607",
         dv_name="dv-5607",
@@ -248,6 +261,7 @@ def test_clone_from_fs_to_block_using_dv_template(
     )
 
 
+@pytest.mark.conformance
 @pytest.mark.polarion("CNV-5608")
 @pytest.mark.smoke()
 @pytest.mark.s390x
@@ -259,6 +273,18 @@ def test_clone_from_block_to_fs_using_dv_template(
     storage_class_with_filesystem_volume_mode,
     default_fs_overhead,
 ):
+    """Test cloning a DV from block to filesystem volume mode via DV template.
+
+    Preconditions:
+        - Fedora DataVolume with block volume mode
+        - Storage class supporting filesystem volume mode
+
+    Steps:
+        1. Create a VM using a clone DataVolume template that clones the block DV to filesystem
+
+    Expected:
+        - VM is created successfully with the cloned filesystem DV
+    """
     create_vm_from_clone_dv_template(
         vm_name="vm-5608",
         dv_name="dv-5608",


### PR DESCRIPTION
##### What this PR does / why we need it:

Add `conformance` marker and STD docstrings to the existing clone tests (CNV-5607 and CNV-5608) to cover the "Host-assisted cloning" GA conformance requirement.

Changes:

* **CNV-5607** (`test_clone_from_fs_to_block_using_dv_template`): added `conformance` marker + STD docstring
* **CNV-5608** (`test_clone_from_block_to_fs_using_dv_template`): added `conformance` marker + STD docstring

No test behavior or fixture changes — only markers and docstrings added.

> **Note:** These tests use quay.io as the Fedora image source. In disconnected environments, the image is available via mirroring.

##### Which issue(s) this PR fixes:

CNV-88909

##### Special notes for reviewer:

Tests executed on GCP cluster with `sp-balanced-storage` SC
and on SC `ocs-storagecluster-ceph-rbd-virtualization`

Replaces #5624 (stuck smoke CI).

##### jira-ticket:

CNV-88909

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance classification for DataVolume clone scenarios.
  * Documented successful cloning between filesystem and block volume modes, including prerequisites, steps, and expected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->