### PR TITLE
Exclude e1000e pod-network connectivity from s390x runs

### DIFF
--- a/tests/network/connectivity/conftest.py
+++ b/tests/network/connectivity/conftest.py
@@ -8,6 +8,11 @@ from utilities.network import compose_cloud_init_data_dict, network_device, netw
 
 
 @pytest.fixture(scope="module")
+def pod_network_nic_model(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
 def bridge_device_name(index_number):
     yield f"br{next(index_number)}test"
 

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -17,7 +17,7 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, vm_console_ru
 def pod_net_vma(
     namespace,
     unprivileged_client,
-    nic_models_matrix__module__,
+    pod_network_nic_model,
     cloud_init_ipv6_network_data,
     schedulable_nodes,
 ):
@@ -28,7 +28,7 @@ def pod_net_vma(
         name=name,
         node_selector=get_node_selector_dict(node_selector=node_selector),
         client=unprivileged_client,
-        network_model=nic_models_matrix__module__,
+        network_model=pod_network_nic_model,
         body=fedora_vm_body(name=name),
         cloud_init_data=cloud_init_ipv6_network_data,
     ) as vm:
@@ -40,7 +40,7 @@ def pod_net_vma(
 def pod_net_vmb(
     namespace,
     unprivileged_client,
-    nic_models_matrix__module__,
+    pod_network_nic_model,
     cloud_init_ipv6_network_data,
     schedulable_nodes,
 ):
@@ -51,7 +51,7 @@ def pod_net_vmb(
         name=name,
         node_selector=get_node_selector_dict(node_selector=node_selector),
         client=unprivileged_client,
-        network_model=nic_models_matrix__module__,
+        network_model=pod_network_nic_model,
         body=fedora_vm_body(name=name),
         cloud_init_data=cloud_init_ipv6_network_data,
     ) as vm:
@@ -77,6 +77,15 @@ def cloud_init_ipv6_network_data(ipv6_primary_interface_cloud_init_data):
 
 
 @pytest.mark.parametrize(
+    "pod_network_nic_model",
+    [
+        pytest.param("virtio", marks=[pytest.mark.s390x, pytest.mark.polarion("CNV-16553")], id="#virtio#"),
+        pytest.param("e1000e", marks=[pytest.mark.polarion("CNV-16554")], id="#e1000e#"),
+    ],
+    indirect=True,
+    scope="module",
+)
+@pytest.mark.parametrize(
     "ip_family",
     [
         pytest.param(
@@ -98,7 +107,6 @@ def cloud_init_ipv6_network_data(ipv6_primary_interface_cloud_init_data):
 )
 @pytest.mark.gating
 @pytest.mark.single_nic
-@pytest.mark.s390x
 # conformance candidate
 def test_connectivity_over_pod_network(
     ip_family,


### PR DESCRIPTION
##### What this PR does / why we need it:
`test_connectivity_over_pod_network` is parametrized over NIC models `virtio` and `e1000e`. Marking the whole test with `@pytest.mark.s390x` caused the e1000e variants to run on s390x, where e1000e is unsupported and fails.
This PR moves NIC model selection to an indirect `@pytest.mark.parametrize` and applies `@pytest.mark.s390x` only to the virtio parameter. The e1000e parameter is left unmarked so it is not collected on s390x lanes that use `-m s390x`, while both virtio and e1000e continue to run on amd64/x86.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded pod network connectivity coverage to include Virtio and e1000e network models.
  * Retained IPv4 and IPv6 validation across supported network configurations.
  * Updated VM connectivity scenarios to consistently apply the selected network model.
  * Improved architecture-specific coverage by restricting network model combinations appropriately.
  * Strengthened consistency when validating connectivity across supported VM network configurations.
  * Increased confidence that supported network models operate correctly across relevant architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->