### PR TITLE
fix(chaos): pass client to Namespace, Node.get, and Instancetype helpers

### DIFF
--- a/tests/chaos/conftest.py
+++ b/tests/chaos/conftest.py
@@ -369,7 +369,7 @@ def artifactory_config_map_chaos_namespace_scope_module(chaos_namespace):
 
 @pytest.fixture(scope="class")
 def chaos_vms_instancetype_list(request, admin_client, chaos_namespace):
-    required_instancetype = get_instance_type(name=U1_SMALL)
+    required_instancetype = get_instance_type(name=U1_SMALL, client=admin_client)
 
     vms_list = []
     for idx in range(request.param["number_of_vms"]):

--- a/tests/chaos/migration/test_migration.py
+++ b/tests/chaos/migration/test_migration.py
@@ -79,7 +79,7 @@ def test_pod_delete_migration(
     wait_for_vmi_relocation_and_running(vm=chaos_vm_rhel9, initial_node=tainted_node_for_vm_chaos_rhel9_migration)
     wait_for_pods_running(
         admin_client=admin_client,
-        namespace=Namespace(name=pod_deleting_process["namespace_name"]),
+        namespace=Namespace(client=admin_client, name=pod_deleting_process["namespace_name"]),
         number_of_consecutive_checks=10,
         filter_pods_by_name=pod_deleting_process["pod_prefix"],
     )

--- a/tests/chaos/utils.py
+++ b/tests/chaos/utils.py
@@ -204,9 +204,9 @@ def get_daemonset_replicas(admin_client, namespaces):
     return daemonsets_replicas
 
 
-def get_nodes_status():
+def get_nodes_status(client):
     nodes_status = {"nodes": {}}
-    for node in Node.get():
+    for node in Node.get(client=client):
         # Set loglevel to ERROR to avoid cluttering with the logs resulting from getting node status
         with resource_log_level_error(resource=node) as _node:
             nodes_status["nodes"][node.name] = "ready" if _node.kubelet_ready else "not ready"
@@ -233,7 +233,7 @@ def collect_cluster_health_info(client, hco_namespace, additional_namespaces):
     pods_status = get_pods_status(admin_client=client, namespaces=namespaces_to_monitor)
     deployments_replicas = get_deployment_replicas(admin_client=client, namespaces=namespaces_to_monitor)
     daemonset_replicas = get_daemonset_replicas(admin_client=client, namespaces=namespaces_to_monitor)
-    nodes_status = get_nodes_status()
+    nodes_status = get_nodes_status(client=client)
     hco_status_conditions = get_hyperconverged_status_conditions(client=client, hco_namespace=hco_namespace)
 
     log_content = json.dumps(
@@ -407,11 +407,11 @@ def pod_deleting_process_recover(resources, namespace, pod_prefix):
         raise ResourceNotFoundError(f"No resources found with prefix {pod_prefix} in namespace {namespace}")
 
 
-def get_instance_type(name):
+def get_instance_type(name, client):
     """
     Function to check if the instance type exists
     """
-    instance_type = VirtualMachineClusterInstancetype(name=name)
+    instance_type = VirtualMachineClusterInstancetype(client=client, name=name)
     if not instance_type.exists:
         raise ResourceNotFoundError(f"Required instance type {name} does not exist")
     return instance_type


### PR DESCRIPTION
##### What this PR does / why we need it:
Pass `client`/`admin_client` into chaos helpers that construct `Namespace`, call `Node.get`, or look up `VirtualMachineClusterInstancetype`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Part of the openshift-python-wrapper `client=` pass-through cleanup (shared/general utils split). Draft for incremental review.

##### jira-ticket:
NONE

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chaos and migration test reliability by consistently using the appropriate Kubernetes/OpenShift client when checking nodes, pods, and virtual machine instance types.
  * Updated cluster health and migration checks to operate against the intended environment context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->