### PR TITLE
fix: exempt CNV-75722 in relationship labels check (cnv-4.20)

### DIFF
--- a/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
@@ -58,14 +58,18 @@ OPEN_JIRA = {
     },
     "ConfigMap": {
         "CNV-28182": ["kubevirt-install-strategy"],
+        "CNV-75722": ["kubevirt-migration-controller-config"],
     },
 }
 
 
-def is_jira_allowlisted(kind, resource_name):
-    jira_key = list(OPEN_JIRA[kind].keys())[0] if OPEN_JIRA.get(kind) else None
-    jira_allowlisted_names = OPEN_JIRA[kind][jira_key] if jira_key and is_jira_open(jira_id=jira_key) else []
-    return bool(resource_name.startswith(tuple(jira_allowlisted_names))) if jira_allowlisted_names else False
+def is_jira_allowlisted(kind: str, resource_name: str) -> bool:
+    for jira_key, allowed_names in OPEN_JIRA.get(kind, {}).items():
+        if is_jira_open(jira_id=jira_key) and any(
+            resource_name.startswith(allowed_name) for allowed_name in allowed_names
+        ):
+            return True
+    return False
 
 
 def get_all_api_resources(


### PR DESCRIPTION
## Short Description

Exempt `kubevirt-migration-controller-config` from `test_relationship_labels_all_cnv_resources` in cnv-4.20 while product bug CNV-75722 remains open.

## More Details

The ConfigMap `kubevirt-migration-controller-config` only has `operator.migrations.kubevirt.io` label — it lacks the 4 required relationship labels (`app.kubernetes.io/managed-by`, `version`, `component`, `part-of`). This is a confirmed product bug (CNV-75722) reproducible through CNV 4.23.

The same fix exists in `main`, `cnv-4.22`, and `cnv-4.21` (via PR #3186), but cnv-4.20 was missing it.

## What this PR does / why we need it

- Adds `"CNV-75722": ["kubevirt-migration-controller-config"]` to `OPEN_JIRA["ConfigMap"]`
- Fixes `is_jira_allowlisted` to iterate **all** Jira keys in `OPEN_JIRA[kind]` instead of only the first one — the old implementation silently ignored any second+ exemption entry
- When CNV-75722 is closed, the exemption deactivates automatically (no code change needed)

Fixes failing iuo-ocs lane: test-pytest-cnv-4.20-iuo-ocs/121/

Jira: CNV-75722