### PR TITLE
[Storage] Add concurrent 20 VM boot conformance test + STD

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -85,6 +85,7 @@ markers =
 
     ## Resources requirements
     high_resource_vm: Tests that create VM using a lot of resources (like Windows OS VMs, hight performance VMs, etc)
+    high_vm_concurrent: Tests that boot a large number of VMs simultaneously, requiring sufficient cluster capacity (nodes, memory, storage) to schedule them all at once
 
     # CI
     smoke: Mark tests as smoke tests

--- a/tests/storage/concurrent_vm_boot/conftest.py
+++ b/tests/storage/concurrent_vm_boot/conftest.py
@@ -1,0 +1,163 @@
+import logging
+from gc import collect
+
+import pytest
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+
+from tests.storage.concurrent_vm_boot.constants import NUM_CONCURRENT_VMS, REQUIRED_CLUSTER_MEMORY_GI
+from tests.storage.concurrent_vm_boot.utils import (
+    assert_cluster_memory,
+    create_concurrent_vm,
+    run_parallel,
+    run_vms_parallel,
+)
+from utilities.constants.images import OS_FLAVOR_FEDORA
+from utilities.constants.instance_types import U1_SMALL
+from utilities.constants.timeouts import TIMEOUT_10MIN
+from utilities.exceptions import ClusterSanityError
+from utilities.virt import wait_for_running_vm
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def cluster_memory_for_concurrent_vms(schedulable_nodes):
+    """Assert the cluster has enough aggregate allocatable memory for the concurrent VM boot test.
+
+    The budget is derived from the instance type (2 GiB guest RAM per u1.small VM) plus a
+    1 GiB per-VM overhead margin for virt-launcher and the gap between allocatable and free
+    memory. Storage capacity is not pre-checked: the storage class supports dynamic provisioning
+    and PVC scheduling failures surface quickly during concurrent VM creation — add a storage
+    preflight if false-negative timeouts become a problem.
+
+    Args:
+        schedulable_nodes: Schedulable worker nodes used to compute aggregate allocatable memory.
+
+    Raises:
+        ClusterSanityError: If aggregate allocatable memory is below the required threshold.
+    """
+    assert_cluster_memory(nodes=schedulable_nodes, required_gi=REQUIRED_CLUSTER_MEMORY_GI)
+
+
+@pytest.fixture(scope="module")
+def created_vms_with_five_disks(
+    request,
+    unprivileged_client,
+    namespace,
+    storage_class_name_scope_module,
+    fedora_data_source_scope_module,
+):
+    """Create 20 VMs each with 1 golden image boot volume, 1 cloud-init disk, and 3 blank DVs.
+
+    VMs are created concurrently and not yet started. All VMs are cleaned up in the finally block
+    regardless of test outcome.
+
+    Args:
+        request: Pytest request for tracking test session failure state.
+        unprivileged_client: Kubernetes client for resource operations.
+        namespace: Test namespace for VM deployment.
+        storage_class_name_scope_module: Storage class for boot and blank PVCs.
+        fedora_data_source_scope_module: Fedora golden image DataSource for boot volumes.
+
+    Yields:
+        List of deployed VirtualMachineForTests instances, not yet started.
+
+    Raises:
+        ClusterSanityError: If any VMs fail to create or if cleanup fails after a successful run.
+    """
+    instance_type = VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client, ensure_exists=True)
+    preference = VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client, ensure_exists=True)
+
+    vms = []
+    failed_labels: list[str] = []
+    testsfailed_before = request.session.testsfailed
+    try:
+        vms, failed_labels = run_parallel(
+            items=list(range(NUM_CONCURRENT_VMS)),
+            func=lambda vm_index: create_concurrent_vm(
+                index=vm_index,
+                namespace_name=namespace.name,
+                client=unprivileged_client,
+                storage_class_name=storage_class_name_scope_module,
+                data_source=fedora_data_source_scope_module,
+                vm_instance_type=instance_type,
+                vm_preference=preference,
+                os_flavor=OS_FLAVOR_FEDORA,
+            ),
+            label="Failed to create VM index",
+        )
+        if failed_labels:
+            raise ClusterSanityError(
+                err_str=f"{len(failed_labels)}/{NUM_CONCURRENT_VMS} VMs failed to create: {failed_labels}"
+            )
+
+        yield vms
+    finally:
+        errors = run_vms_parallel(
+            vms=vms,
+            func=lambda vm: vm.clean_up(),
+            label="Failed to clean up VM",
+        )
+        # Force GC to reclaim thread-local state and deferred object cleanup after concurrent workload.
+        collect()
+        if errors:
+            cleanup_msg = f"Failed to clean up VMs: {errors}"
+            if failed_labels or request.session.testsfailed > testsfailed_before:
+                LOGGER.error(cleanup_msg)
+            else:
+                raise ClusterSanityError(err_str=cleanup_msg)
+
+
+@pytest.fixture(scope="module")
+def started_vms_with_five_disks(created_vms_with_five_disks):
+    """Submit start requests for all VMs concurrently without waiting for boot.
+
+    Args:
+        created_vms_with_five_disks: Deployed VMs not yet started.
+
+    Yields:
+        Same VM list with start requests submitted.
+
+    Raises:
+        ClusterSanityError: If any VMs fail to accept the start request.
+    """
+    errors = run_vms_parallel(
+        vms=created_vms_with_five_disks,
+        func=lambda vm: vm.start(wait=False),
+        label="Failed to start VM",
+    )
+    if errors:
+        raise ClusterSanityError(
+            err_str=f"{len(errors)}/{len(created_vms_with_five_disks)} VMs failed to start: {errors}"
+        )
+    yield created_vms_with_five_disks
+
+
+@pytest.fixture(scope="module")
+def running_vms_with_five_disks(started_vms_with_five_disks):
+    """Wait for all VMs to reach Running state with SSH connectivity confirmed.
+
+    Args:
+        started_vms_with_five_disks: VMs with start requests submitted.
+
+    Yields:
+        Same VM list, all confirmed running with SSH connectivity.
+
+    Raises:
+        ClusterSanityError: If any VMs fail to reach Running state within the timeout.
+    """
+    errors = run_vms_parallel(
+        vms=started_vms_with_five_disks,
+        func=lambda vm: wait_for_running_vm(
+            vm=vm,
+            wait_until_running_timeout=TIMEOUT_10MIN,
+            check_ssh_connectivity=True,
+        ),
+        label="VM failed to reach Running state",
+    )
+    if errors:
+        raise ClusterSanityError(
+            err_str=f"{len(errors)}/{len(started_vms_with_five_disks)} VMs failed to boot: {errors}"
+        )
+    yield started_vms_with_five_disks

