### PR TITLE
net, localnet: Decouple cloud-init assembly from VM factory

### DIFF
--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -33,6 +33,7 @@ from tests.network.localnet.liblocalnet import (
     LOCALNET_VM_ANTI_AFFINITY,
     create_nncp_localnet_on_secondary_node_nic,
     ip_addresses_from_pool,
+    localnet_cloudinit,
     localnet_cudn,
     localnet_vm,
 )
@@ -159,21 +160,23 @@ def vm_localnet_1(
             Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={}),
             Interface(name=LOCALNET_BR_EX_INTERFACE_NO_VLAN, bridge={}),
         ],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        ),
                     ),
-                ),
-                GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+                    GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        ),
                     ),
-                ),
-            }
+                }
+            )
         ),
         affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
@@ -194,15 +197,17 @@ def vm_localnet_2(
         client=unprivileged_client,
         networks=[Network(name=LOCALNET_BR_EX_INTERFACE, multus=Multus(networkName=cudn_localnet.name))],
         interfaces=[Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
-                    ),
-                )
-            }
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        ),
+                    )
+                }
+            )
         ),
         affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
@@ -265,15 +270,17 @@ def vm_ovs_bridge_localnet_link_down(
             Network(name=LOCALNET_OVS_BRIDGE_INTERFACE, multus=Multus(networkName=cudn_localnet_ovs_bridge.name))
         ],
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={}, state=LINK_STATE_DOWN)],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        )
                     )
-                )
-            }
+                }
+            )
         ),
         affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
@@ -296,15 +303,17 @@ def vm_ovs_bridge_localnet_1(
             Network(name=LOCALNET_OVS_BRIDGE_INTERFACE, multus=Multus(networkName=cudn_localnet_ovs_bridge.name))
         ],
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        )
                     )
-                )
-            }
+                }
+            )
         ),
         affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
@@ -327,15 +336,17 @@ def vm_ovs_bridge_localnet_2(
             Network(name=LOCALNET_OVS_BRIDGE_INTERFACE, multus=Multus(networkName=cudn_localnet_ovs_bridge.name))
         ],
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        )
                     )
-                )
-            }
+                }
+            )
         ),
         affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
@@ -480,15 +491,17 @@ def vm1_ovs_bridge_localnet_jumbo_frame(
             )
         ],
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        )
                     )
-                )
-            }
+                }
+            )
         ),
         affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:
@@ -513,15 +526,17 @@ def vm2_ovs_bridge_localnet_jumbo_frame(
             )
         ],
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        )
                     )
-                )
-            }
+                }
+            )
         ),
         affinity=LOCALNET_VM_ANTI_AFFINITY,
     ) as vm:

