### PR TITLE
[virt] fix: add missing fixture to opted_out_custom_template_namespace

### DIFF
--- a/tests/virt/cluster/common_templates/custom_namespace/conftest.py
+++ b/tests/virt/cluster/common_templates/custom_namespace/conftest.py
@@ -113,6 +113,7 @@ def edited_default_namespace_template(admin_client, hco_namespace, first_base_te
 
 @pytest.fixture()
 def opted_out_custom_template_namespace(
+    admin_client,
     unprivileged_client,
     hco_namespace,
     custom_vm_template_namespace,


### PR DESCRIPTION
##### What this PR does / why we need it:
after merging 2 PRs (https://github.com/RedHatQE/openshift-virtualization-tests/pull/5817 & https://github.com/RedHatQE/openshift-virtualization-tests/pull/5777) modifying `opted_out_custom_template_namespace`, `admin_client` fixture is missing causing failures

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to support administrative client access when configuring opted-out custom template namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->