--- a/tests/storage/concurrent_vm_boot/constants.py
+++ b/tests/storage/concurrent_vm_boot/constants.py
@@ -1,0 +1,11 @@
+"""Constants for concurrent VM boot tests."""
+
+NUM_CONCURRENT_VMS = 20
+NUM_BLANK_DISKS_PER_VM = 3
+NUM_FIXED_DISKS_PER_VM = 2  # boot disk (golden image clone) + cloud-init
+BLANK_DV_SIZE = "1Gi"
+
+# Memory budget: 2 GiB guest RAM (u1.small) + 1 GiB virt-launcher/OS overhead per VM.
+GUEST_GI_PER_VM = 2  # u1.small provides 2 GiB guest RAM
+VIRT_LAUNCHER_OVERHEAD_GI_PER_VM = 1  # per-VM overhead estimate (virt-launcher + kernel)
+REQUIRED_CLUSTER_MEMORY_GI = NUM_CONCURRENT_VMS * (GUEST_GI_PER_VM + VIRT_LAUNCHER_OVERHEAD_GI_PER_VM)

--- a/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
+++ b/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
@@ -1,0 +1,56 @@
+"""
+Concurrent VM Boot Tests
+
+Validates booting 20 virtual machines simultaneously, each with a multi-disk
+configuration: one cloned boot volume, one cloud-init disk, and three blank
+data volumes (five disk devices total in the VMI spec).
+
+Jira: https://redhat.atlassian.net/browse/CNV-88906  # <skip-jira-utils-check>
+
+Markers:
+    - tier3
+    - conformance
+"""
+
+import pytest
+
+__test__ = False
+
+pytestmark = [pytest.mark.tier3, pytest.mark.conformance]
+
+
+class TestConcurrentVMBoot:
+    """
+    Tests for booting multiple VMs simultaneously with multi-disk configurations.
+
+    Preconditions:
+        - Fedora golden image DataSource available in the openshift-virtualization-os-images namespace
+        - All schedulable worker nodes share the same architecture as the golden image
+        - Storage class supporting dynamic provisioning and CSI volume cloning
+        - Sufficient cluster resources to schedule 20 VMs simultaneously
+    """
+
+    @pytest.mark.polarion("CNV-16335")
+    def test_concurrent_vms_boot_with_five_disks(self):
+        """
+        Test that 20 VMs boot simultaneously with five disk devices each and all reach Running state.
+
+        Preconditions:
+            - Fedora golden image DataSource available in the openshift-virtualization-os-images namespace
+            - All schedulable worker nodes share the same architecture as the golden image
+            - Storage class supporting dynamic provisioning and CSI volume cloning
+            - Sufficient cluster resources to schedule 20 VMs simultaneously
+            - 20 VMs created, each with one golden image boot volume (PVC clone via DataSource),
+              one cloud-init disk, and three blank data volumes
+            - All 20 VMs started simultaneously and reached Running state
+
+        Steps:
+            1. Create 20 VMs, each with one golden image boot volume (PVC clone via DataSource),
+               one cloud-init disk, and three blank data volumes
+            2. Start all 20 VMs simultaneously
+            3. Wait for all 20 VMs to reach Running state
+            4. For each VM, inspect the disk devices reported in the VMI spec
+
+        Expected:
+            - All 20 VMs report exactly five disk devices each in the VMI spec
+        """

