### PR TITLE
feat(scripts): add CodeRabbit rate limit CLI tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: flake8
         language_version: python3.14
         args: [--config=.flake8]
-        exclude: "(utilities/unittests/|utilities/junit_ai_utils\\.py|scripts/std_placeholder_stats/tests/)"
+        exclude: "(utilities/unittests/|utilities/junit_ai_utils\\.py|scripts/std_placeholder_stats/tests/|scripts/coderabbit_rate_limit/tests/)"
         additional_dependencies:
           [
             "git+https://github.com/RedHatQE/flake8-plugins.git@v1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ dependencies = [
   "pytest-html>=4.1.1",
   "openshift-python-wrapper>=11.0.132",
   "cachetools>=6.2.2",
+  "myk-pi-tools",
   "dacite>=1.9.2",
   "python-dotenv>=1.2.1",
   "pytest-jira>=0.3.22",
@@ -140,6 +141,7 @@ utilities-test = [
 quarantine-dashboard = "scripts.quarantine_stats.generate_dashboard:main"
 pytest-marker-analyzer = "scripts.tests_analyzer.pytest_marker_analyzer:main"
 compare-coderabbit-decisions = "scripts.tests_analyzer.compare_coderabbit_decisions:main"
+coderabbit-rate-limit = "scripts.coderabbit_rate_limit.coderabbit_rate_limit:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["libs", "scripts", "tests", "utilities"]

--- a/scripts/coderabbit_rate_limit/README.md
+++ b/scripts/coderabbit_rate_limit/README.md
@@ -5,12 +5,14 @@ CLI tool for detecting and recovering from CodeRabbit rate limiting and reviews-
 ## Prerequisites
 
 - `gh` CLI authenticated with a token that has `pull-requests:write` scope
+- `uv` for running the tool (`uv run coderabbit-rate-limit ...`)
+- `jq` (optional, used in the recovery workflow example)
 
 ## Commands
 
 ### check
 
-Detect rate limiting or reviews-paused state on a PR. Outputs JSON to stdout.
+Detect rate-limited or reviews-paused states on a PR. Outputs JSON to stdout.
 
 ```bash
 uv run coderabbit-rate-limit check <owner/repo> <pr_number>

--- a/scripts/coderabbit_rate_limit/README.md
+++ b/scripts/coderabbit_rate_limit/README.md
@@ -57,3 +57,7 @@ uv run coderabbit-rate-limit trigger RedHatQE/openshift-virtualization-tests 586
 # 2b. If reviews paused — resume
 uv run coderabbit-rate-limit resume RedHatQE/openshift-virtualization-tests 5869
 ```
+
+## Credits
+
+Built on [myk-pi-tools](https://github.com/myk-org/pi-config) — all rate limit detection, wait time parsing, review triggering, and polling logic is provided by `myk_pi_tools.coderabbit`.

--- a/scripts/coderabbit_rate_limit/README.md
+++ b/scripts/coderabbit_rate_limit/README.md
@@ -1,0 +1,59 @@
+# CodeRabbit Rate Limit Handler
+
+CLI tool for detecting and recovering from CodeRabbit rate limiting and reviews-paused states on pull requests.
+
+## Prerequisites
+
+- `gh` CLI authenticated with a token that has `pull-requests:write` scope
+
+## Commands
+
+### check
+
+Detect rate limiting or reviews-paused state on a PR. Outputs JSON to stdout.
+
+```bash
+uv run coderabbit-rate-limit check <owner/repo> <pr_number>
+```
+
+**JSON output shapes:**
+
+| State | Output |
+|-------|--------|
+| Clear | `{"rate_limited": false, "reviews_paused": false}` |
+| Rate limited | `{"rate_limited": true, "reviews_paused": false, "wait_seconds": N, "comment_id": N}` |
+| Reviews paused | `{"rate_limited": false, "reviews_paused": true, "comment_id": N}` |
+
+Exit code `0` on success (JSON written), `1` on error.
+
+### trigger
+
+Wait then re-trigger a CodeRabbit review. Polls until review starts (max 10 minutes).
+
+```bash
+uv run coderabbit-rate-limit trigger <owner/repo> <pr_number> --wait <seconds>
+```
+
+Add ~30 seconds buffer to the `wait_seconds` from `check` output.
+
+### resume
+
+Resume paused CodeRabbit reviews by posting `@coderabbitai resume`.
+
+```bash
+uv run coderabbit-rate-limit resume <owner/repo> <pr_number>
+```
+
+## Typical Recovery Workflow
+
+```bash
+# 1. Check if rate limited
+result=$(uv run coderabbit-rate-limit check RedHatQE/openshift-virtualization-tests 5869)
+
+# 2a. If rate limited — wait and trigger
+wait=$(echo "$result" | jq '.wait_seconds')
+uv run coderabbit-rate-limit trigger RedHatQE/openshift-virtualization-tests 5869 --wait $((wait + 30))
+
+# 2b. If reviews paused — resume
+uv run coderabbit-rate-limit resume RedHatQE/openshift-virtualization-tests 5869
+```

--- a/scripts/coderabbit_rate_limit/__init__.py
+++ b/scripts/coderabbit_rate_limit/__init__.py
@@ -1,0 +1,1 @@
+# skip-unused-code

--- a/scripts/coderabbit_rate_limit/coderabbit_rate_limit.py
+++ b/scripts/coderabbit_rate_limit/coderabbit_rate_limit.py
@@ -1,0 +1,99 @@
+"""CodeRabbit rate limit handler — thin wrapper around myk-pi-tools.
+
+CLI tool to detect and handle CodeRabbit rate limiting on pull requests.
+Delegates to myk_pi_tools.coderabbit for all logic.
+
+Usage:
+    uv run coderabbit-rate-limit check RedHatQE/openshift-virtualization-tests 5869
+    uv run coderabbit-rate-limit trigger RedHatQE/openshift-virtualization-tests 5869 --wait 330
+    uv run coderabbit-rate-limit resume RedHatQE/openshift-virtualization-tests 5869
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+from myk_pi_tools.coderabbit.rate_limit import run_check, run_trigger
+from myk_pi_tools.coderabbit.utils import run_gh, validate_owner_repo
+from simple_logger.logger import get_logger
+
+LOGGER = get_logger(name=__name__)
+
+
+def _run_resume(owner_repo: str, pr_number: int) -> int:
+    """Resume paused CodeRabbit reviews on a PR.
+
+    Args:
+        owner_repo: Repository in 'owner/repo' format.
+        pr_number: Pull request number.
+
+    Returns:
+        Exit code (0 = success, 1 = error).
+    """
+    if not validate_owner_repo(owner_repo=owner_repo):
+        return 1
+
+    owner, repo = owner_repo.split("/")
+    LOGGER.info("Posting @coderabbitai resume...")
+    exit_code, stdout, stderr = run_gh(
+        args=[
+            "api",
+            f"repos/{owner}/{repo}/issues/{pr_number}/comments",
+            "-f",
+            "body=@coderabbitai resume",
+        ],
+        timeout=30,
+    )
+    if exit_code != 0:
+        LOGGER.error(f"Failed to post resume trigger: {stderr}")
+        return 1
+
+    try:
+        comment_id = json.loads(stdout).get("id")
+    except json.JSONDecodeError, AttributeError:
+        comment_id = None
+
+    LOGGER.info(f"Resume trigger posted (comment ID: {comment_id}).")
+    return 0
+
+
+@click.group()
+def main() -> None:
+    """CodeRabbit rate limit handler."""
+
+
+@main.command("check")
+@click.argument("owner_repo")
+@click.argument("pr_number", type=int)
+def check_command(owner_repo: str, pr_number: int) -> None:
+    """Check if CodeRabbit is rate limited or reviews are paused on a PR.
+
+    Outputs JSON to stdout with rate limit status and wait time.
+    """
+    sys.exit(run_check(owner_repo=owner_repo, pr_number=pr_number))
+
+
+@main.command("trigger")
+@click.argument("owner_repo")
+@click.argument("pr_number", type=int)
+@click.option("--wait", "wait_seconds", type=int, default=0, help="Seconds to wait before posting review trigger.")
+def trigger_command(owner_repo: str, pr_number: int, wait_seconds: int) -> None:
+    """Wait and trigger a CodeRabbit review on a PR.
+
+    Waits the specified duration, posts @coderabbitai review,
+    then polls until the review starts (max 10 minutes).
+    """
+    sys.exit(run_trigger(owner_repo=owner_repo, pr_number=pr_number, wait_seconds=wait_seconds))
+
+
+@main.command("resume")
+@click.argument("owner_repo")
+@click.argument("pr_number", type=int)
+def resume_command(owner_repo: str, pr_number: int) -> None:
+    """Resume paused CodeRabbit reviews on a PR.
+
+    Posts @coderabbitai resume to unblock paused reviews.
+    """
+    sys.exit(_run_resume(owner_repo=owner_repo, pr_number=pr_number))

--- a/scripts/coderabbit_rate_limit/coderabbit_rate_limit.py
+++ b/scripts/coderabbit_rate_limit/coderabbit_rate_limit.py
@@ -11,8 +11,8 @@ Usage:
 
 from __future__ import annotations
 
-import json
 import sys
+from json import JSONDecodeError, loads
 
 import click
 from myk_pi_tools.coderabbit.rate_limit import run_check, run_trigger
@@ -51,8 +51,10 @@ def _run_resume(owner_repo: str, pr_number: int) -> int:
         return 1
 
     try:
-        comment_id = json.loads(stdout).get("id")
-    except json.JSONDecodeError, AttributeError:
+        comment_id = loads(stdout).get("id")
+    except JSONDecodeError:
+        comment_id = None
+    except AttributeError:
         comment_id = None
 
     LOGGER.info(f"Resume trigger posted (comment ID: {comment_id}).")
@@ -78,7 +80,13 @@ def check_command(owner_repo: str, pr_number: int) -> None:
 @main.command("trigger")
 @click.argument("owner_repo")
 @click.argument("pr_number", type=int)
-@click.option("--wait", "wait_seconds", type=int, default=0, help="Seconds to wait before posting review trigger.")
+@click.option(
+    "--wait",
+    "wait_seconds",
+    type=click.IntRange(min=0),
+    default=0,
+    help="Seconds to wait before posting review trigger.",
+)
 def trigger_command(owner_repo: str, pr_number: int, wait_seconds: int) -> None:
     """Wait and trigger a CodeRabbit review on a PR.
 

--- a/scripts/coderabbit_rate_limit/tests/__init__.py
+++ b/scripts/coderabbit_rate_limit/tests/__init__.py
@@ -1,0 +1,1 @@
+# skip-unused-code

--- a/scripts/coderabbit_rate_limit/tests/pytest.ini
+++ b/scripts/coderabbit_rate_limit/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# Isolate these tests from the project's top-level conftest.py
+# which requires an OpenShift cluster connection.

--- a/scripts/coderabbit_rate_limit/tests/test_coderabbit_rate_limit.py
+++ b/scripts/coderabbit_rate_limit/tests/test_coderabbit_rate_limit.py
@@ -1,0 +1,71 @@
+"""Tests for the local resume flow in coderabbit_rate_limit."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from scripts.coderabbit_rate_limit.coderabbit_rate_limit import _run_resume
+
+
+class TestRunResume:
+    """Tests for _run_resume function."""
+
+    def test_invalid_owner_repo_no_slash(self) -> None:
+        """Test that owner/repo without slash returns exit code 1."""
+        assert _run_resume(owner_repo="invalid", pr_number=1) == 1
+
+    def test_invalid_owner_repo_empty(self) -> None:
+        """Test that empty owner/repo returns exit code 1."""
+        assert _run_resume(owner_repo="", pr_number=1) == 1
+
+    def test_invalid_owner_repo_too_many_slashes(self) -> None:
+        """Test that owner/repo with too many slashes returns exit code 1."""
+        assert _run_resume(owner_repo="a/b/c", pr_number=1) == 1
+
+    def test_gh_api_failure(self) -> None:
+        """Test that GitHub API failure returns exit code 1."""
+        mock_run_gh = MagicMock(return_value=(1, "", "API error"))
+        with patch(
+            "scripts.coderabbit_rate_limit.coderabbit_rate_limit.run_gh",
+            mock_run_gh,
+        ):
+            assert _run_resume(owner_repo="owner/repo", pr_number=123) == 1
+
+    def test_successful_resume(self) -> None:
+        """Test that successful resume returns exit code 0."""
+        mock_run_gh = MagicMock(return_value=(0, '{"id": 42}', ""))
+        with patch(
+            "scripts.coderabbit_rate_limit.coderabbit_rate_limit.run_gh",
+            mock_run_gh,
+        ):
+            result = _run_resume(owner_repo="owner/repo", pr_number=123)
+            assert result == 0
+            mock_run_gh.assert_called_once_with(
+                args=[
+                    "api",
+                    "repos/owner/repo/issues/123/comments",
+                    "-f",
+                    "body=@coderabbitai resume",
+                ],
+                timeout=30,
+            )
+
+    def test_malformed_json_response(self) -> None:
+        """Test that malformed JSON response still returns exit code 0."""
+        mock_run_gh = MagicMock(return_value=(0, "not json", ""))
+        with patch(
+            "scripts.coderabbit_rate_limit.coderabbit_rate_limit.run_gh",
+            mock_run_gh,
+        ):
+            result = _run_resume(owner_repo="owner/repo", pr_number=123)
+            assert result == 0
+
+    def test_empty_stdout(self) -> None:
+        """Test that empty stdout still returns exit code 0."""
+        mock_run_gh = MagicMock(return_value=(0, "", ""))
+        with patch(
+            "scripts.coderabbit_rate_limit.coderabbit_rate_limit.run_gh",
+            mock_run_gh,
+        ):
+            result = _run_resume(owner_repo="owner/repo", pr_number=123)
+            assert result == 0

--- a/tox.ini
+++ b/tox.ini
@@ -121,7 +121,7 @@ setenv =
 deps:
     python-utility-scripts
 commands =
-    pyutils-unusedcode --exclude-files "pytest_matrix_utils.py" --exclude-function-prefixes "pytest_"
+    pyutils-unusedcode --exclude-files "pytest_matrix_utils.py,coderabbit_rate_limit.py" --exclude-function-prefixes "pytest_"
 
 # Utilities unit tests with coverage verification
 [testenv:utilities-unittests]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,16 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "ai-cli-runner"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "python-simple-logger" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/84/e26cac819bd930f785d66bc61ae40025399bbbd45c78448c8985431d8f09/ai_cli_runner-0.5.0.tar.gz", hash = "sha256:cb41eaa9fdf729fe33751d716b9e7b4571b348e70970f6230f5e38050ccf469c", size = 50626, upload-time = "2026-05-15T11:10:12.934Z" }
+
+[[package]]
 name = "aiofile"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1249,6 +1259,17 @@ wheels = [
 ]
 
 [[package]]
+name = "myk-pi-tools"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ai-cli-runner" },
+    { name = "beautifulsoup4" },
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/fb/a74d8d4258fb32169c0e4db8f6739a8746ab84bb3ab1ac526e3c397c996a/myk_pi_tools-4.2.0.tar.gz", hash = "sha256:71b642c044929fb58c324a60b8f1f7ea459f4301851f0712fe751766da39158f", size = 919378, upload-time = "2026-07-30T11:17:35.323Z" }
+
+[[package]]
 name = "netaddr"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1353,6 +1374,7 @@ dependencies = [
     { name = "jira" },
     { name = "jsons" },
     { name = "kubernetes" },
+    { name = "myk-pi-tools" },
     { name = "netaddr" },
     { name = "openshift-python-utilities" },
     { name = "openshift-python-wrapper" },
@@ -1419,6 +1441,7 @@ requires-dist = [
     { name = "jira", specifier = ">=3.8.0" },
     { name = "jsons", specifier = ">=1.6.3" },
     { name = "kubernetes", specifier = ">=34.1.0" },
+    { name = "myk-pi-tools" },
     { name = "netaddr", specifier = ">=1.3.0" },
     { name = "openshift-python-utilities", specifier = ">=6.0.0" },
     { name = "openshift-python-wrapper", specifier = ">=11.0.132" },


### PR DESCRIPTION
##### What this PR does / why we need it:

Adds `scripts/coderabbit_rate_limit/` — a thin CLI wrapper around [myk-pi-tools](https://github.com/myk-org/pi-config) for detecting and handling CodeRabbit rate limiting and reviews-paused states on PRs.

**Commands:**
- `check` — detect rate limiting, output JSON status
- `trigger` — wait + re-trigger review with polling
- `resume` — unblock paused reviews

All logic is delegated to `myk_pi_tools.coderabbit` (`run_check`, `run_trigger`, `run_gh`). Only `resume` has minimal local logic since upstream does not expose a public resume function.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

Adds `myk-pi-tools` as a project dependency.

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to check, trigger, and resume CodeRabbit rate-limit workflows.
  * Supports configurable wait times, repository and pull request validation, JSON results, and actionable exit codes.
  * Registered the tool for direct command-line use.

* **Documentation**
  * Added setup, command usage, output guidance, timing recommendations, and recovery workflow documentation.

* **Tests**
  * Added coverage for successful operations, invalid inputs, API failures, malformed responses, and empty output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->