### PR TITLE
infra: Implement TestVMTemplateAdmission

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -103,6 +103,7 @@ pytest_plugins = [
     "tests.fixtures.storage.storage_classes",
     "tests.fixtures.images.golden_images",
     "tests.fixtures.storage.data_volumes",
+    "tests.fixtures.infrastructure.vm_template",
 ]
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/fixtures/infrastructure/vm_template.py
+++ b/tests/fixtures/infrastructure/vm_template.py
@@ -1,0 +1,30 @@
+import pytest
+from ocp_resources.virtual_machine_template import VirtualMachineTemplate
+
+from utilities.constants.vm_template import VALID_VM_TEMPLATE_PARAMETERS, VALID_VM_TEMPLATE_VIRTUAL_MACHINE
+
+
+@pytest.fixture()
+def valid_vm_template(admin_client, namespace):
+    """Create and yield a VirtualMachineTemplate with valid defaulted parameters.
+
+    Creates a namespaced VirtualMachineTemplate whose parameter defaults
+    (a generated VM name, an instance type, and a preference) all resolve to a
+    structurally valid VM definition accepted by the admission webhook.
+    The template is deleted from the cluster when the fixture tears down.
+
+    Args:
+        admin_client: Kubernetes client with cluster-admin privileges.
+        namespace: Namespace object that determines where the template is created.
+
+    Yields:
+        VirtualMachineTemplate: The created template resource.
+    """
+    with VirtualMachineTemplate(
+        client=admin_client,
+        name="valid-test-template",
+        namespace=namespace.name,
+        parameters=VALID_VM_TEMPLATE_PARAMETERS,
+        virtual_machine=VALID_VM_TEMPLATE_VIRTUAL_MACHINE,
+    ) as vm_template:
+        yield vm_template

--- a/tests/infrastructure/vm_template/test_vm_template_admission.py
+++ b/tests/infrastructure/vm_template/test_vm_template_admission.py
@@ -14,19 +14,23 @@ Markers:
 
 import pytest
 
-__test__ = False
+from tests.infrastructure.vm_template.utils import process_and_create_vm
 
 
-class TestVMTemplateAdmission:
+@pytest.mark.smoke
+class TestVMTemplateAdmissionPositive:
     """
-    Tests for VirtualMachineTemplate admission behavior under defaulted parameters.
+    Positive tests for VirtualMachineTemplate admission behavior under defaulted parameters.
 
     Preconditions:
-        - OpenShift Virtualization cluster with common instance types deployed
+        - OpenShift Virtualization cluster with enabled Template feature gate
+
+    Markers:
+        - smoke
     """
 
     @pytest.mark.polarion("CNV-16314")
-    def test_valid_template_with_defaulted_parameters_accepted(self):
+    def test_valid_template_with_defaulted_parameters_accepted(self, valid_vm_template):
         """
         Test that a VirtualMachineTemplate whose default parameter values resolve to a
         valid VM definition is accepted by the cluster.
@@ -40,22 +44,25 @@ class TestVMTemplateAdmission:
 
         Expected:
             - VirtualMachineTemplate is created successfully
-
-        Markers:
-            - smoke
         """
+        assert valid_vm_template.exists, (
+            f"VirtualMachineTemplate {valid_vm_template.name} should have been created successfully"
+        )
 
-    @pytest.mark.polarion("CNV-16315")
-    def test_invalid_by_default_template_rejected(self):
+    @pytest.mark.polarion("CNV-16336")
+    def test_vm_created_from_valid_template(self, valid_vm_template):
         """
-        [NEGATIVE] Test that a VirtualMachineTemplate whose default parameter values would
-        always produce an invalid VM definition is rejected by the admission webhook.
+        Test that a VirtualMachine can be created using the spec defined in a valid
+        VirtualMachineTemplate.
+
+        Preconditions:
+            - A valid VirtualMachineTemplate exists on the cluster
 
         Steps:
-            1. Submit a VirtualMachineTemplate resource whose defaulted parameters produce
-               an invalid VM definition
+            1. Create a VirtualMachine using the instance type and preference parameters
+               defined as defaults in the valid VirtualMachineTemplate
 
         Expected:
-            - VirtualMachineTemplate creation is rejected with an admission error indicating
-              the template would always produce an invalid VM
+            - VirtualMachine is created successfully
         """
+        process_and_create_vm(vmt=valid_vm_template)

--- a/tests/infrastructure/vm_template/utils.py
+++ b/tests/infrastructure/vm_template/utils.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from ocp_resources.virtual_machine import VirtualMachine
+from ocp_resources.virtual_machine_template import VirtualMachineTemplate
+
+
+def process_and_create_vm(
+    vmt: VirtualMachineTemplate,
+    parameters: dict[str, Any] | None = None,
+    namespace: str | None = None,
+    client: Any = None,
+) -> VirtualMachine:
+    """
+    Process the VirtualMachineTemplate and create the resulting VirtualMachine.
+
+    Calls :meth:`process` to render the template into a ``VirtualMachine`` spec,
+    then deploys that VM in the cluster.  The ``/process`` subresource does not
+    set a namespace on the returned VM metadata, so the namespace is taken from
+    the ``namespace`` argument, falling back to the template's own namespace
+    (``self.namespace``).
+
+    Args:
+        vmt (VirtualMachineTemplate): The template to process and deploy.
+        parameters (dict[str, Any] | None): Key-value pairs of template parameters
+            to substitute, e.g. ``{"NAME": "my-vm", "INSTANCETYPE": "u1.large"}``.
+            Defaults to an empty dict (no substitutions).
+        namespace (str | None): Namespace in which to create the VirtualMachine.
+            Defaults to the template's namespace (``self.namespace``).
+        client: Optional Kubernetes API client. Defaults to ``self.client``.
+
+    Returns:
+        VirtualMachine: The deployed :class:`~ocp_resources.virtual_machine.VirtualMachine`
+        object.
+    """
+    request_response = vmt.process(parameters=parameters, client=client)
+    vm_dict: dict[str, Any] = request_response.to_dict()["virtualMachine"]
+    vm_dict["metadata"]["namespace"] = namespace or vmt.namespace
+    vm = VirtualMachine(kind_dict=vm_dict, client=client or vmt.client)
+    vm.deploy(wait=True)
+    return vm

