### PR TITLE
feat(ci): add 4h cooldown for /rerun-smoke retest-smoke label

### DIFF
--- a/.github/workflows/retest-smoke.yml
+++ b/.github/workflows/retest-smoke.yml
@@ -35,7 +35,7 @@ jobs:
       # Matches expected Jenkins smoke re-trigger window for github-events-listener.
       RETEST_SMOKE_COOLDOWN_HOURS: '4'
     steps:
-      # Acknowledge the request immediately; replaced with eyes if we skip re-trigger.
+      # Acknowledge the request immediately; replaced with -1 if we skip re-trigger.
       - name: Acknowledge request
         uses: peter-evans/create-or-update-comment@v5
         with:
@@ -136,5 +136,5 @@ jobs:
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: eyes
+          reactions: '-1'
           reactions-edit-mode: replace

--- a/.github/workflows/retest-smoke.yml
+++ b/.github/workflows/retest-smoke.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   retest-smoke:
+    # Only /rerun-smoke on PRs from trusted associations.
     if: >-
       startsWith(github.event.comment.body, '/rerun-smoke')
       && github.event.issue.pull_request
@@ -65,6 +66,7 @@ jobs:
             });
             const hasLabel = issue.labels.some((label) => label.name === labelName);
 
+            // Label already present: decide skip (cooldown) vs remove+re-add (stale).
             if (hasLabel) {
               const events = await github.paginate(github.rest.issues.listEvents, {
                 owner,
@@ -75,14 +77,17 @@ jobs:
 
               let labeledAtMs = null;
               for (const event of events) {
+                // Keep only retest-smoke "labeled" events from issue history.
                 if (event.event === 'labeled' && event.label?.name === labelName) {
                   const eventMs = Date.parse(event.created_at);
+                  // Track the most recent labeled timestamp (order-independent).
                   if (labeledAtMs === null || eventMs > labeledAtMs) {
                     labeledAtMs = eventMs;
                   }
                 }
               }
 
+              // No history → cannot compute age; fail closed (treat as in cooldown).
               if (labeledAtMs === null) {
                 console.log(
                   'retest-smoke is present but no labeled event was found; ' +
@@ -94,6 +99,7 @@ jobs:
 
               const labeledAt = new Date(labeledAtMs);
               const ageMs = Date.now() - labeledAtMs;
+              // Still within cooldown → Jenkins may still be handling the last trigger.
               if (ageMs < cooldownMs) {
                 console.log(
                   `retest-smoke was added less than ${cooldownHours} hours ago ` +
@@ -115,6 +121,7 @@ jobs:
                   name: labelName,
                 });
               } catch (error) {
+                // 404: label already gone (e.g. Jenkins raced us); continue to addLabels.
                 if (error.status !== 404) {
                   throw error;
                 }
@@ -124,6 +131,7 @@ jobs:
               }
             }
 
+            // Fresh add, or re-add after stale remove (also the no-label path).
             await github.rest.issues.addLabels({
               owner,
               repo,
@@ -133,6 +141,7 @@ jobs:
             console.log('Added retest-smoke label.');
             core.setOutput('label_added', 'true');
 
+      # Cooldown/skip path: replace the initial +1 with -1.
       - name: Mark request skipped
         if: steps.manage-label.outputs.label_added == 'false'
         uses: peter-evans/create-or-update-comment@v5

--- a/.github/workflows/retest-smoke.yml
+++ b/.github/workflows/retest-smoke.yml
@@ -1,3 +1,16 @@
+# Trigger Jenkins smoke re-run via the retest-smoke label when a trusted
+# contributor comments `/rerun-smoke` on a PR.
+#
+# Flow: GHA adds `retest-smoke` → Jenkins job github-events-listener handles it
+# (and typically removes the label after processing).
+#
+# Cooldown: if `retest-smoke` is already on the PR and was labeled less than
+# 4 hours ago, skip re-add and log guidance to check github-events-listener.
+# If the label is still present and older than 4 hours, remove then re-add so
+# Jenkins sees a fresh labeled event.
+#
+# Auth: OWNER / MEMBER / COLLABORATOR only.
+
 name: Retest Smoke
 on:
   issue_comment:
@@ -5,7 +18,7 @@ on:
 
 concurrency:
   group: retest-smoke-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   retest-smoke:
@@ -18,20 +31,102 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    env:
+      # Matches expected Jenkins smoke re-trigger window for github-events-listener.
+      RETEST_SMOKE_COOLDOWN_HOURS: '4'
     steps:
+      - name: Manage retest-smoke label
+        id: manage-label
+        uses: actions/github-script@v9
+        env:
+          RETEST_SMOKE_COOLDOWN_HOURS: ${{ env.RETEST_SMOKE_COOLDOWN_HOURS }}
+        with:
+          script: |
+            const labelName = 'retest-smoke';
+            const cooldownHours = Number(process.env.RETEST_SMOKE_COOLDOWN_HOURS);
+            const cooldownMs = cooldownHours * 60 * 60 * 1000;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number,
+            });
+            const hasLabel = issue.labels.some((label) => label.name === labelName);
+
+            if (hasLabel) {
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              });
+
+              let labeledAtMs = null;
+              for (const event of events) {
+                if (event.event === 'labeled' && event.label?.name === labelName) {
+                  const eventMs = Date.parse(event.created_at);
+                  if (labeledAtMs === null || eventMs > labeledAtMs) {
+                    labeledAtMs = eventMs;
+                  }
+                }
+              }
+
+              if (labeledAtMs === null) {
+                console.log(
+                  'retest-smoke is present but no labeled event was found; ' +
+                    'treating as within cooldown. Check Jenkins job github-events-listener.'
+                );
+                core.setOutput('label_added', 'false');
+                return;
+              }
+
+              const labeledAt = new Date(labeledAtMs);
+              const ageMs = Date.now() - labeledAtMs;
+              if (ageMs < cooldownMs) {
+                console.log(
+                  `retest-smoke was added less than ${cooldownHours} hours ago ` +
+                    `(${labeledAt.toISOString()}). Check Jenkins job github-events-listener.`
+                );
+                core.setOutput('label_added', 'false');
+                return;
+              }
+
+              console.log(
+                `retest-smoke is older than ${cooldownHours} hours ` +
+                  `(labeled at ${labeledAt.toISOString()}); removing before re-adding.`
+              );
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number,
+                  name: labelName,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                console.log(
+                  'retest-smoke was already removed before removeLabel; continuing to addLabels.'
+                );
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [labelName],
+            });
+            console.log('Added retest-smoke label.');
+            core.setOutput('label_added', 'true');
+
       - name: Add thumbs up reaction
