### PR TITLE
utils: update ruff to v0.16.1 and align code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       - id: ruff
         stages: [pre-commit]

--- a/tests/network/bgp/evpn/libevpn.py
+++ b/tests/network/bgp/evpn/libevpn.py
@@ -138,8 +138,10 @@ def _build_bridge_commands(
     return [
         f"ip link add {_BRIDGE_NAME} type bridge vlan_filtering 1 vlan_default_pvid 0",
         f"ip link set {_BRIDGE_NAME} up",
-        f"ip link add {_VXLAN_NAME} type vxlan dstport {_VXLAN_DEST_PORT} local {local_vtep_ip}"
-        " nolearning external vnifilter",
+        (
+            f"ip link add {_VXLAN_NAME} type vxlan dstport {_VXLAN_DEST_PORT} local {local_vtep_ip}"
+            " nolearning external vnifilter"
+        ),
         f"ip link set {_VXLAN_NAME} master {_BRIDGE_NAME}",
         f"bridge link set dev {_VXLAN_NAME} vlan_tunnel on neigh_suppress on learning off",
         f"ip link set {_VXLAN_NAME} up",

--- a/tests/network/flat_overlay/utils.py
+++ b/tests/network/flat_overlay/utils.py
@@ -88,8 +88,10 @@ def start_nc_response_on_vm(flat_l2_port, vm, num_connections):
     vm_console_run_commands(
         vm=vm,
         commands=[
-            f'for i in {{1..{num_connections}}}; do echo -e "{HTTP_SUCCESS_RESPONSE_STR}-$i\n\n" | nc '
-            f"-lp {flat_l2_port}; done &"
+            (
+                f'for i in {{1..{num_connections}}}; do echo -e "{HTTP_SUCCESS_RESPONSE_STR}-$i\n\n" | nc '
+                f"-lp {flat_l2_port}; done &"
+            )
         ],
         return_code_validation=False,
     )

--- a/tests/network/libs/stuntime.py
+++ b/tests/network/libs/stuntime.py
@@ -64,8 +64,10 @@ class ContinuousPing:
         # Use SIGINT (not default SIGTERM) to ensure ping flushes statistics summary before exit
         self._vm.console(
             commands=[
-                f"pkill -SIGINT -f '{self._cmd}' || true; "
-                f"while pgrep -f '{self._cmd}' >/dev/null 2>&1; do sleep 0.1; done"
+                (
+                    f"pkill -SIGINT -f '{self._cmd}' || true; "
+                    f"while pgrep -f '{self._cmd}' >/dev/null 2>&1; do sleep 0.1; done"
+                )
             ],
             timeout=DEFAULT_COMMAND_TIMEOUT_SECONDS,
         )

--- a/tests/observability/metrics/utils.py
+++ b/tests/observability/metrics/utils.py
@@ -555,8 +555,10 @@ def expected_metric_labels_and_values(
 ) -> None:
     mismatch = {
         label: {
-            f"{label} metric result: {values_from_prometheus.get(label)}, "
-            f"expected_label_results: {expected_label_results}"
+            (
+                f"{label} metric result: {values_from_prometheus.get(label)}, "
+                f"expected_label_results: {expected_label_results}"
+            )
         }
         for label, expected_label_results in expected_labels_and_values.items()
         if values_from_prometheus.get(label) != expected_label_results

--- a/tests/virt/cluster/common_templates/general/test_base_template.py
+++ b/tests/virt/cluster/common_templates/general/test_base_template.py
@@ -203,7 +203,7 @@ def test_base_templates_annotations(base_templates, common_templates_expected_li
 
     assert not set(base_templates) ^ set(common_templates_expected_list), (
         f"Not all base CNV templates exist\n extra templates: {extra_templates}\n "
-        f"missing templates: {missing_templates}",
+        f"missing templates: {missing_templates}"
     )
 
 

--- a/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
+++ b/tests/virt/cluster/common_templates/windows/test_windows_custom_options.py
@@ -106,8 +106,10 @@ def initialize_and_format_windows_drive(vm, disk_number, partition_number, drive
             for cmd in [
                 f'powershell -command "initialize-disk -number {disk_number}"',
                 f'powershell -command "new-partition -disknumber {disk_number} -usemaximumsize"',
-                f'powershell -command "set-partition -disknumber {disk_number} -partitionnumber {partition_number} '
-                f'-newdriveletter {drive_letter}"',
+                (
+                    f'powershell -command "set-partition -disknumber {disk_number} '
+                    f'-partitionnumber {partition_number} -newdriveletter {drive_letter}"'
+                ),
                 f'powershell -command "format-volume -driveletter {drive_letter} -filesystem NTFS"',
             ]
         ],


### PR DESCRIPTION
##### What this PR does / why we need it:
updates: [github.com/astral-sh/ruff-pre-commit: v0.15.22 → v0.16.1](https://github.com/astral-sh/ruff-pre-commit/compare/v0.15.22...v0.16.0)

Change all unparenthesized implicit string concatenation in collection to have parentheses.

##### Which issue(s) this PR fixes:
https://github.com/RedHatQE/openshift-virtualization-tests/pull/5797

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated development checks to use the latest configured linting rules.
- **Refactor**
  - Improved formatting and readability across network, observability, and virtualization test utilities without changing runtime behavior.
- **Tests**
  - Corrected assertion message construction for clearer failure output.
  - Preserved existing test commands, validation behavior, and generated command content while improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->