### PR TITLE
fix(tests): pass client into shared Resource fixtures in tests/conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2436,11 +2436,11 @@ def rhel_vm_with_cluster_instance_type_and_preference(namespace, unprivileged_cl
         namespace=namespace.name,
         client=unprivileged_client,
         vm_instance_type=VirtualMachineClusterInstancetype(
-            client=namespace.client,
+            client=unprivileged_client,
             name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[INSTANCE_TYPE_STR],
         ),
         vm_preference=VirtualMachineClusterPreference(
-            client=namespace.client,
+            client=unprivileged_client,
             name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR],
         ),
         os_flavor=OS_FLAVOR_RHEL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1163,8 +1163,10 @@ def golden_images_cluster_role_edit(
 def golden_images_edit_rolebinding(
     golden_images_namespace,
     golden_images_cluster_role_edit,
+    admin_client,
 ):
     with RoleBinding(
+        client=admin_client,
         name="role-bind-create-dv",
         namespace=golden_images_namespace.name,
         subjects_kind="User",
@@ -1372,13 +1374,13 @@ def hyperconverged_with_node_placement(request, admin_client, hco_namespace, hyp
 
 
 @pytest.fixture(scope="module")
-def hostpath_provisioner_scope_module():
-    yield HostPathProvisioner(name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
+def hostpath_provisioner_scope_module(admin_client):
+    yield HostPathProvisioner(client=admin_client, name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
 
 
 @pytest.fixture(scope="session")
-def hostpath_provisioner_scope_session():
-    yield HostPathProvisioner(name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
+def hostpath_provisioner_scope_session(admin_client):
+    yield HostPathProvisioner(client=admin_client, name=HostPathProvisioner.Name.HOSTPATH_PROVISIONER)
 
 
 @pytest.fixture(scope="session")
@@ -1466,15 +1468,15 @@ def kmp_enabled_ns(admin_client, kmp_vm_label):
 
 
 @pytest.fixture(scope="session")
-def cdi(hco_namespace):
-    cdi = CDI(name=CDI_KUBEVIRT_HYPERCONVERGED)
+def cdi(hco_namespace, admin_client):
+    cdi = CDI(client=admin_client, name=CDI_KUBEVIRT_HYPERCONVERGED)
     assert cdi.instance is not None
     yield cdi
 
 
 @pytest.fixture(scope="session")
-def cdi_config():
-    cdi_config = CDIConfig(name="config")
+def cdi_config(admin_client):
+    cdi_config = CDIConfig(client=admin_client, name="config")
     assert cdi_config.instance is not None
     return cdi_config
 
@@ -2119,9 +2121,10 @@ def fips_enabled_cluster(workers_utility_pods):
 
 
 @pytest.fixture(scope="class")
-def instance_type_for_test_scope_class(namespace, common_instance_type_param_dict):
+def instance_type_for_test_scope_class(namespace, common_instance_type_param_dict, admin_client):
     instance_type_param_dict = copy.deepcopy(common_instance_type_param_dict)
     instance_type_param_dict["namespace"] = namespace.name
+    instance_type_param_dict["client"] = admin_client
     return VirtualMachineInstancetype(**instance_type_param_dict)
 
 
@@ -2158,9 +2161,11 @@ def common_instance_type_param_dict(request):
 
 
 @pytest.fixture(scope="class")
-def vm_preference_for_test(namespace, common_vm_preference_param_dict):
+def vm_preference_for_test(namespace, common_vm_preference_param_dict, admin_client):
     vm_preference_param_dict = copy.deepcopy(common_vm_preference_param_dict)
     vm_preference_param_dict["namespace"] = namespace.name
+    if vm_preference_param_dict.get("client") is None:
+        vm_preference_param_dict["client"] = admin_client
     return VirtualMachinePreference(**vm_preference_param_dict)
 
 
@@ -2291,8 +2296,9 @@ def is_disconnected_cluster():
 
 
 @pytest.fixture()
-def migration_policy_with_bandwidth():
+def migration_policy_with_bandwidth(admin_client):
     with MigrationPolicy(
+        client=admin_client,
         name="migration-policy",
         bandwidth_per_migration="128Ki",
         vmi_selector=MIGRATION_POLICY_VM_LABEL,
@@ -2301,8 +2307,9 @@ def migration_policy_with_bandwidth():
 
 
 @pytest.fixture(scope="class")
-def migration_policy_with_bandwidth_scope_class():
+def migration_policy_with_bandwidth_scope_class(admin_client):
     with MigrationPolicy(
+        client=admin_client,
         name="migration-policy",
         bandwidth_per_migration="128Ki",
         vmi_selector=MIGRATION_POLICY_VM_LABEL,
@@ -2311,8 +2318,9 @@ def migration_policy_with_bandwidth_scope_class():
 
 
 @pytest.fixture(scope="session")
-def worker_machine1(worker_node1):
+def worker_machine1(worker_node1, admin_client):
     machine = Machine(
+        client=admin_client,
         name=worker_node1.machine_name,
         namespace=py_config["machine_api_namespace"],
     )
@@ -2365,6 +2373,7 @@ def migrated_vm_multiple_times(request, vm_for_migration_test):
     vmim = []
     for migration_index in range(request.param):
         migration_obj = VirtualMachineInstanceMigration(
+            client=vm_for_migration_test.client,
             name=f"{vm_for_migration_test.name}-{migration_index}",
             namespace=vm_for_migration_test.namespace,
             vmi_name=vm_for_migration_test.vmi.name,
@@ -2428,9 +2437,13 @@ def rhel_vm_with_cluster_instance_type_and_preference(namespace, unprivileged_cl
         namespace=namespace.name,
         client=unprivileged_client,
         vm_instance_type=VirtualMachineClusterInstancetype(
-            name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[INSTANCE_TYPE_STR]
+            client=unprivileged_client,
+            name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[INSTANCE_TYPE_STR],
         ),
-        vm_preference=VirtualMachineClusterPreference(name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR]),
+        vm_preference=VirtualMachineClusterPreference(
+            client=unprivileged_client,
+            name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR],
+        ),
         os_flavor=OS_FLAVOR_RHEL,
     ) as vm:
         running_vm(
@@ -2555,8 +2568,8 @@ def ssp_resource_scope_class(admin_client, hco_namespace):
 
 
 @pytest.fixture(scope="session")
-def kube_system_namespace():
-    kube_system_ns = Namespace(name="kube-system")
+def kube_system_namespace(admin_client):
+    kube_system_ns = Namespace(client=admin_client, name="kube-system")
     if kube_system_ns.exists:
         return kube_system_ns
     raise ResourceNotFoundError(f"{kube_system_ns.name} namespace not found")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1161,9 +1161,9 @@ def golden_images_cluster_role_edit(
 
 @pytest.fixture()
 def golden_images_edit_rolebinding(
+    admin_client,
     golden_images_namespace,
     golden_images_cluster_role_edit,
-    admin_client,
 ):
     with RoleBinding(
         client=admin_client,
@@ -1468,7 +1468,7 @@ def kmp_enabled_ns(admin_client, kmp_vm_label):
 
 
 @pytest.fixture(scope="session")
-def cdi(hco_namespace, admin_client):
+def cdi(admin_client, hco_namespace):
     cdi = CDI(client=admin_client, name=CDI_KUBEVIRT_HYPERCONVERGED)
     assert cdi.instance is not None
     yield cdi
@@ -2121,7 +2121,7 @@ def fips_enabled_cluster(workers_utility_pods):
 
 
 @pytest.fixture(scope="class")
-def instance_type_for_test_scope_class(namespace, common_instance_type_param_dict, admin_client):
+def instance_type_for_test_scope_class(admin_client, namespace, common_instance_type_param_dict):
     instance_type_param_dict = copy.deepcopy(common_instance_type_param_dict)
     instance_type_param_dict["namespace"] = namespace.name
     instance_type_param_dict["client"] = admin_client
@@ -2161,7 +2161,7 @@ def common_instance_type_param_dict(request):
 
 
 @pytest.fixture(scope="class")
-def vm_preference_for_test(namespace, common_vm_preference_param_dict, admin_client):
+def vm_preference_for_test(admin_client, namespace, common_vm_preference_param_dict):
     vm_preference_param_dict = copy.deepcopy(common_vm_preference_param_dict)
     vm_preference_param_dict["namespace"] = namespace.name
     if vm_preference_param_dict.get("client") is None:
@@ -2318,7 +2318,7 @@ def migration_policy_with_bandwidth_scope_class(admin_client):
 
 
 @pytest.fixture(scope="session")
-def worker_machine1(worker_node1, admin_client):
+def worker_machine1(admin_client, worker_node1):
     machine = Machine(
         client=admin_client,
         name=worker_node1.machine_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2368,11 +2368,11 @@ def vm_for_test(request, namespace, unprivileged_client):
 
 
 @pytest.fixture(scope="class")
-def migrated_vm_multiple_times(request, vm_for_migration_test):
+def migrated_vm_multiple_times(request, admin_client, vm_for_migration_test):
     vmim = []
     for migration_index in range(request.param):
         migration_obj = VirtualMachineInstanceMigration(
-            client=vm_for_migration_test.client,
+            client=admin_client,
             name=f"{vm_for_migration_test.name}-{migration_index}",
             namespace=vm_for_migration_test.namespace,
             vmi_name=vm_for_migration_test.vmi.name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1161,12 +1161,11 @@ def golden_images_cluster_role_edit(
 
 @pytest.fixture()
 def golden_images_edit_rolebinding(
-    admin_client,
     golden_images_namespace,
     golden_images_cluster_role_edit,
 ):
     with RoleBinding(
-        client=admin_client,
+        client=golden_images_namespace.client,
         name="role-bind-create-dv",
         namespace=golden_images_namespace.name,
         subjects_kind="User",
@@ -1468,8 +1467,8 @@ def kmp_enabled_ns(admin_client, kmp_vm_label):
 
 
 @pytest.fixture(scope="session")
-def cdi(admin_client, hco_namespace):
-    cdi = CDI(client=admin_client, name=CDI_KUBEVIRT_HYPERCONVERGED)
+def cdi(hco_namespace):
+    cdi = CDI(client=hco_namespace.client, name=CDI_KUBEVIRT_HYPERCONVERGED)
     assert cdi.instance is not None
     yield cdi
 
@@ -2121,10 +2120,10 @@ def fips_enabled_cluster(workers_utility_pods):
 
 
 @pytest.fixture(scope="class")
-def instance_type_for_test_scope_class(admin_client, namespace, common_instance_type_param_dict):
+def instance_type_for_test_scope_class(namespace, common_instance_type_param_dict):
     instance_type_param_dict = copy.deepcopy(common_instance_type_param_dict)
     instance_type_param_dict["namespace"] = namespace.name
-    instance_type_param_dict["client"] = admin_client
+    instance_type_param_dict["client"] = namespace.client
     return VirtualMachineInstancetype(**instance_type_param_dict)
 
 
@@ -2161,11 +2160,11 @@ def common_instance_type_param_dict(request):
 
 
 @pytest.fixture(scope="class")
-def vm_preference_for_test(admin_client, namespace, common_vm_preference_param_dict):
+def vm_preference_for_test(namespace, common_vm_preference_param_dict):
     vm_preference_param_dict = copy.deepcopy(common_vm_preference_param_dict)
     vm_preference_param_dict["namespace"] = namespace.name
     if vm_preference_param_dict.get("client") is None:
-        vm_preference_param_dict["client"] = admin_client
+        vm_preference_param_dict["client"] = namespace.client
     return VirtualMachinePreference(**vm_preference_param_dict)
 
 
@@ -2318,9 +2317,9 @@ def migration_policy_with_bandwidth_scope_class(admin_client):
 
 
 @pytest.fixture(scope="session")
-def worker_machine1(admin_client, worker_node1):
+def worker_machine1(worker_node1):
     machine = Machine(
-        client=admin_client,
+        client=worker_node1.client,
         name=worker_node1.machine_name,
         namespace=py_config["machine_api_namespace"],
     )
@@ -2437,11 +2436,11 @@ def rhel_vm_with_cluster_instance_type_and_preference(namespace, unprivileged_cl
         namespace=namespace.name,
         client=unprivileged_client,
         vm_instance_type=VirtualMachineClusterInstancetype(
-            client=unprivileged_client,
+            client=namespace.client,
             name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[INSTANCE_TYPE_STR],
         ),
         vm_preference=VirtualMachineClusterPreference(
-            client=unprivileged_client,
+            client=namespace.client,
             name=EXPECTED_CLUSTER_INSTANCE_TYPE_LABELS[PREFERENCE_STR],
         ),
         os_flavor=OS_FLAVOR_RHEL,

--- a/tests/fixtures/credentials/rhsm.py
+++ b/tests/fixtures/credentials/rhsm.py
@@ -16,8 +16,9 @@ def rhsm_credentials_from_bitwarden():
 
 
 @pytest.fixture(scope="module")
-def rhsm_created_secret(rhsm_credentials_from_bitwarden, namespace):
+def rhsm_created_secret(admin_client, rhsm_credentials_from_bitwarden, namespace):
     with Secret(
+        client=admin_client,
         name=RHSM_SECRET_NAME,
         namespace=namespace.name,
         data_dict={

--- a/tests/fixtures/credentials/rhsm.py
+++ b/tests/fixtures/credentials/rhsm.py
@@ -16,9 +16,9 @@ def rhsm_credentials_from_bitwarden():
 
 
 @pytest.fixture(scope="module")
-def rhsm_created_secret(admin_client, rhsm_credentials_from_bitwarden, namespace):
+def rhsm_created_secret(rhsm_credentials_from_bitwarden, namespace):
     with Secret(
-        client=admin_client,
+        client=namespace.client,
         name=RHSM_SECRET_NAME,
         namespace=namespace.name,
         data_dict={


### PR DESCRIPTION
##### What this PR does / why we need it:
Pass an explicit `client` into shared Resource constructors in `tests/conftest.py` and `tests/fixtures/credentials/rhsm.py` so they do not fall back to implicit `get_client()`.

When a related resource is already in scope, use its `.client` (e.g. `namespace.client`, `golden_images_namespace.client`, `hco_namespace.client`, `worker_node1.client`, `vm.client`). Use `admin_client` / `unprivileged_client` only when no related resource client is available (e.g. cluster-scoped `cdi_config`, `migration_policy_*`, `hostpath_provisioner_*`, `kube_system_namespace`).

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Part of the openshift-python-wrapper `client=` pass-through cleanup (shared/general utils split). Draft for incremental review.

##### jira-ticket:
NONE

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test resource setup by explicitly associating Kubernetes/OpenShift resources and secrets with the correct client contexts.
  * Updated fixtures for namespaces, CDI and CDI configuration, migration policies (including scope-class variants), virtual machine migration scenarios, and storage provisioning to ensure consistent wiring.
  * Refined fixture signatures and dependencies across multiple test scopes to support the new client requirements and improve test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->