### PR TITLE
[VIRT] Switch to admin_client in ACRQ second namespace fixture

### DIFF
--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -226,12 +226,12 @@ def removed_acrq_label_from_second_namespace(second_namespace_for_acrq_test):
 
 
 @pytest.fixture(scope="class")
-def vm_in_second_namespace_for_acrq_test(unprivileged_client, second_namespace_for_acrq_test):
+def vm_in_second_namespace_for_acrq_test(admin_client, second_namespace_for_acrq_test):
     vm_name = "vm-another-namespace-for-acrq-test"
     with VirtualMachineForTests(
         name=vm_name,
         namespace=second_namespace_for_acrq_test.name,
-        client=unprivileged_client,
+        client=admin_client,
         cpu_cores=VM_CPU_CORES,
         memory_guest=VM_MEMORY_GUEST,
         body=fedora_vm_body(name=vm_name),


### PR DESCRIPTION
##### What this PR does / why we need it:
The `vm_in_second_namespace_for_acrq_test` fixture was using `unprivileged_client` to create
VMs in the second namespace, which caused 403 Forbidden errors. Since the ACRQ tests validate
cluster-level quota behavior (an admin-level concern), this switches the fixture to use
`admin_client`, consistent with how the second namespace is already created with `admin_client`.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The second namespace (`second_namespace_for_acrq_test`) is already created with `admin_client`.
This change aligns VM creation in that namespace to use the same client.

##### jira-ticket:
NONE

Assisted-by: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Updated test setup to create the second test namespace using the appropriate client context.
  * Improved namespace label-removal test setup to use administrative access where required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->