### PR TITLE
quarantine: [Storage] TestCheckupNegative: wrong failure reason and insufficient debug info

### DIFF
--- a/tests/storage/checkups/test_checkups_negative.py
+++ b/tests/storage/checkups/test_checkups_negative.py
@@ -2,6 +2,7 @@ import pytest
 from ocp_resources.job import Job
 
 from tests.storage.checkups.utils import assert_results_in_configmap
+from utilities.constants.pytest import QUARANTINED
 
 DEFAULT_STORAGE_CLASS_ENTRY = "defaultStorageClass"
 MSG_NO_DEFAULT_STORAGE_CLASS = "no default storage class"
@@ -18,6 +19,12 @@ MSG_UNKNOWN_PROVISIONER = "there are StorageProfiles with empty ClaimPropertySet
         ),
     ],
     indirect=True,
+)
+@pytest.mark.xfail(
+    reason=(
+        f"{QUARANTINED}: wrong failure reason: CNV-94365, not enough info to debug the failed checkup job: CNV-72377"
+    ),
+    run=False,
 )
 class TestCheckupNegative:
     @pytest.mark.polarion("CNV-10701")


### PR DESCRIPTION
##### What this PR does / why we need it:

Quarantine TestCheckupNegative: wrong failure reason and insufficient debug info

Assisted-by: Claude <noreply@anthropic.com>


##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Quarantined failing negative checkup tests so they no longer run as part of the standard test suite.
  * Documented the related tracking references for follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->