### PR TITLE
[4.22] Update must-gather test to use renamed node IP file ip_addr

### DIFF
--- a/tests/install_upgrade_operators/must_gather/test_must_gather.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather.py
@@ -250,7 +250,7 @@ class TestMustGatherCluster:
             ),
             pytest.param(
                 ["ip", "a"],
-                "ip.txt",
+                "ip_addr",
                 "not_empty",
                 marks=(pytest.mark.polarion("CNV-2732"),),
                 id="test_nodes_ip_data",


### PR DESCRIPTION


##### What this PR does / why we need it:

- Observed on s390x CNV 4.22 post-upgrade IUO run: `test_node_resource[*test_nodes_ip_data]` failed looking for `nodes/<node>/ip.txt` while must-gather wrote `ip_addr` (valid `ip a` content)
- Fixed `ip.txt` file name to `ip_addr` after must-gather rename

##### Which issue(s) this PR fixes:

- `test_node_resource[*test_nodes_ip_data]` `FileNotFoundError` for `nodes/<node>/ip.txt` on s390x / CNV 4.22

##### Special notes for reviewer:

Same must-gather rename already fixed on main via #5633; needed on 4.22 as well

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
