### PR TITLE
[IUO] add missing client param

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/conftest.py
+++ b/tests/infrastructure/golden_images/update_boot_source/conftest.py
@@ -66,13 +66,16 @@ def enabled_common_boot_image_import_feature_gate_scope_class(
 
 
 @pytest.fixture()
-def updated_hco_with_custom_data_import_cron_scope_function(request, hyperconverged_resource_scope_function):
+def updated_hco_with_custom_data_import_cron_scope_function(
+    request, admin_client, hyperconverged_resource_scope_function
+):
     data_import_cron_dict = generate_data_import_cron_dict(
         name=request.param["data_import_cron_name"],
         source_url=request.param["data_import_cron_source_url"],
         managed_data_source_name=request.param["managed_data_source_name"],
     )
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_function: {"spec": {"dataImportCronTemplates": [data_import_cron_dict]}}
         },

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -58,11 +58,12 @@ class TestDataImportCronValidation:
 
     @pytest.mark.polarion("CNV-8032")
     @pytest.mark.s390x
-    def test_data_import_cron_blocked_update(self, golden_images_data_import_crons_scope_function):
+    def test_data_import_cron_blocked_update(self, admin_client, golden_images_data_import_crons_scope_function):
         first_data_import_cron = golden_images_data_import_crons_scope_function[0]
         LOGGER.info(f"Verify dataImportCron {first_data_import_cron.name} cannot be updated.")
         with pytest.raises(UnprocessibleEntityError, match=r".*Cannot update DataImportCron Spec.*"):
             with ResourceEditorValidateHCOReconcile(
+                admin_client=admin_client,
                 patches={first_data_import_cron: {"spec": {"managedDataSource": CUSTOM_DATA_SOURCE_NAME}}},
             ):
                 pytest.fail("Expected UnprocessibleEntityError was not raised")

