### PR TITLE
net, tests, bridge-marker: Supply client required by VM creation

### DIFF
--- a/tests/network/general/test_bridge_marker.py
+++ b/tests/network/general/test_bridge_marker.py
@@ -19,7 +19,7 @@ BRIDGEMARKER3 = "bridgemarker3"
 
 
 @contextmanager
-def create_bridge_attached_vm_for_bridge_marker(namespace, bridge_marker_bridge_network):
+def create_bridge_attached_vm_for_bridge_marker(unprivileged_client, namespace, bridge_marker_bridge_network):
     networks = {bridge_marker_bridge_network.name: bridge_marker_bridge_network.name}
     name = _get_name(suffix="bridge-vm")
     with VirtualMachineForTests(
@@ -28,6 +28,7 @@ def create_bridge_attached_vm_for_bridge_marker(namespace, bridge_marker_bridge_
         networks=networks,
         interfaces=sorted(networks.keys()),
         body=fedora_vm_body(name=name),
+        client=unprivileged_client,
     ) as vm:
         yield vm
 
@@ -68,18 +69,22 @@ def bridge_networks(admin_client, namespace):
 
 
 @pytest.fixture()
-def bridge_attached_vmi_for_bridge_marker_no_device(namespace, bridge_marker_bridge_network):
+def bridge_attached_vmi_for_bridge_marker_no_device(unprivileged_client, namespace, bridge_marker_bridge_network):
     with create_bridge_attached_vm_for_bridge_marker(
-        namespace=namespace, bridge_marker_bridge_network=bridge_marker_bridge_network
+        unprivileged_client=unprivileged_client,
+        namespace=namespace,
+        bridge_marker_bridge_network=bridge_marker_bridge_network,
     ) as vm:
         vm.start()
         yield vm.vmi
 
 
 @pytest.fixture()
-def bridge_attached_vmi_for_bridge_marker_device_exists(namespace, bridge_marker_bridge_network):
+def bridge_attached_vmi_for_bridge_marker_device_exists(unprivileged_client, namespace, bridge_marker_bridge_network):
     with create_bridge_attached_vm_for_bridge_marker(
-        namespace=namespace, bridge_marker_bridge_network=bridge_marker_bridge_network
+        unprivileged_client=unprivileged_client,
+        namespace=namespace,
+        bridge_marker_bridge_network=bridge_marker_bridge_network,
     ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()


### PR DESCRIPTION
##### What this PR does / why we need it:
Add missing mandatory client in _create_bridge_attached_vm_for_bridge_marker_ and using fixtures.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-72392


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated bridge-marker test setup to create virtual machine resources through an unprivileged client.
  * Preserved existing assertions and resource readiness checks while improving test coverage of permission-aware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->