### PR TITLE
[VIRT] Quarantine post-copy migration tests on RHCOS 10

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ from ocp_resources.virtual_machine_instance_migration import (
 from ocp_resources.virtual_machine_instancetype import VirtualMachineInstancetype
 from ocp_resources.virtual_machine_preference import VirtualMachinePreference
 from ocp_utilities.monitoring import Prometheus
-from packaging.version import parse
+from packaging.version import Version, parse
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
@@ -175,6 +175,7 @@ from utilities.infra import (
     run_virtctl_command,
     scale_deployment_replicas,
 )
+from utilities.jira import is_jira_open
 from utilities.network import (
     EthernetNetworkConfigurationPolicy,
     MacPool,
@@ -498,6 +499,33 @@ def workers(nodes):
 @pytest.fixture(scope="session")
 def control_plane_nodes(nodes):
     return get_nodes_with_label(nodes=nodes, label=f"{NODE_ROLE_KUBERNETES_IO}/control-plane")
+
+
+@pytest.fixture(scope="session")
+def workers_rhcos_version(schedulable_nodes):
+    """Returns a dict mapping each schedulable node name to its RHCOS version.
+
+    Returns:
+        dict[str, str]: Node name to RHCOS version (e.g. {"node-1": "10.2.20260408", ...}).
+    """
+    rhcos_version_re = re.compile(r"CoreOS\s+([\d.]+)")
+    versions = {}
+    for node in schedulable_nodes:
+        os_image = node.instance.status.nodeInfo.osImage
+        match = rhcos_version_re.search(string=os_image)
+        assert match, f"Failed to parse RHCOS version from osImage '{os_image}' on node '{node.name}'"
+        versions[node.name] = match.group(1)
+    return versions
+
+
+@pytest.fixture(scope="session")
+def cluster_has_rhcos10_or_above(workers_rhcos_version):
+    return any(Version(ver) >= Version("10") for ver in workers_rhcos_version.values())
+
+
+@pytest.fixture(scope="session")
+def is_postcopy_migration_bug_open(cluster_has_rhcos10_or_above):
+    return cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-84023")
 
 
 @pytest.fixture(scope="session")

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -1,12 +1,9 @@
 import logging
-import re
 
 import pytest
 from ocp_resources.ssp import SSP
-from packaging.version import Version
 
 from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.jira import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
@@ -22,30 +19,3 @@ def paused_ssp_operator(admin_client, hco_namespace, ssp_resource_scope_class):
         list_resource_reconcile=[SSP],
     ):
         yield
-
-
-@pytest.fixture(scope="session")
-def workers_rhcos_version(schedulable_nodes):
-    """Returns a dict mapping each schedulable node name to its RHCOS version.
-
-    Returns:
-        dict[str, str]: Node name to RHCOS version (e.g. {"node-1": "10.2.20260408", ...}).
-    """
-    rhcos_version_re = re.compile(r"CoreOS\s+([\d.]+)")
-    versions = {}
-    for node in schedulable_nodes:
-        os_image = node.instance.status.nodeInfo.osImage
-        match = rhcos_version_re.search(string=os_image)
-        assert match, f"Failed to parse RHCOS version from osImage '{os_image}' on node '{node.name}'"
-        versions[node.name] = match.group(1)
-    return versions
-
-
-@pytest.fixture(scope="session")
-def cluster_has_rhcos10_or_above(workers_rhcos_version):
-    return any(Version(ver) >= Version("10") for ver in workers_rhcos_version.values())
-
-
-@pytest.fixture(scope="session")
-def is_postcopy_migration_bug_open(cluster_has_rhcos10_or_above):
-    return cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-84023")

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 pytestmark = [
     pytest.mark.rwx_default_storage,
-    pytest.mark.usefixtures("created_post_copy_migration_policy"),
+    pytest.mark.usefixtures("postcopy_migration_quarantine", "created_post_copy_migration_policy"),
     pytest.mark.data_collector_scope(scope="module"),
 ]
 
@@ -55,6 +55,12 @@ def assert_same_pid_after_migration(orig_pid, vm):
     else:
         new_pid = fetch_pid_from_linux_vm(vm=vm, process_name="ping")
     assert new_pid == orig_pid, f"PID mismatch after migration! orig_pid: {orig_pid}; new_pid: {new_pid}"
+
+
+@pytest.fixture(scope="module")
+def postcopy_migration_quarantine(is_postcopy_migration_bug_open):
+    if is_postcopy_migration_bug_open:
+        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### What this PR does / why we need it:
Post-copy migration fails on clusters running RHCOS 10 or above. This PR moves the RHCOS
version detection and bug-check fixtures from `tests/observability/conftest.py` to
`tests/conftest.py` so they can be shared across teams, and adds a module-scoped xfail guard
that skips all post-copy migration tests before creating any resources when the bug is active.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added environment-aware handling for post-copy migration tests.
  * Tests are now marked as expected failures when the known migration issue remains open on clusters running RHCOS 10 or later.
  * Added validation for node operating system version information.
  * Centralized environment checks to provide more consistent and reliable test results across cluster configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->