### PR TITLE
[Storage] Use Windows 2k22 with vTPM in Storage Class migration test

### DIFF
--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -26,9 +26,9 @@ from tests.storage.storage_migration.utils import (
     wait_for_storage_migration_completed,
 )
 from tests.storage.utils import create_windows_directory, get_storage_class_for_storage_migration
-from utilities.artifactory import get_http_image_url
+from tests.utils import create_windows2022_vm_with_data_volume_template
 from utilities.constants import Images
-from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_RHEL, OS_FLAVOR_WINDOWS
+from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_RHEL
 from utilities.constants.instance_types import U1_SMALL
 from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_5SEC
 from utilities.infra import create_ns
@@ -376,34 +376,18 @@ def windows_vm_with_vtpm_for_storage_migration(
     namespace,
     modern_cpu_for_migration,
     source_storage_class,
-    artifactory_secret_scope_module,
-    artifactory_config_map_scope_module,
+    windows_validation_os_images_data_source_scope_session,
 ):
-    dv = DataVolume(
-        name="windows-11-dv",
-        namespace=namespace.name,
-        storage_class=source_storage_class,
-        source_dict=construct_datavolume_source_dict(
-            source="http",
-            # Using WSL image to avoid the issue of the Windows VM not being able to boot
-            url=get_http_image_url(image_directory=Images.Windows.DIR, image_name=Images.Windows.WIN11_WSL2_IMG),
-            secret_name=artifactory_secret_scope_module.name,
-            cert_configmap_name=artifactory_config_map_scope_module.name,
-        ),
-        size=Images.Windows.DEFAULT_DV_SIZE,
-        client=unprivileged_client,
-        api_name="storage",
-    )
-    dv.to_dict()
-    with VirtualMachineForTests(
-        os_flavor=OS_FLAVOR_WINDOWS,
-        name="windows-11-vm",
+    with create_windows2022_vm_with_data_volume_template(
         namespace=namespace.name,
         client=unprivileged_client,
-        vm_instance_type=VirtualMachineClusterInstancetype(name="u1.large"),
-        vm_preference=VirtualMachineClusterPreference(name="windows.11"),
-        data_volume_template={"metadata": dv.res["metadata"], "spec": dv.res["spec"]},
+        vm_name="windows-2022-vm",
         cpu_model=modern_cpu_for_migration,
+        dv_template=data_volume_template_with_source_ref_dict(
+            data_source=windows_validation_os_images_data_source_scope_session,
+            storage_class=source_storage_class,
+        ),
+        check_running_vm=False,
     ) as vm:
         vm.start()
         yield vm

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -714,6 +714,7 @@ def create_windows2022_vm_using_existing_dv(
     vm_name: str,
     cpu_model: str | None = None,
     existing_data_volume: DataVolume | None = None,
+    check_running_vm: bool = True,
 ) -> Generator[VirtualMachineForTests]:
     """
     Creates a Windows Server 2022 VM with vTPM using existing DataVolume.
@@ -724,6 +725,7 @@ def create_windows2022_vm_using_existing_dv(
         client: Kubernetes client
         vm_name: Name for the VirtualMachine
         cpu_model: CPU model specification (can be None)
+        check_running_vm: If True, start the VM and wait for Windows boot
 
     Yields:
         VirtualMachineForTests: Running Windows 2022 VM with vTPM
@@ -739,8 +741,9 @@ def create_windows2022_vm_using_existing_dv(
         data_volume=existing_data_volume,
         cpu_model=cpu_model,
     ) as vm:
-        running_vm(vm=vm)
-        wait_for_windows_vm(vm=vm, version="2022")
+        if check_running_vm:
+            running_vm(vm=vm)
+            wait_for_windows_vm(vm=vm, version="2022")
         yield vm
 
 
@@ -751,6 +754,7 @@ def create_windows2022_vm_with_data_volume_template(
     vm_name: str,
     cpu_model: str | None = None,
     dv_template: dict | None = None,
+    check_running_vm: bool = True,
 ) -> Generator[VirtualMachineForTests]:
     """
     Creates a Windows Server 2022 VM with vTPM with dv template.
@@ -761,9 +765,10 @@ def create_windows2022_vm_with_data_volume_template(
         client: Kubernetes client
         vm_name: Name for the VirtualMachine
         cpu_model: CPU model specification (can be None)
+        check_running_vm: If True, start the VM and wait for Windows boot
 
     Yields:
-        VirtualMachineForTests: Running Windows 2022 VM with vTPM
+        VirtualMachineForTests: Windows 2022 VM with vTPM
     """
 
     with VirtualMachineForTests(
@@ -776,6 +781,7 @@ def create_windows2022_vm_with_data_volume_template(
         data_volume_template=dv_template,
         cpu_model=cpu_model,
     ) as vm:
-        running_vm(vm=vm)
-        wait_for_windows_vm(vm=vm, version="2022")
+        if check_running_vm:
+            running_vm(vm=vm)
+            wait_for_windows_vm(vm=vm, version="2022")
         yield vm

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -728,7 +728,7 @@ def create_windows2022_vm_using_existing_dv(
         check_running_vm: If True, start the VM and wait for Windows boot
 
     Yields:
-        VirtualMachineForTests: Running Windows 2022 VM with vTPM
+        VirtualMachineForTests: Windows 2022 VM with vTPM
     """
 
     with VirtualMachineForTests(


### PR DESCRIPTION
##### What this PR does / why we need it:
This is part of a project where we use common Windows datasource for windows VMs in storage module.

Also adjusted the helper functions that create Windows VMs with bool attribute that just yields the VM and doesn't verify it if it's running if the argument is set to False manually.

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-51351

##### Special notes for reviewer:
Co-Authored-By: Claude <noreply@anthropic.com>

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Windows storage migration test setup to use Windows Server 2022 virtual machines.
  * Added an option to create test virtual machines without automatically starting them or waiting for Windows to boot.
  * Simplified test data volume setup by using a shared configuration helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->