### PR TITLE
fix: use local variable in upgrade stream error message

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1805,7 +1805,7 @@ def determine_upgrade_stream(current_version, target_version):
             # Upgrade only if a newer CNV version is requested
             raise ValueError(
                 f"Cannot upgrade to older/identical versions,"
-                f"current: {cnv_current_version} target: {target_cnv_version}"
+                f"current: {current_cnv_version} target: {target_cnv_version}"
             )
         raise ValueError(
             f"Unknown upgrade stream. Current cnv version: {current_cnv_version}, "


### PR DESCRIPTION
##### What this PR does / why we need it:

Fix variable name typo in `determine_upgrade_stream()` error message: `cnv_current_version` (module-scope pytest fixture function) → `current_cnv_version` (local parsed version variable).

Without this fix, the ValueError message displays `<pytest_fixture(<function cnv_current_version at 0x...>)>` instead of the actual version string (e.g. `4.22.4`), which is misleading during failure triage.

##### Which issue(s) this PR fixes:

https://redhat.atlassian.net/browse/VMEDO-586

##### Special notes for reviewer:

One-character fix — adds the `current_` prefix to reference the correct local variable. The adjacent error message on line 1813 already uses the correct `current_cnv_version`.

##### jira-ticket:

https://redhat.atlassian.net/browse/VMEDO-586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the error message shown when an upgrade request is invalid, ensuring it displays the accurate current CNV version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->