### PR TITLE
fix: wait_for_migration_finished handle None status

### DIFF
--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -1998,7 +1998,11 @@ def wait_for_migration_finished(migration: VirtualMachineInstanceMigration, time
     """
 
     sleep = TIMEOUT_10SEC
-    samples = TimeoutSampler(wait_timeout=timeout, sleep=sleep, func=lambda: migration.instance.status.phase)
+    samples = TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=sleep,
+        func=lambda: (status := migration.instance.status) and status.phase,
+    )
     counter = 0
     sample = None
     try:


### PR DESCRIPTION
##### What this PR does / why we need it:
When calling `migration.instance.status.phase` the `status` dictionary might be `None`, which results in a `ValueError`, this PR checks if the `status` dictionary is valid, and if not it will try another sample.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors during migration status polling when status information is unavailable.
  * Migration polling now safely reports no phase when a migration status cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->