### PR TITLE
utils: move code rabbit PR Template Validation to custom_checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -71,18 +71,6 @@ reviews:
 
     - path: "**"
       instructions: |
-        ## PR Template Validation
-        Check the PR description for required sections from `.github/pull_request_template.md`.
-        Required sections (must be present, even if empty):
-        - `##### What this PR does / why we need it:` — MUST be present AND have meaningful content.
-          Flag as HIGH if the section is missing, empty, whitespace-only, contains only HTML comments,
-          or contains only placeholder tokens such as `TBD`, `TBA`, `N/A`, `-`, `—`, `none`, or `.`.
-        - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
-        - `##### Special notes for reviewer:` — must be present (may be empty)
-        - `##### jira-ticket:` — must be present (may be empty)
-        If any required section is absent, or `What this PR does / why we need it:` has no content,
-        flag it as HIGH severity and ask the author to restore the missing template section(s).
-
         ## Approval Policy
         You may approve the PR when ALL of the following are true:
         - All your review comments have been addressed with either:
@@ -136,10 +124,26 @@ reviews:
       mode: error
       requirements: "Must be under 120 chars and clearly describe the change."
     description:
-      mode: error
+      mode: "off"
     docstrings:
       mode: "off"
     custom_checks:
+      - name: "PR Template Sections"
+        mode: error
+        instructions: |
+          Check the current PR description (the actual, live PR body — not a cached or
+          per-file view of it) for required sections from `.github/pull_request_template.md`.
+          Required sections (must be present, even if empty):
+          - `##### What this PR does / why we need it:` — MUST be present AND have meaningful
+            content. Fail as HIGH if the section is missing, empty, whitespace-only, contains
+            only HTML comments, or contains only placeholder tokens such as `TBD`, `TBA`,
+            `N/A`, `-`, `—`, `none`, or `.`.
+          - `##### Which issue(s) this PR fixes:` — must be present (may be empty)
+          - `##### Special notes for reviewer:` — must be present (may be empty)
+          - `##### jira-ticket:` — must be present (may be empty)
+          If any required section is absent, or `What this PR does / why we need it:` has no content,
+          flag it as HIGH severity and ask the author to restore the missing template section(s).
+
       - name: "STP link required"
         mode: error
         instructions: |


### PR DESCRIPTION
##### What this PR does / why we need it:
Moves the PR template validation logic from a path-level instructions block to a dedicated custom_checks entry in .coderabbit.yaml, and switches the built-in description check to "off" to avoid duplicate enforcement.

##### Which issue(s) this PR fixes:
False alerts on PR's by code rabbit, saying missing parts in the description, for example:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/5819#discussion_r3672956548

##### Special notes for reviewer:
The check behavior is unchanged, only the placement within the CodeRabbit config has moved. The description built-in was disabled because custom_checks now owns that validation.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation rules to focus on required template sections and meaningful purpose descriptions.
  * Removed redundant global template instructions and disabled separate description and documentation checks.
  * Added stricter validation for required sections and meaningful content in the primary purpose section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->