--- a/utilities/constants/vm_template.py
+++ b/utilities/constants/vm_template.py
@@ -1,0 +1,89 @@
+"""VirtualMachineTemplate constants for test fixtures.
+
+Covers parameter lists and virtual machine spec definitions used when
+creating VirtualMachineTemplate resources in test fixtures.
+
+Not here:
+- Instance type or preference name strings → ``instance_types.py``
+- OS flavor strings → ``images.py``
+- Generic VM runtime configuration (eviction strategy, disk names, …) → ``virt.py``
+"""
+
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.instance_types import U1_SMALL
+
+# Parameter list whose defaults resolve to a structurally valid VM definition.
+VALID_VM_TEMPLATE_PARAMETERS = [
+    {
+        "name": "NAME",
+        "generate": "expression",
+        "from": "vm-[a-z0-9]{8}",
+        "description": "Unique VM name",
+    },
+    {
+        "name": "INSTANCETYPE",
+        "value": U1_SMALL,
+        "description": "Instance type for the VM",
+    },
+    {
+        "name": "PREFERENCE",
+        "value": OS_FLAVOR_FEDORA,
+        "description": "VM preference",
+    },
+]
+
+# Virtual machine spec rendered by the valid VirtualMachineTemplate fixture.
+VALID_VM_TEMPLATE_VIRTUAL_MACHINE = {
+    "metadata": {"name": "${NAME}"},
+    "spec": {
+        "instancetype": {
+            "kind": VirtualMachineClusterInstancetype.kind,
+            "name": "${INSTANCETYPE}",
+        },
+        "preference": {
+            "kind": VirtualMachineClusterPreference.kind,
+            "name": "${PREFERENCE}",
+        },
+        "runStrategy": "Halted",
+        "dataVolumeTemplates": [
+            {
+                "metadata": {"name": "${NAME}"},
+                "spec": {
+                    "sourceRef": {
+                        "kind": "DataSource",
+                        "name": "rhel10",
+                        "namespace": "openshift-virtualization-os-images",
+                    },
+                    "storage": {
+                        "resources": {
+                            "requests": {
+                                "storage": "30Gi",
+                            }
+                        }
+                    },
+                },
+            }
+        ],
+        "template": {
+            "spec": {
+                "architecture": "amd64",
+                "domain": {
+                    "devices": {
+                        "autoattachPodInterface": False,
+                    }
+                },
+                "volumes": [
+                    {
+                        "name": "rootdisk",
+                        "dataVolume": {
+                            "name": "${NAME}",
+                        },
+                    }
+                ],
+            }
+        },
+    },
+}

--- a/utilities/unittests/test_constants.py
+++ b/utilities/unittests/test_constants.py
@@ -89,6 +89,10 @@ from utilities.constants.virt import (
     WIN_10,
     WIN_11,
 )
+from utilities.constants.vm_template import (
+    VALID_VM_TEMPLATE_PARAMETERS,
+    VALID_VM_TEMPLATE_VIRTUAL_MACHINE,
+)
 
 
 class TestConstants:
@@ -211,6 +215,14 @@ class TestConstants:
         assert FILE_NAME_FOR_BACKUP == "file_before_backup.txt"
         assert TEXT_TO_TEST == "text"
         assert BACKUP_STORAGE_LOCATION == "dpa-1"
+
+    def test_vm_template_constants(self):
+        """Test VirtualMachineTemplate parameter and spec constants are defined."""
+        param_names = [param["name"] for param in VALID_VM_TEMPLATE_PARAMETERS]
+        assert param_names == ["NAME", "INSTANCETYPE", "PREFERENCE"]
+        assert VALID_VM_TEMPLATE_VIRTUAL_MACHINE["metadata"] == {"name": "${NAME}"}
+        assert "instancetype" in VALID_VM_TEMPLATE_VIRTUAL_MACHINE["spec"]
+        assert "preference" in VALID_VM_TEMPLATE_VIRTUAL_MACHINE["spec"]
 
     def test_tekton_constants(self):
         """Test Tekton pipeline and task name constants are defined."""


### PR DESCRIPTION
##### What this PR does / why we need it:
Implement TestVMTemplateAdmission in tests/infrastructure/vm_template/test_vm_template_admission.py

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Dependent on https://github.com/RedHatQE/openshift-python-wrapper/pull/2775

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-86112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added smoke coverage confirming that valid virtual machine templates are accepted.
  * Added coverage for creating virtual machines from valid templates with default parameters.
  * Added reusable fixtures and validation for template defaults, metadata, instance types, preferences, storage, and architecture.
* **Bug Fixes**
  * Improved template-based virtual machine creation, including parameter handling, namespace assignment, deployment, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->