### PR TITLE
WIP: [DO NOT REVIEW] Check new win11 wsl2 image

### DIFF
--- a/utilities/constants/images.py
+++ b/utilities/constants/images.py
@@ -73,7 +73,7 @@ class ArchImages:
             WIN2k25_IMG="win_2k25_uefi.qcow2",
             WIN2k19_HA_IMG="win_2019_virtio.qcow2",
             WIN11_IMG="win_11.qcow2",
-            WIN11_WSL2_IMG="win_11_wsl2.qcow2",
+            WIN11_WSL2_IMG="win_11_wsl2_new.qcow2",
             WIN11_ISO_IMG="en-us_windows_11_business_editions_version_24h2_x64_dvd_59a1851e.iso",
             WIN19_RAW="win_2k19_uefi.raw",
             WIN2022_IMG="win_2022.qcow2",


### PR DESCRIPTION
Check new win11 wsl2 image with disabled windows update service

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AMD64 Windows 11 WSL2 image reference to use the correct QCOW2 filename.
  * Other operating system and architecture image mappings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->