### PR TITLE
test(network): drop e1000e from pod-network connectivity matrix

### DIFF
--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -122,11 +122,6 @@ cnv_vm_resources_limits_matrix = [
     "cpu",
     "memory",
 ]
-nic_models_matrix = [
-    "virtio",
-    "e1000e",
-]
-
 cnv_must_gather_matrix = [
     "cnv-gather",
     "all-images",

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -17,7 +17,6 @@ from utilities.virt import VirtualMachineForTests, fedora_vm_body, vm_console_ru
 def pod_net_vma(
     namespace,
     unprivileged_client,
-    nic_models_matrix__module__,
     cloud_init_ipv6_network_data,
     schedulable_nodes,
 ):
@@ -28,7 +27,7 @@ def pod_net_vma(
         name=name,
         node_selector=get_node_selector_dict(node_selector=node_selector),
         client=unprivileged_client,
-        network_model=nic_models_matrix__module__,
+        network_model="virtio",
         body=fedora_vm_body(name=name),
         cloud_init_data=cloud_init_ipv6_network_data,
     ) as vm:
@@ -40,7 +39,6 @@ def pod_net_vma(
 def pod_net_vmb(
     namespace,
     unprivileged_client,
-    nic_models_matrix__module__,
     cloud_init_ipv6_network_data,
     schedulable_nodes,
 ):
@@ -51,7 +49,7 @@ def pod_net_vmb(
         name=name,
         node_selector=get_node_selector_dict(node_selector=node_selector),
         client=unprivileged_client,
-        network_model=nic_models_matrix__module__,
+        network_model="virtio",
         body=fedora_vm_body(name=name),
         cloud_init_data=cloud_init_ipv6_network_data,
     ) as vm:


### PR DESCRIPTION
test_connectivity_over_pod_network was the top-failing D/S test, run for both virtio and e1000e NIC models. The e1000e variant only exercises QEMU/libvirt's device emulation rather than any KubeVirt/CNV-owned code path, while virtio (the default, recommended model) already covers the real connectivity story. Dropping it removes flaky, low-value coverage without losing the meaningful assertion.

##### What this PR does / why we need it:

Removes the "e1000e" NIC model from `nic_models_matrix` in `tests/global_config.py`, so `test_connectivity_over_pod_network` (tests/network/connectivity/test_pod_network.py) now only runs with the "virtio" NIC model. `nic_models_matrix` is not referenced by any other test. The e1000e variant of this test was our top-failing D/S test; it only re-tests QEMU/libvirt device emulation rather than any KubeVirt/CNV-owned code path, so dropping it removes flaky, low-value coverage while virtio (the default/recommended model) continues to cover the real connectivity story.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

The existing Polarion markers on this test (CNV-2332, CNV-11845) are keyed to `ip_family`, not to the NIC model, so there is no separate Polarion case tied specifically to the e1000e parametrization that needs deprecation.

##### jira-ticket:
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Updated network testing coverage to use the `virtio` NIC model exclusively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->