### PR TITLE
Fix(hco): use json.loads/dumps for jsonpatch annotation merge

### DIFF
--- a/utilities/hco.py
+++ b/utilities/hco.py
@@ -497,9 +497,9 @@ def update_hco_annotations(
     # {"op": "add", "path": "/spec/configuration/cpuModel", "value": "Haswell-noTSX"}]]'
     if resource_existing_jsonpatch_annotation and not overwrite_patches:
         hco_annotations_dict = hco_config_jsonpath_dict["metadata"]["annotations"]
-        hco_annotations_dict[jsonpatch_key] = (
-            f"{resource_existing_jsonpatch_annotation[:-1]},{hco_annotations_dict[jsonpatch_key][1:]}"
-        )
+        existing_patches = json.loads(resource_existing_jsonpatch_annotation)
+        new_patches = json.loads(hco_annotations_dict[jsonpatch_key])
+        hco_annotations_dict[jsonpatch_key] = json.dumps(existing_patches + new_patches)
 
     with ResourceEditorValidateHCOReconcile(
         admin_client=admin_client,

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -1020,6 +1020,62 @@ class TestUpdateHcoAnnotations:
 
         mock_editor_class.assert_called_once()
 
+    @patch("utilities.hco.ResourceEditorValidateHCOReconcile")
+    def test_update_annotations_merge_with_empty_array(self, mock_editor_class):
+        """Test annotation merge when existing annotation is an empty JSON array"""
+        mock_hco = MagicMock()
+        mock_hco.instance.metadata = {"annotations": {"kubevirt.kubevirt.io/jsonpatch": "[]"}}
+
+        mock_editor = MagicMock()
+        mock_editor.__enter__ = MagicMock(return_value=mock_editor)
+        mock_editor.__exit__ = MagicMock(return_value=None)
+        mock_editor_class.return_value = mock_editor
+
+        with update_hco_annotations(
+            resource=mock_hco,
+            path="machineType",
+            value="pc-q35-rhel8.4.0",
+            overwrite_patches=False,
+        ):
+            pass
+
+        call_kwargs = mock_editor_class.call_args[1]
+        patches = call_kwargs["patches"]
+        annotation_value = list(patches.values())[0]["metadata"]["annotations"]["kubevirt.kubevirt.io/jsonpatch"]
+        parsed = json.loads(annotation_value)
+        assert len(parsed) == 1
+        assert parsed[0]["op"] == "add"
+        assert parsed[0]["path"] == "/spec/configuration/machineType"
+        assert parsed[0]["value"] == "pc-q35-rhel8.4.0"
+
+    @patch("utilities.hco.ResourceEditorValidateHCOReconcile")
+    def test_update_annotations_merge_produces_valid_json(self, mock_editor_class):
+        """Test annotation merge with existing patches produces valid combined JSON array"""
+        mock_hco = MagicMock()
+        existing_annotation = '[{"op": "add", "path": "/spec/configuration/cpuModel", "value": "Haswell"}]'
+        mock_hco.instance.metadata = {"annotations": {"kubevirt.kubevirt.io/jsonpatch": existing_annotation}}
+
+        mock_editor = MagicMock()
+        mock_editor.__enter__ = MagicMock(return_value=mock_editor)
+        mock_editor.__exit__ = MagicMock(return_value=None)
+        mock_editor_class.return_value = mock_editor
+
+        with update_hco_annotations(
+            resource=mock_hco,
+            path="machineType",
+            value="pc-q35-rhel8.4.0",
+            overwrite_patches=False,
+        ):
+            pass
+
+        call_kwargs = mock_editor_class.call_args[1]
+        patches = call_kwargs["patches"]
+        annotation_value = list(patches.values())[0]["metadata"]["annotations"]["kubevirt.kubevirt.io/jsonpatch"]
+        parsed = json.loads(annotation_value)
+        assert len(parsed) == 2
+        assert parsed[0]["path"] == "/spec/configuration/cpuModel"
+        assert parsed[1]["path"] == "/spec/configuration/machineType"
+
 
 class TestWaitForAutoBootConfigStabilization:
     """Test cases for wait_for_auto_boot_config_stabilization function"""

--- a/utilities/unittests/test_hco.py
+++ b/utilities/unittests/test_hco.py
@@ -1031,7 +1031,9 @@ class TestUpdateHcoAnnotations:
         mock_editor.__exit__ = MagicMock(return_value=None)
         mock_editor_class.return_value = mock_editor
 
+        mock_client = MagicMock()
         with update_hco_annotations(
+            admin_client=mock_client,
             resource=mock_hco,
             path="machineType",
             value="pc-q35-rhel8.4.0",
@@ -1060,7 +1062,9 @@ class TestUpdateHcoAnnotations:
         mock_editor.__exit__ = MagicMock(return_value=None)
         mock_editor_class.return_value = mock_editor
 
+        mock_client = MagicMock()
         with update_hco_annotations(
+            admin_client=mock_client,
             resource=mock_hco,
             path="machineType",
             value="pc-q35-rhel8.4.0",


### PR DESCRIPTION
##### What this PR does / why we need it:

String-concatenation merge produced invalid JSON when the existing annotation was an empty array ([]), yielding [,{...}]. Also adds unit tests

##### Which issue(s) this PR fixes:

Invalid JSON patch was applied to HCO, leading to cascading failures in 4.23-iuo-ocs #9 and #10. HCO ticket: https://redhat.atlassian.net/browse/CNV-94341

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-94342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HCO JSON-patch annotations when adding new machine-type patches.
  * Existing patches are now preserved correctly, including when annotations are empty or contain a single patch.
  * Generated annotations remain valid JSON, reducing the risk of malformed annotation data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->