### PR TITLE
Component builder CI workflows for s390x and arm VMs

### DIFF
--- a/.github/component-builder-config.json
+++ b/.github/component-builder-config.json
@@ -1,0 +1,27 @@
+{
+  "fedora_version": "43",
+  "fedora_image_base": "Fedora-Cloud-Base-Generic-43-1.6",
+  "fedora_checksum_base": "Fedora-Cloud-43-1.6",
+  "matrix": {
+    "include": [
+      {
+        "arch": "amd64",
+        "url_arch": "x86_64",
+        "qemu_package": "qemu-system-x86",
+        "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
+      },
+      {
+        "arch": "arm64",
+        "url_arch": "aarch64",
+        "qemu_package": "qemu-system-aarch64",
+        "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
+      },
+      {
+        "arch": "s390x",
+        "url_arch": "s390x",
+        "qemu_package": "qemu-system-s390x",
+        "fedora_url": "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images"
+      }
+    ]
+  }
+}

--- a/.github/component-builder-config.json
+++ b/.github/component-builder-config.json
@@ -14,7 +14,7 @@
       {
         "arch": "arm64",
         "url_arch": "aarch64",
-        "qemu_package": "qemu-system-aarch64",
+        "qemu_package": "qemu-system-aarch64 qemu-efi-aarch64",
         "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
       },
       {

--- a/.github/component-builder-config.json
+++ b/.github/component-builder-config.json
@@ -2,6 +2,7 @@
   "fedora_version": "43",
   "fedora_image_base": "Fedora-Cloud-Base-Generic-43-1.6",
   "fedora_checksum_base": "Fedora-Cloud-43-1.6",
+  "remote_repository": "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging",
   "matrix": {
     "include": [
       {

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -94,20 +94,61 @@ jobs:
           fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
           wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
 
-      - name: Verify Fedora image checksum
+      - name: Verify Fedora CHECKSUM OpenPGP signature and image digest
         working-directory: ./containers/fedora
         env:
           URL_ARCH: ${{ matrix.url_arch }}
+          # Fedora 43 primary release signing key fingerprint.
+          # Source: https://fedoraproject.org/security
+          # Fingerprint must be updated when the Fedora version changes.
+          FEDORA_SIGNING_KEY_FINGERPRINT: "C6E7F081CF80E13146676E88829B606631645531"
         run: |
+          set -euo pipefail
           FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          # Extract the SHA256 line for the exact artifact and verify it.
+
+          # ---------------------------------------------------------------
+          # Step 1: Import the Fedora release signing key from the official
+          # Fedora site (separate trust root — not the same mirror that
+          # served the qcow2 and CHECKSUM).  Then verify that the imported
+          # key's fingerprint exactly matches the pinned value above.
+          # ---------------------------------------------------------------
+          GPG_HOME="$(mktemp -d)"
+          chmod 0700 "${GPG_HOME}"
+          # Fetch the Fedora keyring from the authoritative source.
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            "https://fedoraproject.org/fedora.gpg" \
+            -o "${GPG_HOME}/fedora.gpg"
+          # Import into the isolated keyring.
+          gpg --homedir "${GPG_HOME}" --import "${GPG_HOME}/fedora.gpg"
+          # Confirm the pinned fingerprint is present in the imported keyring.
+          if ! gpg --homedir "${GPG_HOME}" --fingerprint --with-colons \
+               | grep -q "^fpr:.*:${FEDORA_SIGNING_KEY_FINGERPRINT}:$"; then
+            echo "ERROR: Pinned fingerprint ${FEDORA_SIGNING_KEY_FINGERPRINT} not found in fedora.gpg"
+            rm -rf "${GPG_HOME}"
+            exit 1
+          fi
+          echo "Signing key fingerprint verified: ${FEDORA_SIGNING_KEY_FINGERPRINT}"
+
+          # ---------------------------------------------------------------
+          # Step 2: Verify the OpenPGP clearsignature on the CHECKSUM file.
+          # This ensures the digest we are about to extract was produced by
+          # Fedora's release key — a compromised mirror cannot forge this.
+          # ---------------------------------------------------------------
+          gpg --homedir "${GPG_HOME}" --verify CHECKSUM \
+            || { echo "ERROR: OpenPGP signature verification failed for CHECKSUM"; rm -rf "${GPG_HOME}"; exit 1; }
+          echo "OpenPGP signature on CHECKSUM is valid"
+          rm -rf "${GPG_HOME}"
+
+          # ---------------------------------------------------------------
+          # Step 3: Extract the SHA256 digest and verify the qcow2 image.
           # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
           # sha256sum expects: <digest>  <filename>
+          # ---------------------------------------------------------------
           grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
             | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
             | sha256sum --check --status \
             || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
-          echo "Checksum verified for ${FEDORA_IMAGE}"
+          echo "SHA256 digest verified for ${FEDORA_IMAGE}"
           rm CHECKSUM
 
       - name: Install uv

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -114,13 +114,15 @@ jobs:
           # ---------------------------------------------------------------
           GPG_HOME="$(mktemp -d)"
           chmod 0700 "${GPG_HOME}"
-          # Fetch the Fedora keyring from the authoritative source.
+          # Fetch the full Fedora keyring from the authoritative source into a
+          # temporary import-only homedir.  We never verify against this
+          # multi-key bundle; it is only used to extract the one pinned key.
           curl -fsSL --proto '=https' --tlsv1.2 \
             "https://fedoraproject.org/fedora.gpg" \
             -o "${GPG_HOME}/fedora.gpg"
-          # Import into the isolated keyring.
+          # Import all keys from the bundle so we can query them.
           gpg --homedir "${GPG_HOME}" --import "${GPG_HOME}/fedora.gpg"
-          # Confirm the pinned fingerprint is present in the imported keyring.
+          # Confirm the pinned fingerprint is present before exporting.
           if ! gpg --homedir "${GPG_HOME}" --fingerprint --with-colons \
                | grep -q "^fpr:.*:${FEDORA_SIGNING_KEY_FINGERPRINT}:$"; then
             echo "ERROR: Pinned fingerprint ${FEDORA_SIGNING_KEY_FINGERPRINT} not found in fedora.gpg"
@@ -130,17 +132,27 @@ jobs:
           echo "Signing key fingerprint verified: ${FEDORA_SIGNING_KEY_FINGERPRINT}"
 
           # ---------------------------------------------------------------
-          # Step 2: Verify the OpenPGP clearsignature on the CHECKSUM file.
-          # This ensures the digest we are about to extract was produced by
-          # Fedora's release key — a compromised mirror cannot forge this.
+          # Step 2: Build a dedicated keyring that contains ONLY the pinned
+          # release key (and its signing subkeys).  gpgv will then accept
+          # signatures from that single key and nothing else.
           # ---------------------------------------------------------------
-          gpg --homedir "${GPG_HOME}" --verify CHECKSUM \
+          PINNED_KEYRING="${GPG_HOME}/pinned.gpg"
+          gpg --homedir "${GPG_HOME}" \
+            --export --armor "${FEDORA_SIGNING_KEY_FINGERPRINT}" \
+            | gpg --dearmor > "${PINNED_KEYRING}"
+
+          # ---------------------------------------------------------------
+          # Step 3: Verify the OpenPGP clearsignature on the CHECKSUM file
+          # using gpgv and the single-key keyring.  gpgv has no trust model
+          # and no keyring fallback — only keys in --keyring are accepted.
+          # ---------------------------------------------------------------
+          gpgv --keyring "${PINNED_KEYRING}" CHECKSUM \
             || { echo "ERROR: OpenPGP signature verification failed for CHECKSUM"; rm -rf "${GPG_HOME}"; exit 1; }
-          echo "OpenPGP signature on CHECKSUM is valid"
+          echo "OpenPGP signature on CHECKSUM is valid (verified against pinned key only)"
           rm -rf "${GPG_HOME}"
 
           # ---------------------------------------------------------------
-          # Step 3: Extract the SHA256 digest and verify the qcow2 image.
+          # Step 4: Extract the SHA256 digest and verify the qcow2 image.
           # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
           # sha256sum expects: <digest>  <filename>
           # ---------------------------------------------------------------

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -128,7 +128,7 @@ jobs:
           grep "${archive}" bws-checksums.txt | sha256sum --check --status \
             || { echo "ERROR: SHA256 digest mismatch for ${archive}"; exit 1; }
           echo "Checksum verified for ${archive}"
-          tmpdir="${mktemp -d}"
+          tmpdir="$(mktemp -d)"
           unzip -o "${archive}" -d "${tmpdir}"
           sudo install -m 0755 "${tmpdir}/bws" /usr/local/bin/bws
           rm -rf "${tmpdir}" "${archive}" bws-checksums.txt

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -120,10 +120,17 @@ jobs:
         env:
           BWS_VERSION: "2.1.0"
         run: |
-          curl -fsSL "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip" -o bws.zip
+          archive="bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip"
+          checksums_file="bws-sha256-checksums-${BWS_VERSION}.txt"
+          base_url="https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}"
+          curl -fsSL "${base_url}/${archive}" -o bws.zip
+          curl -fsSL "${base_url}/${checksums_file}" -o bws-checksums.txt
+          grep "${archive}" bws-checksums.txt | sha256sum --check --status \
+            || { echo "ERROR: SHA256 digest mismatch for ${archive}"; exit 1; }
+          echo "Checksum verified for ${archive}"
           unzip -o bws.zip -d /usr/local/bin
           chmod +x /usr/local/bin/bws
-          rm bws.zip
+          rm bws.zip bws-checksums.txt
           bws --version
 
       - name: Create VM

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -128,9 +128,10 @@ jobs:
           grep "${archive}" bws-checksums.txt | sha256sum --check --status \
             || { echo "ERROR: SHA256 digest mismatch for ${archive}"; exit 1; }
           echo "Checksum verified for ${archive}"
-          sudo unzip -o "${archive}" -d /usr/local/bin
-          sudo chmod +x /usr/local/bin/bws
-          rm "${archive}" bws-checksums.txt
+          tmpdir="${mktemp -d}"
+          unzip -o "${archive}" -d "${tmpdir}"
+          sudo install -m 0755 "${tmpdir}/bws" /usr/local/bin/bws
+          rm -rf "${tmpdir}" "${archive}" bws-checksums.txt
           bws --version
 
       - name: Create VM

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            "$QEMU_PACKAGE" \
+            $QEMU_PACKAGE \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -123,14 +123,14 @@ jobs:
           archive="bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip"
           checksums_file="bws-sha256-checksums-${BWS_VERSION}.txt"
           base_url="https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}"
-          curl -fsSL "${base_url}/${archive}" -o bws.zip
+          curl -fsSL "${base_url}/${archive}" -o "${archive}"
           curl -fsSL "${base_url}/${checksums_file}" -o bws-checksums.txt
           grep "${archive}" bws-checksums.txt | sha256sum --check --status \
             || { echo "ERROR: SHA256 digest mismatch for ${archive}"; exit 1; }
           echo "Checksum verified for ${archive}"
-          sudo unzip -o bws.zip -d /usr/local/bin
+          sudo unzip -o "${archive}" -d /usr/local/bin
           sudo chmod +x /usr/local/bin/bws
-          rm bws.zip bws-checksums.txt
+          rm "${archive}" bws-checksums.txt
           bws --version
 
       - name: Create VM

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -128,8 +128,8 @@ jobs:
           grep "${archive}" bws-checksums.txt | sha256sum --check --status \
             || { echo "ERROR: SHA256 digest mismatch for ${archive}"; exit 1; }
           echo "Checksum verified for ${archive}"
-          unzip -o bws.zip -d /usr/local/bin
-          chmod +x /usr/local/bin/bws
+          sudo unzip -o bws.zip -d /usr/local/bin
+          sudo chmod +x /usr/local/bin/bws
           rm bws.zip bws-checksums.txt
           bws --version
 

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -111,7 +111,7 @@ jobs:
           rm CHECKSUM
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.11.30"
 

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -1,0 +1,175 @@
+name: "Component Builder Build"
+on:
+  workflow_call:
+    inputs:
+      fedora_version:
+        description: "Fedora version string (e.g. '43')"
+        required: true
+        type: string
+      fedora_image_base:
+        description: "Base name of the Fedora cloud image"
+        required: true
+        type: string
+      fedora_checksum_base:
+        description: "Base name of the Fedora checksum file"
+        required: true
+        type: string
+      matrix:
+        description: "JSON matrix string consumed by the build job via fromJson()"
+        required: true
+        type: string
+      remote_repository:
+        description: "Remote container repository used for tagging (e.g. quay.io/org/repo)"
+        required: true
+        type: string
+      no_secrets:
+        description: "Set to true to build without real credentials (Check workflow)"
+        required: false
+        type: boolean
+        default: false
+      upload_artifact:
+        description: "Set to true to save the built image as a workflow artifact"
+        required: false
+        type: boolean
+        default: false
+      push_image:
+        description: "Set to true to push the built image to the remote registry"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      BITWARDEN_ORGANIZATION_ID:
+        required: false
+      BITWARDEN_ACCESS_TOKEN:
+        required: false
+      QUAY_USER:
+        required: false
+      QUAY_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.matrix) }}
+    env:
+      FEDORA_VERSION: ${{ inputs.fedora_version }}
+      FEDORA_IMAGE_BASE: ${{ inputs.fedora_image_base }}
+      FEDORA_CHECKSUM_BASE: ${{ inputs.fedora_checksum_base }}
+      CPU_ARCH: ${{ matrix.arch }}
+      FULL_EMULATION: "true"
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies for VM build
+        env:
+          QEMU_PACKAGE: ${{ matrix.qemu_package }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            "$QEMU_PACKAGE" \
+            libvirt-daemon-system \
+            virtinst cloud-image-utils \
+            libguestfs-tools
+
+      - name: Tweak hosted runner to enable 'virt-sysprep'
+        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
+        run: sudo chmod 0644 /boot/vmlinuz*
+
+      - name: Fetch base Fedora image
+        working-directory: ./containers/fedora
+        env:
+          FEDORA_URL: ${{ matrix.fedora_url }}
+          URL_ARCH: ${{ matrix.url_arch }}
+        run: |
+          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          wget -q "${FEDORA_URL}/${fedora_image}"
+          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
+          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
+
+      - name: Verify Fedora image checksum
+        working-directory: ./containers/fedora
+        env:
+          URL_ARCH: ${{ matrix.url_arch }}
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          # Extract the SHA256 line for the exact artifact and verify it.
+          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
+          # sha256sum expects: <digest>  <filename>
+          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
+            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
+            | sha256sum --check --status \
+            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
+          echo "Checksum verified for ${FEDORA_IMAGE}"
+          rm CHECKSUM
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: "0.11.30"
+
+      - name: Install Bitwarden Secrets Manager CLI
+        if: ${{ !inputs.no_secrets }}
+        env:
+          BWS_VERSION: "2.1.0"
+        run: |
+          curl -fsSL "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip" -o bws.zip
+          unzip -o bws.zip -d /usr/local/bin
+          chmod +x /usr/local/bin/bws
+          rm bws.zip
+          bws --version
+
+      - name: Create VM
+        working-directory: ./containers/fedora
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          NO_SECRETS: ${{ inputs.no_secrets && 'true' || '' }}
+          ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
+          ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: "${{ inputs.fedora_image_base }}.${{ matrix.url_arch }}.qcow2"
+        run: ./build.sh
+
+      - name: Save container image as tarball
+        if: ${{ inputs.upload_artifact }}
+        env:
+          local_repository: "localhost/fedora"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          REMOTE_REPOSITORY: ${{ inputs.remote_repository }}
+        run: |
+          mkdir -p artifacts
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman save -o "artifacts/fedora-image-${CPU_ARCH}.tar" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${CPU_ARCH}.tar"
+
+      - name: Upload container image artifact
+        if: ${{ inputs.upload_artifact }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
+          retention-days: 5
+          compression-level: 0
+
+      - name: Log in to quay.io
+        if: ${{ inputs.push_image }}
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
+
+      - name: Tag & Push image to staging
+        if: ${{ inputs.push_image }}
+        env:
+          local_repository: "localhost/fedora"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          REMOTE_REPOSITORY: ${{ inputs.remote_repository }}
+        run: |
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman push "${REMOTE_REPOSITORY}":"${arch_tag}"

--- a/.github/workflows/component-builder-build.yml
+++ b/.github/workflows/component-builder-build.yml
@@ -1,0 +1,175 @@
+name: "Component Builder Build"
+on:
+  workflow_call:
+    inputs:
+      fedora_version:
+        description: "Fedora version string (e.g. '43')"
+        required: true
+        type: string
+      fedora_image_base:
+        description: "Base name of the Fedora cloud image"
+        required: true
+        type: string
+      fedora_checksum_base:
+        description: "Base name of the Fedora checksum file"
+        required: true
+        type: string
+      matrix:
+        description: "JSON matrix string consumed by the build job via fromJson()"
+        required: true
+        type: string
+      remote_repository:
+        description: "Remote container repository used for tagging (e.g. quay.io/org/repo)"
+        required: true
+        type: string
+      no_secrets:
+        description: "Set to true to build without real credentials (Check workflow)"
+        required: false
+        type: boolean
+        default: false
+      upload_artifact:
+        description: "Set to true to save the built image as a workflow artifact"
+        required: false
+        type: boolean
+        default: false
+      push_image:
+        description: "Set to true to push the built image to the remote registry"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      BITWARDEN_ORGANIZATION_ID:
+        required: false
+      BITWARDEN_ACCESS_TOKEN:
+        required: false
+      QUAY_USER:
+        required: false
+      QUAY_TOKEN:
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.matrix) }}
+    env:
+      FEDORA_VERSION: ${{ inputs.fedora_version }}
+      FEDORA_IMAGE_BASE: ${{ inputs.fedora_image_base }}
+      FEDORA_CHECKSUM_BASE: ${{ inputs.fedora_checksum_base }}
+      CPU_ARCH: ${{ matrix.arch }}
+      FULL_EMULATION: "true"
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies for VM build
+        env:
+          QEMU_PACKAGE: ${{ matrix.qemu_package }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            "$QEMU_PACKAGE" \
+            libvirt-daemon-system \
+            virtinst cloud-image-utils \
+            libguestfs-tools
+
+      - name: Tweak hosted runner to enable 'virt-sysprep'
+        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
+        run: sudo chmod 0644 /boot/vmlinuz*
+
+      - name: Fetch base Fedora image
+        working-directory: ./containers/fedora
+        env:
+          FEDORA_URL: ${{ matrix.fedora_url }}
+          URL_ARCH: ${{ matrix.url_arch }}
+        run: |
+          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          wget -q "${FEDORA_URL}/${fedora_image}"
+          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
+          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
+
+      - name: Verify Fedora image checksum
+        working-directory: ./containers/fedora
+        env:
+          URL_ARCH: ${{ matrix.url_arch }}
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          # Extract the SHA256 line for the exact artifact and verify it.
+          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
+          # sha256sum expects: <digest>  <filename>
+          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
+            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
+            | sha256sum --check --status \
+            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
+          echo "Checksum verified for ${FEDORA_IMAGE}"
+          rm CHECKSUM
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.10"
+
+      - name: Install Bitwarden Secrets Manager CLI
+        if: ${{ !inputs.no_secrets }}
+        env:
+          BWS_VERSION: "2.1.0"
+        run: |
+          curl -fsSL "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip" -o bws.zip
+          unzip -o bws.zip -d /usr/local/bin
+          chmod +x /usr/local/bin/bws
+          rm bws.zip
+          bws --version
+
+      - name: Create VM
+        working-directory: ./containers/fedora
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+          NO_SECRETS: ${{ inputs.no_secrets && 'true' || '' }}
+          ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
+          ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: "${{ inputs.fedora_image_base }}.${{ matrix.url_arch }}.qcow2"
+        run: ./build.sh
+
+      - name: Save container image as tarball
+        if: ${{ inputs.upload_artifact }}
+        env:
+          local_repository: "localhost/fedora"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          REMOTE_REPOSITORY: ${{ inputs.remote_repository }}
+        run: |
+          mkdir -p artifacts
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman save -o "artifacts/fedora-image-${CPU_ARCH}.tar" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${CPU_ARCH}.tar"
+
+      - name: Upload container image artifact
+        if: ${{ inputs.upload_artifact }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
+          retention-days: 5
+          compression-level: 0
+
+      - name: Log in to quay.io
+        if: ${{ inputs.push_image }}
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
+
+      - name: Tag & Push image to staging
+        if: ${{ inputs.push_image }}
+        env:
+          local_repository: "localhost/fedora"
+          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
+          REMOTE_REPOSITORY: ${{ inputs.remote_repository }}
+        run: |
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman push "${REMOTE_REPOSITORY}":"${arch_tag}"

--- a/.github/workflows/component-builder-prepare.yml
+++ b/.github/workflows/component-builder-prepare.yml
@@ -17,6 +17,9 @@ on:
       architectures:
         description: "Space-separated list of architectures (e.g. 'amd64 arm64 s390x')"
         value: ${{ jobs.prepare.outputs.architectures }}
+      remote_repository:
+        description: "Remote container repository used for tagging and pushing (e.g. quay.io/org/repo)"
+        value: ${{ jobs.prepare.outputs.remote_repository }}
 
 jobs:
   prepare:
@@ -29,6 +32,7 @@ jobs:
       fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
       fedora_checksum_base: ${{ steps.component-builder-config.outputs.fedora_checksum_base }}
       architectures: ${{ steps.component-builder-config.outputs.architectures }}
+      remote_repository: ${{ steps.component-builder-config.outputs.remote_repository }}
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -45,3 +49,4 @@ jobs:
           echo "fedora_image_base=$(jq -re '.fedora_image_base' "${config}")" >> "${GITHUB_OUTPUT}"
           echo "fedora_checksum_base=$(jq -re '.fedora_checksum_base' "${config}")" >> "${GITHUB_OUTPUT}"
           echo "architectures=$(jq -re '[.matrix.include[].arch] | join(" ")' "${config}")" >> "${GITHUB_OUTPUT}"
+          echo "remote_repository=$(jq -re '.remote_repository' "${config}")" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/component-builder-prepare.yml
+++ b/.github/workflows/component-builder-prepare.yml
@@ -49,6 +49,7 @@ jobs:
           jq -e --arg fedora_version "${fedora_version}" '
             (.fedora_image_base    | contains($fedora_version))
             and (.fedora_checksum_base | contains($fedora_version))
+            and (.matrix.include | length > 0)
             and (
               .matrix.include
               | all(.[];

--- a/.github/workflows/component-builder-prepare.yml
+++ b/.github/workflows/component-builder-prepare.yml
@@ -44,8 +44,14 @@ jobs:
         run: |
           set -euo pipefail
           config=".github/component-builder-config.json"
+          fedora_version=$(jq -re '.fedora_version' "${config}")
+
+          jq -e --arg fedora_version "${fedora_version}" '
+            .matrix.include
+            | all(.[]; .fedora_url | contains("/" + $fedora_version + "/"))
+          ' "${config}" > /dev/null
           echo "matrix=$(jq -ce '.matrix' "${config}")" >> "${GITHUB_OUTPUT}"
-          echo "fedora_version=$(jq -re '.fedora_version' "${config}")" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=${fedora_version}" >> "${GITHUB_OUTPUT}"
           echo "fedora_image_base=$(jq -re '.fedora_image_base' "${config}")" >> "${GITHUB_OUTPUT}"
           echo "fedora_checksum_base=$(jq -re '.fedora_checksum_base' "${config}")" >> "${GITHUB_OUTPUT}"
           echo "architectures=$(jq -re '[.matrix.include[].arch] | join(" ")' "${config}")" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/component-builder-prepare.yml
+++ b/.github/workflows/component-builder-prepare.yml
@@ -47,8 +47,18 @@ jobs:
           fedora_version=$(jq -re '.fedora_version' "${config}")
 
           jq -e --arg fedora_version "${fedora_version}" '
-            .matrix.include
-            | all(.[]; .fedora_url | contains("/" + $fedora_version + "/"))
+            (.fedora_image_base    | contains($fedora_version))
+            and (.fedora_checksum_base | contains($fedora_version))
+            and (
+              .matrix.include
+              | all(.[];
+                (.fedora_url | contains("/" + $fedora_version + "/"))
+                and (
+                  (.fedora_url | test("^https://download\\.fedoraproject\\.org/"))
+                  or (.fedora_url | test("^https://dl\\.fedoraproject\\.org/"))
+                )
+              )
+            )
           ' "${config}" > /dev/null
           echo "matrix=$(jq -ce '.matrix' "${config}")" >> "${GITHUB_OUTPUT}"
           echo "fedora_version=${fedora_version}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/component-builder-prepare.yml
+++ b/.github/workflows/component-builder-prepare.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Read component builder config
         id: component-builder-config
         run: |
-          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_checksum_base=$(jq -r '.fedora_checksum_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "architectures=$(jq -r '[.matrix.include[].arch] | join(" ")' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          set -euo pipefail
+          config=".github/component-builder-config.json"
+          echo "matrix=$(jq -ce '.matrix' "${config}")" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=$(jq -re '.fedora_version' "${config}")" >> "${GITHUB_OUTPUT}"
+          echo "fedora_image_base=$(jq -re '.fedora_image_base' "${config}")" >> "${GITHUB_OUTPUT}"
+          echo "fedora_checksum_base=$(jq -re '.fedora_checksum_base' "${config}")" >> "${GITHUB_OUTPUT}"
+          echo "architectures=$(jq -re '[.matrix.include[].arch] | join(" ")' "${config}")" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/component-builder-prepare.yml
+++ b/.github/workflows/component-builder-prepare.yml
@@ -1,0 +1,45 @@
+name: "Component Builder Prepare"
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: "JSON matrix consumed by build jobs via fromJson()"
+        value: ${{ jobs.prepare.outputs.matrix }}
+      fedora_version:
+        description: "Fedora version string (e.g. '43')"
+        value: ${{ jobs.prepare.outputs.fedora_version }}
+      fedora_image_base:
+        description: "Base name of the Fedora cloud image"
+        value: ${{ jobs.prepare.outputs.fedora_image_base }}
+      fedora_checksum_base:
+        description: "Base name of the Fedora checksum file"
+        value: ${{ jobs.prepare.outputs.fedora_checksum_base }}
+      architectures:
+        description: "Space-separated list of architectures (e.g. 'amd64 arm64 s390x')"
+        value: ${{ jobs.prepare.outputs.architectures }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.component-builder-config.outputs.matrix }}
+      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
+      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ steps.component-builder-config.outputs.fedora_checksum_base }}
+      architectures: ${{ steps.component-builder-config.outputs.architectures }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Read component builder config
+        id: component-builder-config
+        run: |
+          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_checksum_base=$(jq -r '.fedora_checksum_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "architectures=$(jq -r '[.matrix.include[].arch] | join(" ")' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -10,12 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       FEDORA_VERSION: 43
-      CPU_ARCH: amd64
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -35,6 +33,8 @@ jobs:
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
         run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        env:
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
@@ -54,11 +54,14 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
+          CPU_ARCH: amd64
         run: ./build.sh
       - name: Logging to quay.io
         run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
       - name: Tag & Push image to staging
         env:
+          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
           remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -6,6 +6,7 @@ on:
       - '.github/component-builder-config.json'
       - '.github/workflows/component-builder-prepare.yml'
       - '.github/workflows/component-builder-build.yml'
+      - '.github/workflows/component-builder-publish.yml'
     branches:
       - 'main'
 

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -13,6 +13,14 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Serialize publish runs at the workflow level so concurrent main-branch pushes
+# cannot interleave their matrix jobs and publish a mixed-commit manifest.
+# cancel-in-progress: false ensures an in-progress run is never abandoned
+# mid-publish, which could leave arch-specific tags in an inconsistent state.
+concurrency:
+  group: component-builder-publish
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -7,6 +7,8 @@ on:
   push:
     paths:
       - 'containers/fedora/**'
+      - '.github/component-builder-config.json'
+      - '.github/workflows/component-builder-prepare.yml'
     branches:
       - 'main'
 

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -14,37 +14,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Single source of truth for the architecture list.
-  # Both build-images (matrix) and create-manifest (ARCHITECTURES) derive
-  # their values from this job's outputs so they can never drift.
   prepare:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      # JSON object consumed by build-images via fromJson(), e.g.
-      # {"include":[{"arch":"amd64","url_arch":"x86_64",...}, ...]}
-      matrix: ${{ steps.component-builder-config.outputs.matrix }}
-      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
-      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
-      fedora_checksum_base: ${{ steps.component-builder-config.outputs.fedora_checksum_base }}
-      # Space-separated string consumed by create-manifest, e.g.
-      # "amd64 arm64 s390x"
-      architectures: ${{ steps.component-builder-config.outputs.architectures }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Read component builder config
-        id: component-builder-config
-        run: |
-          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_checksum_base=$(jq -r '.fedora_checksum_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "architectures=$(jq -r '[.matrix.include[].arch] | join(" ")' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+    uses: ./.github/workflows/component-builder-prepare.yml
 
   build-images:
     runs-on: ubuntu-latest
@@ -158,7 +129,7 @@ jobs:
         env:
           QUAY_USER: ${{ secrets.QUAY_USER }}
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
 
       - name: Create and push manifest
         env:
@@ -173,4 +144,4 @@ jobs:
           done
           # Create and push the multi-arch manifest
           podman manifest create "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
-          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2
+          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=oci

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
       FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
@@ -65,8 +66,10 @@ jobs:
 
       - name: Verify Fedora image checksum
         working-directory: ./containers/fedora
+        env:
+          URL_ARCH: ${{ matrix.url_arch }}
         run: |
-          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
           # Extract the SHA256 line for the exact artifact and verify it.
           # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
           # sha256sum expects: <digest>  <filename>
@@ -136,6 +139,11 @@ jobs:
           FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
           REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
         run: |
+          set -euo pipefail
+          if [ -z "${ARCHITECTURES// /}" ]; then
+            echo "ERROR: ARCHITECTURES is empty; refusing to publish an empty manifest"
+            exit 1
+          fi
           remote_tag="${FEDORA_VERSION}-dev"
           # Build the list of arch-specific image references
           ARCH_IMAGES=""
@@ -144,4 +152,7 @@ jobs:
           done
           # Create and push the multi-arch manifest
           podman manifest create "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
-          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=oci
+          # Confirm every expected platform is present before publishing
+          podman manifest inspect "${REMOTE_REPOSITORY}":"${remote_tag}" \
+            | jq -e --argjson n "$(printf '%s\n' ${ARCHITECTURES} | wc -l)" '(.manifests | length) == $n'
+          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -1,4 +1,9 @@
 name: "Component Builder Publish"
+permissions:
+  contents: read
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
     paths:
@@ -10,31 +15,92 @@ on:
   workflow_dispatch:
 
 jobs:
-  guest-fedora:
+  # Single source of truth for the architecture list.
+  # Both build-images (matrix) and create-manifest (ARCHITECTURES) derive
+  # their values from this job's outputs so they can never drift.
+  prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      # JSON object consumed by build-images via fromJson(), e.g.
+      # {"include":[{"arch":"amd64","url_arch":"x86_64",...}, ...]}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      # Space-separated string consumed by create-manifest, e.g.
+      # "amd64 arm64 s390x"
+      architectures: ${{ steps.set-matrix.outputs.architectures }}
+    steps:
+      - name: Set architecture matrix and list
+        id: set-matrix
+        run: |
+          matrix=$(cat <<'EOF'
+          {
+            "include": [
+              {
+                "arch": "amd64",
+                "url_arch": "x86_64",
+                "qemu_package": "qemu-system-x86",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
+              },
+              {
+                "arch": "arm64",
+                "url_arch": "aarch64",
+                "qemu_package": "qemu-system-aarch64",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
+              },
+              {
+                "arch": "s390x",
+                "url_arch": "s390x",
+                "qemu_package": "qemu-system-s390x",
+                "fedora_url": "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images"
+              }
+            ]
+          }
+          EOF
+          )
+          # Compact to a single line for the output
+          echo "matrix=$(echo "${matrix}" | jq -c .)" >> "${GITHUB_OUTPUT}"
+          # Derive the space-separated arch list directly from the same JSON
+          archs=$(echo "${matrix}" | jq -r '[.include[].arch] | join(" ")')
+          echo "architectures=${archs}" >> "${GITHUB_OUTPUT}"
+
+  build-images:
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      contents: read
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
-      FEDORA_VERSION: 43
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
-        env:
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
@@ -54,20 +120,52 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
           ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
           ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
-          FEDORA_IMAGE: Fedora-Cloud-Base-Generic-41-1.4.x86_64.qcow2
-          CPU_ARCH: amd64
+          FEDORA_IMAGE: "${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2"
         run: ./build.sh
+
       - name: Logging to quay.io
-        run: podman login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+
       - name: Tag & Push image to staging
         env:
-          CPU_ARCH: amd64
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-          remote_tag: "${{ env.FEDORA_VERSION }}-dev"
+          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
         run: |
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman push "${remote_repository}":"${arch_tag}"
-          podman manifest create --log-level=debug "${remote_repository}":"${remote_tag}" "${remote_repository}":"${arch_tag}"
-          podman manifest push "${remote_repository}":"${remote_tag}" --all --format=v2s2
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman push "${REMOTE_REPOSITORY}":"${arch_tag}"
+
+  create-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - prepare
+      - build-images
+    env:
+      # Derived from prepare job output — stays in sync with the matrix automatically
+      ARCHITECTURES: ${{ needs.prepare.outputs.architectures }}
+    steps:
+      - name: Logging to quay.io
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+
+      - name: Create and push manifest
+        env:
+          FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
+          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
+        run: |
+          remote_tag="${FEDORA_VERSION}-dev"
+          # Build the list of arch-specific image references
+          ARCH_IMAGES=""
+          for arch in ${ARCHITECTURES}; do
+            ARCH_IMAGES="${ARCH_IMAGES} ${REMOTE_REPOSITORY}:${FEDORA_VERSION}-${arch}"
+          done
+          # Create and push the multi-arch manifest
+          podman manifest create --log-level=debug "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
+          podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -2,7 +2,6 @@ name: "Component Builder Publish"
 permissions:
   contents: read
 env:
-  FEDORA_VERSION: 43
   REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
@@ -25,44 +24,27 @@ jobs:
     outputs:
       # JSON object consumed by build-images via fromJson(), e.g.
       # {"include":[{"arch":"amd64","url_arch":"x86_64",...}, ...]}
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.component-builder-config.outputs.matrix }}
+      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
+      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ steps.component-builder-config.outputs.fedora_checksum_base }}
       # Space-separated string consumed by create-manifest, e.g.
       # "amd64 arm64 s390x"
-      architectures: ${{ steps.set-matrix.outputs.architectures }}
+      architectures: ${{ steps.component-builder-config.outputs.architectures }}
     steps:
-      - name: Set architecture matrix and list
-        id: set-matrix
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Read component builder config
+        id: component-builder-config
         run: |
-          matrix=$(cat <<'EOF'
-          {
-            "include": [
-              {
-                "arch": "amd64",
-                "url_arch": "x86_64",
-                "qemu_package": "qemu-system-x86",
-                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
-              },
-              {
-                "arch": "arm64",
-                "url_arch": "aarch64",
-                "qemu_package": "qemu-system-aarch64",
-                "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images"
-              },
-              {
-                "arch": "s390x",
-                "url_arch": "s390x",
-                "qemu_package": "qemu-system-s390x",
-                "fedora_url": "https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images"
-              }
-            ]
-          }
-          EOF
-          )
-          # Compact to a single line for the output
-          echo "matrix=$(echo "${matrix}" | jq -c .)" >> "${GITHUB_OUTPUT}"
-          # Derive the space-separated arch list directly from the same JSON
-          archs=$(echo "${matrix}" | jq -r '[.include[].arch] | join(" ")')
-          echo "architectures=${archs}" >> "${GITHUB_OUTPUT}"
+          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_checksum_base=$(jq -r '.fedora_checksum_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "architectures=$(jq -r '[.matrix.include[].arch] | join(" ")' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
 
   build-images:
     runs-on: ubuntu-latest
@@ -72,7 +54,9 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
-      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
+      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
+      FEDORA_CHECKSUM_BASE: ${{ needs.prepare.outputs.fedora_checksum_base }}
       CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -83,10 +67,12 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies for VM build
+        env:
+          QEMU_PACKAGE: ${{ matrix.qemu_package }}
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            ${{ matrix.qemu_package }} \
+            "$QEMU_PACKAGE" \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
@@ -97,9 +83,28 @@ jobs:
 
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
+        env:
+          FEDORA_URL: ${{ matrix.fedora_url }}
+          URL_ARCH: ${{ matrix.url_arch }}
+        run: |
+          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          wget -q "${FEDORA_URL}/${fedora_image}"
+          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
+          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
+
+      - name: Verify Fedora image checksum
+        working-directory: ./containers/fedora
         run: |
           FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
-          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+          # Extract the SHA256 line for the exact artifact and verify it.
+          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
+          # sha256sum expects: <digest>  <filename>
+          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
+            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
+            | sha256sum --check --status \
+            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
+          echo "Checksum verified for ${FEDORA_IMAGE}"
+          rm CHECKSUM
 
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
@@ -127,7 +132,7 @@ jobs:
         env:
           QUAY_USER: ${{ secrets.QUAY_USER }}
           QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        run: podman login -u "$QUAY_USER" -p "$QUAY_TOKEN" quay.io
+        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
 
       - name: Tag & Push image to staging
         env:
@@ -157,7 +162,7 @@ jobs:
 
       - name: Create and push manifest
         env:
-          FEDORA_VERSION: ${{ env.FEDORA_VERSION }}
+          FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
           REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
         run: |
           remote_tag="${FEDORA_VERSION}-dev"
@@ -167,5 +172,5 @@ jobs:
             ARCH_IMAGES="${ARCH_IMAGES} ${REMOTE_REPOSITORY}:${FEDORA_VERSION}-${arch}"
           done
           # Create and push the multi-arch manifest
-          podman manifest create --log-level=debug "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
+          podman manifest create "${REMOTE_REPOSITORY}":"${remote_tag}" ${ARCH_IMAGES}
           podman manifest push "${REMOTE_REPOSITORY}":"${remote_tag}" --all --format=v2s2

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -15,9 +15,6 @@ on:
 permissions:
   contents: read
 
-env:
-  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
-
 jobs:
   prepare:
     uses: ./.github/workflows/component-builder-prepare.yml
@@ -30,7 +27,7 @@ jobs:
       fedora_image_base: ${{ needs.prepare.outputs.fedora_image_base }}
       fedora_checksum_base: ${{ needs.prepare.outputs.fedora_checksum_base }}
       matrix: ${{ needs.prepare.outputs.matrix }}
-      remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+      remote_repository: ${{ needs.prepare.outputs.remote_repository }}
       push_image: true
     secrets:
       BITWARDEN_ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
@@ -58,7 +55,7 @@ jobs:
       - name: Create and push manifest
         env:
           FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
-          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
+          REMOTE_REPOSITORY: ${{ needs.prepare.outputs.remote_repository }}
         run: |
           set -euo pipefail
           if [ -z "${ARCHITECTURES// /}" ]; then

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -1,123 +1,42 @@
 name: "Component Builder Publish"
-permissions:
-  contents: read
-env:
-  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
     paths:
       - 'containers/fedora/**'
       - '.github/component-builder-config.json'
       - '.github/workflows/component-builder-prepare.yml'
+      - '.github/workflows/component-builder-build.yml'
     branches:
       - 'main'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+
 jobs:
   prepare:
     uses: ./.github/workflows/component-builder-prepare.yml
 
   build-images:
-    runs-on: ubuntu-latest
     needs: prepare
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    env:
-      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
-      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
-      FEDORA_CHECKSUM_BASE: ${{ needs.prepare.outputs.fedora_checksum_base }}
-      CPU_ARCH: ${{ matrix.arch }}
-      FULL_EMULATION: "true"
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Install dependencies for VM build
-        env:
-          QEMU_PACKAGE: ${{ matrix.qemu_package }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            "$QEMU_PACKAGE" \
-            libvirt-daemon-system \
-            virtinst cloud-image-utils \
-            libguestfs-tools
-
-      - name: Tweak hosted runner to enable 'virt-sysprep'
-        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
-        run: sudo chmod 0644 /boot/vmlinuz*
-
-      - name: Fetch base Fedora image
-        working-directory: ./containers/fedora
-        env:
-          FEDORA_URL: ${{ matrix.fedora_url }}
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          wget -q "${FEDORA_URL}/${fedora_image}"
-          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
-          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
-
-      - name: Verify Fedora image checksum
-        working-directory: ./containers/fedora
-        env:
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          # Extract the SHA256 line for the exact artifact and verify it.
-          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
-          # sha256sum expects: <digest>  <filename>
-          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
-            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
-            | sha256sum --check --status \
-            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
-          echo "Checksum verified for ${FEDORA_IMAGE}"
-          rm CHECKSUM
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          version: "0.12.5"
-      - name: Install Bitwarden Secrets Manager CLI
-        env:
-          BWS_VERSION: "2.1.0"
-        run: |
-          curl -fsSL "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip" -o bws.zip
-          unzip -o bws.zip -d /usr/local/bin
-          chmod +x /usr/local/bin/bws
-          rm bws.zip
-          bws --version
-      - name: Create VM
-        working-directory: ./containers/fedora
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-          ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
-          ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
-          FEDORA_IMAGE: "${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2"
-        run: ./build.sh
-
-      - name: Logging to quay.io
-        env:
-          QUAY_USER: ${{ secrets.QUAY_USER }}
-          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
-
-      - name: Tag & Push image to staging
-        env:
-          local_repository: "localhost/fedora"
-          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
-        run: |
-          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
-          podman push "${REMOTE_REPOSITORY}":"${arch_tag}"
+    uses: ./.github/workflows/component-builder-build.yml
+    with:
+      fedora_version: ${{ needs.prepare.outputs.fedora_version }}
+      fedora_image_base: ${{ needs.prepare.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ needs.prepare.outputs.fedora_checksum_base }}
+      matrix: ${{ needs.prepare.outputs.matrix }}
+      remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+      push_image: true
+    secrets:
+      BITWARDEN_ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
+      BITWARDEN_ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+      QUAY_USER: ${{ secrets.QUAY_USER }}
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
   create-manifest:
     runs-on: ubuntu-latest

--- a/.github/workflows/component-builder-publish.yml
+++ b/.github/workflows/component-builder-publish.yml
@@ -1,123 +1,42 @@
 name: "Component Builder Publish"
-permissions:
-  contents: read
-env:
-  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
 on:
   push:
     paths:
       - 'containers/fedora/**'
       - '.github/component-builder-config.json'
       - '.github/workflows/component-builder-prepare.yml'
+      - '.github/workflows/component-builder-build.yml'
     branches:
       - 'main'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  REMOTE_REPOSITORY: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+
 jobs:
   prepare:
     uses: ./.github/workflows/component-builder-prepare.yml
 
   build-images:
-    runs-on: ubuntu-latest
     needs: prepare
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    env:
-      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
-      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
-      FEDORA_CHECKSUM_BASE: ${{ needs.prepare.outputs.fedora_checksum_base }}
-      CPU_ARCH: ${{ matrix.arch }}
-      FULL_EMULATION: "true"
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Install dependencies for VM build
-        env:
-          QEMU_PACKAGE: ${{ matrix.qemu_package }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            "$QEMU_PACKAGE" \
-            libvirt-daemon-system \
-            virtinst cloud-image-utils \
-            libguestfs-tools
-
-      - name: Tweak hosted runner to enable 'virt-sysprep'
-        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
-        run: sudo chmod 0644 /boot/vmlinuz*
-
-      - name: Fetch base Fedora image
-        working-directory: ./containers/fedora
-        env:
-          FEDORA_URL: ${{ matrix.fedora_url }}
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          wget -q "${FEDORA_URL}/${fedora_image}"
-          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
-          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
-
-      - name: Verify Fedora image checksum
-        working-directory: ./containers/fedora
-        env:
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          # Extract the SHA256 line for the exact artifact and verify it.
-          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
-          # sha256sum expects: <digest>  <filename>
-          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
-            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
-            | sha256sum --check --status \
-            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
-          echo "Checksum verified for ${FEDORA_IMAGE}"
-          rm CHECKSUM
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          version: "0.12.10"
-      - name: Install Bitwarden Secrets Manager CLI
-        env:
-          BWS_VERSION: "2.1.0"
-        run: |
-          curl -fsSL "https://github.com/bitwarden/sdk-sm/releases/download/bws-v${BWS_VERSION}/bws-x86_64-unknown-linux-gnu-${BWS_VERSION}.zip" -o bws.zip
-          unzip -o bws.zip -d /usr/local/bin
-          chmod +x /usr/local/bin/bws
-          rm bws.zip
-          bws --version
-      - name: Create VM
-        working-directory: ./containers/fedora
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-          ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
-          ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
-          FEDORA_IMAGE: "${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2"
-        run: ./build.sh
-
-      - name: Logging to quay.io
-        env:
-          QUAY_USER: ${{ secrets.QUAY_USER }}
-          QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
-        run: printf '%s' "$QUAY_TOKEN" | podman login -u "$QUAY_USER" --password-stdin quay.io
-
-      - name: Tag & Push image to staging
-        env:
-          local_repository: "localhost/fedora"
-          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-          REMOTE_REPOSITORY: ${{ env.REMOTE_REPOSITORY }}
-        run: |
-          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
-          podman push "${REMOTE_REPOSITORY}":"${arch_tag}"
+    uses: ./.github/workflows/component-builder-build.yml
+    with:
+      fedora_version: ${{ needs.prepare.outputs.fedora_version }}
+      fedora_image_base: ${{ needs.prepare.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ needs.prepare.outputs.fedora_checksum_base }}
+      matrix: ${{ needs.prepare.outputs.matrix }}
+      remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+      push_image: true
+    secrets:
+      BITWARDEN_ORGANIZATION_ID: ${{ secrets.BITWARDEN_ORGANIZATION_ID }}
+      BITWARDEN_ACCESS_TOKEN: ${{ secrets.BITWARDEN_ACCESS_TOKEN }}
+      QUAY_USER: ${{ secrets.QUAY_USER }}
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
   create-manifest:
     runs-on: ubuntu-latest

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -51,12 +51,12 @@ jobs:
         run: |
           mkdir -p artifacts
           podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image.tar "${remote_repository}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image.tar"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:
-          name: fedora-container-image
-          path: artifacts/fedora-image.tar
+          name: fedora-container-image-${{ env.CPU_ARCH }}
+          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
           retention-days: 5
           compression-level: 0

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -11,29 +11,38 @@ permissions:
   contents: read
 
 env:
-  FEDORA_VERSION: 43
   REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.component-builder-config.outputs.matrix }}
+      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
+      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Read component builder config
+        id: component-builder-config
+        run: |
+          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+
   guest-fedora:
     runs-on: ubuntu-latest
+    needs: prepare
     strategy:
-      matrix:
-        include:
-          - arch: amd64
-            url_arch: x86_64
-            qemu_package: qemu-system-x86
-            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images
-          - arch: arm64
-            url_arch: aarch64
-            qemu_package: qemu-system-aarch64
-            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images
-          - arch: s390x
-            url_arch: s390x
-            qemu_package: qemu-system-s390x
-            fedora_url: https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
-      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
+      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
       CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - 'containers/fedora/**'
+      - '.github/component-builder-config.json'
+      - '.github/workflows/component-builder-prepare.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
       FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
+      FEDORA_CHECKSUM_BASE: ${{ needs.prepare.outputs.fedora_checksum_base }}
       CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
@@ -51,9 +52,30 @@ jobs:
 
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
+        env:
+          FEDORA_URL: ${{ matrix.fedora_url }}
+          URL_ARCH: ${{ matrix.url_arch }}
         run: |
-          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
-          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          wget -q "${FEDORA_URL}/${fedora_image}"
+          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
+          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
+
+      - name: Verify Fedora image checksum
+        working-directory: ./containers/fedora
+        env:
+          URL_ARCH: ${{ matrix.url_arch }}
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
+          # Extract the SHA256 line for the exact artifact and verify it.
+          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
+          # sha256sum expects: <digest>  <filename>
+          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
+            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
+            | sha256sum --check --status \
+            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
+          echo "Checksum verified for ${FEDORA_IMAGE}"
+          rm CHECKSUM
 
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -6,6 +6,7 @@ on:
       - '.github/component-builder-config.json'
       - '.github/workflows/component-builder-prepare.yml'
       - '.github/workflows/component-builder-build.yml'
+      - '.github/workflows/component-builder-publish.yml'
       - '.github/workflows/component-builder.yml'
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -15,25 +15,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      matrix: ${{ steps.component-builder-config.outputs.matrix }}
-      fedora_version: ${{ steps.component-builder-config.outputs.fedora_version }}
-      fedora_image_base: ${{ steps.component-builder-config.outputs.fedora_image_base }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Read component builder config
-        id: component-builder-config
-        run: |
-          echo "matrix=$(jq -c '.matrix' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_version=$(jq -r '.fedora_version' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
-          echo "fedora_image_base=$(jq -r '.fedora_image_base' .github/component-builder-config.json)" >> "${GITHUB_OUTPUT}"
+    uses: ./.github/workflows/component-builder-prepare.yml
 
   guest-fedora:
     runs-on: ubuntu-latest

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     env:
       FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
@@ -34,10 +35,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Install dependencies for VM build
+        env:
+          QEMU_PACKAGE: ${{ matrix.qemu_package }}
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            ${{ matrix.qemu_package }} \
+            "$QEMU_PACKAGE" \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
@@ -70,8 +73,8 @@ jobs:
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
         run: |
           mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
-          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
+          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
+          podman save -o artifacts/fedora-image-${CPU_ARCH}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
           echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
 
       - name: Upload container image artifact

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -6,6 +6,7 @@ on:
       - '.github/component-builder-config.json'
       - '.github/workflows/component-builder-prepare.yml'
       - '.github/workflows/component-builder-build.yml'
+      - '.github/workflows/component-builder.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -7,32 +7,60 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  FEDORA_VERSION: 43
+  REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
+
 jobs:
-  guest-fedora-amd64:
+  guest-fedora:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            url_arch: x86_64
+            qemu_package: qemu-system-x86
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images
+          - arch: arm64
+            url_arch: aarch64
+            qemu_package: qemu-system-aarch64
+            fedora_url: https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/aarch64/images
+          - arch: s390x
+            url_arch: s390x
+            qemu_package: qemu-system-s390x
+            fedora_url: https://download.fedoraproject.org/pub/fedora-secondary/releases/43/Cloud/s390x/images
     env:
-      FEDORA_IMAGE: Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2
-      FEDORA_VERSION: 43
-      CPU_ARCH: amd64
+      FEDORA_IMAGE_BASE: Fedora-Cloud-Base-Generic-43-1.6
+      CPU_ARCH: ${{ matrix.arch }}
       FULL_EMULATION: "true"
       DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install dependencies for VM build
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            qemu-system-x86 \
+            ${{ matrix.qemu_package }} \
             libvirt-daemon-system \
             virtinst cloud-image-utils \
             libguestfs-tools
+
       - name: Tweak hosted runner to enable 'virt-sysprep'
         # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
         run: sudo chmod 0644 /boot/vmlinuz*
+
       - name: Fetch base Fedora image
         working-directory: ./containers/fedora
-        run: wget -q "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images/${{ env.FEDORA_IMAGE }}"
+        run: |
+          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${{ matrix.url_arch }}.qcow2"
+          wget -q "${{ matrix.fedora_url }}/${FEDORA_IMAGE}"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
@@ -42,17 +70,19 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
           NO_SECRETS: "true"
+          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2
         run: ./build.sh
+
       - name: Save container image as tarball
         env:
           local_repository: "localhost/fedora"
-          remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
           arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
         run: |
           mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${remote_repository}":"${arch_tag}"
-          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${remote_repository}":"${arch_tag}"
+          podman tag "${local_repository}":"${arch_tag}" "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
+          podman save -o artifacts/fedora-image-${{ env.CPU_ARCH }}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
           echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
+
       - name: Upload container image artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -25,6 +25,6 @@ jobs:
       fedora_image_base: ${{ needs.prepare.outputs.fedora_image_base }}
       fedora_checksum_base: ${{ needs.prepare.outputs.fedora_checksum_base }}
       matrix: ${{ needs.prepare.outputs.matrix }}
-      remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+      remote_repository: ${{ needs.prepare.outputs.remote_repository }}
       no_secrets: true
       upload_artifact: true

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -5,6 +5,7 @@ on:
       - 'containers/fedora/**'
       - '.github/component-builder-config.json'
       - '.github/workflows/component-builder-prepare.yml'
+      - '.github/workflows/component-builder-build.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -12,99 +13,18 @@ on:
 permissions:
   contents: read
 
-env:
-  REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
-
 jobs:
   prepare:
     uses: ./.github/workflows/component-builder-prepare.yml
 
-  guest-fedora:
-    runs-on: ubuntu-latest
+  build:
     needs: prepare
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    env:
-      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
-      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
-      FEDORA_CHECKSUM_BASE: ${{ needs.prepare.outputs.fedora_checksum_base }}
-      CPU_ARCH: ${{ matrix.arch }}
-      FULL_EMULATION: "true"
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - name: Install dependencies for VM build
-        env:
-          QEMU_PACKAGE: ${{ matrix.qemu_package }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            "$QEMU_PACKAGE" \
-            libvirt-daemon-system \
-            virtinst cloud-image-utils \
-            libguestfs-tools
-
-      - name: Tweak hosted runner to enable 'virt-sysprep'
-        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
-        run: sudo chmod 0644 /boot/vmlinuz*
-
-      - name: Fetch base Fedora image
-        working-directory: ./containers/fedora
-        env:
-          FEDORA_URL: ${{ matrix.fedora_url }}
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          wget -q "${FEDORA_URL}/${fedora_image}"
-          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
-          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
-
-      - name: Verify Fedora image checksum
-        working-directory: ./containers/fedora
-        env:
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          # Extract the SHA256 line for the exact artifact and verify it.
-          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
-          # sha256sum expects: <digest>  <filename>
-          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
-            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
-            | sha256sum --check --status \
-            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
-          echo "Checksum verified for ${FEDORA_IMAGE}"
-          rm CHECKSUM
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          version: "0.12.5"
-      - name: Create VM
-        working-directory: ./containers/fedora
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-          NO_SECRETS: "true"
-          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2
-        run: ./build.sh
-
-      - name: Save container image as tarball
-        env:
-          local_repository: "localhost/fedora"
-          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-        run: |
-          mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
-          podman save -o artifacts/fedora-image-${CPU_ARCH}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
-
-      - name: Upload container image artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: fedora-container-image-${{ env.CPU_ARCH }}
-          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
-          retention-days: 5
-          compression-level: 0
+    uses: ./.github/workflows/component-builder-build.yml
+    with:
+      fedora_version: ${{ needs.prepare.outputs.fedora_version }}
+      fedora_image_base: ${{ needs.prepare.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ needs.prepare.outputs.fedora_checksum_base }}
+      matrix: ${{ needs.prepare.outputs.matrix }}
+      remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+      no_secrets: true
+      upload_artifact: true

--- a/.github/workflows/component-builder.yml
+++ b/.github/workflows/component-builder.yml
@@ -5,6 +5,7 @@ on:
       - 'containers/fedora/**'
       - '.github/component-builder-config.json'
       - '.github/workflows/component-builder-prepare.yml'
+      - '.github/workflows/component-builder-build.yml'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -12,99 +13,18 @@ on:
 permissions:
   contents: read
 
-env:
-  REMOTE_REPOSITORY: quay.io/openshift-cnv/qe-cnv-tests-fedora-staging
-
 jobs:
   prepare:
     uses: ./.github/workflows/component-builder-prepare.yml
 
-  guest-fedora:
-    runs-on: ubuntu-latest
+  build:
     needs: prepare
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    env:
-      FEDORA_VERSION: ${{ needs.prepare.outputs.fedora_version }}
-      FEDORA_IMAGE_BASE: ${{ needs.prepare.outputs.fedora_image_base }}
-      FEDORA_CHECKSUM_BASE: ${{ needs.prepare.outputs.fedora_checksum_base }}
-      CPU_ARCH: ${{ matrix.arch }}
-      FULL_EMULATION: "true"
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - name: Install dependencies for VM build
-        env:
-          QEMU_PACKAGE: ${{ matrix.qemu_package }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            "$QEMU_PACKAGE" \
-            libvirt-daemon-system \
-            virtinst cloud-image-utils \
-            libguestfs-tools
-
-      - name: Tweak hosted runner to enable 'virt-sysprep'
-        # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725
-        run: sudo chmod 0644 /boot/vmlinuz*
-
-      - name: Fetch base Fedora image
-        working-directory: ./containers/fedora
-        env:
-          FEDORA_URL: ${{ matrix.fedora_url }}
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          fedora_image="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          wget -q "${FEDORA_URL}/${fedora_image}"
-          fedora_checksum="${FEDORA_CHECKSUM_BASE}-${URL_ARCH}-CHECKSUM"
-          wget -q "${FEDORA_URL}/${fedora_checksum}" -O CHECKSUM
-
-      - name: Verify Fedora image checksum
-        working-directory: ./containers/fedora
-        env:
-          URL_ARCH: ${{ matrix.url_arch }}
-        run: |
-          FEDORA_IMAGE="${FEDORA_IMAGE_BASE}.${URL_ARCH}.qcow2"
-          # Extract the SHA256 line for the exact artifact and verify it.
-          # The Fedora CHECKSUM file uses the format: SHA256 (filename) = <digest>
-          # sha256sum expects: <digest>  <filename>
-          grep "SHA256 (${FEDORA_IMAGE})" CHECKSUM \
-            | sed 's/SHA256 (\(.*\)) = \(.*\)/\2  \1/' \
-            | sha256sum --check --status \
-            || { echo "ERROR: SHA256 digest mismatch for ${FEDORA_IMAGE}"; exit 1; }
-          echo "Checksum verified for ${FEDORA_IMAGE}"
-          rm CHECKSUM
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          version: "0.12.10"
-      - name: Create VM
-        working-directory: ./containers/fedora
-        env:
-          PYTHONPATH: ${{ github.workspace }}
-          NO_SECRETS: "true"
-          FEDORA_IMAGE: ${{ env.FEDORA_IMAGE_BASE }}.${{ matrix.url_arch }}.qcow2
-        run: ./build.sh
-
-      - name: Save container image as tarball
-        env:
-          local_repository: "localhost/fedora"
-          arch_tag: "${{ env.FEDORA_VERSION }}-${{ env.CPU_ARCH }}"
-        run: |
-          mkdir -p artifacts
-          podman tag "${local_repository}":"${arch_tag}" "${REMOTE_REPOSITORY}":"${arch_tag}"
-          podman save -o artifacts/fedora-image-${CPU_ARCH}.tar "${{ env.REMOTE_REPOSITORY }}":"${arch_tag}"
-          echo "Saved image to artifacts/fedora-image-${{ env.CPU_ARCH }}.tar"
-
-      - name: Upload container image artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: fedora-container-image-${{ env.CPU_ARCH }}
-          path: artifacts/fedora-image-${{ env.CPU_ARCH }}.tar
-          retention-days: 5
-          compression-level: 0
+    uses: ./.github/workflows/component-builder-build.yml
+    with:
+      fedora_version: ${{ needs.prepare.outputs.fedora_version }}
+      fedora_image_base: ${{ needs.prepare.outputs.fedora_image_base }}
+      fedora_checksum_base: ${{ needs.prepare.outputs.fedora_checksum_base }}
+      matrix: ${{ needs.prepare.outputs.matrix }}
+      remote_repository: "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging"
+      no_secrets: true
+      upload_artifact: true

--- a/containers/fedora/README.md
+++ b/containers/fedora/README.md
@@ -73,6 +73,13 @@ The resulting files are stored in the `fedora_build_${CPU_ARCH}` directory:
 3. Container Image Tarball.
 
 ### Step 6: Creating multi-arch image manifest
+
+> **⚠️ Only follow this step for local/manual builds.**
+> When a PR that touches `containers/fedora/**` or `.github/component-builder-config.json`
+> is merged to `main`, CI automatically handles everything up to and including the
+> staging multi-arch manifest (see [CI pipeline](#ci-pipeline-automated) below).
+> Skip to [Staging → production promotion](#staging--production-promotion-manual) instead.
+
 After building VM images for Fedora AMD64, ARM64, and S390X architectures, the
 following procedure should help in building multi-arch image manifest
 
@@ -149,6 +156,38 @@ b. then new tag for uploaded multi-arch image manifest '43.rev-250318' is create
 
 This way there will be minimal impact for test runs that
 tried to pull the latest fedora container image with tag '43'
+
+## CI Pipeline (automated)
+
+Merging any change to `containers/fedora/**`, `.github/component-builder-config.json`,
+or either of the shared workflow files (`component-builder-prepare.yml`,
+`component-builder-build.yml`) into `main` automatically triggers
+[`component-builder-publish.yml`](../../.github/workflows/component-builder-publish.yml).
+
+**You do not need to run any of the steps above after a PR merge — CI does this for you.**
+
+The automated pipeline performs the following steps in sequence:
+
+1. **Read config** — reads `FEDORA_VERSION` and the architecture matrix from
+   `.github/component-builder-config.json`.
+2. **Build all architectures in parallel** — for each arch (`amd64`, `arm64`, `s390x`):
+   - Downloads and SHA-256 verifies the upstream Fedora cloud image.
+   - Builds the VM and packages it into a container image.
+   - Pushes the per-arch image as
+     `quay.io/openshift-cnv/qe-cnv-tests-fedora-staging:${FEDORA_VERSION}-${arch}`
+     (e.g. `…:43-amd64`).
+3. **Create and push multi-arch manifest** — assembles all per-arch images into a
+   single multi-arch manifest and pushes it as
+   `quay.io/openshift-cnv/qe-cnv-tests-fedora-staging:${FEDORA_VERSION}-dev`
+   (e.g. `…:43-dev`).
+
+The pipeline uses the `QUAY_USER` / `QUAY_TOKEN` GitHub secrets; no manual
+registry login is required.
+
+> **Note:** The `component-builder.yml` workflow also runs on every **pull request**
+> that touches the same paths.  On PRs it builds all architectures but does **not**
+> push to any registry; it uploads the images as downloadable workflow artifacts
+> instead (see [Test build via GitHub](#test-build-via-github) below).
 
 ## Component Builder Configuration
 

--- a/containers/fedora/README.md
+++ b/containers/fedora/README.md
@@ -25,8 +25,8 @@ uv sync
 
 ### Environment Variables
 Set the following environment variables before running the script:
-- `FEDORA_IMAGE`: Path to the Fedora base image file (e.g., `Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2`).
-- `FEDORA_VERSION`: Version of Fedora (e.g., `40`).
+- `FEDORA_IMAGE`: Path to the Fedora base image file (e.g., `Fedora-Cloud-Base-Generic.43-1.6.x86_64.qcow2`).
+- `FEDORA_VERSION`: Version of Fedora (e.g., `43`).
 - `CPU_ARCH`: Target CPU architecture. Use `amd64` for x86_64, `arm64` for aarch64, or `s390x` for s390x.
 - `ACCESS_TOKEN`: Bitwarden access token for authentication.
 - `ORGANIZATION_ID`: Bitwarden organization ID for accessing secrets.
@@ -40,7 +40,7 @@ Ensure you have the necessary permissions to run virtualization and container-re
 Define the environment variables in your shell:
 ```bash
 export FEDORA_IMAGE=/path/to/fedora-image.qcow2
-export FEDORA_VERSION=40
+export FEDORA_VERSION=43
 export CPU_ARCH=amd64  # Use arm64 or s390x if targeting ARM or s390x architecture
 ```
 

--- a/containers/fedora/README.md
+++ b/containers/fedora/README.md
@@ -27,7 +27,7 @@ uv sync
 
 ### Environment Variables
 Set the following environment variables before running the script:
-- `FEDORA_IMAGE`: Path to the Fedora base image file (e.g., `Fedora-Cloud-Base-Generic.43-1.6.x86_64.qcow2`).
+- `FEDORA_IMAGE`: Path to the Fedora base image file (e.g., `Fedora-Cloud-Base-Generic-43-1.6.x86_64.qcow2`).
 - `FEDORA_VERSION`: Version of Fedora (e.g., `43`).
 - `CPU_ARCH`: Target CPU architecture. Use `amd64` for x86_64, `arm64` for aarch64, or `s390x` for s390x.
 - `ACCESS_TOKEN`: Bitwarden access token for authentication.
@@ -80,7 +80,6 @@ The resulting files are stored in the `fedora_build_${CPU_ARCH}` directory:
 > When a PR that touches `containers/fedora/**` or `.github/component-builder-config.json`
 > is merged to `main`, CI automatically handles everything up to and including the
 > staging multi-arch manifest (see [CI pipeline](#ci-pipeline-automated) below).
-> Skip to [Staging → production promotion](#staging--production-promotion-manual) instead.
 
 After building VM images for Fedora AMD64, ARM64, and S390X architectures, the
 following procedure should help in building multi-arch image manifest

--- a/containers/fedora/README.md
+++ b/containers/fedora/README.md
@@ -15,6 +15,8 @@ Ensure the following tools are installed on your system:
 - `cloud-localds`
 - `virt-sysprep`
 - `qemu-efi-aarch64` / `AAVMF` (required for `arm64` UEFI vars)
+- `qemu-system-aarch64` (required for local `arm64` builds)
+- `qemu-system-s390x` (required for local `s390x` builds)
 - `libguestfs-tools` (provides `guestfish` and `virt-sysprep`, required for `arm64` BLS kernel cmdline patching and image sysprep)
 
 Ensure Your Python Environment Is Ready

--- a/containers/fedora/README.md
+++ b/containers/fedora/README.md
@@ -226,8 +226,17 @@ To update the Fedora version or target CPU architectures, update this configurat
 Editing `.github/component-builder-config.json` automatically updates the GitHub workflow parameters and matrix for builds, tests, and releases across all specified architectures (`amd64`, `arm64`, `s390x`).
 
 # Test build via GitHub
-When pushing a new commit which affects a file under this directory or `.github/component-builder-config.json`, a GitHub action will be triggered to build new Fedora container images.
-To test these images locally:
+Opening (or updating) a pull request that touches any of the following paths triggers the **Component Builder Check** workflow ([`component-builder.yml`](../../.github/workflows/component-builder.yml)):
+
+- `containers/fedora/**`
+- `.github/component-builder-config.json`
+- `.github/workflows/component-builder-prepare.yml`
+- `.github/workflows/component-builder-build.yml`
+- `.github/workflows/component-builder.yml`
+
+The same workflow can also be started manually from the **Actions** tab (`workflow_dispatch`).
+
+To test images built by a PR check run locally:
 - Access the action workflow on GitHub: https://github.com/RedHatQE/openshift-virtualization-tests/actions/workflows/component-builder.yml
 - Click on the relevant run
 - At the bottom of the page, click on the architecture-specific artifact to download (`fedora-container-image-amd64`, `fedora-container-image-arm64`, or `fedora-container-image-s390x`).
@@ -240,3 +249,12 @@ For example, for `amd64`:
 ```bash
 podman load -i fedora-image-amd64.tar
 ```
+
+> **⚠️ Security limitation — PR artifact images use a known password.**
+> PR-check builds run with `NO_SECRETS=true`, which skips secure password
+> injection. The VM inside these artifacts retains the placeholder password
+> `CHANGE_ME` (with `ssh_pwauth: true` enabled in cloud-init). Do **not**
+> treat PR artifact images as equivalent to published images, and do **not**
+> use them in any environment where SSH access must be restricted.
+> Published images (built after merge to `main`) always receive a securely
+> generated password via the `QUAY_TOKEN`-protected CI pipeline.

--- a/containers/fedora/README.md
+++ b/containers/fedora/README.md
@@ -14,6 +14,8 @@ Ensure the following tools are installed on your system:
 - `qemu-img`
 - `cloud-localds`
 - `virt-sysprep`
+- `qemu-efi-aarch64` / `AAVMF` (required for `arm64` UEFI vars)
+- `libguestfs-tools` (provides `guestfish` and `virt-sysprep`, required for `arm64` BLS kernel cmdline patching and image sysprep)
 
 Ensure Your Python Environment Is Ready
 Install the required Python dependencies: Run the following command to set up the Python environment:
@@ -25,7 +27,7 @@ uv sync
 Set the following environment variables before running the script:
 - `FEDORA_IMAGE`: Path to the Fedora base image file (e.g., `Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2`).
 - `FEDORA_VERSION`: Version of Fedora (e.g., `40`).
-- `CPU_ARCH`: Target CPU architecture. Use `amd64` for x86_64 or `arm64` for aarch64.
+- `CPU_ARCH`: Target CPU architecture. Use `amd64` for x86_64, `arm64` for aarch64, or `s390x` for s390x.
 - `ACCESS_TOKEN`: Bitwarden access token for authentication.
 - `ORGANIZATION_ID`: Bitwarden organization ID for accessing secrets.
 
@@ -39,7 +41,7 @@ Define the environment variables in your shell:
 ```bash
 export FEDORA_IMAGE=/path/to/fedora-image.qcow2
 export FEDORA_VERSION=40
-export CPU_ARCH=amd64  # Use arm64 if targeting ARM architecture
+export CPU_ARCH=amd64  # Use arm64 or s390x if targeting ARM or s390x architecture
 ```
 
 ### Step 2: Ensure You Are Logged In to quay.io
@@ -56,7 +58,7 @@ Execute the script in a terminal:
 ### Step 4: Script Workflow
 1. Validates the required environment variables.
 2. Determines appropriate virtualization settings based on CPU_ARCH.
-3. Creates a working directory named fedora_build.
+3. Creates a working directory named `fedora_build_${CPU_ARCH}`.
 4. Generates a secure password for the VM OS login.
 5. Configures cloud-init with the secure password.
 6. Runs the Fedora VM and performs customizations.
@@ -65,58 +67,62 @@ Execute the script in a terminal:
 9. Builds the container image and saves it as a tarball.
 
 ### Step 5: Retrieve Outputs
-The resulting files are stored in the fedora_build directory:
+The resulting files are stored in the `fedora_build_${CPU_ARCH}` directory:
 1. Compressed VM Image: A compressed .qcow2 file.
 2. Dockerfile: Used to build the container image.
 3. Container Image Tarball.
 
 ### Step 6: Creating multi-arch image manifest
-After building VM images for Fedora AMD64 and ARM64 architectures,the
+After building VM images for Fedora AMD64, ARM64, and S390X architectures, the
 following procedure should help in building multi-arch image manifest
 
 1. Create a new tag for container images with revision number.
 
 Note: Revision number is required to prevent overriding of existing tags
 in the container image 'qe-cnv-tests-fedora'. Revision number is not
-required for the very first build of Fedora container image.Revision
+required for the very first build of Fedora container image. Revision
 number is created with naming convention as *.rev-YYMMDD* suffixed to
 the image tag.
 
-Make sure that the chosen tag does not exists already for the fedora
+Make sure that the chosen tag does not exist already for the fedora
 container image
 ```bash
 export REV=.rev-250317
-oc image info quay.io/openshift-cnv/qe-cnv-tests-fedora:41${REV}
-oc image info quay.io/openshift-cnv/qe-cnv-tests-fedora:41-amd64${REV}
-oc image info quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64${REV}
+oc image info quay.io/openshift-cnv/qe-cnv-tests-fedora:43${REV}
+oc image info quay.io/openshift-cnv/qe-cnv-tests-fedora:43-amd64${REV}
+oc image info quay.io/openshift-cnv/qe-cnv-tests-fedora:43-arm64${REV}
+oc image info quay.io/openshift-cnv/qe-cnv-tests-fedora:43-s390x${REV}
 ```
-Above commands should return 'image not found'. After confirming that this
-tags are not used already, it could be used to tag images
+Above commands should return 'image not found'. After confirming that these
+tags are not used already, they can be used to tag images
 
 ```bash
-podman tag localhost/fedora:41-amd64 quay.io/openshift-cnv/qe-cnv-tests-fedora:41-amd64[${REV}]
-podman tag localhost/fedora:41-arm64 quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64[${REV}]
+podman tag localhost/fedora:43-amd64 quay.io/openshift-cnv/qe-cnv-tests-fedora:43-amd64${REV}
+podman tag localhost/fedora:43-arm64 quay.io/openshift-cnv/qe-cnv-tests-fedora:43-arm64${REV}
+podman tag localhost/fedora:43-s390x quay.io/openshift-cnv/qe-cnv-tests-fedora:43-s390x${REV}
 ```
 
 2. Create a new multi-arch image manifest with the images
 ```bash
-podman manifest create quay.io/openshift-cnv/qe-cnv-tests-fedora:41[${REV}] \
-  quay.io/openshift-cnv/qe-cnv-tests-fedora:41-amd64[${REV}] \
-  quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64[${REV}]
+podman manifest create quay.io/openshift-cnv/qe-cnv-tests-fedora:43${REV} \
+  quay.io/openshift-cnv/qe-cnv-tests-fedora:43-amd64${REV} \
+  quay.io/openshift-cnv/qe-cnv-tests-fedora:43-arm64${REV} \
+  quay.io/openshift-cnv/qe-cnv-tests-fedora:43-s390x${REV}
 ```
 
 3. Inspect the multi-arch image manifest
 ```bash
-podman manifest inspect quay.io/openshift-cnv/qe-cnv-tests-fedora:41[${REV}] | jq '.manifests[]|."platform"|."architecture"'
+podman manifest inspect quay.io/openshift-cnv/qe-cnv-tests-fedora:43${REV} | jq '.manifests[]|."platform"|."architecture"'
 ```
-The above should list *amd64* and *arm64* as output, which means that architecture specific images are now part of image
+The above should list *amd64*, *arm64*, and *s390x* as output, which means that architecture-specific images are now part of the image
 manifest
 
 4. Push the images and multi-arch image manifest
 ```bash
-podman push quay.io/openshift-cnv/qe-cnv-tests-fedora:41-amd64[${REV}]
-podman push quay.io/openshift-cnv/qe-cnv-tests-fedora:41-arm64[${REV}]
-podman manifest push quay.io/openshift-cnv/qe-cnv-tests-fedora:41[${REV}] --all --format=v2s2
+podman push quay.io/openshift-cnv/qe-cnv-tests-fedora:43-amd64${REV}
+podman push quay.io/openshift-cnv/qe-cnv-tests-fedora:43-arm64${REV}
+podman push quay.io/openshift-cnv/qe-cnv-tests-fedora:43-s390x${REV}
+podman manifest push quay.io/openshift-cnv/qe-cnv-tests-fedora:43${REV} --all --format=v2s2
 ```
 
 5. Swapping newly built image for latest
@@ -131,27 +137,57 @@ multi-arch image manifest.
 
 This operation is performed from quay.io web UI.
 
-For example, if the latest tag for 'qe-cnv-tests-fedora' is '41'
-and new multi-arch image is validated with tag '41.rev-250318'.
+For example, if the latest tag for 'qe-cnv-tests-fedora' is '43'
+and new multi-arch image is validated with tag '43.rev-250318'.
 
-Check if there is an existing 'rev-xxxxxx' tag associated with the active tag (i.e) 41.
+Check if there is an existing 'rev-xxxxxx' tag associated with the active tag (i.e) 43.
 In this case, new tag for uploaded multi-arch image manifest can be created same
-as active tag (i.e) 41
+as active tag (i.e) 43
 Otherwise:
-a. New tag is created for the active tag '41' as '41.rev-xxxxxx'
-b. then new tag for uploaded multi-arch image manifest '41.rev-250318' is created as '41'.
+a. New tag is created for the active tag '43' as '43.rev-xxxxxx'
+b. then new tag for uploaded multi-arch image manifest '43.rev-250318' is created as '43'.
 
 This way there will be minimal impact for test runs that
-tried to pull the latest fedora container image with tag '41'
+tried to pull the latest fedora container image with tag '43'
+
+## Component Builder Configuration
+
+All multi-arch build options, Fedora image versions, checksums, and target architecture matrices are central to `.github/component-builder-config.json`.
+To update the Fedora version or target CPU architectures, update this configuration file ("one-file-edit" workflow):
+
+```json
+{
+  "fedora_version": "43",
+  "fedora_image_base": "Fedora-Cloud-Base-Generic-43-1.6",
+  "fedora_checksum_base": "Fedora-Cloud-43-1.6",
+  "matrix": {
+    "include": [
+      {
+        "arch": "amd64",
+        "url_arch": "x86_64",
+        "qemu_package": "qemu-system-x86",
+        "fedora_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/43/Cloud/x86_64/images"
+      },
+      ...
+    ]
+  }
+}
+```
+
+Editing `.github/component-builder-config.json` automatically updates the GitHub workflow parameters and matrix for builds, tests, and releases across all specified architectures (`amd64`, `arm64`, `s390x`).
 
 # Test build via GitHub
-When pushing a new commit which affects a file under this directory, a GitHub action will be triggered to build a new Fedora container image.
-To test this image locally:
-- Access the action workflow on github: https://github.com/RedHatQE/openshift-virtualization-tests/actions/workflows/component-builder.yml
+When pushing a new commit which affects a file under this directory or `.github/component-builder-config.json`, a GitHub action will be triggered to build new Fedora container images.
+To test these images locally:
+- Access the action workflow on GitHub: https://github.com/RedHatQE/openshift-virtualization-tests/actions/workflows/component-builder.yml
 - Click on the relevant run
-- On the bottom of the page, click on the artifact to download.
-- Once on the local storage, extract the tar file from the zip.
-- Load the image into the local image storage using podman:
+- At the bottom of the page, click on the architecture-specific artifact to download (`fedora-container-image-amd64`, `fedora-container-image-arm64`, or `fedora-container-image-s390x`).
+- Once on local storage, extract the tar file from the zip archive.
+- Load the image into local image storage using podman:
+```bash
+podman load -i fedora-image-${CPU_ARCH}.tar
 ```
-podman load -i fedora-image.tar
+For example, for `amd64`:
+```bash
+podman load -i fedora-image-amd64.tar
 ```

--- a/containers/fedora/README.md
+++ b/containers/fedora/README.md
@@ -199,6 +199,7 @@ To update the Fedora version or target CPU architectures, update this configurat
   "fedora_version": "43",
   "fedora_image_base": "Fedora-Cloud-Base-Generic-43-1.6",
   "fedora_checksum_base": "Fedora-Cloud-43-1.6",
+  "remote_repository": "quay.io/openshift-cnv/qe-cnv-tests-fedora-staging",
   "matrix": {
     "include": [
       {
@@ -212,6 +213,14 @@ To update the Fedora version or target CPU architectures, update this configurat
   }
 }
 ```
+
+| Key | Description |
+|---|---|
+| `fedora_version` | Fedora major version number (e.g. `"43"`) |
+| `fedora_image_base` | Base filename of the Fedora Cloud image (without architecture suffix and extension) |
+| `fedora_checksum_base` | Base filename of the Fedora checksum file (without architecture suffix) |
+| `remote_repository` | Target container registry repository for tagging and pushing images (e.g. `quay.io/org/repo`) |
+| `matrix.include` | Per-architecture build parameters (`arch`, `url_arch`, `qemu_package`, `fedora_url`) |
 
 Editing `.github/component-builder-config.json` automatically updates the GitHub workflow parameters and matrix for builds, tests, and releases across all specified architectures (`amd64`, `arm64`, `s390x`).
 

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -71,21 +71,58 @@ if [ $FEDORA_VERSION -gt 40 ]; then
    OS_VARIANT="fedora40"
 fi
 
+# Work on a copy of the base image so the original is never mutated.
+# This ensures cloud-init always runs fresh on repeated executions.
+WORK_IMAGE="${FEDORA_IMAGE%.qcow2}-work.qcow2"
+cp "${FEDORA_IMAGE}" "${WORK_IMAGE}"
+
+
+# Clean up any leftovers from a previous failed run
+rm -rf $BUILD_DIR
+if virsh domstate "${NAME}" &>/dev/null; then
+    echo "Found existing domain '${NAME}', removing it before proceeding..."
+    virsh destroy "${NAME}" 2>/dev/null || true
+    if [ "${CPU_ARCH}" = "arm64" ]; then
+        virsh undefine --nvram "${NAME}"
+    else
+        virsh undefine "${NAME}"
+    fi
+fi
+
 echo "Run the VM (ctrl+] to exit)"
 virt-install \
   --memory 2048 \
   --vcpus 2 \
   --arch $CPU_ARCH_CODE \
   --name $NAME \
-  --disk $FEDORA_IMAGE,device=disk \
+  --disk $WORK_IMAGE,device=disk \
   --disk $CLOUD_INIT_ISO,device=cdrom \
   --os-variant $OS_VARIANT \
   --virt-type $VIRT_TYPE \
   --graphics none \
   --network default \
   --noautoconsole \
-  --wait 30 \
   --import
+
+# Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
+# virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.
+echo "Waiting for VM to shut down after cloud-init completes..."
+WAIT_SECONDS=0
+PERIOD_SECONDS=60
+TIMEOUT_SECONDS=1800
+while true; do
+    DOMAIN_STATE=$(virsh domstate "${NAME}" 2>&1) || true
+    if [ "${DOMAIN_STATE}" = "shut off" ] || echo "${DOMAIN_STATE}" | grep -q "failed to get domain"; then
+        break
+    fi
+    if [ ${WAIT_SECONDS} -ge ${TIMEOUT_SECONDS} ]; then
+        echo "ERROR: VM did not shut down within ${TIMEOUT_SECONDS} seconds (last state: ${DOMAIN_STATE})"
+        exit 1
+    fi
+    sleep ${PERIOD_SECONDS}
+    WAIT_SECONDS=$((WAIT_SECONDS + PERIOD_SECONDS))
+done
+echo "VM shut down after ${WAIT_SECONDS} seconds"
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr
@@ -104,7 +141,7 @@ rm -f "${CLOUD_INIT_ISO}"
 
 mkdir $BUILD_DIR
 echo "Snapshot image"
-qemu-img convert -c -O qcow2 "${FEDORA_IMAGE}" "${BUILD_DIR}/${FEDORA_IMAGE}"
+qemu-img convert -c -O qcow2 "${WORK_IMAGE}" "${BUILD_DIR}/${FEDORA_IMAGE}"
 
 echo "Create Dockerfile"
 

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -89,6 +89,10 @@ if virsh domstate "${NAME}" &>/dev/null; then
     fi
 fi
 
+CONSOLE_LOG="/tmp/console-${NAME}.log"
+# Pre-create the log file with open permissions so the qemu process can write to it
+touch "${CONSOLE_LOG}"
+chmod 666 "${CONSOLE_LOG}"
 echo "Run the VM (ctrl+] to exit)"
 virt-install \
   --memory 2048 \
@@ -102,7 +106,13 @@ virt-install \
   --graphics none \
   --network default \
   --noautoconsole \
+  --serial file,path="${CONSOLE_LOG}" \
   --import
+
+# Stream the guest serial console log to stdout so CI logs show what is happening inside the VM.
+# tail -f works without a TTY and streams as lines are written by the guest.
+tail -f "${CONSOLE_LOG}" &
+CONSOLE_PID=$!
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
 # virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.
@@ -123,6 +133,9 @@ while true; do
     WAIT_SECONDS=$((WAIT_SECONDS + PERIOD_SECONDS))
 done
 echo "VM shut down after ${WAIT_SECONDS} seconds"
+# Stop the console tailer and clean up the log file
+kill "${CONSOLE_PID}" 2>/dev/null || true
+rm -f "${CONSOLE_LOG}"
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -30,14 +30,32 @@ case "$CPU_ARCH" in
     "amd64")
         CPU_ARCH_CODE="x86_64"
         VIRT_TYPE="kvm"
+        BOOT_OPTS=""
 	;;
     "arm64")
         CPU_ARCH_CODE="aarch64"
         VIRT_TYPE="qemu"
-	;;
+        # aarch64 requires UEFI and a writable per-VM NVRAM vars file.
+        # Without the vars file libvirt cannot configure ACPI on aarch64.
+        AARCH64_VARS="/tmp/aavmf-vars-${NAME}.fd"
+        for vars_path in \
+            "/usr/share/edk2/aarch64/vars-template-pflash.qcow2" \
+            "/usr/share/AAVMF/AAVMF_VARS.fd"; do
+            if [ -f "${vars_path}" ]; then
+                cp "${vars_path}" "${AARCH64_VARS}"
+                break
+            fi
+        done
+        if [ ! -f "${AARCH64_VARS}" ]; then
+            echo "ERROR: No aarch64 UEFI vars template found. Install qemu-efi-aarch64."
+            exit 1
+        fi
+        BOOT_OPTS="--boot uefi,nvram=${AARCH64_VARS}"
+ ;;
     "s390x")
         CPU_ARCH_CODE="s390x"
         VIRT_TYPE="qemu"
+        BOOT_OPTS=""
 	;;
     *)
         echo "Use the value amd64, s390x or arm64 for CPU_ARCH env variable"
@@ -94,6 +112,7 @@ CONSOLE_LOG="/tmp/console-${NAME}.log"
 touch "${CONSOLE_LOG}"
 chmod 666 "${CONSOLE_LOG}"
 echo "Run the VM (ctrl+] to exit)"
+# shellcheck disable=SC2086
 virt-install \
   --memory 2048 \
   --vcpus 2 \
@@ -107,6 +126,7 @@ virt-install \
   --network default \
   --noautoconsole \
   --serial file,path="${CONSOLE_LOG}" \
+  $BOOT_OPTS \
   --import
 
 # Stream the guest serial console log to stdout so CI logs show what is happening inside the VM.
@@ -133,9 +153,9 @@ while true; do
     WAIT_SECONDS=$((WAIT_SECONDS + PERIOD_SECONDS))
 done
 echo "VM shut down after ${WAIT_SECONDS} seconds"
-# Stop the console tailer and clean up the log file
+# Stop the console tailer and clean up temp files
 kill "${CONSOLE_PID}" 2>/dev/null || true
-rm -f "${CONSOLE_LOG}"
+rm -f "${CONSOLE_LOG}" "${AARCH64_VARS:-}"
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -31,7 +31,7 @@ case "$CPU_ARCH" in
         CPU_ARCH_CODE="x86_64"
         VIRT_TYPE="kvm"
         BOOT_OPTS=""
-	;;
+ ;;
     "arm64")
         CPU_ARCH_CODE="aarch64"
         VIRT_TYPE="qemu"
@@ -56,7 +56,7 @@ case "$CPU_ARCH" in
         CPU_ARCH_CODE="s390x"
         VIRT_TYPE="qemu"
         BOOT_OPTS=""
-	;;
+ ;;
     *)
         echo "Use the value amd64, s390x or arm64 for CPU_ARCH env variable"
         exit 1
@@ -94,6 +94,44 @@ fi
 WORK_IMAGE="${FEDORA_IMAGE%.qcow2}-work.qcow2"
 cp "${FEDORA_IMAGE}" "${WORK_IMAGE}"
 
+# On arm64 QEMU emulation (arm64, s390x) the real-root systemd device timeout
+# (DefaultDeviceTimeoutSec, 45s) can expire before virtio devices are
+# enumerated after pivot-root, causing local-fs.target to fail and breaking
+# cloud-init's dependency chain.
+#
+# Fedora uses BLS (Boot Loader Specification): the kernel cmdline lives in a
+# per-entry .conf file under /boot/loader/entries/ on the ext4 /boot partition
+# (vda2). grub.cfg only sets a kernelopts fallback and delegates to blscfg.
+# We must patch the options line in that .conf file directly.
+#
+# guestfish operations are pure host-side filesystem ops requiring no guest
+# code execution, so they work cross-architecture without KVM.
+if [ "${CPU_ARCH}" = "arm64" ]; then
+    BLS_ENTRY_TMP=$(mktemp)
+    # Mount the ext4 /boot partition (second partition) explicitly.
+    # guestfish -i mounts the btrfs root subvolume, which does not contain
+    # the BLS entries.
+    BLS_ENTRY=$(guestfish -a "${WORK_IMAGE}" \
+        run : \
+        mount /dev/sda2 / : \
+        ls /loader/entries \
+        | grep '\.conf$' | head -1)
+    if [ -z "${BLS_ENTRY}" ]; then
+        echo "ERROR: No BLS entry found in /boot/loader/entries/"
+        rm -f "${BLS_ENTRY_TMP}"
+        exit 1
+    fi
+    guestfish -a "${WORK_IMAGE}" \
+        run : \
+        mount /dev/sda2 / : \
+        download "/loader/entries/${BLS_ENTRY}" "${BLS_ENTRY_TMP}"
+    sed -i 's/^\(options .*\)/\1 systemd.default_device_timeout_sec=300/' "${BLS_ENTRY_TMP}"
+    guestfish -a "${WORK_IMAGE}" \
+        run : \
+        mount /dev/sda2 / : \
+        upload "${BLS_ENTRY_TMP}" "/loader/entries/${BLS_ENTRY}"
+    rm -f "${BLS_ENTRY_TMP}"
+fi
 
 # Clean up any leftovers from a previous failed run
 rm -rf $BUILD_DIR
@@ -139,7 +177,7 @@ CONSOLE_PID=$!
 echo "Waiting for VM to shut down after cloud-init completes..."
 WAIT_SECONDS=0
 PERIOD_SECONDS=60
-TIMEOUT_SECONDS=1800
+TIMEOUT_SECONDS=3600
 while true; do
     DOMAIN_STATE=$(virsh domstate "${NAME}" 2>&1) || true
     if [ "${DOMAIN_STATE}" = "shut off" ] || echo "${DOMAIN_STATE}" | grep -q "failed to get domain"; then

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -61,7 +61,7 @@ case "$CPU_ARCH" in
     *)
         echo "Use the value amd64, s390x or arm64 for CPU_ARCH env variable"
         exit 1
-	;;
+ ;;
 esac
 
 if [ "$FULL_EMULATION" = "true" ]; then

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -9,7 +9,6 @@ cleanup() {
     fi
     set -x
 }
-trap cleanup EXIT
 
 [ -z "${FEDORA_IMAGE}" ] && echo "Set the env variable FEDORA_IMAGE" && exit 1
 [ -z "${FEDORA_VERSION}" ] && echo "Set the env variable FEDORA_VERSION" && exit 1
@@ -38,7 +37,7 @@ cleanup_build_resources() {
         virsh undefine "${NAME}" 2>/dev/null || true
     fi
     rm -f -- "${BLS_ENTRY_TMP:-}" "${CONSOLE_LOG:-}" \
-        "${AARCH64_VARS:-}" "${WORK_IMAGE:-}"
+        "${AARCH64_VARS:-}" "${WORK_IMAGE:-}" "${CLOUD_INIT_ISO:-}"
     rm -rf -- "${RUN_TMP_DIR:?}"
     cleanup
 }
@@ -191,10 +190,15 @@ virt-install \
   $BOOT_OPTS \
   --import
 
+# When NO_SECRETS==true:
 # Stream the guest serial console log to stdout so CI logs show what is happening inside the VM.
 # tail -n +1 -f works without a TTY and streams as lines are written by the guest.
-tail -n +1 -f "${CONSOLE_LOG}" &
-CONSOLE_PID=$!
+if [ "${NO_SECRETS}" = "true" ]; then
+  tail -n +1 -f "${CONSOLE_LOG}" &
+  CONSOLE_PID=$!
+else
+  echo "NO_SECRETS unset: not streaming guest serial console to CI logs"
+fi
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
 # virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -46,7 +46,7 @@ case "$CPU_ARCH" in
     "amd64")
         CPU_ARCH_CODE="x86_64"
         VIRT_TYPE="kvm"
-        BOOT_OPTS=""
+        BOOT_OPTS=()
  ;;
     "arm64")
         CPU_ARCH_CODE="aarch64"
@@ -67,12 +67,12 @@ case "$CPU_ARCH" in
             exit 1
         fi
         chmod 0660 "${AARCH64_VARS}"
-        BOOT_OPTS="--boot uefi,nvram=${AARCH64_VARS}"
+        BOOT_OPTS=(--boot "uefi,nvram=${AARCH64_VARS}")
  ;;
     "s390x")
         CPU_ARCH_CODE="s390x"
         VIRT_TYPE="qemu"
-        BOOT_OPTS=""
+        BOOT_OPTS=()
  ;;
     *)
         echo "Use the value amd64, s390x or arm64 for CPU_ARCH env variable"
@@ -173,7 +173,6 @@ CONSOLE_LOG="${RUN_TMP_DIR}/console-${NAME}.log"
 touch "${CONSOLE_LOG}"
 chmod 0660 "${CONSOLE_LOG}"
 echo "Run the VM (ctrl+] to exit)"
-# shellcheck disable=SC2086
 virt-install \
   --memory 2048 \
   --vcpus 2 \
@@ -187,7 +186,7 @@ virt-install \
   --network default \
   --noautoconsole \
   --serial file,path="${CONSOLE_LOG}" \
-  $BOOT_OPTS \
+  "${BOOT_OPTS[@]}" \
   --import
 
 # When NO_SECRETS==true:
@@ -207,8 +206,14 @@ WAIT_SECONDS=0
 PERIOD_SECONDS=60
 TIMEOUT_SECONDS=3600
 while true; do
-    DOMAIN_STATE=$(virsh domstate "${NAME}" 2>&1) || true
-    if [ "${DOMAIN_STATE}" = "shut off" ] || echo "${DOMAIN_STATE}" | grep -q "failed to get domain"; then
+    if ! DOMAIN_STATE=$(LC_ALL=C virsh domstate "${NAME}" 2>&1); then
+        if echo "${DOMAIN_STATE}" | grep -q "failed to get domain"; then
+            break
+        fi
+        echo "ERROR: Failed to query VM '${NAME}' state: ${DOMAIN_STATE}"
+        exit 1
+    fi
+    if [ "${DOMAIN_STATE}" = "shut off" ]; then
         break
     fi
     case "${DOMAIN_STATE}" in
@@ -252,11 +257,13 @@ FROM scratch
 COPY --chown=107:107 ${FEDORA_IMAGE} /disk/
 EOF
 
-pushd "${BUILD_DIR}"
-echo "Build container image"
-${IMAGE_BUILD_CMD} build -f Dockerfile --arch="${CPU_ARCH}" -t "${FEDORA_CONTAINER_IMAGE}" .
+# Run build/save commands in a subshell so cleanup executes from the original directory
+(
+    cd "${BUILD_DIR}"
+    echo "Build container image"
+    ${IMAGE_BUILD_CMD} build -f Dockerfile --arch="${CPU_ARCH}" -t "${FEDORA_CONTAINER_IMAGE}" .
 
-echo "Save container image as TAR"
-${IMAGE_BUILD_CMD} save --output "fedora${FEDORA_VERSION}-${CPU_ARCH}.tar" "${FEDORA_CONTAINER_IMAGE}"
-popd
-echo "Fedora image located in ${BUILD_DIR}/"
+    echo "Save container image as TAR"
+    ${IMAGE_BUILD_CMD} save --output "fedora${FEDORA_VERSION}-${CPU_ARCH}.tar" "${FEDORA_CONTAINER_IMAGE}"
+    echo "Fedora image located in ${BUILD_DIR}/"
+)

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -129,11 +129,15 @@ if [ "${CPU_ARCH}" = "arm64" ]; then
     # Mount the ext4 /boot partition (second partition) explicitly.
     # guestfish -i mounts the btrfs root subvolume, which does not contain
     # the BLS entries.
-    BLS_ENTRY=$(guestfish -a "${WORK_IMAGE}" \
+    if ! guestfish -a "${WORK_IMAGE}" \
         run : \
         mount /dev/sda2 / : \
-        ls /loader/entries \
-        | grep '\.conf$' | head -1)
+        ls /loader/entries > "${BLS_ENTRY_TMP}"; then
+        echo "ERROR: guestfish failed while listing BLS entries" >&2
+        rm -f "${BLS_ENTRY_TMP}"
+        exit 1
+    fi
+    BLS_ENTRY=$(awk '/\.conf$/ { print; exit }' "${BLS_ENTRY_TMP}")
     if [ -z "${BLS_ENTRY}" ]; then
         echo "ERROR: No BLS entry found in /boot/loader/entries/"
         rm -f "${BLS_ENTRY_TMP}"
@@ -204,7 +208,7 @@ while true; do
         break
     fi
     case "${DOMAIN_STATE}" in
-        crashed|"pmsuspended")
+        crashed*|pmsuspended*|paused*)
             echo "ERROR: VM entered terminal state '${DOMAIN_STATE}' after ${WAIT_SECONDS} seconds"
             exit 1
             ;;

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -27,6 +27,16 @@ if [ -z $IMAGE_BUILD_CMD ]; then
 fi
 
 RUN_TMP_DIR=$(mktemp -d)
+cleanup_build_resources() {
+    if [ -n "${CONSOLE_PID:-}" ]; then
+        kill "${CONSOLE_PID}" 2>/dev/null || true
+    fi
+    rm -f -- "${BLS_ENTRY_TMP:-}" "${CONSOLE_LOG:-}" \
+        "${AARCH64_VARS:-}" "${WORK_IMAGE:-}"
+    rm -rf -- "${RUN_TMP_DIR:?}"
+    cleanup
+}
+trap cleanup_build_resources EXIT
 case "$CPU_ARCH" in
     "amd64")
         CPU_ARCH_CODE="x86_64"
@@ -51,6 +61,7 @@ case "$CPU_ARCH" in
             echo "ERROR: No aarch64 UEFI vars template found. Install qemu-efi-aarch64."
             exit 1
         fi
+        chmod 0660 "${AARCH64_VARS}"
         BOOT_OPTS="--boot uefi,nvram=${AARCH64_VARS}"
  ;;
     "s390x")
@@ -147,9 +158,11 @@ if virsh domstate "${NAME}" &>/dev/null; then
 fi
 
 CONSOLE_LOG="${RUN_TMP_DIR}/console-${NAME}.log"
-# Pre-create the log file so everyone can write to it
+# Pre-create the log file. QEMU runs as the same user invoking this script
+# (qemu:///session, the libvirt default when no --connect is specified), so
+# owner rw access is sufficient; group rw is kept for headroom.
 touch "${CONSOLE_LOG}"
-chmod 666 "${CONSOLE_LOG}"
+chmod 0660 "${CONSOLE_LOG}"
 echo "Run the VM (ctrl+] to exit)"
 # shellcheck disable=SC2086
 virt-install \
@@ -172,8 +185,6 @@ virt-install \
 # tail -f works without a TTY and streams as lines are written by the guest.
 tail -f "${CONSOLE_LOG}" &
 CONSOLE_PID=$!
-# Clean up on every exit path, including the timeout and set -e aborts.
-trap 'kill "${CONSOLE_PID}" 2>/dev/null || true; rm -rf "${CONSOLE_LOG}" "${AARCH64_VARS:-}" "${WORK_IMAGE}" "${RUN_TMP_DIR}"; cleanup' EXIT
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
 # virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -173,7 +173,7 @@ virt-install \
 tail -f "${CONSOLE_LOG}" &
 CONSOLE_PID=$!
 # Clean up on every exit path, including the timeout and set -e aborts.
-trap 'kill "${CONSOLE_PID}" 2>/dev/null || true; rm -f "${CONSOLE_LOG}" "${AARCH64_VARS:-}"' EXIT
+trap 'kill "${CONSOLE_PID}" 2>/dev/null || true; rm -f "${CONSOLE_LOG}" "${AARCH64_VARS:-}"; cleanup' EXIT
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
 # virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -26,6 +26,7 @@ if [ -z $IMAGE_BUILD_CMD ]; then
     exit 1
 fi
 
+RUN_TMP_DIR=$(mktemp -d)
 case "$CPU_ARCH" in
     "amd64")
         CPU_ARCH_CODE="x86_64"
@@ -37,7 +38,7 @@ case "$CPU_ARCH" in
         VIRT_TYPE="qemu"
         # aarch64 requires UEFI and a writable per-VM NVRAM vars file.
         # Without the vars file libvirt cannot configure ACPI on aarch64.
-        AARCH64_VARS="/tmp/aavmf-vars-${NAME}.fd"
+        AARCH64_VARS="${RUN_TMP_DIR}/aavmf-vars-${NAME}.fd"
         for vars_path in \
             "/usr/share/edk2/aarch64/vars-template-pflash.qcow2" \
             "/usr/share/AAVMF/AAVMF_VARS.fd"; do
@@ -94,7 +95,7 @@ fi
 WORK_IMAGE="${FEDORA_IMAGE%.qcow2}-work.qcow2"
 cp "${FEDORA_IMAGE}" "${WORK_IMAGE}"
 
-# On arm64 QEMU emulation (arm64, s390x) the real-root systemd device timeout
+# Under arm64 QEMU full emulation the real-root systemd device timeout
 # (DefaultDeviceTimeoutSec, 45s) can expire before virtio devices are
 # enumerated after pivot-root, causing local-fs.target to fail and breaking
 # cloud-init's dependency chain.
@@ -134,19 +135,19 @@ if [ "${CPU_ARCH}" = "arm64" ]; then
 fi
 
 # Clean up any leftovers from a previous failed run
-rm -rf $BUILD_DIR
+rm -rf -- "${BUILD_DIR:?BUILD_DIR is unset}"
 if virsh domstate "${NAME}" &>/dev/null; then
     echo "Found existing domain '${NAME}', removing it before proceeding..."
     virsh destroy "${NAME}" 2>/dev/null || true
     if [ "${CPU_ARCH}" = "arm64" ]; then
-        virsh undefine --nvram "${NAME}"
+        virsh undefine --nvram "${NAME}" || true
     else
-        virsh undefine "${NAME}"
+        virsh undefine "${NAME}" || true
     fi
 fi
 
-CONSOLE_LOG="/tmp/console-${NAME}.log"
-# Pre-create the log file with open permissions so the qemu process can write to it
+CONSOLE_LOG="${RUN_TMP_DIR}/console-${NAME}.log"
+# Pre-create the log file so everyone can write to it
 touch "${CONSOLE_LOG}"
 chmod 666 "${CONSOLE_LOG}"
 echo "Run the VM (ctrl+] to exit)"
@@ -171,6 +172,8 @@ virt-install \
 # tail -f works without a TTY and streams as lines are written by the guest.
 tail -f "${CONSOLE_LOG}" &
 CONSOLE_PID=$!
+# Clean up on every exit path, including the timeout and set -e aborts.
+trap 'kill "${CONSOLE_PID}" 2>/dev/null || true; rm -f "${CONSOLE_LOG}" "${AARCH64_VARS:-}"' EXIT
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
 # virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.
@@ -183,6 +186,12 @@ while true; do
     if [ "${DOMAIN_STATE}" = "shut off" ] || echo "${DOMAIN_STATE}" | grep -q "failed to get domain"; then
         break
     fi
+    case "${DOMAIN_STATE}" in
+        crashed|"pmsuspended")
+            echo "ERROR: VM entered terminal state '${DOMAIN_STATE}' after ${WAIT_SECONDS} seconds"
+            exit 1
+            ;;
+    esac
     if [ ${WAIT_SECONDS} -ge ${TIMEOUT_SECONDS} ]; then
         echo "ERROR: VM did not shut down within ${TIMEOUT_SECONDS} seconds (last state: ${DOMAIN_STATE})"
         exit 1
@@ -191,9 +200,6 @@ while true; do
     WAIT_SECONDS=$((WAIT_SECONDS + PERIOD_SECONDS))
 done
 echo "VM shut down after ${WAIT_SECONDS} seconds"
-# Stop the console tailer and clean up temp files
-kill "${CONSOLE_PID}" 2>/dev/null || true
-rm -f "${CONSOLE_LOG}" "${AARCH64_VARS:-}"
 
 # Prepare VM image
 virt-sysprep -d "${NAME}" --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -16,8 +16,8 @@ trap cleanup EXIT
 [ -z "${CPU_ARCH}" ] && echo "Set the env variable CPU_ARCH" && exit 1
 
 BUILD_DIR="fedora_build_${CPU_ARCH}"
-CLOUD_INIT_ISO="cidata.iso"
-NAME="fedora${FEDORA_VERSION}"
+CLOUD_INIT_ISO="cidata-${CPU_ARCH}.iso"
+NAME="fedora${FEDORA_VERSION}-${CPU_ARCH}"
 FEDORA_CONTAINER_IMAGE="localhost/fedora:${FEDORA_VERSION}-${CPU_ARCH}"
 
 IMAGE_BUILD_CMD=$(which podman 2>/dev/null || which docker)
@@ -188,8 +188,8 @@ virt-install \
   --import
 
 # Stream the guest serial console log to stdout so CI logs show what is happening inside the VM.
-# tail -f works without a TTY and streams as lines are written by the guest.
-tail -f "${CONSOLE_LOG}" &
+# tail -n +1 -f works without a TTY and streams as lines are written by the guest.
+tail -n +1 -f "${CONSOLE_LOG}" &
 CONSOLE_PID=$!
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -31,6 +31,12 @@ cleanup_build_resources() {
     if [ -n "${CONSOLE_PID:-}" ]; then
         kill "${CONSOLE_PID}" 2>/dev/null || true
     fi
+    virsh destroy "${NAME}" 2>/dev/null || true
+    if [ "${CPU_ARCH:-}" = "arm64" ]; then
+        virsh undefine "${NAME}" --nvram 2>/dev/null || true
+    else
+        virsh undefine "${NAME}" 2>/dev/null || true
+    fi
     rm -f -- "${BLS_ENTRY_TMP:-}" "${CONSOLE_LOG:-}" \
         "${AARCH64_VARS:-}" "${WORK_IMAGE:-}"
     rm -rf -- "${RUN_TMP_DIR:?}"

--- a/containers/fedora/build.sh
+++ b/containers/fedora/build.sh
@@ -173,7 +173,7 @@ virt-install \
 tail -f "${CONSOLE_LOG}" &
 CONSOLE_PID=$!
 # Clean up on every exit path, including the timeout and set -e aborts.
-trap 'kill "${CONSOLE_PID}" 2>/dev/null || true; rm -f "${CONSOLE_LOG}" "${AARCH64_VARS:-}"; cleanup' EXIT
+trap 'kill "${CONSOLE_PID}" 2>/dev/null || true; rm -rf "${CONSOLE_LOG}" "${AARCH64_VARS:-}" "${WORK_IMAGE}" "${RUN_TMP_DIR}"; cleanup' EXIT
 
 # Wait for cloud-init to finish (user-data issues 'shutdown' as its last step).
 # virsh domstate exits non-zero for unknown domains, so we treat that as "shut off" too.


### PR DESCRIPTION
##### What this PR does / why we need it:
The component builder CI workflows were tightly coupled to a single amd64 build, with the Fedora version, image names, and architecture-specific settings hardcoded in multiple places. This PR refactors and extends the component builder to support multi-architecture (amd64, arm64, s390x) Fedora image builds and publishes, reducing duplication and making future architecture changes a one-file edit.

Changes (CI workflow):
- New shared config file (.github/component-builder-config.json): Centralises all architecture- and version-specific values (Fedora version, image base name, QEMU package, download URLs) in a single source of truth. Previously this data was duplicated and hardcoded across both workflow files.
- New reusable prepare workflow (.github/workflows/component-builder-prepare.yml): Reads the config file and exposes its values as workflow outputs (matrix, Fedora version, image base, checksum base, architectures, remote repository). Both orchestrating workflows (component-builder.yml and component-builder-publish.yml) now call this reusable workflow instead of repeating the same setup logic.
- New reusable build workflow (.github/workflows/component-builder-build.yml): Extracts the full per-architecture build logic — dependency installation, image download, checksum verification, Bitwarden CLI setup, VM creation, artifact upload, and image push — into a single reusable workflow called by both component-builder.yml and component-builder-publish.yml. The matrix strategy that fans out over amd64, arm64, and s390x lives here, not in the caller workflows.
- `component-builder.yml` and `component-builder-publish.yml` slimmed down: Both now delegate to the prepare + build reusable chain. The single hardcoded guest-fedora-amd64 job is gone from each.
- Multi-arch manifest creation (component-builder-publish.yml): A new create-manifest job runs after all per-arch images are pushed. It assembles the arch-specific tags, creates an OCI multi-arch manifest list (-dev tag), verifies the manifest entry count matches the number of built architectures, and pushes it.
- Supply-chain checksum verification: Fedora cloud image SHA256 digest is verified against the official Fedora CHECKSUM file before the image is used. The Bitwarden CLI (bws) archive is verified against its published SHA256 checksum file before installation.
- PR trigger paths updated: Both component-builder.yml and component-builder-publish.yml now also trigger on changes to component-builder-config.json, component-builder-prepare.yml, and component-builder-build.yml, ensuring CI runs whenever any part of the build system changes.
- Explicit permissions: contents: read added at the workflow level in both caller workflows.

Changes (build.sh)
- Works on a copy of the base image (*-work.qcow2) so repeated executions never corrupt the original.
- Cleans up any leftover libvirt domain from a previous failed run before starting.
- Streams the VM serial console to stdout via tail -f for visible CI logs.
- Replaces the fixed --wait timeout with an explicit poll loop (up to 60 min, 60 s period) that waits for cloud-init to signal completion via shutdown. Detects and fails fast on crashed/pmsuspended states.
- arm64 UEFI/NVRAM boot options: Adds --boot uefi,nvram=… with a per-VM writable vars file copied from the host template, required by aarch64 libvirt guests.
- arm64 BLS kernel cmdline patch: Patches systemd.default_device_timeout_sec=300 into the BLS entry in the arm64 image's /boot partition using guestfish, preventing local-fs.target failures under QEMU full-emulation.
- Security: Quay credentials are passed via printf '%s' "$QUAY_TOKEN" | podman login --password-stdin instead of -p, avoiding token exposure in process lists.
- Cleanup on all exit paths: A trap ... EXIT ensures the console log, NVRAM vars file, work image, and temp directory are removed whether the script exits cleanly, via timeout, or via set -e.

##### Which issue(s) this PR fixes:
NONE

##### Special notes for reviewer:
NONE


##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Fedora 43 image builds for amd64, arm64, and s390x.
  - Added automated multi-architecture builds, artifact uploads, image publishing, and manifest creation.
  - Added architecture-specific image downloads with checksum verification.

- **Bug Fixes**
  - Improved arm64 boot configuration, cleanup, logging, and timeout handling.
  - Added validation to prevent incomplete or inconsistent multi-architecture releases.

- **Documentation**
  - Updated build instructions, publishing examples, and CI guidance for Fedora 43 and supported architectures.
  - Documented architecture-specific prerequisites, artifacts, and secure handling for PR-check builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->