--- a/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
+++ b/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
@@ -10,47 +10,57 @@ Jira: https://redhat.atlassian.net/browse/CNV-88906  # <skip-jira-utils-check>
 Markers:
     - tier3
     - conformance
+    - high_vm_concurrent
+
+Preconditions:
+    - Storage class supporting dynamic provisioning
+    - Sufficient cluster resources to schedule 20 VMs simultaneously
 """
 
 import pytest
 
-__test__ = False
+from tests.storage.concurrent_vm_boot.constants import (
+    NUM_BLANK_DISKS_PER_VM,
+    NUM_FIXED_DISKS_PER_VM,
+)
 
-pytestmark = [pytest.mark.tier3, pytest.mark.conformance]
+pytestmark = [
+    pytest.mark.tier3,
+    pytest.mark.conformance,
+    pytest.mark.high_vm_concurrent,
+    pytest.mark.usefixtures("cluster_memory_for_concurrent_vms"),
+]
+
+EXPECTED_DISK_COUNT = NUM_FIXED_DISKS_PER_VM + NUM_BLANK_DISKS_PER_VM
 
 
 class TestConcurrentVMBoot:
-    """
-    Tests for booting multiple VMs simultaneously with multi-disk configurations.
+    """Tests for booting multiple VMs simultaneously with multi-disk configurations.
 
     Preconditions:
         - Fedora golden image DataSource available in the openshift-virtualization-os-images namespace
-        - All schedulable worker nodes share the same architecture as the golden image
         - Storage class supporting dynamic provisioning and CSI volume cloning
         - Sufficient cluster resources to schedule 20 VMs simultaneously
     """
 
     @pytest.mark.polarion("CNV-16335")
-    def test_concurrent_vms_boot_with_five_disks(self):
+    def test_concurrent_vms_boot_with_five_disks(self, running_vms_with_five_disks):
         """
         Test that 20 VMs boot simultaneously with five disk devices each and all reach Running state.
 
         Preconditions:
-            - Fedora golden image DataSource available in the openshift-virtualization-os-images namespace
-            - All schedulable worker nodes share the same architecture as the golden image
-            - Storage class supporting dynamic provisioning and CSI volume cloning
-            - Sufficient cluster resources to schedule 20 VMs simultaneously
-            - 20 VMs created, each with one golden image boot volume (PVC clone via DataSource),
+            - 20 running VMs, each with one golden image boot volume (PVC clone via DataSource),
               one cloud-init disk, and three blank data volumes
-            - All 20 VMs started simultaneously and reached Running state
 
         Steps:
-            1. Create 20 VMs, each with one golden image boot volume (PVC clone via DataSource),
-               one cloud-init disk, and three blank data volumes
-            2. Start all 20 VMs simultaneously
-            3. Wait for all 20 VMs to reach Running state
-            4. For each VM, inspect the disk devices reported in the VMI spec
+            1. For each VM, query the disk devices reported in the VMI spec
 
         Expected:
             - All 20 VMs report exactly five disk devices each in the VMI spec
         """
