### PR TITLE
[Storage] add Windows 2022 to the CDI Upload test with vTPM

### DIFF
--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -472,6 +472,8 @@ def test_virtctl_image_upload_dv_in_pudn_namespace(
                 "template_labels": LATEST_WINDOWS_OS_DICT.get("template_labels"),
                 "ssh": True,
                 "os_version": LATEST_WINDOWS_OS_DICT.get("os_version"),
+                "tpm_params": {"persistent": True},
+                "efi_params": {"persistent": True},
             },
             marks=(pytest.mark.polarion("CNV-3410")),
         ),

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -2156,6 +2156,8 @@ def vm_instance_from_template(
         machine_type=params.get("machine_type"),
         eviction_strategy=params.get("eviction_strategy"),
         vm_affinity=vm_affinity,
+        tpm_params=params.get("tpm_params"),
+        efi_params=params.get("efi_params"),
     ) as vm:
         if params.get("start_vm", True):
             running_vm(


### PR DESCRIPTION
##### Short description:
part of a task to make all Windows VMs used in storage tests to use vTPM

##### More details:

##### What this PR does / why we need it:
There's project to switch all the Windows VMs to 2k22 with vTPM. 

We need it because most of the bugs were due to components having bugs with VMs that use vTPM so we can catch the bugs early.

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-51351

##### Special notes for reviewer:

Co-authored : Opus 4.6 <noreply@anthropic.com>

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows virtual machine test setup by enabling persistent TPM and EFI devices.
  * Ensured TPM and EFI configuration is correctly carried over when creating virtual machines from templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->