+        if: steps.manage-label.outputs.label_added == 'true'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: '+1'
-
-      - name: Add retest-smoke label
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              labels: ['retest-smoke']
-            });

--- a/.github/workflows/retest-smoke.yml
+++ b/.github/workflows/retest-smoke.yml
@@ -35,6 +35,13 @@ jobs:
       # Matches expected Jenkins smoke re-trigger window for github-events-listener.
       RETEST_SMOKE_COOLDOWN_HOURS: '4'
     steps:
+      # Acknowledge the request immediately; replaced with eyes if we skip re-trigger.
+      - name: Acknowledge request
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: '+1'
+
       - name: Manage retest-smoke label
         id: manage-label
         uses: actions/github-script@v9
@@ -124,9 +131,10 @@ jobs:
             console.log('Added retest-smoke label.');
             core.setOutput('label_added', 'true');
 
-      - name: Add thumbs up reaction
-        if: steps.manage-label.outputs.label_added == 'true'
+      - name: Mark request skipped
+        if: steps.manage-label.outputs.label_added == 'false'
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: '+1'
+          reactions: eyes
+          reactions-edit-mode: replace

--- a/.github/workflows/retest-smoke.yml
+++ b/.github/workflows/retest-smoke.yml
@@ -1,15 +1,17 @@
-# Trigger Jenkins smoke re-run via the retest-smoke label when a trusted
-# contributor comments `/rerun-smoke` on a PR.
+# /rerun-smoke — re-trigger Jenkins smoke via the retest-smoke label.
 #
-# Flow: GHA adds `retest-smoke` → Jenkins job github-events-listener handles it
-# (and typically removes the label after processing).
+# Trigger: PR comment starting with `/rerun-smoke` from OWNER/MEMBER/COLLABORATOR.
 #