--- a/tests/network/localnet/liblocalnet.py
+++ b/tests/network/localnet/liblocalnet.py
@@ -63,14 +63,35 @@ def ip_addresses_from_pool(
     return addresses
 
 
+def localnet_cloudinit(
+    network_data: cloudinit.NetworkData,
+    runcmd: list[str] | None = None,
+) -> CloudInitNoCloud:
+    """Build a CloudInitNoCloud for a localnet VM.
+
+    Sets users=[] to prevent cloud-init from overriding the default OS user credentials.
+
+    Args:
+        network_data: Cloud-init network configuration to apply.
+        runcmd: Commands to run on first boot via cloud-init runcmd. None means no extra commands.
+
+    Returns:
+        CloudInitNoCloud configured with the given network and user data.
+    """
+    userdata = cloudinit.UserData(users=[], runcmd=runcmd)
+    return CloudInitNoCloud(
+        networkData=cloudinit.asyaml(no_cloud=network_data),
+        userData=cloudinit.format_cloud_config(userdata=userdata),
+    )
+
+
 def localnet_vm(
     namespace: str,
     name: str,
     client: DynamicClient,
     networks: list[Network],
     interfaces: list[Interface],
-    network_data: cloudinit.NetworkData | None = None,
-    runcmd: list[str] | None = None,
+    cloud_init: CloudInitNoCloud | None = None,
     affinity: Affinity | None = None,
     vm_labels: dict[str, str] | None = None,
 ) -> BaseVirtualMachine:
@@ -82,41 +103,22 @@ def localnet_vm(
     - Based on a standard Fedora VM template.
 
     Args:
-        namespace (str): The namespace where the VM should be created.
-        name (str): The name of the VM.
-        client (DynamicClient): The Kubernetes dynamic client for resource creation.
-        networks (list[Network]): List of Network objects defining the networks to attach.
+        namespace: The namespace where the VM should be created.
+        name: The name of the VM.
+        client: The Kubernetes dynamic client for resource creation.
+        networks: List of Network objects defining the networks to attach.
             Each Network should have a name and configuration.
-        interfaces (list[Interface]): List of Interface objects defining the interface configurations.
+        interfaces: List of Interface objects defining the interface configurations.
             Each Interface should have a name matching a Network, and additional configuration and state.
-        network_data (cloudinit.NetworkData | None): Cloud-init NetworkData object containing the network
-            configuration for the VM interfaces. If None, no network configuration is applied via cloud-init.
-        runcmd (list[str] | None): Commands to run on first boot via cloud-init runcmd. None means no
-            extra commands are injected.
-        affinity (Affinity | None): Optional Affinity object for VM scheduling. Controls the VM scheduling
-            location. If None, no affinity constraints are applied.
-        vm_labels (dict[str, str] | None): Optional labels to apply to the VM template metadata.
+        cloud_init: Optional pre-composed cloud-init configuration.
+            If None, no cloud-init configuration is applied.
+        affinity: Optional Affinity object for VM scheduling. If None, no affinity constraints are applied.
+        vm_labels: Optional labels to apply to the VM template metadata.
             These labels are set on the VMI pod and can be used for affinity/anti-affinity matching.
             If None, no additional labels are applied beyond LOCALNET_TEST_LABEL.
 
     Returns:
         BaseVirtualMachine: The configured VM object ready for creation.
-
-    Example:
-        >>> networks = [
-        ...     Network(name="net1", multus=Multus(networkName="physical-net1")),
-        ...     Network(name="net2", multus=Multus(networkName="physical-net2")),
-        ... ]
-        >>> interfaces = [
-        ...     Interface(name="net1", bridge={}, state="up"),
-        ...     Interface(name="net2", bridge={}, state="up"),
-        ... ]
-        >>> network_data = cloudinit.NetworkData(ethernets={
-        ...     "eth0": cloudinit.EthernetDevice(addresses=["172.16.1.1/24"]),
-        ...     "eth1": cloudinit.EthernetDevice(addresses=["172.16.2.1/24"]),
-        ... })
-        >>> vm = localnet_vm(namespace="test-localnet", name="vm1", client=client,
-        ...                   networks=networks, interfaces=interfaces, network_data=network_data)
     """
     spec = base_vmspec()
     spec.template.metadata = spec.template.metadata or Metadata()
@@ -130,15 +132,8 @@ def localnet_vm(
     vmi_spec.domain.devices = vmi_spec.domain.devices or Devices()
     vmi_spec.domain.devices.interfaces = interfaces
 
-    if network_data is not None:
-        # Prevents cloud-init from overriding the default OS user credentials
-        userdata = cloudinit.UserData(users=[], runcmd=runcmd)
-        disk, volume = cloudinitdisk_storage(
-            data=CloudInitNoCloud(
-                networkData=cloudinit.asyaml(no_cloud=network_data),
-                userData=cloudinit.format_cloud_config(userdata=userdata),
-            )
-        )
+    if cloud_init is not None:
+        disk, volume = cloudinitdisk_storage(data=cloud_init)
         vmi_spec = add_volume_disk(vmi_spec=vmi_spec, volume=volume, disk=disk)
 
     if affinity is not None:

--- a/tests/network/localnet/migration_stuntime/conftest.py
+++ b/tests/network/localnet/migration_stuntime/conftest.py
@@ -17,6 +17,7 @@ from tests.network.localnet.liblocalnet import (
     LOCALNET_OVS_BRIDGE_INTERFACE,
     ip_addresses_from_pool,
     libnncp,
+    localnet_cloudinit,
     localnet_vm,
 )
 
@@ -47,15 +48,17 @@ def localnet_stuntime_server_vm(
             Network(name=LOCALNET_OVS_BRIDGE_INTERFACE, multus=Multus(networkName=cudn_localnet_ovs_bridge.name))
         ],
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        )
                     )
-                )
-            }
+                }
+            )
         ),
         vm_labels=dict([SERVER_VM_LABEL]),
     ) as server_vm:
@@ -81,15 +84,17 @@ def localnet_stuntime_client_vm(
             Network(name=LOCALNET_OVS_BRIDGE_INTERFACE, multus=Multus(networkName=cudn_localnet_ovs_bridge.name))
         ],
         interfaces=[Interface(name=LOCALNET_OVS_BRIDGE_INTERFACE, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
-                    addresses=ip_addresses_from_pool(
-                        ipv4_pool=ipv4_localnet_address_pool,
-                        ipv6_pool=ipv6_localnet_address_pool,
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        )
                     )
-                )
-            }
+                }
+            )
         ),
         affinity=new_pod_affinity(label=SERVER_VM_LABEL),
         vm_labels=dict([CLIENT_VM_LABEL]),

--- a/tests/network/localnet/nad_ref_change/conftest.py
+++ b/tests/network/localnet/nad_ref_change/conftest.py
@@ -21,6 +21,7 @@ from tests.network.localnet.liblocalnet import (
     IFACE_B_NAME,
     LOCALNET_BR_EX_NETWORK,
     LOCALNET_TEST_LABEL,
+    localnet_cloudinit,
     localnet_cudn,
     localnet_vm,
 )
@@ -66,13 +67,15 @@ def ref_vm_localnet(
             Interface(name=IFACE_A_NAME, bridge={}),
             Interface(name=IFACE_B_NAME, bridge={}),
         ],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_a_ips),
-                GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_b_ips),
-            }
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_a_ips),
+                    GUEST_2ND_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_b_ips),
+                }
+            ),
+            runcmd=ARP_ISOLATION_SYSCTL_CMD,
         ),
-        runcmd=ARP_ISOLATION_SYSCTL_CMD,
     ) as vm:
         run_vm(
             vm=vm,
@@ -97,8 +100,10 @@ def under_test_vm_localnet(
         client=unprivileged_client,
         networks=[Network(name=IFACE_A_NAME, multus=Multus(networkName=cudn_localnet.name))],
         interfaces=[Interface(name=IFACE_A_NAME, bridge={})],
-        network_data=cloudinit.NetworkData(
-            ethernets={GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_a_ips)},
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(addresses=iface_a_ips)}
+            ),
         ),
     ) as vm:
         run_vm(

--- a/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
+++ b/tests/network/localnet/rhel9_rhel10_cluster/conftest.py
@@ -20,6 +20,7 @@ from tests.network.libs.cloudinit import EthernetDevice
 from tests.network.localnet.liblocalnet import (
     GUEST_2ND_IFACE_NAME,
     LOCALNET_BR_EX_INTERFACE,
+    localnet_cloudinit,
     localnet_vm,
 )
 from utilities.constants.cluster import RHCOS9_WORKER_LABEL
@@ -47,12 +48,14 @@ def localnet_server_vm(
             Interface(name="default", masquerade={}),
             Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={}),
         ],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_2ND_IFACE_NAME: EthernetDevice(
-                    addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_SERVER_HOST_ADDRESS)
-                )
-            }
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_2ND_IFACE_NAME: EthernetDevice(
+                        addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_SERVER_HOST_ADDRESS)
+                    )
+                }
+            )
         ),
         affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
     ) as vm:
@@ -78,12 +81,14 @@ def localnet_client_vm(
             Interface(name="default", masquerade={}),
             Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={}),
         ],
-        network_data=cloudinit.NetworkData(
-            ethernets={
-                GUEST_2ND_IFACE_NAME: EthernetDevice(
-                    addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_CLIENT_HOST_ADDRESS)
-                )
-            }
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_2ND_IFACE_NAME: EthernetDevice(
+                        addresses=random_cidr_addresses_by_family(net_seed=0, host_address=_CLIENT_HOST_ADDRESS)
+                    )
+                }
+            )
         ),
         affinity=new_node_affinity(key=RHCOS9_WORKER_LABEL, exists=True),
     ) as vm:


### PR DESCRIPTION
##### What this PR does / why we need it:
The localnet VM factory used individual cloud-init fields (network configuration and boot runcmd commands) through its signature. Boot commands only took effect when network configuration was also provided — with no error and no visible effect when the two were passed independently.

##### Which issue(s) this PR fixes:
The factory now accepts a single, pre-composed cloud-init object. Callers build the complete configuration before passing it in, eliminating the conditional coupling between fields. A localnet-specific helper in the same module encapsulates the credential-override prevention convention that all localnet VMs require.


##### Special notes for reviewer:
Requested follow-up after [this](https://github.com/RedHatQE/openshift-virtualization-tests/pull/5039/changes/d2e31ea7d585acf1090f819a6fa7695c1ffa15e7#r3318769478) change

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-88853
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved local network VM test setup with consistent cloud-init configuration.
  * Preserved existing IPv4 and IPv6 networking scenarios across standard, OVS-bridge, jumbo-frame, migration, and cluster tests.
  * Ensured default operating system user credentials remain unchanged during test provisioning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->