### PR TITLE
infra: Remove s390x marker from clock values test

### DIFF
--- a/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
+++ b/tests/infrastructure/instance_types/test_vm_with_instance_and_pref.py
@@ -155,7 +155,6 @@ class TestVmWithInstanceTypeAndPref:
 
     @pytest.mark.dependency(depends=["start_vm_with_instance_type_and_preference"])
     @pytest.mark.polarion("CNV-9821")
-    @pytest.mark.s390x
     def test_validate_clock_values(self, rhel_vm_with_instance_type_and_preference):
         clock_dict = rhel_vm_with_instance_type_and_preference.vmi.instance.to_dict()["spec"]["domain"]["clock"]
         vmi_clock_values = [


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove `s390x` marker from test_validate_clock_values:
 - The `s390x` architecture doesn't support some of the values used in this tests, causing the VMI to fail booting up.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-92408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration so clock validation runs without the platform-specific `s390x` marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->