-# Cooldown: if `retest-smoke` is already on the PR and was labeled less than
-# 4 hours ago, skip re-add and log guidance to check github-events-listener.
-# If the label is still present and older than 4 hours, remove then re-add so
-# Jenkins sees a fresh labeled event.
-#
-# Auth: OWNER / MEMBER / COLLABORATOR only.
+# Logic:
+#   1. React +1 immediately (request acknowledged).
+#   2. If retest-smoke is absent → add it (Jenkins job github-events-listener
+#      picks up the labeled event; Jenkins usually removes the label after).
+#   3. If retest-smoke is present:
+#        - labeled < 4h ago (or no labeled event found) → do not re-add;
+#          log "check github-events-listener"; replace +1 with -1.
+#        - labeled >= 4h ago → remove then re-add so Jenkins sees a fresh
+#          labeled event; leave +1.
+#   4. Reactions: +1 = label added/refreshed; -1 = skipped (cooldown).
 
 name: Retest Smoke
 on:

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -134,7 +134,8 @@ Comment on your GitHub PR (OWNER / MEMBER / COLLABORATOR only):
 This adds the `retest-smoke` label so Jenkins job `github-events-listener` can pick up a smoke re-run (Jenkins typically removes the label after processing).
 If `retest-smoke` is already on the PR and was added less than 4 hours ago, the workflow skips re-adding the label and logs guidance to check that Jenkins job.
 If the label is still present and older than 4 hours, the workflow removes and re-adds it so Jenkins sees a fresh labeled event.
-A thumbs-up on the comment means the label was added or refreshed. No thumbs-up means the request was skipped (4-hour cooldown, or label present without usable label history); check the workflow Action logs and Jenkins job `github-events-listener`.
+A thumbs-up on the comment means the workflow accepted the request and added or refreshed the label.
+If the request is skipped (4-hour cooldown, or label present without usable label history), the thumbs-up is replaced with 👀 — check the workflow Action logs and Jenkins job `github-events-listener`.
 
 ### Run the tests via a Jenkins job
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -135,7 +135,7 @@ This adds the `retest-smoke` label so Jenkins job `github-events-listener` can p
 If `retest-smoke` is already on the PR and was added less than 4 hours ago, the workflow skips re-adding the label and logs guidance to check that Jenkins job.
 If the label is still present and older than 4 hours, the workflow removes and re-adds it so Jenkins sees a fresh labeled event.
 A thumbs-up on the comment means the workflow accepted the request and added or refreshed the label.
-If the request is skipped (4-hour cooldown, or label present without usable label history), the thumbs-up is replaced with 👀 — check the workflow Action logs and Jenkins job `github-events-listener`.
+If the request is skipped (4-hour cooldown, or label present without usable label history), the thumbs-up is replaced with 👎 — check the workflow Action logs and Jenkins job `github-events-listener`.
 
 ### Run the tests via a Jenkins job
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -123,6 +123,19 @@ Comment on your GitHub PR:
 
 This triggers CodeRabbit to analyze the PR's changed files and post an inline review comment with a test execution plan (smoke/gating impact, affected tests to run).
 
+### Re-run smoke tests
+
+Comment on your GitHub PR (OWNER / MEMBER / COLLABORATOR only):
+
+```bash
+/rerun-smoke
+```
+
+This adds the `retest-smoke` label so Jenkins job `github-events-listener` can pick up a smoke re-run (Jenkins typically removes the label after processing).
+If `retest-smoke` is already on the PR and was added less than 4 hours ago, the workflow skips re-adding the label and logs guidance to check that Jenkins job.
+If the label is still present and older than 4 hours, the workflow removes and re-adds it so Jenkins sees a fresh labeled event.
+A thumbs-up on the comment means the label was added or refreshed. No thumbs-up means the request was skipped (4-hour cooldown, or label present without usable label history); check the workflow Action logs and Jenkins job `github-events-listener`.
+
 ### Run the tests via a Jenkins job
 
 #### Build and push a container with your changes


### PR DESCRIPTION
##### What this PR does / why we need it:
When `/rerun-smoke` is used while `retest-smoke` is still on the PR, re-adding the label does not create a new Jenkins trigger. This change:
- skips re-add (and thumbs-up) if the label was applied less than 4 hours ago, and logs guidance to check Jenkins job `github-events-listener`
- removes then re-adds the label if it is still present after 4 hours, so Jenkins sees a fresh labeled event
- documents `/rerun-smoke` in `docs/DEVELOPER_GUIDE.md`

##### Which issue(s) this PR fixes:
<!-- none -->

##### Special notes for reviewer:
- Cooldown applies only when the label is currently present (matches Jenkins still holding/processing the label).
- `removeLabel` 404 is ignored so a concurrent Jenkins unlabeled event cannot abort the re-add.
- Thumbs-up reaction runs only after a successful label add/refresh.

##### jira-ticket:


Made with [Cursor](https://cursor.com)