### PR TITLE
fix(infra): pass client when resolving HCO namespace in data_collector

### DIFF
--- a/utilities/data_collector.py
+++ b/utilities/data_collector.py
@@ -139,7 +139,7 @@ def collect_ocp_must_gather(since_time):
 
 def collect_default_cnv_must_gather_with_vm_gather(since_time, target_dir, admin_client):
     cnv_csv = utilities.hco.get_installed_hco_csv(
-        admin_client=admin_client, hco_namespace=Namespace(name=py_config["hco_namespace"])
+        admin_client=admin_client, hco_namespace=Namespace(client=admin_client, name=py_config["hco_namespace"])
     )
     LOGGER.info(f"Collecting cnv-must gather using CSV: {cnv_csv.name}")
     must_gather_image = [

--- a/utilities/unittests/test_data_collector.py
+++ b/utilities/unittests/test_data_collector.py
@@ -425,7 +425,7 @@ class TestCollectDefaultCnvMustGatherWithVmGather:
 
         collect_default_cnv_must_gather_with_vm_gather(1800, "/target/dir", admin_client=mock_client)
 
-        mock_namespace_class.assert_called_once_with(name="test-hco-ns")
+        mock_namespace_class.assert_called_once_with(client=mock_client, name="test-hco-ns")
         mock_get_csv.assert_called_once_with(admin_client=mock_client, hco_namespace=mock_namespace)
 
         # ASSERTION: Verify the expected must-gather image selection behavior


### PR DESCRIPTION
##### What this PR does / why we need it:
Pass `admin_client` into the `Namespace` used when collecting CNV must-gather so the resource does not implicitly call `get_client()`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Part of the openshift-python-wrapper `client=` pass-through cleanup (shared/general utils split). Draft for incremental review.

##### jira-ticket:
NONE

Made with [Cursor](https://cursor.com)