### PR TITLE
fix(storage): pass client to openshift-python-wrapper resources in storage tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1272,9 +1272,9 @@ def available_storage_classes_names():
 
 
 @pytest.fixture(scope="session")
-def storage_class_with_filesystem_volume_mode(available_storage_classes_names):
+def storage_class_with_filesystem_volume_mode(admin_client, available_storage_classes_names):
     yield get_storage_class_with_specified_volume_mode(
-        volume_mode=DataVolume.VolumeMode.FILE, sc_names=available_storage_classes_names
+        volume_mode=DataVolume.VolumeMode.FILE, sc_names=available_storage_classes_names, client=admin_client
     )
 
 
@@ -1285,10 +1285,11 @@ def skip_test_if_no_block_sc(storage_class_with_block_volume_mode):
 
 
 @pytest.fixture(scope="session")
-def storage_class_with_block_volume_mode(available_storage_classes_names):
+def storage_class_with_block_volume_mode(admin_client, available_storage_classes_names):
     yield get_storage_class_with_specified_volume_mode(
         volume_mode=DataVolume.VolumeMode.BLOCK,
         sc_names=available_storage_classes_names,
+        client=admin_client,
     )
 
 

--- a/tests/data_protection/oadp/conftest.py
+++ b/tests/data_protection/oadp/conftest.py
@@ -341,7 +341,7 @@ def uploaded_rhel_dv(
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)
-        yield DataVolume(namespace=namespace_for_backup2.name, name=dv_name)
+        yield DataVolume(namespace=namespace_for_backup2.name, name=dv_name, client=namespace_for_backup2.client)
 
 
 @pytest.fixture()