--- a/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
+++ b/tests/infrastructure/vhostmd/test_downwardmetrics_virtio.py
@@ -93,9 +93,11 @@ def parsed_metrics_command_data(vm):
 
 @pytest.fixture()
 def enabled_feature_gate_for_downward_metrics_scope_function(
+    admin_client,
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {"featureGates": {"downwardMetrics": True}}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/infrastructure/vhostmd/test_vhostmd.py
+++ b/tests/infrastructure/vhostmd/test_vhostmd.py
@@ -54,8 +54,9 @@ def download_and_install_vm_dump_metrics(vm, rpm_file_name):
 
 
 @pytest.fixture(scope="module")
-def enabled_downward_metrics_hco_featuregate(hyperconverged_resource_scope_module):
+def enabled_downward_metrics_hco_featuregate(admin_client, hyperconverged_resource_scope_module):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_module: {"spec": {"featureGates": {"downwardMetrics": True}}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/install_upgrade_operators/cert_renewal/conftest.py
+++ b/tests/install_upgrade_operators/cert_renewal/conftest.py
@@ -42,6 +42,7 @@ def hyperconverged_resource_certconfig_change(
     }
     LOGGER.info("Modifying certconfig in HCO CR")
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_class: {"spec": {HCO_CR_CERT_CONFIG_KEY: target_certconfig_stanza}}},
         list_resource_reconcile=[CDI, NetworkAddonsConfig, SSP],
         wait_for_reconcile_post_update=True,

--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -180,6 +180,7 @@ def updated_hco_cr(request, hyperconverged_resource_scope_function, admin_client
     This fixture updates HCO CR with values specified via request.param
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: request.param["patch"]},
         list_resource_reconcile=request.param.get("list_resource_reconcile", [NetworkAddonsConfig, CDI, KubeVirt]),
         wait_for_reconcile_post_update=True,
@@ -193,6 +194,7 @@ def updated_kubevirt_cr(request, kubevirt_resource, admin_client, hco_namespace)
     Attempts to update kubevirt CR
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={kubevirt_resource: request.param["patch"]},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,
@@ -294,6 +296,7 @@ def updated_resource(
         namespace=request.param.get(RESOURCE_NAMESPACE_STR),
     )
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={cr: request.param["patch"]},
         action="replace",
         list_resource_reconcile=request.param.get("list_resource_reconcile", [cr_kind]),

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_crypto_policy_propagation.py
@@ -33,10 +33,12 @@ def hco_crypto_policy(
 
 @pytest.fixture()
 def updated_hco_crypto_policy(
+    admin_client,
     hyperconverged_resource_scope_function,
     cnv_crypto_policy_matrix__function__,
 ):
     with set_hco_crypto_policy(
+        admin_client=admin_client,
         hco_resource=hyperconverged_resource_scope_function,
         tls_spec=CRYPTO_POLICY_SPEC_DICT[cnv_crypto_policy_matrix__function__],
     ):

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.s390x
 
 @pytest.mark.polarion("CNV-9367")
 def test_set_hco_crypto_failed_without_required_cipher(
+    admin_client,
     hyperconverged_resource_scope_function,
 ):
     """
@@ -35,6 +36,7 @@ def test_set_hco_crypto_failed_without_required_cipher(
     tls_spec = {"spec": {TLS_SECURITY_PROFILE: tls_custom_profile}}
     with pytest.raises(ForbiddenError, match=r"missing an HTTP/2-required"):
         with ResourceEditorValidateHCOReconcile(
+            admin_client=admin_client,
             patches={hyperconverged_resource_scope_function: tls_spec},
             list_resource_reconcile=MANAGED_CRS_LIST,
             wait_for_reconcile_post_update=True,
@@ -45,12 +47,13 @@ def test_set_hco_crypto_failed_without_required_cipher(
 
 
 @pytest.mark.polarion("CNV-10551")
-def test_set_ciphers_for_tlsv13(hyperconverged_resource_scope_function):
+def test_set_ciphers_for_tlsv13(admin_client, hyperconverged_resource_scope_function):
     error_string = r"custom ciphers cannot be selected when minTLSVersion is VersionTLS13"
     tls_custom_profile = copy.deepcopy(TLS_CUSTOM_PROFILE)
     tls_custom_profile[TLS_CUSTOM_POLICY]["minTLSVersion"] = "VersionTLS13"
     with pytest.raises(ForbiddenError, match=error_string):
         with ResourceEditorValidateHCOReconcile(
+            admin_client=admin_client,
             patches={hyperconverged_resource_scope_function: {"spec": {TLS_SECURITY_PROFILE: tls_custom_profile}}}
         ):
             LOGGER.error(

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_custom_profile_negative.py
@@ -54,7 +54,7 @@ def test_set_ciphers_for_tlsv13(admin_client, hyperconverged_resource_scope_func
     with pytest.raises(ForbiddenError, match=error_string):
         with ResourceEditorValidateHCOReconcile(
             admin_client=admin_client,
-            patches={hyperconverged_resource_scope_function: {"spec": {TLS_SECURITY_PROFILE: tls_custom_profile}}}
+            patches={hyperconverged_resource_scope_function: {"spec": {TLS_SECURITY_PROFILE: tls_custom_profile}}},
         ):
             LOGGER.error(
                 "Setting HCO with custom tlsSecurityProfile with TLS Version 1.3 "

--- a/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
@@ -22,8 +22,9 @@ pytestmark = pytest.mark.tier3
 
 
 @pytest.fixture()
-def updated_hco_tls_custom_policy(hyperconverged_resource_scope_function):
+def updated_hco_tls_custom_policy(admin_client, hyperconverged_resource_scope_function):
     with set_hco_crypto_policy(
+        admin_client=admin_client,
         hco_resource=hyperconverged_resource_scope_function,
         tls_spec=TLS_CUSTOM_PROFILE,
     ):

--- a/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_update_specific_component_crypto_policy.py
@@ -82,6 +82,7 @@ def updated_cr_with_custom_crypto_policy(
     value = request.param["value"]
     tls_policy = {**value, **TLS_POLICIES_WITHOUT_CUSTOM_POLICY}
     with update_hco_annotations(
+        admin_client=admin_client,
         resource=hyperconverged_resource_scope_function,
         path=request.param["key"],
         value=tls_policy,

--- a/tests/install_upgrade_operators/crypto_policy/utils.py
+++ b/tests/install_upgrade_operators/crypto_policy/utils.py
@@ -263,8 +263,9 @@ def assert_tls_ciphers_blocked(utility_pods, node, services, tls_version, allowe
 
 
 @contextmanager
-def set_hco_crypto_policy(hco_resource, tls_spec):
+def set_hco_crypto_policy(admin_client, hco_resource, tls_spec):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hco_resource: {"spec": {TLS_SECURITY_PROFILE: tls_spec}}},
         wait_for_reconcile_post_update=True,
         list_resource_reconcile=MANAGED_CRS_LIST,

--- a/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
+++ b/tests/install_upgrade_operators/feature_gates/test_update_featuregate_hco.py
@@ -15,9 +15,11 @@ pytestmark = [pytest.mark.s390x, pytest.mark.skip_must_gather_collection]
 @pytest.fixture()
 def updated_fg_hco(
     request,
+    admin_client,
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {FEATUREGATES: request.param["featuregate"]}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -97,12 +97,14 @@ def default_common_templates_related_resources(default_common_template_hco_statu
 
 @pytest.fixture(scope="class")
 def updated_common_template_custom_ns(
+    admin_client,
     unprivileged_client,
     golden_images_namespace,
     hyperconverged_resource_scope_class,
     custom_golden_images_namespace,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {COMMON_BOOT_IMAGE_NAMESPACE_STR: custom_golden_images_namespace.name}
@@ -129,6 +131,7 @@ def updated_common_templates_non_existent_ns(
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {COMMON_BOOT_IMAGE_NAMESPACE_STR: "non-existent-ns"}}}
     ):
         yield

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -132,7 +132,9 @@ def updated_common_templates_non_existent_ns(
 ):
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
-        patches={hyperconverged_resource_scope_function: {"spec": {COMMON_BOOT_IMAGE_NAMESPACE_STR: "non-existent-ns"}}}
+        patches={
+            hyperconverged_resource_scope_function: {"spec": {COMMON_BOOT_IMAGE_NAMESPACE_STR: "non-existent-ns"}}
+        },
     ):
         yield
     wait_for_hco_conditions(

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -101,6 +101,7 @@ def updated_common_template(
         )
     LOGGER.info(f"Common templates {updated_templates}, updating to: {updated_common_template}")
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_function: {
                 "spec": {SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME: updated_common_template_dict_list}

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cdi.py
@@ -27,6 +27,7 @@ pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 @pytest.fixture(scope="class")
 def json_patched_cdi(admin_client, hco_namespace, prometheus, hyperconverged_resource_scope_class):
     with update_hco_annotations(
+        admin_client=admin_client,
         resource=hyperconverged_resource_scope_class,
         path=PATH_CDI,
         op="remove",

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_cnao.py
@@ -32,6 +32,7 @@ def json_patched_cnao(
     hyperconverged_resource_scope_class,
 ):
     with update_hco_annotations(
+        admin_client=admin_client,
         resource=hyperconverged_resource_scope_class,
         path=PATH,
         op="replace",

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_kubevirt.py
@@ -27,6 +27,7 @@ pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 @pytest.fixture(scope="class")
 def json_patched_kubevirt(admin_client, hco_namespace, prometheus, hyperconverged_resource_scope_class):
     with update_hco_annotations(
+        admin_client=admin_client,
         resource=hyperconverged_resource_scope_class,
         path=PATH_KUBEVIRT,
         value={DISABLE_TLS: True},

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_multiple_updates.py
@@ -60,6 +60,7 @@ def get_metadata():
 @pytest.fixture(scope="class")
 def multiple_json_patched(admin_client, hco_namespace, prometheus, hyperconverged_resource_scope_class):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: get_metadata(),
         },

--- a/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
+++ b/tests/install_upgrade_operators/json_patch/test_json_patch_annotation_ssp.py
@@ -28,6 +28,7 @@ pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 @pytest.fixture(scope="class")
 def json_patched_ssp(admin_client, hco_namespace, prometheus, hyperconverged_resource_scope_class):
     with update_hco_annotations(
+        admin_client=admin_client,
         resource=hyperconverged_resource_scope_class,
         path=TEMPLATE_VALIDATOR,
         value={"replicas": REPLICAS},

--- a/tests/install_upgrade_operators/launcher_updates/conftest.py
+++ b/tests/install_upgrade_operators/launcher_updates/conftest.py
@@ -14,6 +14,7 @@ def updated_workload_strategy_custom_values(hyperconverged_resource_scope_functi
     Note: This is needed for tests that modify such fields to default values
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: CUSTOM_WORKLOAD_STRATEGY_SPEC.copy()},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -638,9 +638,10 @@ def must_gather_vm_files_path(collected_vm_details_must_gather, vm_for_migration
 
 
 @pytest.fixture(scope="class")
-def updated_disable_serial_console_log_false(hyperconverged_resource_scope_class):
+def updated_disable_serial_console_log_false(admin_client, hyperconverged_resource_scope_class):
     if hyperconverged_resource_scope_class.instance.spec.virtualMachineOptions.disableSerialConsoleLog:
         with ResourceEditorValidateHCOReconcile(
+            admin_client=admin_client,
             patches={
                 hyperconverged_resource_scope_class: {
                     "spec": {"virtualMachineOptions": {"disableSerialConsoleLog": False}}

--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -646,7 +646,7 @@ def updated_disable_serial_console_log_false(admin_client, hyperconverged_resour
                 hyperconverged_resource_scope_class: {
                     "spec": {"virtualMachineOptions": {"disableSerialConsoleLog": False}}
                 }
-            }
+            },
         ):
             yield
     else:

--- a/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
+++ b/tests/install_upgrade_operators/node_component/test_deploy_cnv_on_subset_of_nodes_sanity.py
@@ -156,6 +156,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
     )
     def test_workload_components_selection_change_denied_with_workloads(
         self,
+        admin_client,
         nodes_labeled,
         vm_placement_vm_work3,
         hyperconverged_resource_scope_function,
@@ -163,6 +164,7 @@ class TestDeployCNVOnSubsetOfClusterNodes:
         LOGGER.info("Attempting to update HCO with node placement, expecting it to fail")
         try:
             with ResourceEditorValidateHCOReconcile(
+                admin_client=admin_client,
                 patches={hyperconverged_resource_scope_function: {"spec": {"workloads": WORK_LABEL_1}}},
             ):
                 LOGGER.info("Expected ability to change workloads label {WORK_LABEL_1} while VM/Workload is present.")

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
@@ -136,7 +136,7 @@ def hco_uninstall_strategy_remove_workloads(
 ):
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
-        patches={hyperconverged_resource_scope_function: {"spec": {"uninstallStrategy": REMOVE_STRATEGY}}}
+        patches={hyperconverged_resource_scope_function: {"spec": {"uninstallStrategy": REMOVE_STRATEGY}}},
     ):
         wait_for_hco_conditions(
             admin_client=admin_client,

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_hco.py
@@ -135,6 +135,7 @@ def hco_uninstall_strategy_remove_workloads(
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {"uninstallStrategy": REMOVE_STRATEGY}}}
     ):
         wait_for_hco_conditions(

--- a/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
+++ b/tests/install_upgrade_operators/product_uninstall/test_remove_kubevirt.py
@@ -14,8 +14,9 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 
 @pytest.fixture()
-def set_uninstall_strategy_remove_workloads(hyperconverged_resource_scope_function):
+def set_uninstall_strategy_remove_workloads(admin_client, hyperconverged_resource_scope_function):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {"uninstallStrategy": "RemoveWorkloads"}}},
         list_resource_reconcile=[CDI, KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/install_upgrade_operators/product_upgrade/conftest.py
+++ b/tests/install_upgrade_operators/product_upgrade/conftest.py
@@ -380,11 +380,13 @@ def eus_unpaused_worker_mcp(
 
 @pytest.fixture()
 def eus_paused_workload_update(
+    admin_client,
     hyperconverged_resource_scope_module,
     default_workload_update_strategy,
 ):
     LOGGER.info("Pause workload updates in HCO")
     set_workload_update_methods_hco(
+        admin_client=admin_client,
         hyperconverged_resource=hyperconverged_resource_scope_module,
         workload_update_method=[],
     )
@@ -392,11 +394,13 @@ def eus_paused_workload_update(
 
 @pytest.fixture()
 def eus_unpaused_workload_update(
+    admin_client,
     hyperconverged_resource_scope_module,
     default_workload_update_strategy,
 ):
     LOGGER.info(f"Reset hco.spec.{WORKLOAD_UPDATE_STRATEGY_KEY_NAME}.")
     set_workload_update_methods_hco(
+        admin_client=admin_client,
         hyperconverged_resource=hyperconverged_resource_scope_module,
         workload_update_method=default_workload_update_strategy[WORKLOADUPDATEMETHODS],
     )

--- a/tests/install_upgrade_operators/product_upgrade/utils.py
+++ b/tests/install_upgrade_operators/product_upgrade/utils.py
@@ -720,8 +720,11 @@ def update_mcp_paused_spec(mcp: list[MachineConfigPool], paused: bool = True) ->
         ResourceEditor(patches={_mcp: {"spec": {"paused": paused}}}).update()
 
 
-def set_workload_update_methods_hco(hyperconverged_resource: HyperConverged, workload_update_method: list[str]) -> None:
+def set_workload_update_methods_hco(
+    admin_client: DynamicClient, hyperconverged_resource: HyperConverged, workload_update_method: list[str]
+) -> None:
     ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource: {
                 "spec": {WORKLOAD_UPDATE_STRATEGY_KEY_NAME: {WORKLOADUPDATEMETHODS: workload_update_method}}

--- a/tests/install_upgrade_operators/strict_reconciliation/conftest.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/conftest.py
@@ -25,8 +25,9 @@ DISABLED_KUBEVIRT_FEATUREGATES_IN_SNO = ["LiveMigration", "SRIOVLiveMigration"]
 
 
 @pytest.fixture()
-def deleted_stanza_on_hco_cr(request, hyperconverged_resource_scope_function):
+def deleted_stanza_on_hco_cr(request, admin_client, hyperconverged_resource_scope_function):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: request.param["rpatch"]},
         action="replace",
         list_resource_reconcile=request.param.get("list_resource_reconcile"),
@@ -36,7 +37,7 @@ def deleted_stanza_on_hco_cr(request, hyperconverged_resource_scope_function):
 
 
 @pytest.fixture()
-def hco_cr_custom_values(hyperconverged_resource_scope_function):
+def hco_cr_custom_values(admin_client, hyperconverged_resource_scope_function):
     """
     This fixture updates HCO CR with custom values for spec.CertConfig, spec.liveMigrationConfig and
     spec.featureGates and cleans those up at the end.
@@ -47,6 +48,7 @@ def hco_cr_custom_values(hyperconverged_resource_scope_function):
 
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: CUSTOM_HCO_CR_SPEC.copy()},
         list_resource_reconcile=[CDI, KubeVirt, NetworkAddonsConfig],
         wait_for_reconcile_post_update=True,
@@ -55,12 +57,13 @@ def hco_cr_custom_values(hyperconverged_resource_scope_function):
 
 
 @pytest.fixture()
-def updated_cdi_cr(request, cdi_resource_scope_function):
+def updated_cdi_cr(request, admin_client, cdi_resource_scope_function):
     """
     Attempts to update cdi, however, since these changes get reconciled to values propagated by hco cr, we don't need
     to restore these.
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             cdi_resource_scope_function: request.param["patch"],
         },
@@ -71,12 +74,13 @@ def updated_cdi_cr(request, cdi_resource_scope_function):
 
 
 @pytest.fixture()
-def updated_cnao_cr(request, cnao_resource):
+def updated_cnao_cr(request, admin_client, cnao_resource):
     """
     Attempts to update cnao, however, since these changes get reconciled to values propagated by hco cr, we don't need
     to restore these.
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={cnao_resource: request.param["patch"]},
         list_resource_reconcile=[NetworkAddonsConfig],
         wait_for_reconcile_post_update=True,
@@ -85,12 +89,13 @@ def updated_cnao_cr(request, cnao_resource):
 
 
 @pytest.fixture()
-def updated_kv_with_feature_gates(request, kubevirt_resource):
+def updated_kv_with_feature_gates(request, admin_client, kubevirt_resource):
     kv_dict = kubevirt_resource.instance.to_dict()
     fgs = kv_dict["spec"]["configuration"]["developerConfiguration"]["featureGates"].copy()
     fgs.extend(request.param)
 
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={kubevirt_resource: {"spec": {"configuration": {"developerConfiguration": {"featureGates": fgs}}}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,
@@ -99,11 +104,12 @@ def updated_kv_with_feature_gates(request, kubevirt_resource):
 
 
 @pytest.fixture()
-def updated_cdi_with_feature_gates(request, cdi_resource_scope_function):
+def updated_cdi_with_feature_gates(request, admin_client, cdi_resource_scope_function):
     cdi_dict = cdi_resource_scope_function.instance.to_dict()
     fgs = cdi_dict["spec"]["config"]["featureGates"].copy()
     fgs.extend(request.param)
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={cdi_resource_scope_function: {"spec": {"config": {"featureGates": fgs}}}},
         list_resource_reconcile=[CDI],
         wait_for_reconcile_post_update=True,
@@ -114,6 +120,7 @@ def updated_cdi_with_feature_gates(request, cdi_resource_scope_function):
 @pytest.fixture()
 def hco_with_non_default_feature_gates(
     request,
+    admin_client,
     hyperconverged_resource_scope_function,
 ):
     new_fgs = request.param["fgs"]
@@ -122,6 +129,7 @@ def hco_with_non_default_feature_gates(
     for fg in new_fgs:
         hco_fgs[fg] = True
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {"featureGates": hco_fgs}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_default_cpu_model.py
@@ -75,10 +75,12 @@ def fedora_vm_scope_function(unprivileged_client, namespace):
 
 @pytest.fixture()
 def hco_with_default_cpu_model_set(
+    admin_client,
     hyperconverged_resource_scope_function,
     cluster_common_node_cpu,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_function: {
                 "spec": {

--- a/tests/network/user_defined_network/test_user_defined_network_passt.py
+++ b/tests/network/user_defined_network/test_user_defined_network_passt.py
@@ -36,9 +36,11 @@ def wait_for_ready_vm_with_restart(vm: BaseVirtualMachine) -> bool:
 
 @pytest.fixture(scope="module")
 def passt_enabled_in_hco(
+    admin_client: DynamicClient,
     hyperconverged_resource_scope_module: HyperConverged,
 ) -> Generator[None]:
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_module: {
                 "metadata": {"annotations": {"hco.kubevirt.io/deployPasstNetworkBinding": "true"}}

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -17,6 +17,7 @@ def paused_ssp_operator(admin_client, hco_namespace, ssp_resource_scope_class):
     Pause ssp-operator to avoid from reconciling any related objects
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={ssp_resource_scope_class: {"metadata": {"annotations": {"kubevirt.io/operator.paused": "true"}}}},
         list_resource_reconcile=[SSP],
     ):

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -403,7 +403,8 @@ def storage_class_labels_for_testing(admin_client):
 def template_validator_finalizer(admin_client, hco_namespace):
     deployment = Deployment(name=VIRT_TEMPLATE_VALIDATOR, namespace=hco_namespace.name, client=admin_client)
     with ResourceEditorValidateHCOReconcile(
-        patches={deployment: {"metadata": {"finalizers": ["ssp.kubernetes.io/temporary-finalizer"]}}}
+        admin_client=admin_client,
+        patches={deployment: {"metadata": {"finalizers": ["ssp.kubernetes.io/temporary-finalizer"]}}},
     ):
         yield
 

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -371,7 +371,7 @@ def file_system_metric_mountpoints_existence(request, prometheus, vm_for_test, d
 
 
 @pytest.fixture(scope="class")
-def vm_for_test_with_resource_limits(namespace):
+def vm_for_test_with_resource_limits(namespace, unprivileged_client):
     vm_name = "vm-with-limits"
     with VirtualMachineForTests(
         name=vm_name,
@@ -379,6 +379,7 @@ def vm_for_test_with_resource_limits(namespace):
         cpu_limits=ONE_CPU_CORE,
         memory_limits=Images.Fedora.DEFAULT_MEMORY_SIZE,
         body=fedora_vm_body(name=vm_name),
+        client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm)
         yield vm
@@ -494,7 +495,7 @@ def windows_vm_for_test(windows_vm_namespace, unprivileged_client):
 
 
 @pytest.fixture(scope="class")
-def vm_for_migration_metrics_test(namespace, cpu_for_migration, is_postcopy_migration_bug_open):
+def vm_for_migration_metrics_test(namespace, unprivileged_client, cpu_for_migration, is_postcopy_migration_bug_open):
     if is_postcopy_migration_bug_open:
         pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
 
@@ -505,6 +506,7 @@ def vm_for_migration_metrics_test(namespace, cpu_for_migration, is_postcopy_migr
         body=fedora_vm_body(name=name),
         cpu_model=cpu_for_migration,
         additional_labels=MIGRATION_POLICY_VM_LABEL,
+        client=unprivileged_client,
     ) as vm:
         running_vm(vm=vm, check_ssh_connectivity=False)
         yield vm
@@ -593,8 +595,8 @@ def fedora_vm_with_stress_ng(namespace, unprivileged_client, golden_images_names
         client=unprivileged_client,
         name="fedora-vm-test-with-stress-ng",
         namespace=namespace.name,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
-        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA),
+        vm_instance_type=VirtualMachineClusterInstancetype(client=unprivileged_client, name=U1_SMALL),
+        vm_preference=VirtualMachineClusterPreference(client=unprivileged_client, name=OS_FLAVOR_FEDORA),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=DataSource(
                 name=OS_FLAVOR_FEDORA,

--- a/tests/observability/metrics/test_ssp_metrics.py
+++ b/tests/observability/metrics/test_ssp_metrics.py
@@ -24,7 +24,8 @@ KUBEVIRT_SSP_OPERATOR_RECONCILE_SUCCEEDED_AGGREGATED = "kubevirt_ssp_operator_re
 @pytest.fixture()
 def template_modified(admin_client, base_templates):
     with ResourceEditorValidateHCOReconcile(
-        patches={base_templates[0]: {"metadata": {"annotations": {"description": "New Description"}}}}
+        admin_client=admin_client,
+        patches={base_templates[0]: {"metadata": {"annotations": {"description": "New Description"}}}},
     ):
         yield
 

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -82,13 +82,14 @@ def stopped_vm_metric_1(vm_metric_1):
 
 
 @pytest.fixture()
-def vm_in_error_state(namespace):
+def vm_in_error_state(namespace, unprivileged_client):
     vm_name = "vm-in-error-state"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace.name,
         body=fedora_vm_body(name=vm_name),
         node_selector=get_node_selector_dict(node_selector="non-existent-node"),
+        client=unprivileged_client,
     ) as vm:
         vm.start()
         vm.wait_for_specific_status(status=VirtualMachine.Status.ERROR_UNSCHEDULABLE)
@@ -109,13 +110,14 @@ def pvc_for_vm_in_starting_state(unprivileged_client, namespace):
 
 
 @pytest.fixture()
-def vm_in_starting_state(namespace, pvc_for_vm_in_starting_state):
+def vm_in_starting_state(namespace, unprivileged_client, pvc_for_vm_in_starting_state):
     vm_name = "vm-in-starting-state"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace.name,
         body=fedora_vm_body(name=vm_name),
         pvc=pvc_for_vm_in_starting_state,
+        client=unprivileged_client,
     ) as vm:
         vm.start()
         vm.wait_for_specific_status(status=VirtualMachine.Status.WAITING_FOR_VOLUME_BINDING)

--- a/tests/observability/runbook_url/conftest.py
+++ b/tests/observability/runbook_url/conftest.py
@@ -15,17 +15,23 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def cnv_prometheus_rules_names(hco_namespace):
-    return [prometheus_rule.name for prometheus_rule in PrometheusRule.get(namespace=hco_namespace.name)]
+def cnv_prometheus_rules_names(admin_client, hco_namespace):
+    return [
+        prometheus_rule.name
+        for prometheus_rule in PrometheusRule.get(dyn_client=admin_client, namespace=hco_namespace.name)
+    ]
 
 
 @pytest.fixture()
-def cnv_alerts_runbook_urls_from_prometheus_rule(cnv_prometheus_rules_matrix__function__, hpp_cr_installed):
+def cnv_alerts_runbook_urls_from_prometheus_rule(
+    admin_client, cnv_prometheus_rules_matrix__function__, hpp_cr_installed
+):
     rule_name = cnv_prometheus_rules_matrix__function__
     if rule_name == "prometheus-hpp-rules" and not hpp_cr_installed:
         pytest.xfail(f"Rule {rule_name} should not be present if HPP CR is not installed")
 
     cnv_prometheus_rule_by_name = PrometheusRule(
+        client=admin_client,
         namespace=py_config["hco_namespace"],
         name=rule_name,
     )

--- a/tests/storage/cdi_config/conftest.py
+++ b/tests/storage/cdi_config/conftest.py
@@ -10,8 +10,9 @@ from utilities.storage import cdi_feature_gate_list_with_added_feature
 
 
 @pytest.fixture()
-def cdi_with_extra_non_existent_feature_gate(cdi):
+def cdi_with_extra_non_existent_feature_gate(admin_client, cdi):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             cdi: {
                 "spec": {

--- a/tests/storage/cdi_config/test_cdi_config.py
+++ b/tests/storage/cdi_config/test_cdi_config.py
@@ -119,6 +119,7 @@ def test_cdi_spec_reconciled_by_hco(initial_cdi_config_from_cr, cdi_with_extra_n
 )
 @pytest.mark.s390x
 def test_cdi_tunables_in_hco_propagated_to_cr(
+    admin_client,
     hyperconverged_resource_scope_module,
     cdi,
     namespace,
@@ -142,6 +143,7 @@ def test_cdi_tunables_in_hco_propagated_to_cr(
         return current_cdi_config_from_cr == initial_cdi_config_from_cr
 
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_module: {"spec": hco_updated_spec_stanza}},
         list_resource_reconcile=[CDI],
     ):

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -230,12 +230,14 @@ def uploadproxy_route_deleted(hco_namespace):
 
 @pytest.fixture()
 def cdi_config_upload_proxy_overridden(
+    admin_client,
     hco_namespace,
     hyperconverged_resource_scope_function,
     cdi_config,
     new_route_created,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_function: hco_cr_jsonpatch_annotations_dict(
                 component="cdi",

--- a/tests/storage/disk_preallocation/conftest.py
+++ b/tests/storage/disk_preallocation/conftest.py
@@ -13,9 +13,10 @@ from utilities.storage import create_dv
 
 
 @pytest.fixture(scope="module")
-def cdi_preallocation_enabled(hyperconverged_resource_scope_module, cdi_config):
+def cdi_preallocation_enabled(admin_client, hyperconverged_resource_scope_module, cdi_config):
     preallocation_value = True
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_module: hco_cr_jsonpatch_annotations_dict(
                 component="cdi",

--- a/tests/storage/fs_overhead/test_fs_overhead.py
+++ b/tests/storage/fs_overhead/test_fs_overhead.py
@@ -35,7 +35,9 @@ def assert_fs_overhead_added(actual_size: bitmath.Bitmath, requested_size: bitma
 
 
 @pytest.fixture(scope="module")
-def updated_fs_overhead_20_with_hco(admin_client, storage_class_with_filesystem_volume_mode, hyperconverged_resource_scope_module):
+def updated_fs_overhead_20_with_hco(
+    admin_client, storage_class_with_filesystem_volume_mode, hyperconverged_resource_scope_module
+):
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
         patches={

--- a/tests/storage/fs_overhead/test_fs_overhead.py
+++ b/tests/storage/fs_overhead/test_fs_overhead.py
@@ -35,8 +35,9 @@ def assert_fs_overhead_added(actual_size: bitmath.Bitmath, requested_size: bitma
 
 
 @pytest.fixture(scope="module")
-def updated_fs_overhead_20_with_hco(storage_class_with_filesystem_volume_mode, hyperconverged_resource_scope_module):
+def updated_fs_overhead_20_with_hco(admin_client, storage_class_with_filesystem_volume_mode, hyperconverged_resource_scope_module):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_module: {
                 "spec": {

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -273,9 +273,10 @@ def certificate_exists(cdi_spec, hco_spec):
 
 
 @pytest.fixture()
-def updated_certconfig_in_hco_cr(hyperconverged_resource_scope_function, certificate_exists):
+def updated_certconfig_in_hco_cr(admin_client, hyperconverged_resource_scope_function, certificate_exists):
     # Update cert rotation with a short interval for easy testing.
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_function: {
                 "spec": {

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -49,9 +49,11 @@ def is_dv_migratable(dv):
 
 @pytest.fixture(scope="module")
 def enabled_feature_gate_for_declarative_hotplug_volumes(
+    admin_client,
     hyperconverged_resource_scope_module,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_module: {"spec": {"featureGates": {"declarativeHotplugVolumes": True}}},
         },

--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -95,9 +95,11 @@ def blank_disk_dv_with_default_sc(upgrade_namespace_scope_session):
 
 @pytest.fixture(scope="session")
 def enabled_feature_gate_for_declarative_hotplug_volumes_upg(
+    admin_client,
     hyperconverged_resource_scope_session,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_session: {"spec": {"featureGates": {"declarativeHotplugVolumes": True}}},
         },

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -501,8 +501,9 @@ def download_and_extract_tar(tarfile_url, dest_path):
 
 
 @contextmanager
-def update_hco_with_persistent_storage_config(hco_cr, storage_class):
+def update_hco_with_persistent_storage_config(admin_client, hco_cr, storage_class):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hco_cr: {"spec": {"vmStateStorageClass": storage_class}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -68,8 +68,9 @@ def enabled_aaq_in_hco_scope_package(admin_client, hco_namespace, hyperconverged
 
 
 @pytest.fixture(scope="class")
-def updated_aaq_allocation_method(hyperconverged_resource_scope_class, aaq_allocation_methods_matrix__class__):
+def updated_aaq_allocation_method(admin_client, hyperconverged_resource_scope_class, aaq_allocation_methods_matrix__class__):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {
@@ -84,8 +85,8 @@ def updated_aaq_allocation_method(hyperconverged_resource_scope_class, aaq_alloc
 
 
 @pytest.fixture()
-def updated_hco_memory_overcommit(hyperconverged_resource_scope_class):
-    yield from update_hco_memory_overcommit(hco=hyperconverged_resource_scope_class, percentage=50)
+def updated_hco_memory_overcommit(admin_client, hyperconverged_resource_scope_class):
+    yield from update_hco_memory_overcommit(admin_client=admin_client, hco=hyperconverged_resource_scope_class, percentage=50)
 
 
 @pytest.fixture(scope="class")
@@ -172,6 +173,7 @@ def migrated_arq_vm(admin_client: DynamicClient, vm_for_aaq_test: VirtualMachine
 @pytest.fixture(scope="module")
 def enabled_acrq_support(admin_client, hco_namespace, hyperconverged_resource_scope_module):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_module: {
                 "spec": {

--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -68,7 +68,9 @@ def enabled_aaq_in_hco_scope_package(admin_client, hco_namespace, hyperconverged
 
 
 @pytest.fixture(scope="class")
-def updated_aaq_allocation_method(admin_client, hyperconverged_resource_scope_class, aaq_allocation_methods_matrix__class__):
+def updated_aaq_allocation_method(
+    admin_client, hyperconverged_resource_scope_class, aaq_allocation_methods_matrix__class__
+):
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,
         patches={
@@ -86,7 +88,9 @@ def updated_aaq_allocation_method(admin_client, hyperconverged_resource_scope_cl
 
 @pytest.fixture()
 def updated_hco_memory_overcommit(admin_client, hyperconverged_resource_scope_class):
-    yield from update_hco_memory_overcommit(admin_client=admin_client, hco=hyperconverged_resource_scope_class, percentage=50)
+    yield from update_hco_memory_overcommit(
+        admin_client=admin_client, hco=hyperconverged_resource_scope_class, percentage=50
+    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/virt/cluster/common_templates/custom_namespace/conftest.py
+++ b/tests/virt/cluster/common_templates/custom_namespace/conftest.py
@@ -33,6 +33,7 @@ def opt_in_custom_template_namespace(
     ssp_resource_scope_class,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {COMMON_TEMPLATES_NAMESPACE_KEY: custom_vm_template_namespace.name}
@@ -119,6 +120,7 @@ def opted_out_custom_template_namespace(
     ssp_resource_scope_function,
 ):
     ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {COMMON_TEMPLATES_NAMESPACE_KEY: None}}},
         list_resource_reconcile=[SSP, CDI],
         wait_for_reconcile_post_update=True,

--- a/tests/virt/cluster/general/test_cpu_allocation_ratio.py
+++ b/tests/virt/cluster/general/test_cpu_allocation_ratio.py
@@ -48,9 +48,11 @@ def vmi_cpu_allocation_ratio_from_hco_post_update(
 
 @pytest.fixture()
 def hco_cr_with_vmi_cpu_allocation_ratio(
+    admin_client,
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_function: {
                 "spec": {"resourceRequirements": {"vmiCPUAllocationRatio": VMI_CPU_ALLOCATION_RATIO}}

--- a/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_evictionstrategy.py
@@ -63,9 +63,11 @@ def vmi_old_uid(vm_for_test_from_template_scope_class):
 
 @pytest.fixture()
 def hco_cr_with_evictionstrategy_none(
+    admin_client,
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_function: {"spec": {EVICTIONSTRATEGY: "None"}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -219,9 +219,9 @@ def supported_gpu_device(workers_utility_pods, nodes_with_supported_gpus):
 
 
 @pytest.fixture(scope="session")
-def hco_cr_with_mdev_permitted_hostdevices_scope_session(hyperconverged_resource_scope_session, supported_gpu_device):
+def hco_cr_with_mdev_permitted_hostdevices_scope_session(admin_client, hyperconverged_resource_scope_session, supported_gpu_device):
     yield from patch_hco_cr_with_mdev_permitted_hostdevices(
-        hyperconverged_resource=hyperconverged_resource_scope_session, supported_gpu_device=supported_gpu_device
+        admin_client=admin_client, hyperconverged_resource=hyperconverged_resource_scope_session, supported_gpu_device=supported_gpu_device
     )
 
 
@@ -367,8 +367,8 @@ def vm_for_test_from_template_scope_class(
 
 
 @pytest.fixture(scope="class")
-def hco_memory_overcommit_increased(hyperconverged_resource_scope_class):
-    yield from update_hco_memory_overcommit(hco=hyperconverged_resource_scope_class, percentage=200)
+def hco_memory_overcommit_increased(admin_client, hyperconverged_resource_scope_class):
+    yield from update_hco_memory_overcommit(admin_client=admin_client, hco=hyperconverged_resource_scope_class, percentage=200)
 
 
 @pytest.fixture(scope="session")

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -219,9 +219,13 @@ def supported_gpu_device(workers_utility_pods, nodes_with_supported_gpus):
 
 
 @pytest.fixture(scope="session")
-def hco_cr_with_mdev_permitted_hostdevices_scope_session(admin_client, hyperconverged_resource_scope_session, supported_gpu_device):
+def hco_cr_with_mdev_permitted_hostdevices_scope_session(
+    admin_client, hyperconverged_resource_scope_session, supported_gpu_device
+):
     yield from patch_hco_cr_with_mdev_permitted_hostdevices(
-        admin_client=admin_client, hyperconverged_resource=hyperconverged_resource_scope_session, supported_gpu_device=supported_gpu_device
+        admin_client=admin_client,
+        hyperconverged_resource=hyperconverged_resource_scope_session,
+        supported_gpu_device=supported_gpu_device,
     )
 
 
@@ -368,7 +372,9 @@ def vm_for_test_from_template_scope_class(
 
 @pytest.fixture(scope="class")
 def hco_memory_overcommit_increased(admin_client, hyperconverged_resource_scope_class):
-    yield from update_hco_memory_overcommit(admin_client=admin_client, hco=hyperconverged_resource_scope_class, percentage=200)
+    yield from update_hco_memory_overcommit(
+        admin_client=admin_client, hco=hyperconverged_resource_scope_class, percentage=200
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/virt/node/general/test_machinetype.py
+++ b/tests/virt/node/general/test_machinetype.py
@@ -102,6 +102,7 @@ def updated_kubevirt_config_machine_type(
 ):
     annotations_path = "architectureConfiguration"
     with update_hco_annotations(
+        admin_client=admin_client,
         resource=hyperconverged_resource_scope_class,
         path=annotations_path,
         value={nodes_cpu_architecture: request.param},

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -78,6 +78,7 @@ def enable_bitlocker(vm):
 @pytest.fixture(scope="class")
 def file_system_persistent_storage_hco_config(
     request,
+    admin_client,
     hyperconverged_resource_scope_module,
     rwx_fs_available_storage_classes_names,
 ):
@@ -89,6 +90,7 @@ def file_system_persistent_storage_hco_config(
         storage_class = py_config["default_storage_class"]
 
     with update_hco_with_persistent_storage_config(
+        admin_client=admin_client,
         hco_cr=hyperconverged_resource_scope_module,
         storage_class=storage_class,
     ):

--- a/tests/virt/node/gpu/gpu_pci_passthrough/conftest.py
+++ b/tests/virt/node/gpu/gpu_pci_passthrough/conftest.py
@@ -78,8 +78,9 @@ def fail_if_device_unbound_to_vfiopci_driver(workers_utility_pods, gpu_passthrou
 
 
 @pytest.fixture(scope="class")
-def hco_cr_with_permitted_hostdevices(hyperconverged_resource_scope_class, supported_gpu_device):
+def hco_cr_with_permitted_hostdevices(admin_client, hyperconverged_resource_scope_class, supported_gpu_device):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {

--- a/tests/virt/node/gpu/vgpu/conftest.py
+++ b/tests/virt/node/gpu/vgpu/conftest.py
@@ -30,9 +30,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="class")
-def hco_cr_with_mdev_permitted_hostdevices(hyperconverged_resource_scope_class, supported_gpu_device):
+def hco_cr_with_mdev_permitted_hostdevices(admin_client, hyperconverged_resource_scope_class, supported_gpu_device):
     yield from patch_hco_cr_with_mdev_permitted_hostdevices(
-        hyperconverged_resource=hyperconverged_resource_scope_class, supported_gpu_device=supported_gpu_device
+        admin_client=admin_client, hyperconverged_resource=hyperconverged_resource_scope_class, supported_gpu_device=supported_gpu_device
     )
 
 
@@ -54,11 +54,13 @@ def ready_node_with_grid_vgpu_config(nvidia_sandbox_validator_ds, node_labeled_w
 
 @pytest.fixture(scope="class")
 def hco_cr_with_node_specific_mdev_permitted_hostdevices(
+    admin_client,
     hyperconverged_resource_scope_class,
     supported_gpu_device,
     ready_node_with_grid_vgpu_config,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {
@@ -86,7 +88,7 @@ def hco_cr_with_node_specific_mdev_permitted_hostdevices(
 
 
 @pytest.fixture(scope="package")
-def hco_with_disable_mdev_configuration(hyperconverged_resource_scope_session):
+def hco_with_disable_mdev_configuration(admin_client, hyperconverged_resource_scope_session):
     """
     Enable disableMDevConfiguration feature gate in HCO.
 
@@ -95,6 +97,7 @@ def hco_with_disable_mdev_configuration(hyperconverged_resource_scope_session):
     by NVIDIA GPU Operator).
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_session: {"spec": {FEATURE_GATES: {DISABLE_MDEV_CONFIGURATION: True}}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/virt/node/gpu/vgpu/conftest.py
+++ b/tests/virt/node/gpu/vgpu/conftest.py
@@ -32,7 +32,9 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture(scope="class")
 def hco_cr_with_mdev_permitted_hostdevices(admin_client, hyperconverged_resource_scope_class, supported_gpu_device):
     yield from patch_hco_cr_with_mdev_permitted_hostdevices(
-        admin_client=admin_client, hyperconverged_resource=hyperconverged_resource_scope_class, supported_gpu_device=supported_gpu_device
+        admin_client=admin_client,
+        hyperconverged_resource=hyperconverged_resource_scope_class,
+        supported_gpu_device=supported_gpu_device,
     )
 
 

--- a/tests/virt/node/log_verbosity/conftest.py
+++ b/tests/virt/node/log_verbosity/conftest.py
@@ -9,6 +9,7 @@ from utilities.hco import ResourceEditorValidateHCOReconcile
 
 @pytest.fixture(scope="class")
 def updated_log_verbosity_config(
+    admin_client,
     request,
     worker_node1,
     hyperconverged_resource_scope_class,
@@ -25,6 +26,7 @@ def updated_log_verbosity_config(
         "node": {"kubevirt": {"nodeVerbosity": {worker_node1.name: VIRT_LOG_VERBOSITY_LEVEL_6}}},
     }
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {"logVerbosityConfig": log_verbosity_level_six_config_dict[request.param]}

--- a/tests/virt/node/node_labeller/cpu_features/test_node_feature_discovery.py
+++ b/tests/virt/node/node_labeller/cpu_features/test_node_feature_discovery.py
@@ -47,6 +47,7 @@ def updated_kubevirt_cpus(
     hco_namespace,
 ):
     with update_hco_annotations(
+        admin_client=admin_client,
         resource=hyperconverged_resource_scope_function,
         path=OBSOLETE_CPU,
         value={cluster_common_node_cpu: True},

--- a/tests/virt/node/workload_density/test_free_page_reporting.py
+++ b/tests/virt/node/workload_density/test_free_page_reporting.py
@@ -64,9 +64,11 @@ def vm_with_hugepages(namespace):
 
 @pytest.fixture()
 def disabled_free_page_reporting_in_hco_cr(
+    admin_client,
     hyperconverged_resource_scope_function,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_function: {
                 "spec": {"virtualMachineOptions": {"disableFreePageReporting": True}}

--- a/tests/virt/node/workload_density/test_kernel_samepage_merging.py
+++ b/tests/virt/node/workload_density/test_kernel_samepage_merging.py
@@ -99,8 +99,9 @@ def wait_for_pages_to_scan_value_to_grow(utility_pods, node, initial_value):
 
 
 @pytest.fixture(scope="class")
-def ksm_enabled_in_hco(hyperconverged_resource_scope_class):
+def ksm_enabled_in_hco(admin_client, hyperconverged_resource_scope_class):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_class: {
                 "spec": {"ksmConfiguration": {"nodeLabelSelector": {"matchLabels": KERNEL_SAMEPAGE_MERGING_TEST_LABEL}}}

--- a/tests/virt/upgrade/conftest.py
+++ b/tests/virt/upgrade/conftest.py
@@ -361,8 +361,9 @@ def vm_for_post_copy_upgrade(virt_upgrade_namespace, unprivileged_client, cpu_fo
 
 
 @pytest.fixture(scope="session")
-def parallel_live_migrations_increased(hyperconverged_resource_scope_session):
+def parallel_live_migrations_increased(admin_client, hyperconverged_resource_scope_session):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource_scope_session: {
                 "spec": {

--- a/tests/virt/upgrade_custom/vgpu/conftest.py
+++ b/tests/virt/upgrade_custom/vgpu/conftest.py
@@ -92,7 +92,7 @@ def rhel_vm_for_upgrade_session_scope(
 
 
 @pytest.fixture(scope="session")
-def hco_with_disable_mdev_configuration_session_scope(hyperconverged_resource_scope_session):
+def hco_with_disable_mdev_configuration_session_scope(admin_client, hyperconverged_resource_scope_session):
     """
     Enable disableMDevConfiguration feature gate in HCO.
 
@@ -101,6 +101,7 @@ def hco_with_disable_mdev_configuration_session_scope(hyperconverged_resource_sc
     by NVIDIA GPU Operator).
     """
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource_scope_session: {"spec": {FEATURE_GATES: {DISABLE_MDEV_CONFIGURATION: True}}}},
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,

--- a/tests/virt/utils.py
+++ b/tests/virt/utils.py
@@ -66,6 +66,7 @@ LOGGER = logging.getLogger(__name__)
 @contextmanager
 def append_feature_gate_to_hco(feature_gate, resource, client, namespace):
     with update_hco_annotations(
+        admin_client=client,
         resource=resource,
         path="developerConfiguration/featureGates",
         value=feature_gate,
@@ -239,12 +240,13 @@ def validate_machine_type(vm, expected_machine_type, admin_client):
     )
 
 
-def patch_hco_cr_with_mdev_permitted_hostdevices(hyperconverged_resource, supported_gpu_device):
+def patch_hco_cr_with_mdev_permitted_hostdevices(admin_client, hyperconverged_resource, supported_gpu_device):
     required_keys = [MDEV_TYPE_STR, MDEV_NAME_STR, VGPU_DEVICE_NAME_STR]
     missing_keys = [key for key in required_keys if key not in supported_gpu_device]
     if missing_keys:
         raise ValueError(f"Missing required keys in supported_gpu_device: {missing_keys}")
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hyperconverged_resource: {
                 "spec": {
@@ -478,8 +480,9 @@ def get_data_volume_template_dict_with_default_storage_class(
     return data_volume_template
 
 
-def update_hco_memory_overcommit(hco, percentage):
+def update_hco_memory_overcommit(admin_client, hco, percentage):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={
             hco: {
                 "spec": {

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -386,7 +386,7 @@ def enable_common_boot_image_import_spec_wait_for_data_import_cron(
     namespace: Namespace,
     exclude_data_source_names: Collection[str] | None = None,
 ) -> None:
-    hco_namespace = Namespace(name=hco_resource.namespace)
+    hco_namespace = Namespace(client=admin_client, name=hco_resource.namespace)
     update_common_boot_image_import_spec(
         hco_resource=hco_resource,
         enable=True,
@@ -557,6 +557,7 @@ def enabled_aaq_in_hco(client, hco_namespace, hyperconverged_resource, enable_ac
         patches=patches,
         list_resource_reconcile=[KubeVirt],
         wait_for_reconcile_post_update=True,
+        admin_client=client,
     ):
         yield
     # need to wait when all AAQ system pods removed

--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -11,7 +11,7 @@ from ocp_resources.hyperconverged import HyperConverged
 from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.namespace import Namespace
 from ocp_resources.network_addons_config import NetworkAddonsConfig
-from ocp_resources.resource import Resource, ResourceEditor, get_client
+from ocp_resources.resource import Resource, ResourceEditor
 from ocp_resources.ssp import SSP
 from pytest_testconfig import py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -71,15 +71,15 @@ HCO_JSONPATCH_ANNOTATION_COMPONENT_DICT = {
 class ResourceEditorValidateHCOReconcile(ResourceEditor):
     def __init__(
         self,
+        admin_client,
         hco_namespace="openshift-cnv",
         consecutive_checks_count=3,
         list_resource_reconcile=None,
         wait_for_reconcile_post_update=False,
-        admin_client=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.admin_client = admin_client or get_client()
+        self.admin_client = admin_client
         self.hco_namespace = Namespace(client=self.admin_client, name=hco_namespace)
         self.wait_for_reconcile_post_update = wait_for_reconcile_post_update
         self._consecutive_checks_count = consecutive_checks_count
@@ -455,6 +455,7 @@ def hco_cr_jsonpatch_annotations_dict(component, path, value=None, op="add"):
 
 @contextmanager
 def update_hco_annotations(
+    admin_client,
     resource,
     path,
     value=None,
@@ -467,6 +468,7 @@ def update_hco_annotations(
     Update jsonpatch annotation in HCO CR.
 
     Args:
+        admin_client (DynamicClient): Kubernetes admin client
         resource (HyperConverged): HCO resource object
         path (str): key path in KubeVirt CR
         value (any): key value
@@ -500,6 +502,7 @@ def update_hco_annotations(
         )
 
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={resource: hco_config_jsonpath_dict},
         list_resource_reconcile=resource_list,
         wait_for_reconcile_post_update=True,
@@ -529,6 +532,7 @@ def update_hco_templates_spec(
     golden_images_namespace=None,
 ):
     with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
         patches={hyperconverged_resource: {"spec": {SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME: [updated_template]}}},
         list_resource_reconcile=[SSP, CDI],
         wait_for_reconcile_post_update=True,

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -246,6 +246,7 @@ def get_catalog_source(client: DynamicClient, catalog_name: str) -> CatalogSourc
     if catalog_source.exists:
         return catalog_source
     LOGGER.warning(f"CatalogSource {catalog_name} not found in namespace: {market_place_namespace}")
+    return None
 
 
 def wait_for_catalog_source_disabled(client: DynamicClient, catalog_name: str) -> None:

--- a/utilities/operator.py
+++ b/utilities/operator.py
@@ -220,9 +220,9 @@ def get_machine_config_pools_conditions(machine_config_pools):
     return {mcp.name: mcp.instance.status.conditions for mcp in machine_config_pools}
 
 
-def get_operator_hub():
+def get_operator_hub(client: DynamicClient) -> OperatorHub:
     operator_hub_name = "cluster"
-    operator_hub = OperatorHub(name=operator_hub_name)
+    operator_hub = OperatorHub(client=client, name=operator_hub_name)
     if operator_hub.exists:
         return operator_hub
     raise ResourceNotFoundError(f"OperatorHub {operator_hub_name} not found")
@@ -230,30 +230,31 @@ def get_operator_hub():
 
 @contextmanager
 def disable_default_sources_in_operatorhub(admin_client):
-    operator_hub = get_operator_hub()
+    operator_hub = get_operator_hub(client=admin_client)
     LOGGER.info("Disable default sources in operatorhub.")
     with ResourceEditor(patches={operator_hub: {"spec": {"disableAllDefaultSources": True}}}) as edited_source:
         # wait for all the catalogsources to disappear:
         sources = operator_hub.instance.status.sources
         for catalog_source_name in [catalog_source["name"] for catalog_source in sources]:
-            wait_for_catalog_source_disabled(catalog_name=catalog_source_name)
+            wait_for_catalog_source_disabled(client=admin_client, catalog_name=catalog_source_name)
         yield edited_source
 
 
-def get_catalog_source(catalog_name):
+def get_catalog_source(client: DynamicClient, catalog_name: str) -> CatalogSource | None:
     market_place_namespace = py_config["marketplace_namespace"]
-    catalog_source = CatalogSource(namespace=market_place_namespace, name=catalog_name)
+    catalog_source = CatalogSource(client=client, namespace=market_place_namespace, name=catalog_name)
     if catalog_source.exists:
         return catalog_source
     LOGGER.warning(f"CatalogSource {catalog_name} not found in namespace: {market_place_namespace}")
 
 
-def wait_for_catalog_source_disabled(catalog_name):
+def wait_for_catalog_source_disabled(client: DynamicClient, catalog_name: str) -> None:
     LOGGER.info(f"Wait for catalogsource {catalog_name} to be disabled.")
     samples = TimeoutSampler(
         wait_timeout=TIMEOUT_5MIN,
         sleep=10,
         func=get_catalog_source,
+        client=client,
         catalog_name=catalog_name,
     )
     try:
@@ -296,7 +297,7 @@ def wait_for_catalogsource_ready(admin_client, catalog_name):
             _pod.name
             for _pod in utilities.infra.get_pods(
                 client=admin_client,
-                namespace=Namespace(name=py_config["marketplace_namespace"]),
+                namespace=Namespace(client=admin_client, name=py_config["marketplace_namespace"]),
                 label=f"olm.catalogSource={catalog_name}",
             )
             if _pod.instance.status.phase != Pod.Status.RUNNING
@@ -395,7 +396,7 @@ def get_install_plan_from_subscription(subscription):
 
 
 def wait_for_csv_successful_state(admin_client, namespace_name, subscription_name):
-    subscription = Subscription(name=subscription_name, namespace=namespace_name)
+    subscription = Subscription(client=admin_client, name=subscription_name, namespace=namespace_name)
     if subscription.exists:
         csv = utilities.infra.get_csv_by_name(
             csv_name=subscription.instance.status.installedCSV,
@@ -520,7 +521,7 @@ def wait_for_package_manifest_to_exist(client, cr_name, catalog_name):
 
 
 def update_image_in_catalog_source(client, image, catalog_source_name, cr_name):
-    catalog = get_catalog_source(catalog_name=catalog_source_name)
+    catalog = get_catalog_source(client=client, catalog_name=catalog_source_name)
     if catalog:
         LOGGER.info(f"Updating {catalog_source_name} image to {image}")
         ResourceEditor(patches={catalog: {"spec": {"image": image}}}).update()
@@ -554,8 +555,8 @@ def update_subscription_source(
     }).update()
 
 
-def cluster_with_icsp():
-    icsp_list = list(ImageContentSourcePolicy.get())
+def cluster_with_icsp(client: DynamicClient) -> bool:
+    icsp_list = list(ImageContentSourcePolicy.get(dyn_client=client))
     return len(icsp_list) > 0
 
 

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -588,10 +588,11 @@ class TestResourceEditorValidateHCOReconcile:
         assert editor.hco_namespace == mock_namespace
         assert editor._consecutive_checks_count == 5
         assert editor.list_resource_reconcile == []
+        mock_namespace_class.assert_called_once_with(client=mock_client, name="openshift-cnv")
 
     @patch("utilities.hco.wait_for_hco_conditions")
-    @patch("utilities.hco.Namespace")
-    def test_resource_editor_update_without_reconcile(self, mock_namespace_class, mock_wait_hco):
+    @patch("utilities.hco.Namespace", new=MagicMock())
+    def test_resource_editor_update_without_reconcile(self, mock_wait_hco):
         """Test ResourceEditorValidateHCOReconcile update without wait_for_reconcile_post_update"""
         mock_client = MagicMock()
         mock_resource = MagicMock()
@@ -607,8 +608,8 @@ class TestResourceEditorValidateHCOReconcile:
             mock_wait_hco.assert_not_called()
 
     @patch("utilities.hco.wait_for_hco_conditions")
-    @patch("utilities.hco.Namespace")
-    def test_resource_editor_update_with_reconcile(self, mock_namespace_class, mock_wait_hco):
+    @patch("utilities.hco.Namespace", new=MagicMock())
+    def test_resource_editor_update_with_reconcile(self, mock_wait_hco):
         """Test ResourceEditorValidateHCOReconcile update with wait_for_reconcile_post_update"""
         mock_client = MagicMock()
         mock_resource = MagicMock()
@@ -624,8 +625,8 @@ class TestResourceEditorValidateHCOReconcile:
             mock_wait_hco.assert_called_once()
 
     @patch("utilities.hco.wait_for_hco_conditions")
-    @patch("utilities.hco.Namespace")
-    def test_resource_editor_restore(self, mock_namespace_class, mock_wait_hco):
+    @patch("utilities.hco.Namespace", new=MagicMock())
+    def test_resource_editor_restore(self, mock_wait_hco):
         """Test ResourceEditorValidateHCOReconcile restore"""
         mock_client = MagicMock()
         mock_resource = MagicMock()
@@ -966,6 +967,7 @@ class TestUpdateHcoAnnotations:
             pass
 
         mock_editor_class.assert_called_once()
+        assert mock_editor_class.call_args.kwargs["admin_client"] == mock_client
 
     @patch("utilities.hco.ResourceEditorValidateHCOReconcile")
     def test_update_annotations_with_existing(self, mock_editor_class):
@@ -990,6 +992,7 @@ class TestUpdateHcoAnnotations:
             pass
 
         mock_editor_class.assert_called_once()
+        assert mock_editor_class.call_args.kwargs["admin_client"] == mock_client
 
     @patch("utilities.hco.ResourceEditorValidateHCOReconcile")
     def test_update_annotations_overwrite(self, mock_editor_class):
@@ -1011,6 +1014,9 @@ class TestUpdateHcoAnnotations:
             overwrite_patches=True,
         ):
             pass
+
+        mock_editor_class.assert_called_once()
+        assert mock_editor_class.call_args.kwargs["admin_client"] == mock_client
 
         mock_editor_class.assert_called_once()
 

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -569,12 +569,10 @@ class TestApplyNpChanges:
 class TestResourceEditorValidateHCOReconcile:
     """Test cases for ResourceEditorValidateHCOReconcile class"""
 
-    @patch("utilities.hco.get_client")
     @patch("utilities.hco.Namespace")
-    def test_resource_editor_init(self, mock_namespace_class, mock_get_client):
+    def test_resource_editor_init(self, mock_namespace_class):
         """Test ResourceEditorValidateHCOReconcile initialization"""
         mock_client = MagicMock()
-        mock_get_client.return_value = mock_client
 
         mock_namespace = MagicMock()
         mock_namespace_class.return_value = mock_namespace
@@ -583,22 +581,25 @@ class TestResourceEditorValidateHCOReconcile:
         patches = {mock_resource: {"spec": {"test": "value"}}}
 
         editor = ResourceEditorValidateHCOReconcile(
-            patches=patches, hco_namespace="openshift-cnv", consecutive_checks_count=5
+            admin_client=mock_client, patches=patches, hco_namespace="openshift-cnv", consecutive_checks_count=5
         )
 
+        assert editor.admin_client == mock_client
         assert editor.hco_namespace == mock_namespace
         assert editor._consecutive_checks_count == 5
         assert editor.list_resource_reconcile == []
 
     @patch("utilities.hco.wait_for_hco_conditions")
-    @patch("utilities.hco.get_client")
     @patch("utilities.hco.Namespace")
-    def test_resource_editor_update_without_reconcile(self, mock_namespace_class, mock_get_client, mock_wait_hco):
+    def test_resource_editor_update_without_reconcile(self, mock_namespace_class, mock_wait_hco):
         """Test ResourceEditorValidateHCOReconcile update without wait_for_reconcile_post_update"""
+        mock_client = MagicMock()
         mock_resource = MagicMock()
         patches = {mock_resource: {"spec": {"test": "value"}}}
 
-        editor = ResourceEditorValidateHCOReconcile(patches=patches, wait_for_reconcile_post_update=False)
+        editor = ResourceEditorValidateHCOReconcile(
+            admin_client=mock_client, patches=patches, wait_for_reconcile_post_update=False
+        )
 
         with patch("utilities.hco.ResourceEditor.update") as mock_parent_update:
             editor.update(backup_resources=True)
@@ -606,14 +607,16 @@ class TestResourceEditorValidateHCOReconcile:
             mock_wait_hco.assert_not_called()
 
     @patch("utilities.hco.wait_for_hco_conditions")
-    @patch("utilities.hco.get_client")
     @patch("utilities.hco.Namespace")
-    def test_resource_editor_update_with_reconcile(self, mock_namespace_class, mock_get_client, mock_wait_hco):
+    def test_resource_editor_update_with_reconcile(self, mock_namespace_class, mock_wait_hco):
         """Test ResourceEditorValidateHCOReconcile update with wait_for_reconcile_post_update"""
+        mock_client = MagicMock()
         mock_resource = MagicMock()
         patches = {mock_resource: {"spec": {"test": "value"}}}
 
-        editor = ResourceEditorValidateHCOReconcile(patches=patches, wait_for_reconcile_post_update=True)
+        editor = ResourceEditorValidateHCOReconcile(
+            admin_client=mock_client, patches=patches, wait_for_reconcile_post_update=True
+        )
 
         with patch("utilities.hco.ResourceEditor.update") as mock_parent_update:
             editor.update(backup_resources=False)
@@ -621,14 +624,14 @@ class TestResourceEditorValidateHCOReconcile:
             mock_wait_hco.assert_called_once()
 
     @patch("utilities.hco.wait_for_hco_conditions")
-    @patch("utilities.hco.get_client")
     @patch("utilities.hco.Namespace")
-    def test_resource_editor_restore(self, mock_namespace_class, mock_get_client, mock_wait_hco):
+    def test_resource_editor_restore(self, mock_namespace_class, mock_wait_hco):
         """Test ResourceEditorValidateHCOReconcile restore"""
+        mock_client = MagicMock()
         mock_resource = MagicMock()
         patches = {mock_resource: {"spec": {"test": "value"}}}
 
-        editor = ResourceEditorValidateHCOReconcile(patches=patches)
+        editor = ResourceEditorValidateHCOReconcile(admin_client=mock_client, patches=patches)
 
         with patch("utilities.hco.ResourceEditor.restore") as mock_parent_restore:
             editor.restore()
@@ -953,7 +956,9 @@ class TestUpdateHcoAnnotations:
         mock_editor.__exit__ = MagicMock(return_value=None)
         mock_editor_class.return_value = mock_editor
 
+        mock_client = MagicMock()
         with update_hco_annotations(
+            admin_client=mock_client,
             resource=mock_hco,
             path="machineType",
             value="pc-q35-rhel8.4.0",
@@ -974,7 +979,9 @@ class TestUpdateHcoAnnotations:
         mock_editor.__exit__ = MagicMock(return_value=None)
         mock_editor_class.return_value = mock_editor
 
+        mock_client = MagicMock()
         with update_hco_annotations(
+            admin_client=mock_client,
             resource=mock_hco,
             path="machineType",
             value="pc-q35-rhel8.4.0",
@@ -995,7 +1002,9 @@ class TestUpdateHcoAnnotations:
         mock_editor.__exit__ = MagicMock(return_value=None)
         mock_editor_class.return_value = mock_editor
 
+        mock_client = MagicMock()
         with update_hco_annotations(
+            admin_client=mock_client,
             resource=mock_hco,
             path="machineType",
             value="pc-q35-rhel8.4.0",

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -69,6 +69,7 @@ class TestClusterWithIcsp:
 
         result = cluster_with_icsp(client=mock_client)
         assert result is True
+        mock_icsp_class.get.assert_called_once_with(dyn_client=mock_client)
 
     @patch("utilities.operator.ImageContentSourcePolicy")
     def test_cluster_with_icsp_absent(self, mock_icsp_class):
@@ -78,6 +79,7 @@ class TestClusterWithIcsp:
 
         result = cluster_with_icsp(client=mock_client)
         assert result is False
+        mock_icsp_class.get.assert_called_once_with(dyn_client=mock_client)
 
 
 class TestGetCatalogSource:
@@ -925,6 +927,8 @@ class TestWaitForCatalogSourceDisabled:
         wait_for_catalog_source_disabled(client=mock_client, catalog_name="test-catalog")
 
         mock_sampler.assert_called_once()
+        assert mock_sampler.call_args.kwargs["client"] == mock_client
+        assert mock_sampler.call_args.kwargs["catalog_name"] == "test-catalog"
 
     @patch("utilities.operator.TimeoutSampler")
     @patch("utilities.operator.get_catalog_source")

--- a/utilities/unittests/test_operator.py
+++ b/utilities/unittests/test_operator.py
@@ -65,16 +65,18 @@ class TestClusterWithIcsp:
         mock_icsp2.name = "icsp-2"
 
         mock_icsp_class.get.return_value = [mock_icsp1, mock_icsp2]
+        mock_client = MagicMock()
 
-        result = cluster_with_icsp()
+        result = cluster_with_icsp(client=mock_client)
         assert result is True
 
     @patch("utilities.operator.ImageContentSourcePolicy")
     def test_cluster_with_icsp_absent(self, mock_icsp_class):
         """Test cluster_with_icsp returns False when no ICSP exists"""
         mock_icsp_class.get.return_value = []
+        mock_client = MagicMock()
 
-        result = cluster_with_icsp()
+        result = cluster_with_icsp(client=mock_client)
         assert result is False
 
 
@@ -91,11 +93,13 @@ class TestGetCatalogSource:
         mock_catalog.exists = True
         mock_catalog.name = "test-catalog"
         mock_catalog_source_class.return_value = mock_catalog
+        mock_client = MagicMock()
 
-        result = get_catalog_source("test-catalog")
+        result = get_catalog_source(client=mock_client, catalog_name="test-catalog")
 
         assert result == mock_catalog
         mock_catalog_source_class.assert_called_once_with(
+            client=mock_client,
             namespace="openshift-marketplace",
             name="test-catalog",
         )
@@ -109,8 +113,9 @@ class TestGetCatalogSource:
         mock_catalog = MagicMock()
         mock_catalog.exists = False
         mock_catalog_source_class.return_value = mock_catalog
+        mock_client = MagicMock()
 
-        result = get_catalog_source("nonexistent-catalog")
+        result = get_catalog_source(client=mock_client, catalog_name="nonexistent-catalog")
 
         assert result is None
 
@@ -191,11 +196,12 @@ class TestGetOperatorHub:
         mock_operator_hub.exists = True
         mock_operator_hub.name = "cluster"
         mock_operator_hub_class.return_value = mock_operator_hub
+        mock_client = MagicMock()
 
-        result = get_operator_hub()
+        result = get_operator_hub(client=mock_client)
 
         assert result == mock_operator_hub
-        mock_operator_hub_class.assert_called_once_with(name="cluster")
+        mock_operator_hub_class.assert_called_once_with(client=mock_client, name="cluster")
 
     @patch("utilities.operator.OperatorHub")
     def test_get_operator_hub_not_exists(self, mock_operator_hub_class):
@@ -203,9 +209,10 @@ class TestGetOperatorHub:
         mock_operator_hub = MagicMock()
         mock_operator_hub.exists = False
         mock_operator_hub_class.return_value = mock_operator_hub
+        mock_client = MagicMock()
 
         with pytest.raises(ResourceNotFoundError, match="OperatorHub cluster not found"):
-            get_operator_hub()
+            get_operator_hub(client=mock_client)
 
 
 class TestGetFailedClusterOperator:
@@ -914,7 +921,8 @@ class TestWaitForCatalogSourceDisabled:
         mock_sampler_instance.__iter__ = MagicMock(return_value=iter([None]))
         mock_sampler.return_value = mock_sampler_instance
 
-        wait_for_catalog_source_disabled("test-catalog")
+        mock_client = MagicMock()
+        wait_for_catalog_source_disabled(client=mock_client, catalog_name="test-catalog")
 
         mock_sampler.assert_called_once()
 
@@ -935,9 +943,10 @@ class TestWaitForCatalogSourceDisabled:
                 raise TimeoutExpiredError("Timeout")
 
         mock_sampler.return_value = MockSamplerIterator()
+        mock_client = MagicMock()
 
         with pytest.raises(TimeoutExpiredError):
-            wait_for_catalog_source_disabled("test-catalog")
+            wait_for_catalog_source_disabled(client=mock_client, catalog_name="test-catalog")
 
 
 class TestCreateCatalogSource:


### PR DESCRIPTION
##### What this PR does / why we need it:

Add the mandatory `client` argument to all remaining openshift-python-wrapper resource calls that were relying on the implicit `get_client()` fallback, covering IUO utilities and Observability tests.

Key changes:
- **`utilities/operator.py`**: Add `client` param to `get_operator_hub`, `get_catalog_source`, `wait_for_catalog_source_disabled`, `cluster_with_icsp`, and pass `client=` to `OperatorHub`, `CatalogSource`, `Namespace`, `Subscription`, `ImageContentSourcePolicy.get()` constructors.
- **`utilities/hco.py`**: Make `admin_client` a required parameter in `ResourceEditorValidateHCOReconcile` (remove `get_client()` fallback). Add `admin_client` param to `update_hco_annotations`. Remove `get_client` import.
- **Observability tests**: Add `unprivileged_client`/`admin_client` to fixtures constructing `VirtualMachineForTests`, `VirtualMachineClusterInstancetype`, `VirtualMachineClusterPreference`, and `PrometheusRule`.
- Update all callers across the codebase (63 files).

##### Which issue(s) this PR fixes:

Missing client Argument

##### Special notes for reviewer:

The `ResourceEditorValidateHCOReconcile` change touches 59 files across all teams because every caller relied on the `get_client()` fallback. All changes are mechanical — adding `admin_client` to fixture/function signatures and passing it to the constructor. Unit tests updated accordingly.

##### jira-ticket:
https://issues.redhat.com/browse/CNV-68530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of operator configuration, reconciliation, and resource updates by consistently using the appropriate cluster client.
  * Corrected resource and alert-rule lookups to operate against the intended cluster context.
  * Preserved existing configuration, validation, and reconciliation behavior across feature, storage, networking, and virtualization workflows.

* **Tests**
  * Updated automated coverage to validate client-aware resource operations and utility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->