### PR TITLE
fix(tests): pass client to DataVolume in create_cirros_vm

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -561,6 +561,7 @@ def create_cirros_vm(
     artifactory_config_map = get_artifactory_config_map(namespace=namespace)
 
     dv = DataVolume(
+        client=client,
         name=dv_name,
         namespace=namespace,
         source_dict=construct_datavolume_source_dict(


### PR DESCRIPTION
##### What this PR does / why we need it:
Pass the existing `client` argument into the `DataVolume` constructed by `create_cirros_vm`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Part of the openshift-python-wrapper `client=` pass-through cleanup (shared/general utils split). Draft for incremental review.

##### jira-ticket:
NONE

Made with [Cursor](https://cursor.com)