--- a/tests/data_protection/oadp/conftest.py
+++ b/tests/data_protection/oadp/conftest.py
@@ -111,7 +111,7 @@ def velero_backup_multiple_namespaces(admin_client, imported_dv_second_namespace
 def velero_restore_multiple_namespaces(admin_client, velero_backup_multiple_namespaces):
     # Delete NS in order to restore it
     for ns in velero_backup_multiple_namespaces.included_namespaces:
-        Namespace(name=ns).delete(wait=True)
+        Namespace(name=ns, client=admin_client).delete(wait=True)
     with VeleroRestore(
         client=admin_client,
         included_namespaces=velero_backup_multiple_namespaces.included_namespaces,
@@ -228,7 +228,9 @@ def velero_restore_first_namespace_without_datamover(
     admin_client,
     velero_backup_first_namespace_without_datamover,
 ):
-    Namespace(name=velero_backup_first_namespace_without_datamover.included_namespaces[0]).delete(wait=True)
+    Namespace(name=velero_backup_first_namespace_without_datamover.included_namespaces[0], client=admin_client).delete(
+        wait=True
+    )
     with VeleroRestore(
         client=admin_client,
         included_namespaces=velero_backup_first_namespace_without_datamover.included_namespaces,
@@ -259,7 +261,9 @@ def velero_restore_first_namespace_with_datamover(
     velero_backup_first_namespace_using_datamover,
 ):
     # Delete NS in order to restore it
-    Namespace(name=velero_backup_first_namespace_using_datamover.included_namespaces[0]).delete(wait=True)
+    Namespace(name=velero_backup_first_namespace_using_datamover.included_namespaces[0], client=admin_client).delete(
+        wait=True
+    )
     with VeleroRestore(
         client=admin_client,
         included_namespaces=velero_backup_first_namespace_using_datamover.included_namespaces,
@@ -360,7 +364,9 @@ def velero_restore_second_namespace_with_datamover(
     velero_backup_second_namespace_using_datamover,
 ):
     # Delete NS in order to restore it
-    Namespace(name=velero_backup_second_namespace_using_datamover.included_namespaces[0]).delete(wait=True)
+    Namespace(name=velero_backup_second_namespace_using_datamover.included_namespaces[0], client=admin_client).delete(
+        wait=True
+    )
     with VeleroRestore(
         client=admin_client,
         included_namespaces=velero_backup_second_namespace_using_datamover.included_namespaces,

--- a/tests/storage/cdi_config/conftest.py
+++ b/tests/storage/cdi_config/conftest.py
@@ -17,7 +17,9 @@ def cdi_with_extra_non_existent_feature_gate(admin_client, cdi):
             cdi: {
                 "spec": {
                     "config": {
-                        "featureGates": cdi_feature_gate_list_with_added_feature(feature="ExtraNonExistentFeature")
+                        "featureGates": cdi_feature_gate_list_with_added_feature(
+                            feature="ExtraNonExistentFeature", client=admin_client
+                        )
                     }
                 },
             },

--- a/tests/storage/cdi_config/test_cdi_config.py
+++ b/tests/storage/cdi_config/test_cdi_config.py
@@ -35,7 +35,7 @@ def test_cdi_config_exists(cdi_config, upload_proxy_route):
 
 @pytest.mark.destructive
 @pytest.mark.polarion("CNV-2209")
-def test_different_route_for_upload_proxy(hco_namespace, cdi_config, uploadproxy_route_deleted):
+def test_different_route_for_upload_proxy(admin_client, hco_namespace, cdi_config, uploadproxy_route_deleted):
     """
     Test that CDIConfig's upload_proxy_url changes when the upload-proxy route is deleted
     and recreated with a different host
@@ -44,6 +44,7 @@ def test_different_route_for_upload_proxy(hco_namespace, cdi_config, uploadproxy
         namespace=hco_namespace.name,
         name="new-route-uploadproxy",
         service=CDI_UPLOADPROXY,
+        client=admin_client,
     ) as new_route:
         cdi_config.wait_until_upload_url_changed(uploadproxy_url=new_route.host)
 

--- a/tests/storage/cdi_upload/test_upload.py
+++ b/tests/storage/cdi_upload/test_upload.py
@@ -47,8 +47,8 @@ def wait_for_upload_response_code(token, data, response_code, asynchronous=False
 
 @pytest.mark.polarion("CNV-2318")
 @pytest.mark.s390x
-def test_cdi_uploadproxy_route_owner_references(hco_namespace):
-    route = Route(name=CDI_UPLOADPROXY, namespace=hco_namespace.name)
+def test_cdi_uploadproxy_route_owner_references(admin_client, hco_namespace):
+    route = Route(name=CDI_UPLOADPROXY, namespace=hco_namespace.name, client=admin_client)
     assert route.instance
     assert route.instance["metadata"]["ownerReferences"][0]["name"] == "cdi-deployment"
     assert route.instance["metadata"]["ownerReferences"][0]["kind"] == "Deployment"
@@ -295,6 +295,7 @@ def _upload_image(dv_name, namespace, storage_class, local_name, client):
     indirect=True,
 )
 def test_successful_concurrent_uploads(
+    admin_client,
     unprivileged_client,
     upload_file_path,
     namespace,
@@ -302,7 +303,7 @@ def test_successful_concurrent_uploads(
 ):
     dvs_processes = []
     storage_class = [*storage_class_matrix__module__][0]
-    available_pv = PersistentVolume(name=namespace).max_available_pvs
+    available_pv = PersistentVolume(name=namespace, client=admin_client).max_available_pvs
     for dv in range(available_pv):
         dv_process = multiprocessing.Process(
             target=_upload_image,

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -305,7 +305,7 @@ def empty_pvc(
         if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_module, client=namespace.client):
             # For PVC to bind on WFFC, it must be consumed
             # (this was previously solved by hard coding hostpath_node at all times)
-            create_dummy_first_consumer_pod(pvc=pvc)
+            create_dummy_first_consumer_pod(client=namespace.client, pvc=pvc)
         pvc.wait_for_status(status=PersistentVolumeClaim.Status.BOUND, timeout=60)
         yield pvc
 

--- a/tests/storage/cdi_upload/test_upload_virtctl.py
+++ b/tests/storage/cdi_upload/test_upload_virtctl.py
@@ -42,10 +42,10 @@ LOCAL_PATH = f"/tmp/{Images.Cdi.QCOW2_IMG}"
 LATEST_WINDOWS_OS_DICT = py_config.get("latest_windows_os_dict", {})
 
 
-def get_population_method_by_provisioner(storage_class, cluster_csi_drivers_names):
+def get_population_method_by_provisioner(storage_class, cluster_csi_drivers_names, client):
     return (
         POPULATED_STR
-        if StorageClass(name=storage_class).instance.get("provisioner") in cluster_csi_drivers_names
+        if StorageClass(name=storage_class, client=client).instance.get("provisioner") in cluster_csi_drivers_names
         else NON_CSI_POPULATED_STR
     )
 
@@ -200,6 +200,7 @@ def test_virtctl_image_upload_dv(
 )
 @pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_dv_image(
+    admin_client,
     data_volume_multi_storage_scope_function,
     storage_class_name_scope_function,
     download_image,
@@ -228,6 +229,7 @@ def test_virtctl_image_upload_with_exist_dv_image(
                 populated=get_population_method_by_provisioner(
                     storage_class=storage_class_name_scope_function,
                     cluster_csi_drivers_names=cluster_csi_drivers_names,
+                    client=admin_client,
                 ),
             ),
         )
@@ -257,7 +259,7 @@ def test_virtctl_image_upload_pvc(download_image, namespace, storage_class_name_
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)
-        pvc = PersistentVolumeClaim(namespace=namespace.name, name=pvc_name)
+        pvc = PersistentVolumeClaim(namespace=namespace.name, name=pvc_name, client=namespace.client)
         assert pvc.bound()
 
 
@@ -346,6 +348,7 @@ def test_virtctl_image_upload_with_exist_pvc(
 @pytest.mark.polarion("CNV-3729")
 @pytest.mark.s390x
 def test_virtctl_image_upload_with_exist_pvc_image(
+    admin_client,
     download_image,
     namespace,
     storage_class_name_scope_module,
@@ -383,6 +386,7 @@ def test_virtctl_image_upload_with_exist_pvc_image(
                     populated=get_population_method_by_provisioner(
                         storage_class=storage_class_name_scope_module,
                         cluster_csi_drivers_names=cluster_csi_drivers_names,
+                        client=admin_client,
                     ),
                 ),
             )

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -214,7 +214,7 @@ def upload_proxy_route(admin_client):
 
 
 @pytest.fixture()
-def uploadproxy_route_deleted(hco_namespace):
+def uploadproxy_route_deleted(admin_client, hco_namespace):
     """
     Delete uploadproxy route from kubevirt-hyperconverged namespace.
 
@@ -222,16 +222,16 @@ def uploadproxy_route_deleted(hco_namespace):
     Once the cdi-operator is terminated, route is deleted to perform the test.
     """
     ns = hco_namespace.name
-    deployment = Deployment(name=CDI_OPERATOR, namespace=ns)
+    deployment = Deployment(name=CDI_OPERATOR, namespace=ns, client=admin_client)
     try:
         deployment.scale_replicas(replica_count=0)
         deployment.wait_for_replicas(deployed=False)
-        Route(name=CDI_UPLOADPROXY, namespace=ns).delete(wait=True)
+        Route(name=CDI_UPLOADPROXY, namespace=ns, client=admin_client).delete(wait=True)
         yield
     finally:
         deployment.scale_replicas(replica_count=1)
         deployment.wait_for_replicas()
-        Route(name=CDI_UPLOADPROXY, namespace=ns).wait()
+        Route(name=CDI_UPLOADPROXY, namespace=ns, client=admin_client).wait()
 
 
 @pytest.fixture()

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -258,11 +258,12 @@ def cdi_config_upload_proxy_overridden(
 
 
 @pytest.fixture()
-def new_route_created(hco_namespace):
-    existing_route = Route(name=CDI_UPLOADPROXY, namespace=hco_namespace.name)
+def new_route_created(admin_client, hco_namespace):
+    existing_route = Route(name=CDI_UPLOADPROXY, namespace=hco_namespace.name, client=admin_client)
     route = Route(
         name="newuploadroute-cdi",
         namespace=hco_namespace.name,
+        client=admin_client,
         destination_ca_cert=existing_route.ca_cert,
         service=CDI_UPLOADPROXY,
     )

--- a/tests/storage/data_import_cron/conftest.py
+++ b/tests/storage/data_import_cron/conftest.py
@@ -49,7 +49,9 @@ def vm_for_data_source_import(
         os_flavor=OS_FLAVOR_FEDORA,
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=DataSource(
-                name=imported_data_source.name, namespace=data_import_cron_pvc_target_namespace.name
+                name=imported_data_source.name,
+                namespace=data_import_cron_pvc_target_namespace.name,
+                client=unprivileged_client,
             ),
             storage_class=storage_class_name_scope_module,
         ),
@@ -98,8 +100,10 @@ def data_import_cron_with_pvc_source(
 
 
 @pytest.fixture(scope="class")
-def imported_data_source(data_import_cron_pvc_target_namespace):
-    yield DataSource(namespace=data_import_cron_pvc_target_namespace.name, name="target-data-source")
+def imported_data_source(admin_client, data_import_cron_pvc_target_namespace):
+    yield DataSource(
+        namespace=data_import_cron_pvc_target_namespace.name, name="target-data-source", client=admin_client
+    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/storage/fs_overhead/test_fs_overhead.py
+++ b/tests/storage/fs_overhead/test_fs_overhead.py
@@ -86,15 +86,15 @@ def uploaded_cirros_dv(
         volume_mode=DataVolume.VolumeMode.FILE,
         insecure=True,
     ):
-        yield DataVolume(name=dv_name, namespace=namespace.name)
+        yield DataVolume(name=dv_name, namespace=namespace.name, client=namespace.client)
 
 
 @pytest.mark.polarion("CNV-8635")
-def test_import_vm_with_specify_fs_overhead(updated_fs_overhead_20_with_hco, vm_for_fs_overhead_test):
+def test_import_vm_with_specify_fs_overhead(admin_client, updated_fs_overhead_20_with_hco, vm_for_fs_overhead_test):
     vm_metadata = vm_for_fs_overhead_test.data_volume_template["metadata"]
     assert_fs_overhead_added(
         actual_size=get_pvc_size_gib(
-            pvc=PersistentVolumeClaim(name=vm_metadata["name"], namespace=vm_metadata["namespace"])
+            pvc=PersistentVolumeClaim(name=vm_metadata["name"], namespace=vm_metadata["namespace"], client=admin_client)
         ),
         requested_size=bitmath.GiB(
             int(

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -49,7 +49,7 @@ def test_pvc_recreates_after_deletion(fedora_data_volume, namespace, storage_cla
     pvc.delete()
     wait_for_pvc_recreate(pvc=pvc, pvc_creation_timestamp=pvc_original_timestamp)
     if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_function, client=namespace.client):
-        create_dummy_first_consumer_pod(pvc=pvc)
+        create_dummy_first_consumer_pod(client=namespace.client, pvc=pvc)
     fedora_data_volume.wait_for_dv_success()
 
 

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -7,7 +7,6 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
-from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.volume_snapshot import VolumeSnapshot
 
 from tests.os_params import RHEL_LATEST_LABELS
@@ -38,16 +37,6 @@ def get_rhel9_data_import_cron_template(common_templates):
             del updated_template["status"]
             return updated_template
     pytest.fail(f"{RHEL9_STR} system boot source template should exist on HCO")
-
-
-@pytest.fixture(scope="module")
-def skip_if_no_storage_profile_with_snapshot_import_cron_format(
-    admin_client,
-    snapshot_storage_class_name_scope_module,
-):
-    sc_storage_profile = StorageProfile(name=snapshot_storage_class_name_scope_module, client=admin_client)
-    if sc_storage_profile.instance.status.get("dataImportCronSourceFormat") != "snapshot":
-        pytest.skip(f"Cant create cached snapshot for {snapshot_storage_class_name_scope_module} storageclass")
 
 
 @pytest.fixture(scope="module")

--- a/tests/storage/golden_image/test_cached_snapshots.py
+++ b/tests/storage/golden_image/test_cached_snapshots.py
@@ -7,6 +7,7 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.data_import_cron import DataImportCron
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.storage_profile import StorageProfile
 from ocp_resources.volume_snapshot import VolumeSnapshot
 
 from tests.os_params import RHEL_LATEST_LABELS
@@ -37,6 +38,16 @@ def get_rhel9_data_import_cron_template(common_templates):
             del updated_template["status"]
             return updated_template
     pytest.fail(f"{RHEL9_STR} system boot source template should exist on HCO")
+
+
+@pytest.fixture(scope="module")
+def skip_if_no_storage_profile_with_snapshot_import_cron_format(
+    admin_client,
+    snapshot_storage_class_name_scope_module,
+):
+    sc_storage_profile = StorageProfile(name=snapshot_storage_class_name_scope_module, client=admin_client)
+    if sc_storage_profile.instance.status.get("dataImportCronSourceFormat") != "snapshot":
+        pytest.skip(f"Cant create cached snapshot for {snapshot_storage_class_name_scope_module} storageclass")
 
 
 @pytest.fixture(scope="module")
@@ -72,7 +83,9 @@ def updated_templates_rhel9_data_import_cron(
             namespace=golden_images_namespace.name,
             client=admin_client,
         ).clean_up()
-        wait_for_succeeded_dv(namespace=golden_images_namespace.name, dv_name=rhel9_boot_source_name)
+        wait_for_succeeded_dv(
+            namespace=golden_images_namespace.name, dv_name=rhel9_boot_source_name, client=admin_client
+        )
         wait_for_auto_boot_config_stabilization(admin_client=admin_client, hco_namespace=hco_namespace)
 
 
@@ -117,15 +130,18 @@ def rhel9_boot_source_name(rhel9_data_source_scope_session):
 
 @pytest.fixture(scope="module")
 def rhel9_cached_snapshot(
+    admin_client,
     rhel9_boot_source_name,
     golden_images_namespace,
     updated_rhel9_boot_source,
 ):
     # wait for the snapshot to be created
     rhel9_volume_snapshot = wait_for_volume_snapshot_ready_to_use(
-        namespace=golden_images_namespace.name, name=rhel9_boot_source_name
+        namespace=golden_images_namespace.name, name=rhel9_boot_source_name, client=admin_client
     )
-    verify_dv_and_pvc_does_not_exist(name=rhel9_boot_source_name, namespace=golden_images_namespace.name)
+    verify_dv_and_pvc_does_not_exist(
+        name=rhel9_boot_source_name, namespace=golden_images_namespace.name, client=admin_client
+    )
     yield rhel9_volume_snapshot
 
 

--- a/tests/storage/hpp/conftest.py
+++ b/tests/storage/hpp/conftest.py
@@ -122,6 +122,7 @@ def cirros_pvc_on_hpp(cirros_vm_for_node_placement_tests):
     return PersistentVolumeClaim(
         namespace=cirros_vm_for_node_placement_tests.namespace,
         name=cirros_vm_for_node_placement_tests.data_volume_template["metadata"]["name"],
+        client=cirros_vm_for_node_placement_tests.client,
     )
 
 

--- a/tests/storage/hpp/conftest.py
+++ b/tests/storage/hpp/conftest.py
@@ -126,7 +126,8 @@ def cirros_pvc_on_hpp(cirros_vm_for_node_placement_tests):
 
 
 @pytest.fixture()
-def cirros_pv_on_hpp(cirros_pvc_on_hpp):
+def cirros_pv_on_hpp(admin_client, cirros_pvc_on_hpp):
     return PersistentVolume(
         name=cirros_pvc_on_hpp.instance.spec.volumeName,
+        client=admin_client,
     )

--- a/tests/storage/hpp/test_hostpath.py
+++ b/tests/storage/hpp/test_hostpath.py
@@ -77,21 +77,23 @@ def verify_hpp_app_label(hpp_resources, cnv_version):
 
 
 @pytest.fixture(scope="module")
-def hpp_operator_deployment(hco_namespace):
-    hpp_operator_deployment = Deployment(name=HOSTPATH_PROVISIONER_OPERATOR, namespace=hco_namespace.name)
+def hpp_operator_deployment(admin_client, hco_namespace):
+    hpp_operator_deployment = Deployment(
+        name=HOSTPATH_PROVISIONER_OPERATOR, namespace=hco_namespace.name, client=admin_client
+    )
     assert hpp_operator_deployment.exists
     return hpp_operator_deployment
 
 
 @pytest.fixture(scope="module")
-def hpp_prometheus_resources(hco_namespace):
+def hpp_prometheus_resources(admin_client, hco_namespace):
     rbac_name = "hostpath-provisioner-monitoring"
     yield [
-        PrometheusRule(name="prometheus-hpp-rules", namespace=hco_namespace.name),
-        ServiceMonitor(name="service-monitor-hpp", namespace=hco_namespace.name),
-        Service(name="hpp-prometheus-metrics", namespace=hco_namespace.name),
-        Role(name=rbac_name, namespace=hco_namespace.name),
-        RoleBinding(name=rbac_name, namespace=hco_namespace.name),
+        PrometheusRule(name="prometheus-hpp-rules", namespace=hco_namespace.name, client=admin_client),
+        ServiceMonitor(name="service-monitor-hpp", namespace=hco_namespace.name, client=admin_client),
+        Service(name="hpp-prometheus-metrics", namespace=hco_namespace.name, client=admin_client),
+        Role(name=rbac_name, namespace=hco_namespace.name, client=admin_client),
+        RoleBinding(name=rbac_name, namespace=hco_namespace.name, client=admin_client),
     ]
 
 
@@ -101,28 +103,34 @@ def hpp_clusterrole_version_suffix(is_hpp_cr_legacy_scope_module):
 
 
 @pytest.fixture(scope="module")
-def hpp_serviceaccount(hco_namespace, hpp_cr_suffix_scope_module):
+def hpp_serviceaccount(admin_client, hco_namespace, hpp_cr_suffix_scope_module):
     yield ServiceAccount(
         name=f"{HOSTPATH_PROVISIONER_ADMIN}{hpp_cr_suffix_scope_module}",
         namespace=hco_namespace.name,
+        client=admin_client,
     )
 
 
 @pytest.fixture(scope="module")
-def hpp_scc(hpp_cr_suffix_scope_module):
+def hpp_scc(admin_client, hpp_cr_suffix_scope_module):
     yield SecurityContextConstraints(
-        name=f"{HostPathProvisioner.Name.HOSTPATH_PROVISIONER}{hpp_cr_suffix_scope_module}"
+        name=f"{HostPathProvisioner.Name.HOSTPATH_PROVISIONER}{hpp_cr_suffix_scope_module}",
+        client=admin_client,
     )
 
 
 @pytest.fixture(scope="module")
-def hpp_clusterrole(hpp_clusterrole_version_suffix):
-    yield ClusterRole(name=f"{HostPathProvisioner.Name.HOSTPATH_PROVISIONER}{hpp_clusterrole_version_suffix}")
+def hpp_clusterrole(admin_client, hpp_clusterrole_version_suffix):
+    yield ClusterRole(
+        name=f"{HostPathProvisioner.Name.HOSTPATH_PROVISIONER}{hpp_clusterrole_version_suffix}", client=admin_client
+    )
 
 
 @pytest.fixture(scope="module")
-def hpp_clusterrolebinding(hpp_clusterrole_version_suffix):
-    yield ClusterRoleBinding(name=f"{HostPathProvisioner.Name.HOSTPATH_PROVISIONER}{hpp_clusterrole_version_suffix}")
+def hpp_clusterrolebinding(admin_client, hpp_clusterrole_version_suffix):
+    yield ClusterRoleBinding(
+        name=f"{HostPathProvisioner.Name.HOSTPATH_PROVISIONER}{hpp_clusterrole_version_suffix}", client=admin_client
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -156,6 +156,7 @@ def vm_restore(vm, name):
         namespace=vm.namespace,
         vm_name=vm.name,
         snapshot_name=name,
+        client=vm.client,
     ) as restore:
         restore.wait_restore_done()
         running_vm(vm=vm)

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -93,7 +93,7 @@ def dv_cloned_from_datasource(
 
 
 @pytest.fixture()
-def data_volume_clone_settings(destination_namespace, dv_cloned_from_datasource):
+def data_volume_clone_settings(unprivileged_client, destination_namespace, dv_cloned_from_datasource):
     storage_class = dv_cloned_from_datasource.storage_class
     dv = DataVolume(
         name=f"{TARGET_DV}-{storage_class}",
@@ -106,6 +106,7 @@ def data_volume_clone_settings(destination_namespace, dv_cloned_from_datasource)
         size=dv_cloned_from_datasource.size,
         storage_class=storage_class,
         api_name="storage",
+        client=unprivileged_client,
     )
     dv.to_dict()
     return dv

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -33,7 +33,7 @@ from tests.storage.utils import (
 from utilities.constants import Images
 from utilities.constants.images import OS_FLAVOR_FEDORA
 from utilities.constants.pytest import UNPRIVILEGED_USER
-from utilities.constants.storage import PVC
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, PVC
 from utilities.infra import create_ns
 from utilities.storage import construct_datavolume_source_dict, create_dv, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm
@@ -291,6 +291,8 @@ def dv_cloned_by_unprivileged_user_in_the_same_namespace(
         source_pvc_namespace=namespace,
         client=unprivileged_client,
         storage_class=storage_class_name_scope_module,
+        consume_wffc=False,
+        annotations=BIND_IMMEDIATE_ANNOTATION,
     ) as cdv:
         yield cdv
 
@@ -314,6 +316,8 @@ def dv_destination_cloned_from_pvc(
         source_pvc_namespace=dv_cloned_from_datasource.namespace,
         client=unprivileged_client,
         storage_class=storage_class_name_scope_module,
+        consume_wffc=False,
+        annotations=BIND_IMMEDIATE_ANNOTATION,
     ) as cdv:
         cdv.wait_for_dv_success()
         yield cdv

--- a/tests/storage/snapshots/conftest.py
+++ b/tests/storage/snapshots/conftest.py
@@ -86,6 +86,7 @@ def windows_snapshot(
         name="windows-snapshot",
         namespace=windows_vm_with_vtpm_for_snapshot.namespace,
         vm_name=windows_vm_with_vtpm_for_snapshot.name,
+        client=windows_vm_with_vtpm_for_snapshot.client,
     ) as snapshot:
         yield snapshot
 

--- a/tests/storage/snapshots/test_snapshots.py
+++ b/tests/storage/snapshots/test_snapshots.py
@@ -464,6 +464,7 @@ def test_online_windows_vm_successful_restore(
         namespace=windows_vm_with_vtpm_for_snapshot.namespace,
         vm_name=windows_vm_with_vtpm_for_snapshot.name,
         snapshot_name=windows_snapshot.name,
+        client=windows_vm_with_vtpm_for_snapshot.client,
     ) as restore:
         start_windows_vm_after_restore(vm_restore=restore, windows_vm=windows_vm_with_vtpm_for_snapshot)
         assert_windows_directory_existence(
@@ -496,5 +497,6 @@ def test_write_to_file_while_snapshot(
         namespace=windows_vm_with_vtpm_for_snapshot.namespace,
         vm_name=windows_vm_with_vtpm_for_snapshot.name,
         snapshot_name=windows_snapshot.name,
+        client=windows_vm_with_vtpm_for_snapshot.client,
     ) as restore:
         start_windows_vm_after_restore(vm_restore=restore, windows_vm=windows_vm_with_vtpm_for_snapshot)

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -126,8 +126,8 @@ def vm_for_storage_class_migration_with_instance_type(
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_FEDORA,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
-        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
+        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=golden_images_fedora_data_source,
             storage_class=source_storage_class,
@@ -180,6 +180,7 @@ def vm_for_storage_class_migration_from_template_with_dv(
         size=Images.Rhel.DEFAULT_DV_SIZE,
         storage_class=source_storage_class,
         api_name="storage",
+        client=unprivileged_client,
     )
     dv.to_dict()
     with VirtualMachineForTests(

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -109,6 +109,7 @@ def target_storage_class(request, cluster_storage_classes_names):
 
 @pytest.fixture(scope="class")
 def vm_for_storage_class_migration_with_instance_type(
+    admin_client,
     unprivileged_client,
     namespace,
     golden_images_namespace,
@@ -126,8 +127,8 @@ def vm_for_storage_class_migration_with_instance_type(
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_FEDORA,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
-        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=admin_client),
+        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=admin_client),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=golden_images_fedora_data_source,
             storage_class=source_storage_class,
@@ -299,14 +300,19 @@ def blank_disk_dvs_for_storage_migration(unprivileged_client, namespace, source_
 
 @pytest.fixture(scope="class")
 def fedora_vm_for_hotplug_and_storage_migration(
-    unprivileged_client, namespace, fedora_data_source_scope_module, source_storage_class, cpu_for_migration
+    admin_client,
+    unprivileged_client,
+    namespace,
+    fedora_data_source_scope_module,
+    source_storage_class,
+    cpu_for_migration,
 ):
     with VirtualMachineForTests(
         name="fedora-volume-hotplug-vm",
         namespace=namespace.name,
         client=unprivileged_client,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
-        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=admin_client),
+        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=admin_client),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=fedora_data_source_scope_module,
             storage_class=source_storage_class,

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -109,7 +109,6 @@ def target_storage_class(request, cluster_storage_classes_names):
 
 @pytest.fixture(scope="class")
 def vm_for_storage_class_migration_with_instance_type(
-    admin_client,
     unprivileged_client,
     namespace,
     golden_images_namespace,
@@ -127,8 +126,8 @@ def vm_for_storage_class_migration_with_instance_type(
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_FEDORA,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=admin_client),
-        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=admin_client),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
+        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=golden_images_fedora_data_source,
             storage_class=source_storage_class,
@@ -300,19 +299,14 @@ def blank_disk_dvs_for_storage_migration(unprivileged_client, namespace, source_
 
 @pytest.fixture(scope="class")
 def fedora_vm_for_hotplug_and_storage_migration(
-    admin_client,
-    unprivileged_client,
-    namespace,
-    fedora_data_source_scope_module,
-    source_storage_class,
-    cpu_for_migration,
+    unprivileged_client, namespace, fedora_data_source_scope_module, source_storage_class, cpu_for_migration
 ):
     with VirtualMachineForTests(
         name="fedora-volume-hotplug-vm",
         namespace=namespace.name,
         client=unprivileged_client,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=admin_client),
-        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=admin_client),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
+        vm_preference=VirtualMachineClusterPreference(name=OS_FLAVOR_FEDORA, client=unprivileged_client),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=fedora_data_source_scope_module,
             storage_class=source_storage_class,

--- a/tests/storage/test_cdi_certificate.py
+++ b/tests/storage/test_cdi_certificate.py
@@ -90,7 +90,9 @@ def valid_aggregated_api_client_cert(kube_system_namespace):
     """
     aggregated_cm = "extension-apiserver-authentication"
     cert_end = "-----END CERTIFICATE-----\n"
-    cm_data = ConfigMap(namespace=kube_system_namespace.name, name=aggregated_cm).instance["data"]
+    cm_data = ConfigMap(
+        namespace=kube_system_namespace.name, name=aggregated_cm, client=kube_system_namespace.client
+    ).instance["data"]
     for cert_attr, cert_data in cm_data.items():
         if "ca-file" not in cert_attr:
             continue
@@ -260,7 +262,7 @@ def test_upload_after_validate_aggregated_api_cert(
         insecure=True,
     ) as res:
         check_upload_virtctl_result(result=res)
-        dv = DataVolume(namespace=namespace.name, name=dv_name)
+        dv = DataVolume(namespace=namespace.name, name=dv_name, client=unprivileged_client)
         dv.wait_for_dv_success(timeout=TIMEOUT_1MIN)
         create_vm_from_dv(client=unprivileged_client, dv=dv)
 

--- a/tests/storage/test_data_import_cron.py
+++ b/tests/storage/test_data_import_cron.py
@@ -33,20 +33,20 @@ RHEL8_DIGEST = "947541648d7f12fd56d2224d55ce708d369f76ffeb4938c8846b287197f30970
 LOGGER = logging.getLogger(__name__)
 
 
-def wait_for_succeeded_imported_object(namespace, name, storage_with_import_cron_source_snapshot):
+def wait_for_succeeded_imported_object(namespace, name, storage_with_import_cron_source_snapshot, client):
     if storage_with_import_cron_source_snapshot:
-        wait_for_volume_snapshot_ready_to_use(namespace=namespace, name=name)
+        wait_for_volume_snapshot_ready_to_use(namespace=namespace, name=name, client=client)
     else:
-        wait_for_succeeded_dv(namespace=namespace, dv_name=name)
+        wait_for_succeeded_dv(namespace=namespace, dv_name=name, client=client)
 
 
-def assert_first_imported_object_was_deleted(namespace, name):
+def assert_first_imported_object_was_deleted(namespace, name, client):
     samples = TimeoutSampler(
         wait_timeout=TIMEOUT_3MIN,
         sleep=TIMEOUT_5SEC,
         func=lambda: (
-            PersistentVolumeClaim(namespace=namespace, name=name).exists
-            or VolumeSnapshot(namespace=namespace, name=name).exists
+            PersistentVolumeClaim(namespace=namespace, name=name, client=client).exists
+            or VolumeSnapshot(namespace=namespace, name=name, client=client).exists
         ),
     )
     try:
@@ -60,9 +60,10 @@ def assert_first_imported_object_was_deleted(namespace, name):
 
 @pytest.fixture()
 def storage_with_import_cron_source_snapshot(
+    admin_client,
     storage_class_name_scope_function,
 ):
-    sc_storage_profile = StorageProfile(name=storage_class_name_scope_function)
+    sc_storage_profile = StorageProfile(name=storage_class_name_scope_function, client=admin_client)
     yield sc_storage_profile.instance.status.get("dataImportCronSourceFormat") == "snapshot"
 
 
@@ -83,6 +84,7 @@ def rhel8_image_stream(admin_client, namespace):
         name=RHEL8_IMAGE_STREAM,
         namespace=namespace.name,
         tags=tags,
+        client=admin_client,
     ) as image_stream:
         yield image_stream
 
@@ -139,11 +141,12 @@ def first_object_name(rhel8_latest_image_truncated_sha_from_image_stream):
 
 
 @pytest.fixture()
-def first_imported_object(namespace, first_object_name, storage_with_import_cron_source_snapshot):
+def first_imported_object(admin_client, namespace, first_object_name, storage_with_import_cron_source_snapshot):
     wait_for_succeeded_imported_object(
         namespace=namespace.name,
         name=first_object_name,
         storage_with_import_cron_source_snapshot=storage_with_import_cron_source_snapshot,
+        client=admin_client,
     )
 
 
@@ -154,6 +157,7 @@ def second_object_name():
 
 @pytest.fixture()
 def second_imported_object(
+    admin_client,
     namespace,
     second_object_name,
     storage_with_import_cron_source_snapshot,
@@ -162,6 +166,7 @@ def second_imported_object(
         namespace=namespace.name,
         name=second_object_name,
         storage_with_import_cron_source_snapshot=storage_with_import_cron_source_snapshot,
+        client=admin_client,
     )
 
 
@@ -205,6 +210,7 @@ def second_object_cleanup(
 @pytest.mark.polarion("CNV-7602")
 @pytest.mark.s390x
 def test_data_import_cron_garbage_collection(
+    admin_client,
     namespace,
     second_object_cleanup,
     rhel8_image_stream,
@@ -216,8 +222,8 @@ def test_data_import_cron_garbage_collection(
     second_object_name,
     storage_with_import_cron_source_snapshot,
 ):
-    assert_first_imported_object_was_deleted(namespace=namespace.name, name=first_object_name)
+    assert_first_imported_object_was_deleted(namespace=namespace.name, name=first_object_name, client=admin_client)
     resource_class = VolumeSnapshot if storage_with_import_cron_source_snapshot else PersistentVolumeClaim
-    assert resource_class(namespace=namespace.name, name=second_object_name).exists, (
+    assert resource_class(namespace=namespace.name, name=second_object_name, client=admin_client).exists, (
         f"Second {resource_class.kind} '{second_object_name}' does not exist"
     )

--- a/tests/storage/test_data_import_cron.py
+++ b/tests/storage/test_data_import_cron.py
@@ -194,6 +194,7 @@ def rhel8_image_stream_digest_update(rhel8_image_stream):
 
 @pytest.fixture()
 def second_object_cleanup(
+    admin_client,
     namespace,
     second_object_name,
     storage_with_import_cron_source_snapshot,
@@ -204,7 +205,7 @@ def second_object_cleanup(
         f"(DV/PVC or VolumeSnapshot) that was created by the DataImportCron"
     )
     resource_class = VolumeSnapshot if storage_with_import_cron_source_snapshot else DataVolume
-    resource_class(namespace=namespace.name, name=second_object_name).clean_up()
+    resource_class(namespace=namespace.name, name=second_object_name, client=admin_client).clean_up()
 
 
 @pytest.mark.polarion("CNV-7602")

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -46,8 +46,11 @@ pytestmark = [
 ]
 
 
-def is_dv_migratable(dv):
-    return StorageProfile(name=dv.storage_class).first_claim_property_set_access_modes()[0] == DataVolume.AccessMode.RWX
+def is_dv_migratable(dv: DataVolume, client: DynamicClient) -> bool:
+    return (
+        StorageProfile(name=dv.storage_class, client=client).first_claim_property_set_access_modes()[0]
+        == DataVolume.AccessMode.RWX
+    )
 
 
 @pytest.fixture(scope="module")
@@ -273,7 +276,7 @@ class TestHotPlugWithPersist:
         blank_disk_dv_multi_storage_scope_class: DataVolume,
         fedora_vm_for_hotplug_scope_class: VirtualMachineForTests,
     ):
-        if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
+        if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class, client=admin_client):
             migrate_vm_and_verify(
                 vm=fedora_vm_for_hotplug_scope_class, client=admin_client, check_ssh_connectivity=True
             )
@@ -364,7 +367,7 @@ class TestHotPlugWithSerialPersist:
         Expected:
             - All hotplugged volumes are ready and their disk serials are visible after migration
         """
-        if all(is_dv_migratable(dv=dv) for dv in hotplugged_dvs_scope_class):
+        if all(is_dv_migratable(dv=dv, client=admin_client) for dv in hotplugged_dvs_scope_class):
             migrate_vm_and_verify(
                 vm=fedora_vm_for_hotplug_scope_class, client=admin_client, check_ssh_connectivity=True
             )
@@ -452,7 +455,7 @@ class TestHotPlugWindows:
         blank_disk_dv_multi_storage_scope_class: DataVolume,
         vm_instance_multi_storage_scope_class: VirtualMachineForTests,
     ):
-        if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class):
+        if is_dv_migratable(dv=blank_disk_dv_multi_storage_scope_class, client=admin_client):
             migrate_vm_and_verify(
                 vm=vm_instance_multi_storage_scope_class,
                 client=admin_client,

--- a/tests/storage/test_wffc.py
+++ b/tests/storage/test_wffc.py
@@ -57,7 +57,9 @@ def blank_dv_wffc_scope_function(request, unprivileged_client, namespace, wffc_s
 
 
 @pytest.fixture()
-def blank_dv_template_wffc_scope_function(request, namespace, wffc_storage_class_name_scope_module):
+def blank_dv_template_wffc_scope_function(
+    request, unprivileged_client, namespace, wffc_storage_class_name_scope_module
+):
     blank_dv_template = DataVolume(
         name=f"dv-{request.param['dv_name']}",
         namespace=namespace.name,
@@ -65,6 +67,7 @@ def blank_dv_template_wffc_scope_function(request, namespace, wffc_storage_class
         size=DEFAULT_BLANK_DV_SIZE,
         storage_class=wffc_storage_class_name_scope_module,
         api_name="storage",
+        client=unprivileged_client,
     )
     blank_dv_template.to_dict()
     return blank_dv_template.res

--- a/tests/storage/vm_export/conftest.py
+++ b/tests/storage/vm_export/conftest.py
@@ -211,9 +211,10 @@ def rhel_vm_for_snapshot_with_content(
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_RHEL,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
         vm_preference=VirtualMachineClusterPreference(
             name=py_config["latest_instance_type_rhel_os_dict"][PREFERENCE_STR],
+            client=unprivileged_client,
         ),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=latest_rhel_data_source,

--- a/tests/storage/vm_export/conftest.py
+++ b/tests/storage/vm_export/conftest.py
@@ -201,7 +201,6 @@ def vmexport_download_path(tmp_path):
 
 @pytest.fixture()
 def rhel_vm_for_snapshot_with_content(
-    admin_client,
     unprivileged_client,
     namespace,
     latest_rhel_data_source,
@@ -212,10 +211,10 @@ def rhel_vm_for_snapshot_with_content(
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_RHEL,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=admin_client),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
         vm_preference=VirtualMachineClusterPreference(
             name=py_config["latest_instance_type_rhel_os_dict"][PREFERENCE_STR],
-            client=admin_client,
+            client=unprivileged_client,
         ),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=latest_rhel_data_source,

--- a/tests/storage/vm_export/conftest.py
+++ b/tests/storage/vm_export/conftest.py
@@ -201,6 +201,7 @@ def vmexport_download_path(tmp_path):
 
 @pytest.fixture()
 def rhel_vm_for_snapshot_with_content(
+    admin_client,
     unprivileged_client,
     namespace,
     latest_rhel_data_source,
@@ -211,10 +212,10 @@ def rhel_vm_for_snapshot_with_content(
         namespace=namespace.name,
         client=unprivileged_client,
         os_flavor=OS_FLAVOR_RHEL,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=unprivileged_client),
+        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL, client=admin_client),
         vm_preference=VirtualMachineClusterPreference(
             name=py_config["latest_instance_type_rhel_os_dict"][PREFERENCE_STR],
-            client=unprivileged_client,
+            client=admin_client,
         ),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=latest_rhel_data_source,

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -73,15 +73,23 @@ LOGGER = logging.getLogger(__name__)
 _DEFAULT_DISK_SERIAL_COMMAND = shlex.split("sudo ls /dev/disk/by-id")
 
 
-def create_dummy_first_consumer_pod(volume_mode=DataVolume.VolumeMode.FILE, dv=None, pvc=None):
+def create_dummy_first_consumer_pod(
+    client: DynamicClient,
+    volume_mode: str = DataVolume.VolumeMode.FILE,
+    dv: DataVolume | None = None,
+    pvc: PersistentVolumeClaim | None = None,
+) -> None:
     """
-    Create a dummy pod that will become the PVCs first consumer
-    Triggers start of CDI worker pod
+    Create a dummy pod that will become the PVCs first consumer.
 
-    To consume PVCs that are not backed by DVs, just pass in pvc param
-    Otherwise, it is needed to pass in dv
+    Triggers start of CDI worker pod.
+
+    Args:
+        client: Kubernetes client to use for creating the pod.
+        volume_mode: Volume mode for the PVC mount.
+        dv: DataVolume to consume. Mutually exclusive with pvc.
+        pvc: PVC to consume directly. Mutually exclusive with dv.
     """
-
     if not (pvc or dv):
         raise ValueError("Exactly one of the args: (dv,pvc) must be passed")
     if dv:
@@ -98,13 +106,15 @@ def create_dummy_first_consumer_pod(volume_mode=DataVolume.VolumeMode.FILE, dv=N
         ):
             if sample:
                 break
-    pvc = pvc or dv.pvc
+        pvc = pvc or dv.pvc
+    if not pvc:
+        raise ValueError("Could not resolve PVC from provided arguments")
     with PodWithPVC(
         namespace=pvc.namespace,
         name=f"first-consumer-{pvc.name}",
         pvc_name=pvc.name,
         containers=get_containers_for_pods_with_pvc(volume_mode=volume_mode, pvc_name=pvc.name),
-        client=pvc.client,
+        client=client,
     ) as pod:
         LOGGER.info(
             f"Created dummy pod {pod.name} to be the first consumer of the PVC, "
@@ -279,7 +289,7 @@ def create_dv(
             source_dict=source_dict,
         ) as dv:
             if storage_class and sc_volume_binding_mode_is_wffc(sc=storage_class, client=client) and consume_wffc:
-                create_dummy_first_consumer_pod(dv=dv)
+                create_dummy_first_consumer_pod(client=client, dv=dv)
             yield dv
 
     finally:

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -104,6 +104,7 @@ def create_dummy_first_consumer_pod(volume_mode=DataVolume.VolumeMode.FILE, dv=N
         name=f"first-consumer-{pvc.name}",
         pvc_name=pvc.name,
         containers=get_containers_for_pods_with_pvc(volume_mode=volume_mode, pvc_name=pvc.name),
+        client=pvc.client,
     ) as pod:
         LOGGER.info(
             f"Created dummy pod {pod.name} to be the first consumer of the PVC, "
@@ -535,7 +536,9 @@ def virtctl_upload_dv(
         f"--size={size}",
     ]
     resource_to_cleanup = (
-        PersistentVolumeClaim(namespace=namespace, name=name) if pvc else DataVolume(namespace=namespace, name=name)
+        PersistentVolumeClaim(namespace=namespace, name=name, client=client)
+        if pvc
+        else DataVolume(namespace=namespace, name=name, client=client)
     )
     if pvc:
         command[1] = "pvc"
@@ -707,9 +710,9 @@ def overhead_size_for_dv(image_size, overhead_value):
     return f"{math.ceil(dv_size)}Mi"
 
 
-def cdi_feature_gate_list_with_added_feature(feature):
+def cdi_feature_gate_list_with_added_feature(feature: str, client: DynamicClient) -> list[str]:
     return [
-        *CDIConfig(name="config").instance.to_dict().get("spec", {}).get("featureGates", []),
+        *CDIConfig(name="config", client=client).instance.to_dict().get("spec", {}).get("featureGates", []),
         feature,
     ]
 
@@ -1119,14 +1122,16 @@ def wait_for_cdi_worker_pod(pod_name, storage_ns_name, admin_client):
         raise
 
 
-def get_storage_class_with_specified_volume_mode(volume_mode, sc_names):
+def get_storage_class_with_specified_volume_mode(volume_mode: str, sc_names: list[str], client: DynamicClient) -> str:
     sc_with_volume_mode = f"Storage class with volume mode '{volume_mode}'"
     for storage_class_name in sc_names:
-        for claim_property_set in StorageProfile(name=storage_class_name).instance.status["claimPropertySets"]:
+        for claim_property_set in StorageProfile(name=storage_class_name, client=client).instance.status[
+            "claimPropertySets"
+        ]:
             if claim_property_set["volumeMode"] == volume_mode:
                 LOGGER.info(f"{sc_with_volume_mode}: '{storage_class_name}'")
                 return storage_class_name
-    LOGGER.error(f"No {sc_with_volume_mode} among {sc_names}")
+    raise ValueError(f"No {sc_with_volume_mode} among {sc_names}")
 
 
 @contextmanager
@@ -1182,9 +1187,9 @@ def update_default_sc(default, storage_class):
         yield
 
 
-def verify_dv_and_pvc_does_not_exist(name, namespace, timeout=TIMEOUT_10MIN):
-    dv = DataVolume(namespace=namespace, name=name)
-    pvc = PersistentVolumeClaim(namespace=namespace, name=name)
+def verify_dv_and_pvc_does_not_exist(name: str, namespace: str, client: DynamicClient, timeout: int = TIMEOUT_10MIN):
+    dv = DataVolume(namespace=namespace, name=name, client=client)
+    pvc = PersistentVolumeClaim(namespace=namespace, name=name, client=client)
 
     samples = TimeoutSampler(wait_timeout=timeout, sleep=TIMEOUT_5SEC, func=lambda: dv.exists or pvc.exists)
     try:
@@ -1196,10 +1201,10 @@ def verify_dv_and_pvc_does_not_exist(name, namespace, timeout=TIMEOUT_10MIN):
         raise
 
 
-def wait_for_volume_snapshot_ready_to_use(namespace, name):
+def wait_for_volume_snapshot_ready_to_use(namespace: str, name: str, client: DynamicClient):
     ready_to_use_status = "readyToUse"
     LOGGER.info(f"Wait for VolumeSnapshot '{name}' in '{namespace}' to be '{ready_to_use_status}'")
-    volume_snapshot = VolumeSnapshot(namespace=namespace, name=name)
+    volume_snapshot = VolumeSnapshot(namespace=namespace, name=name, client=client)
     volume_snapshot.wait(timeout=TIMEOUT_10MIN)
     try:
         for sample in TimeoutSampler(
@@ -1216,8 +1221,8 @@ def wait_for_volume_snapshot_ready_to_use(namespace, name):
         raise
 
 
-def wait_for_succeeded_dv(namespace, dv_name):
-    dv = DataVolume(namespace=namespace, name=dv_name)
+def wait_for_succeeded_dv(namespace: str, dv_name: str, client: DynamicClient):
+    dv = DataVolume(namespace=namespace, name=dv_name, client=client)
     try:
         samples = TimeoutSampler(
             wait_timeout=TIMEOUT_2MIN,
@@ -1328,6 +1333,7 @@ def vm_snapshot(vm, name):
         name=name,
         namespace=vm.namespace,
         vm_name=vm.name,
+        client=vm.client,
     ) as snapshot:
         snapshot.wait_snapshot_done()
         virt_util.running_vm(vm=vm, wait_for_interfaces=False)

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1204,7 +1204,7 @@ def verify_dv_and_pvc_does_not_exist(name: str, namespace: str, client: DynamicC
         raise
 
 
-def wait_for_volume_snapshot_ready_to_use(namespace: str, name: str, client: DynamicClient):
+def wait_for_volume_snapshot_ready_to_use(namespace: str, name: str, client: DynamicClient) -> VolumeSnapshot:
     ready_to_use_status = "readyToUse"
     LOGGER.info(f"Wait for VolumeSnapshot '{name}' in '{namespace}' to be '{ready_to_use_status}'")
     volume_snapshot = VolumeSnapshot(namespace=namespace, name=name, client=client)

--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -1122,7 +1122,9 @@ def wait_for_cdi_worker_pod(pod_name, storage_ns_name, admin_client):
         raise
 
 
-def get_storage_class_with_specified_volume_mode(volume_mode: str, sc_names: list[str], client: DynamicClient) -> str:
+def get_storage_class_with_specified_volume_mode(
+    volume_mode: str, sc_names: list[str], client: DynamicClient
+) -> str | None:
     sc_with_volume_mode = f"Storage class with volume mode '{volume_mode}'"
     for storage_class_name in sc_names:
         for claim_property_set in StorageProfile(name=storage_class_name, client=client).instance.status[
@@ -1131,7 +1133,8 @@ def get_storage_class_with_specified_volume_mode(volume_mode: str, sc_names: lis
             if claim_property_set["volumeMode"] == volume_mode:
                 LOGGER.info(f"{sc_with_volume_mode}: '{storage_class_name}'")
                 return storage_class_name
-    raise ValueError(f"No {sc_with_volume_mode} among {sc_names}")
+    LOGGER.error(f"No {sc_with_volume_mode} among {sc_names}")
+    return None
 
 
 @contextmanager


### PR DESCRIPTION
##### What this PR does / why we need it:
Pass an explicit DynamicClient to all ocp_resources constructors in tests/storage/, utilities/storage.py, and tests/data_protection/oadp/ so resource creation does not fall back to implicit get_client(). 

The client is selected based following these criteria:
- `admin_client` for cluster-scoped resources and admin operations
- `unprivileged_client` for test resources that verify RBAC
- `resource.client` when a parent resource already has the correct client

##### Which issue(s) this PR fixes:
Not issue at all. 
In the next major release, all the openshift wrapper constructor will have a mandatory `client` arg. So in this PR we're fixing all the methods where the `client` is not passed.
##### Special notes for reviewer:
The PR is quite big (19 files modified) but the changes are really simple, most of them are just adding a client to method signatures, so nothing complex.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-68536
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of storage, snapshot, upload, migration, restore, and volume-resize validation.
  * Corrected resource access handling across administrative and restricted-namespace scenarios.
  * Improved volume binding behavior for cloning, importing, and test provisioning workflows.

* **Tests**
  * Expanded coverage for storage-class selection, cached snapshots, hostpath provisioning, data protection, CDI configuration, and concurrent uploads.
  * Added stronger validation for resource cleanup, readiness, garbage collection, and missing storage configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->