+        disk_failures = []
+        for vm in running_vms_with_five_disks:
+            actual_count = len(vm.vmi.instance.spec.domain.devices.disks)
+            if actual_count != EXPECTED_DISK_COUNT:
+                disk_failures.append(f"VM {vm.name} has {actual_count} disks, expected {EXPECTED_DISK_COUNT}")
+        assert not disk_failures, "\n".join(disk_failures)

--- a/tests/storage/concurrent_vm_boot/utils.py
+++ b/tests/storage/concurrent_vm_boot/utils.py
@@ -1,0 +1,230 @@
+"""Utilities for concurrent VM boot tests."""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING
+
+from kubernetes.utils.quantity import parse_quantity
+from ocp_resources.datavolume import DataVolume
+
+from tests.storage.concurrent_vm_boot.constants import BLANK_DV_SIZE, NUM_BLANK_DISKS_PER_VM
+from utilities.exceptions import ClusterSanityError
+from utilities.storage import construct_datavolume_source_dict, data_volume_template_with_source_ref_dict
+from utilities.virt import VirtualMachineForTests
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+
+    from kubernetes.dynamic import DynamicClient
+    from ocp_resources.data_source import DataSource
+    from ocp_resources.node import Node
+    from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+    from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
+
+LOGGER = logging.getLogger(__name__)
+
+
+def run_parallel(
+    items: list[Any],
+    func: Callable[..., Any],
+    label: str,
+    item_name: Callable[[Any], str] = str,
+) -> tuple[list[Any], list[str]]:
+    """Run func concurrently for each item, collecting results and error labels.
+
+    Args:
+        items: Items to process.
+        func: Callable accepting one item and returning a value.
+        label: Log prefix used in failure messages.
+        item_name: Function to produce a display name from an item for logging and error tracking.
+
+    Returns:
+        Tuple of (results, errors) where results are successful return values and
+        errors are display names of items for which func raised an exception.
+    """
+    if not items:
+        raise ValueError("run_parallel called with empty items list")
+    results: list[Any] = []
+    errors: list[str] = []
+    with ThreadPoolExecutor(max_workers=len(items)) as executor:
+        futures = {executor.submit(func, item): item for item in items}
+        for future in as_completed(futures):
+            item = futures[future]
+            try:
+                results.append(future.result())
+            except Exception as error:
+                name = item_name(item)
+                LOGGER.error(f"{label} {name}: {error}")
+                errors.append(name)
+    return results, errors
+
+
+def run_vms_parallel(
+    vms: list[VirtualMachineForTests],
+    func: Callable[[VirtualMachineForTests], Any],
+    label: str,
+) -> list[str]:
+    """Run func concurrently for each VM and collect the names of any that fail.
+
+    Args:
+        vms: VMs to process.
+        func: Callable accepting a single VM as its first positional argument.
+        label: Log prefix used in failure messages (e.g. "Failed to start VM").
+
+    Returns:
+        Names of VMs for which func raised an exception.
+    """
+    if not vms:
+        return []
+    _, errors = run_parallel(
+        items=vms,
+        func=func,
+        label=label,
+        item_name=lambda vm: vm.name,
+    )
+    return errors
+
+
+def assert_cluster_memory(nodes: list[Node], required_gi: int) -> None:
+    """Assert the cluster has sufficient aggregate allocatable memory.
+
+    Checks allocatable memory (node capacity minus system-reserved), not free/available memory
+    (allocatable minus currently requested by running pods). Callers should include an overhead
+    margin in ``required_gi`` to account for the gap between allocatable and truly free memory.
+
+    Args:
+        nodes: Schedulable cluster nodes.
+        required_gi: Minimum required aggregate allocatable memory in GiB, including overhead margin.
+
+    Raises:
+        ClusterSanityError: If aggregate allocatable memory across all nodes is below required_gi.
+    """
+    total_bytes = sum(parse_quantity(node.instance.status.allocatable.memory) for node in nodes)
+    required_bytes = required_gi * (2**30)
+    if total_bytes < required_bytes:
+        raise ClusterSanityError(
+            err_str=(
+                f"Insufficient cluster memory: {total_bytes / (2**30):.1f}Gi allocatable across "
+                f"{len(nodes)} schedulable nodes, need ≥ {required_gi}Gi"
+            )
+        )
+
+
+def blank_dv_template(name: str, namespace: str, storage_class_name: str) -> dict[str, Any]:
+    """Build a blank DataVolume template dict suitable for VM dataVolumeTemplates.
+
+    Args:
+        name: DataVolume name.
+        namespace: Target namespace (stripped from the returned dict for template use).
+        storage_class_name: Storage class for the blank PVC.
+
+    Returns:
+        Mutable DataVolume resource dict with namespace removed, ready for use in
+        VM dataVolumeTemplates.
+    """
+    dv = DataVolume(
+        name=name,
+        namespace=namespace,
+        source_dict=construct_datavolume_source_dict(source="blank"),
+        size=BLANK_DV_SIZE,
+        storage_class=storage_class_name,
+        api_name="storage",
+    )
+    dv.to_dict()
+    del dv.res["metadata"]["namespace"]
+    return dv.res
+
+
+class VMWithSeveralBlankDisks(VirtualMachineForTests):
+    """VM that injects blank data disks at creation time to avoid post-creation PATCH calls."""
+
+    def __init__(self, blank_disk_storage_class_name: str, num_blank_disks: int, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.blank_disk_storage_class_name = blank_disk_storage_class_name
+        self.num_blank_disks = num_blank_disks
+
+    def to_dict(self) -> None:
+        """Build the VM resource dict and add blank disk entries to it.
+
+        Note:
+            Do not call more than once. Each call appends the blank disks to the resource dict,
+            so a second call will result in duplicate disks.
+        """
+        super().to_dict()
+        template_spec = self.res["spec"]["template"]["spec"]
+        disks = template_spec["domain"]["devices"]["disks"]
+        volumes = template_spec["volumes"]
+        dv_templates = self.res["spec"]["dataVolumeTemplates"]
+
+        for disk_index in range(self.num_blank_disks):
+            dv_name = f"{self.name}-blank-{disk_index}"
+            template = blank_dv_template(
+                name=dv_name,
+                namespace=self.namespace,
+                storage_class_name=self.blank_disk_storage_class_name,
+            )
+            dv_templates.append(template)
+            disks.append({"disk": {"bus": "virtio"}, "name": dv_name})
+            volumes.append({"name": dv_name, "dataVolume": {"name": dv_name}})
+
+
+def create_concurrent_vm(
+    index: int,
+    namespace_name: str,
+    client: DynamicClient,
+    storage_class_name: str,
+    data_source: DataSource,
+    vm_instance_type: VirtualMachineClusterInstancetype,
+    vm_preference: VirtualMachineClusterPreference,
+    os_flavor: str,
+) -> VirtualMachineForTests:
+    """Create and deploy a VM with a golden image boot volume and blank data disks.
+
+    All disks are included in the VM spec at creation time (single API call).
+    On failure, cleans up the partially created VM before re-raising.
+
+    Args:
+        index: VM index used in the name (e.g. ``concurrent-vm-0``).
+        namespace_name: Namespace to deploy the VM into.
+        client: Kubernetes client for resource operations.
+        storage_class_name: Storage class for boot and blank PVCs.
+        data_source: Golden image DataSource for the boot volume.
+        vm_instance_type: Cluster instance type to assign to the VM.
+        vm_preference: Cluster preference to assign to the VM.
+        os_flavor: OS flavor string used for SSH login parameters and cloud-init.
+
+    Returns:
+        Deployed VirtualMachineForTests with all disks attached.
+    """
+    vm_name = f"concurrent-vm-{index}"
+    LOGGER.info(f"Creating VM {vm_name}")
+
+    vm = VMWithSeveralBlankDisks(
+        name=vm_name,
+        namespace=namespace_name,
+        client=client,
+        os_flavor=os_flavor,
+        vm_instance_type=vm_instance_type,
+        vm_preference=vm_preference,
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=data_source,
+            storage_class=storage_class_name,
+            name=f"{vm_name}-boot",
+        ),
+        blank_disk_storage_class_name=storage_class_name,
+        num_blank_disks=NUM_BLANK_DISKS_PER_VM,
+    )
+
+    try:
+        vm.deploy(wait=True)
+    except Exception as exc:
+        LOGGER.error(f"Failed to set up VM {vm_name}, cleaning up: {exc}")
+        try:
+            vm.clean_up()
+        except Exception as cleanup_error:
+            LOGGER.error(f"Failed to clean up VM {vm_name}: {cleanup_error}")
+        raise ClusterSanityError(err_str=f"VM {vm_name}: setup failed: {exc}") from exc
+
+    LOGGER.info(f"VM {vm_name} created with {NUM_BLANK_DISKS_PER_VM} blank disks attached")
+    return vm

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -689,10 +689,23 @@ def data_volume_template_dict_with_pvc_source(
 
 
 def data_volume_template_with_source_ref_dict(
-    data_source: DataSource, storage_class: str | None = None
+    data_source: DataSource, storage_class: str | None = None, name: str | None = None
 ) -> dict[str, Any]:
+    """Build a DataVolume template dict backed by a DataSource source reference.
+
+    Args:
+        data_source: The DataSource to clone from.
+        storage_class: Storage class for the PVC; if None, the cluster default is used.
+        name: Explicit DataVolume name. If None, a unique name is generated from the
+            DataSource name. The namespace is stripped from the returned dict so the
+            template is safe to embed in a VM's ``dataVolumeTemplates`` list.
+
+    Returns:
+        Mutable DataVolume resource dict with ``metadata.namespace`` removed, ready for
+        use in VM ``dataVolumeTemplates``.
+    """
     dv = DataVolume(
-        name=utilities.infra.unique_name(name=data_source.name),
+        name=name if name is not None else utilities.infra.unique_name(name=data_source.name),
         namespace=data_source.namespace,
         client=data_source.client,
         size=get_dv_size_from_datasource(data_source=data_source),


### PR DESCRIPTION
##### What this PR does / why we need it:

Adds a tier3 conformance test that boots 20 VMs simultaneously, each with 5 disks (boot clone, cloud-init, 3 blank DVs). The goal is to catch storage provisioning issues that only show up under concurrent load.

VMs are created/started/waited/cleaned up in parallel using a shared `run_parallel()` helper.
A memory preflight checks the cluster has at least 60Gi allocatable (20 VMs × 2Gi guest + 1Gi overhead margin) before anything starts.
Boot DVs follow the VM naming scheme (`concurrent-vm-{index}-boot`), All blank DVs are injected into the VM spec at creation time, no post-creation patches.

##### Which issue(s) this PR fixes:

Jira: CNV-88906

##### Special notes for reviewer:

- `u1.small` is used to meet the `fedora` preference minimum of 2Gi guest RAM
- `check_ssh_connectivity=True` — VMs are verified as fully booted (SSH reachable), not just in Running state
- `TIMEOUT_10MIN` per VM — all 20 VMs wait in parallel (each with an independent 10-minute window for slowest vm is reasonable), 
- `vm_preference` and `os_flavor` are passed as arguments to `create_concurrent_vm` instead of being hardcoded

##### jira-ticket:

https://redhat.atlassian.net/browse/CNV-88906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Added coverage for booting 20 Fedora virtual machines concurrently, each configured with five disks.
- Validates cluster memory capacity, startup, Running state, SSH readiness, and disk counts.
- Added cleanup and detailed failure reporting for setup, boot, readiness, and teardown scenarios.
- Introduced a high-concurrency marker for capacity-intensive test scenarios.

## Utilities

- Added reusable support for parallel VM operations, cluster capacity validation, and multi-disk VM provisioning.
- Added support for explicitly naming storage volume templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->