### PR TITLE
remove mixed_os_nodes marker from tier2

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -103,6 +103,7 @@ EXCLUDE_MARKER_FROM_TIER2_MARKER = [
     "cclm",
     "mtv",
     "multiarch",
+    "mixed_os_nodes",
 ]
 
 TEAM_MARKERS = {


### PR DESCRIPTION
##### What this PR does / why we need it:
`mixed_os_nodes` marker is used for dual-stream tests (rhcos9+rhcos10) nodes.
Those tests are ran as part of dedicated lanes and should be excluded from regular t2 test runs

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test categorization so mixed operating system node scenarios are excluded from automatic Tier 2 assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->