### PR TITLE
[4.19] Rename must-gather ip.txt filename to ip_addr

### DIFF
--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -248,7 +248,7 @@ class TestMustGatherCluster:
             ),
             pytest.param(
                 ["ip", "a"],
-                "ip.txt",
+                "ip_addr",
                 "not_empty",
                 marks=(pytest.mark.polarion("CNV-2732"),),
                 id="test_nodes_ip_data",


### PR DESCRIPTION
##### What this PR does / why we need it:

Rename must-gather ip.txt filename to ip_addr

##### Which issue(s) this PR fixes:

jenkins 4.19-iuo-ocs has failures since must-gather [PR #239](https://github.com/kubevirt/must-gather/pull/239) renamed the node IP data output file from ip.txt to ip_addr. Update test parametrization to match.

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-94141