### PR TITLE
infra: Replace latest_windows_data_source with windows_validation_os_images_data_source_scope_session

### DIFF
--- a/tests/infrastructure/instance_types/conftest.py
+++ b/tests/infrastructure/instance_types/conftest.py
@@ -116,95 +116,10 @@ def windows_validating_admission_policy_binding(admin_client):
         yield vapb
 
 
-@pytest.fixture(scope="session")
-def windows_test_images_namespace(admin_client):
-    windows_images_namespace = Namespace(
-        client=admin_client,
-        name=LATEST_WINDOWS_IMAGE_NAMESPACE,
-    )
-    if windows_images_namespace.exists:
-        yield windows_images_namespace
-    else:
-        with windows_images_namespace as win_namespace:
-            yield win_namespace
-
-
-@pytest.fixture(scope="session")
-def windows_test_images_namespace_role_binding(admin_client, windows_test_images_namespace):
-    windows_images_view_role_binding = RoleBinding(
-        client=admin_client,
-        name="windows-test-images-view",
-        namespace=windows_test_images_namespace.name,
-        subjects_kind="Group",
-        subjects_name="system:authenticated",
-        role_ref_kind=ClusterRole.kind,
-        role_ref_name="view",
-    )
-    if windows_images_view_role_binding.exists:
-        yield windows_images_view_role_binding
-    else:
-        with windows_images_view_role_binding as win_view_role_binding:
-            yield win_view_role_binding
-
-
-@pytest.fixture(scope="session")
-def latest_windows_data_volume(
-    admin_client,
-    default_sc,
-    windows_test_images_namespace_role_binding,
-    windows_namespace_artifactory_secret_and_configmap,
-):
-    windows_data_volume = DataVolume(
-        client=admin_client,
-        name="latest-windows",
-        namespace=windows_test_images_namespace_role_binding.namespace,
-        api_name="storage",
-        source_dict=construct_datavolume_source_dict(
-            source="registry",
-            url=(
-                f"{get_test_artifact_server_url(schema='registry')}/"
-                f"{py_config['latest_windows_os_dict'][CONTAINER_DISK_IMAGE_PATH_STR]}"
-            ),
-            secret_name=windows_namespace_artifactory_secret_and_configmap["secret"].name,
-            cert_configmap_name=windows_namespace_artifactory_secret_and_configmap["config_map"].name,
-        ),
-        size=Images.Windows.CONTAINER_DISK_DV_SIZE,
-        storage_class=default_sc.name,
-    )
-    if windows_data_volume.exists:
-        yield windows_data_volume
-    else:
-        with windows_data_volume as win_dv:
-            if sc_volume_binding_mode_is_wffc(sc=default_sc.name, client=windows_data_volume.client):
-                create_dummy_first_consumer_pod(pvc=windows_data_volume.pvc)
-            yield win_dv
-
-
-@pytest.fixture(scope="session")
-def latest_windows_data_source(
-    admin_client,
-    latest_windows_data_volume,
-):
-    windows_data_source = DataSource(
-        name=latest_windows_data_volume.name,
-        namespace=latest_windows_data_volume.namespace,
-        client=admin_client,
-        source=generate_data_source_dict(dv=latest_windows_data_volume),
-    )
-    if windows_data_source.exists:
-        yield windows_data_source
-    else:
-        with windows_data_source as win_ds:
-            windows_data_source.wait_for_condition(
-                condition=windows_data_source.Condition.READY,
-                status=windows_data_source.Condition.Status.TRUE,
-                timeout=TIMEOUT_15MIN,
-            )
-            yield win_ds
-
-
 @pytest.fixture()
-def windows_vm_for_dedicated_cpu(request, unprivileged_client, namespace, latest_windows_data_source):
+def windows_vm_for_dedicated_cpu(
+    request, unprivileged_client, namespace, windows_validation_os_images_data_source_scope_session
+):
     with VirtualMachineForTests(
         client=unprivileged_client,
         name=request.param["vm_name"],
@@ -214,7 +129,7 @@ def windows_vm_for_dedicated_cpu(request, unprivileged_client, namespace, latest
         ),
         vm_preference_infer=True,
         data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=latest_windows_data_source,
+            data_source=windows_validation_os_images_data_source_scope_session,
         ),
         os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
         disk_type=None,
@@ -238,14 +153,3 @@ def rhel_vm_for_dedicated_cpu(unprivileged_client, namespace, latest_rhel_data_s
     ) as vm:
         vm.start()
         yield vm
-
-
-@pytest.fixture(scope="session")
-def windows_namespace_artifactory_secret_and_configmap(windows_test_images_namespace_role_binding):
-    secret = get_artifactory_secret(namespace=windows_test_images_namespace_role_binding.namespace)
-    cert = get_artifactory_config_map(namespace=windows_test_images_namespace_role_binding.namespace)
-    yield {"secret": secret, "config_map": cert}
-    cleanup_artifactory_secret_and_config_map(
-        artifactory_secret=secret,
-        artifactory_config_map=cert,
-    )

--- a/tests/infrastructure/instance_types/conftest.py
+++ b/tests/infrastructure/instance_types/conftest.py
@@ -1,10 +1,5 @@
 import pytest
-from ocp_resources.cluster_role import ClusterRole
-from ocp_resources.data_source import DataSource
-from ocp_resources.datavolume import DataVolume
-from ocp_resources.namespace import Namespace
 from ocp_resources.resource import Resource
-from ocp_resources.role_binding import RoleBinding
 from ocp_resources.validating_admission_policy import ValidatingAdmissionPolicy
 from ocp_resources.validating_admission_policy_binding import ValidatingAdmissionPolicyBinding
 from ocp_resources.virtual_machine_cluster_instancetype import (
@@ -13,28 +8,14 @@ from ocp_resources.virtual_machine_cluster_instancetype import (
 from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
 )
-from pytest_testconfig import config as py_config
 
 from tests.infrastructure.instance_types.constants import WINDOWS_DEDICATED_CPU_MESSAGE, WINDOWS_VCPU_OVERCOMMIT_STR
-from utilities.artifactory import (
-    cleanup_artifactory_secret_and_config_map,
-    get_artifactory_config_map,
-    get_artifactory_secret,
-    get_test_artifact_server_url,
-)
-from utilities.constants import Images
 from utilities.constants.images import (
     OS_FLAVOR_RHEL,
     OS_FLAVOR_WIN_CONTAINER_DISK,
 )
-from utilities.constants.os_matrix import CONTAINER_DISK_IMAGE_PATH_STR
-from utilities.constants.timeouts import TIMEOUT_15MIN
 from utilities.storage import (
-    construct_datavolume_source_dict,
-    create_dummy_first_consumer_pod,
     data_volume_template_with_source_ref_dict,
-    generate_data_source_dict,
-    sc_volume_binding_mode_is_wffc,
 )
 from utilities.virt import VirtualMachineForTests
 


### PR DESCRIPTION
##### What this PR does / why we need it:
In `windows_vm_for_dedicated_cpu` replace `latest_windows_data_source` with `windows_validation_os_images_data_source_scope_session`.

Both fixtures aim to accomplish the same goal, while `latest_windows_data_source` is in a big scope location.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Updated Windows dedicated CPU VM test provisioning to use the validated operating system image source.
  * Simplified test setup by removing redundant Windows image preparation and configuration fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->