### PR TITLE
net: Remove bridge device matrix

### DIFF
--- a/tests/fixtures/network/l2_bridge.py
+++ b/tests/fixtures/network/l2_bridge.py
@@ -10,6 +10,11 @@ from utilities.constants.cluster import WORKER_NODE_LABEL_KEY
 from utilities.constants.networking import LINUX_BRIDGE
 
 
+@pytest.fixture(scope="class")
+def bridge_device_type(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
 @pytest.fixture(scope="module")
 def bridge_nncp(
     nmstate_dependent_placeholder: None,

--- a/tests/network/bond/test_l2_bridge_over_bond.py
+++ b/tests/network/bond/test_l2_bridge_over_bond.py
@@ -10,6 +10,7 @@ import utilities.network
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
 from tests.network.libs import cloudinit as netcloud
+from utilities.constants.networking import LINUX_BRIDGE, OVS_BRIDGE
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
     BondNodeNetworkConfigurationPolicy,
@@ -26,10 +27,10 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.fixture(scope="class")
-def ovs_linux_br1bond_nad(admin_client, bridge_device_matrix__class__, namespace):
+def ovs_linux_br1bond_nad(admin_client, namespace, bridge_device_type):
     with network_nad(
         namespace=namespace,
-        nad_type=bridge_device_matrix__class__,
+        nad_type=bridge_device_type,
         nad_name="br1bond-nad",
         interface_name="br1bond",
         client=admin_client,
@@ -88,16 +89,16 @@ def ovs_linux_bond1_worker_2(
 def ovs_linux_bridge_on_bond_worker_1(
     nmstate_dependent_placeholder,
     admin_client,
-    bridge_device_matrix__class__,
     worker_node1,
     ovs_linux_br1bond_nad,
     ovs_linux_bond1_worker_1,
+    bridge_device_type,
 ):
     """
     Create bridge and attach the BOND to it
     """
     with utilities.network.network_device(
-        interface_type=bridge_device_matrix__class__,
+        interface_type=bridge_device_type,
         nncp_name="bridge-on-bond-worker-1",
         interface_name=ovs_linux_br1bond_nad.bridge_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -111,16 +112,16 @@ def ovs_linux_bridge_on_bond_worker_1(
 def ovs_linux_bridge_on_bond_worker_2(
     nmstate_dependent_placeholder,
     admin_client,
-    bridge_device_matrix__class__,
     worker_node2,
     ovs_linux_br1bond_nad,
     ovs_linux_bond1_worker_2,
+    bridge_device_type,
 ):
     """
     Create bridge and attach the BOND to it
     """
     with utilities.network.network_device(
-        interface_type=bridge_device_matrix__class__,
+        interface_type=bridge_device_type,
         nncp_name="bridge-on-bond-worker-2",
         interface_name=ovs_linux_br1bond_nad.bridge_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
@@ -198,6 +199,7 @@ def ovs_linux_bond_bridge_attached_vms(ovs_linux_bond_bridge_attached_vma, ovs_l
     yield vms
 
 
+@pytest.mark.parametrize(argnames="bridge_device_type", argvalues=[LINUX_BRIDGE, OVS_BRIDGE], indirect=True)
 class TestBondConnectivity:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-3366")

--- a/tests/network/jumbo_frame/test_bond.py
+++ b/tests/network/jumbo_frame/test_bond.py
@@ -9,6 +9,7 @@ import pytest
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
 from tests.network.utils import assert_no_ping
+from utilities.constants.networking import LINUX_BRIDGE, OVS_BRIDGE
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
     BondNodeNetworkConfigurationPolicy,
@@ -84,14 +85,14 @@ def jumbo_frame_bridge_on_bond_worker_1(
     nmstate_dependent_placeholder,
     admin_client,
     cluster_hardware_mtu,
-    bridge_device_matrix__class__,
     jumbo_frame_bond1_worker_1,
+    bridge_device_type,
 ):
     """
     Create bridge and attach the BOND to it
     """
     with network_device(
-        interface_type=bridge_device_matrix__class__,
+        interface_type=bridge_device_type,
         nncp_name="jumbo-frame-bridge-on-bond-1",
         interface_name=BRIDGE_NAME,
         node_selector=jumbo_frame_bond1_worker_1.node_selector,
@@ -107,14 +108,14 @@ def jumbo_frame_bridge_on_bond_worker_2(
     nmstate_dependent_placeholder,
     admin_client,
     cluster_hardware_mtu,
-    bridge_device_matrix__class__,
     jumbo_frame_bond1_worker_2,
+    bridge_device_type,
 ):
     """
     Create bridge and attach the BOND to it
     """
     with network_device(
-        interface_type=bridge_device_matrix__class__,
+        interface_type=bridge_device_type,
         nncp_name="jumbo-frame-bridge-on-bond-2",
         interface_name=BRIDGE_NAME,
         node_selector=jumbo_frame_bond1_worker_2.node_selector,
@@ -129,14 +130,14 @@ def jumbo_frame_bridge_on_bond_worker_2(
 def br1bond_nad(
     admin_client,
     cluster_hardware_mtu,
-    bridge_device_matrix__class__,
     namespace,
     jumbo_frame_bridge_on_bond_worker_1,
     jumbo_frame_bridge_on_bond_worker_2,
+    bridge_device_type,
 ):
     with network_nad(
         namespace=namespace,
-        nad_type=bridge_device_matrix__class__,
+        nad_type=bridge_device_type,
         nad_name=f"{BRIDGE_NAME}-bond-nad",
         interface_name=jumbo_frame_bridge_on_bond_worker_1.bridge_name,
         mtu=cluster_hardware_mtu,
@@ -217,10 +218,11 @@ def running_bond_bridge_attached_vmb(bond_bridge_attached_vmb):
     return bond_bridge_attached_vmb
 
 
+@pytest.mark.parametrize(argnames="bridge_device_type", argvalues=[LINUX_BRIDGE, OVS_BRIDGE], indirect=True)
 class TestBondJumboFrame:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-3367")
-    def test_connectivity_over_linux_bond_large_mtu(
+    def test_connectivity_over_bond_large_mtu(
         self,
         namespace,
         jumbo_frame_bridge_on_bond_worker_1,
@@ -232,7 +234,7 @@ class TestBondJumboFrame:
         running_bond_bridge_attached_vmb,
     ):
         """
-        Check connectivity over linux bridge with custom MTU
+        Check connectivity over bridge with custom MTU
         """
         icmp_header = 8
         ip_header = 20
@@ -246,7 +248,7 @@ class TestBondJumboFrame:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-3368")
-    def test_negative_mtu_linux_bond(
+    def test_negative_mtu_bond(
         self,
         namespace,
         jumbo_frame_bridge_on_bond_worker_1,

--- a/tests/network/jumbo_frame/test_bridge.py
+++ b/tests/network/jumbo_frame/test_bridge.py
@@ -9,6 +9,7 @@ import pytest
 from libs.net.ip import random_ipv4_address
 from libs.net.vmspec import lookup_iface_status_ip
 from tests.network.utils import assert_no_ping
+from utilities.constants.networking import LINUX_BRIDGE, OVS_BRIDGE
 from utilities.infra import get_node_selector_dict
 from utilities.network import (
     assert_ping_successful,
@@ -37,13 +38,13 @@ def jumbo_frame_bridge_device_worker_1(
     nmstate_dependent_placeholder,
     admin_client,
     cluster_hardware_mtu,
-    bridge_device_matrix__class__,
     worker_node1,
     hosts_common_available_ports,
     jumbo_frame_bridge_device_name,
+    bridge_device_type,
 ):
     with network_device(
-        interface_type=bridge_device_matrix__class__,
+        interface_type=bridge_device_type,
         nncp_name="jumbo-frame-bridge-nncp-1",
         interface_name=jumbo_frame_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -59,13 +60,13 @@ def jumbo_frame_bridge_device_worker_2(
     nmstate_dependent_placeholder,
     admin_client,
     cluster_hardware_mtu,
-    bridge_device_matrix__class__,
     worker_node2,
     hosts_common_available_ports,
     jumbo_frame_bridge_device_name,
+    bridge_device_type,
 ):
     with network_device(
-        interface_type=bridge_device_matrix__class__,
+        interface_type=bridge_device_type,
         nncp_name="jumbo-frame-bridge-nncp-2",
         interface_name=jumbo_frame_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
@@ -80,15 +81,15 @@ def jumbo_frame_bridge_device_worker_2(
 def br1test_bridge_nad(
     admin_client,
     cluster_hardware_mtu,
-    bridge_device_matrix__class__,
     namespace,
     jumbo_frame_bridge_device_name,
     jumbo_frame_bridge_device_worker_1,
     jumbo_frame_bridge_device_worker_2,
+    bridge_device_type,
 ):
     with network_nad(
         namespace=namespace,
-        nad_type=bridge_device_matrix__class__,
+        nad_type=bridge_device_type,
         nad_name=f"{jumbo_frame_bridge_device_name}-nad",
         interface_name=jumbo_frame_bridge_device_name,
         mtu=cluster_hardware_mtu,
@@ -147,10 +148,11 @@ def bridge_attached_vmb(worker_node2, namespace, unprivileged_client, br1test_br
         yield vm
 
 
+@pytest.mark.parametrize(argnames="bridge_device_type", argvalues=[LINUX_BRIDGE, OVS_BRIDGE], indirect=True)
 class TestJumboFrameBridge:
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-2685")
-    def test_connectivity_over_linux_bridge_large_mtu(
+    def test_connectivity_over_bridge_large_mtu(
         self,
         namespace,
         br1test_bridge_nad,
@@ -158,7 +160,7 @@ class TestJumboFrameBridge:
         bridge_attached_vmb,
     ):
         """
-        Check connectivity over linux bridge with custom MTU
+        Check connectivity over bridge with custom MTU
         """
         icmp_header = 8
         ip_header = 20
@@ -170,7 +172,7 @@ class TestJumboFrameBridge:
 
     @pytest.mark.ipv4
     @pytest.mark.polarion("CNV-3788")
-    def test_negative_mtu_linux_bridge(
+    def test_negative_mtu_bridge(
         self,
         namespace,
         br1test_bridge_nad,

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -41,11 +41,6 @@ VMB_MPLS_ROUTE_TAG = 200
 
 
 @pytest.fixture(scope="class")
-def bridge_device_type(request):
-    return request.param
-
-
-@pytest.fixture(scope="class")
 def l2_bridge_device_name(index_number):
     yield f"br{next(index_number)}test"
 

--- a/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
+++ b/tests/network/l2_bridge/test_l2_ovs_linux_bridge.py
@@ -17,7 +17,7 @@ pytestmark = [pytest.mark.ipv4, pytest.mark.usefixtures("hyperconverged_ovs_anno
 CUSTOM_ETH_PROTOCOL = "0x88B6"  # rfc5342 Local Experimental Ethertype. Used to test custom eth type
 
 
-@pytest.mark.parametrize("bridge_device_type", [LINUX_BRIDGE, OVS_BRIDGE], indirect=True)
+@pytest.mark.parametrize(argnames="bridge_device_type", argvalues=[LINUX_BRIDGE, OVS_BRIDGE], indirect=True)
 @pytest.mark.s390x
 class TestL2Bridge:
     """


### PR DESCRIPTION
##### What this PR does / why we need it:
During test setup, a matrix was previously used so the fixtures would
run twice: once with the Linux bridge and once with the OVS bridge.
Since the use of a matrix is not explicit and can be confusing, the tests now use
pytest.parametrize at the test class level instead.

##### Which issue(s) this PR fixes:
Drop matrix in setup and use pytest.parametrize

##### Special notes for reviewer:
Follow-up to https://github.com/RedHatQE/openshift-virtualization-tests/pull/4097

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded bridge connectivity and jumbo-frame BOND/bridge coverage to run against both Linux bridge and OVS bridge backends.
  * Standardized bridge-type selection via a shared `bridge_device_type` parameter passed through to bridge device and network attachment setup.
  * Updated related fixtures and test names to be bridge-generic (Linux-specific wording removed), while keeping existing connectivity assertions unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->