### PR TITLE
[Storage] Increase `running_vm.dv_wait_timeout` for Windows 2k22 helpers 

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -717,7 +717,6 @@ def create_windows2022_vm_using_existing_dv(
     cpu_model: str | None = None,
     existing_data_volume: DataVolume | None = None,
     check_running_vm: bool = True,
-    dv_wait_timeout: int = TIMEOUT_50MIN,
 ) -> Generator[VirtualMachineForTests]:
     """
     Creates a Windows Server 2022 VM with vTPM using existing DataVolume.
@@ -728,7 +727,6 @@ def create_windows2022_vm_using_existing_dv(
         client: Kubernetes client
         vm_name: Name for the VirtualMachine
         cpu_model: CPU model specification (can be None)
-        check_running_vm: If True, start the VM and wait for Windows boot
 
     Yields:
         VirtualMachineForTests: Windows 2022 VM with vTPM
@@ -745,7 +743,7 @@ def create_windows2022_vm_using_existing_dv(
         cpu_model=cpu_model,
     ) as vm:
         if check_running_vm:
-            running_vm(vm=vm, dv_wait_timeout=dv_wait_timeout)
+            running_vm(vm=vm)
             wait_for_windows_vm(vm=vm, version="2022")
         yield vm
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,6 +53,7 @@ from utilities.constants.timeouts import (
     TIMEOUT_10SEC,
     TIMEOUT_15SEC,
     TIMEOUT_30MIN,
+    TIMEOUT_50MIN,
 )
 from utilities.constants.virt import DISK_SERIAL, NODE_HUGE_PAGES_1GI_KEY
 from utilities.data_collector import get_data_collector_dir, write_to_file
@@ -716,6 +717,7 @@ def create_windows2022_vm_using_existing_dv(
     cpu_model: str | None = None,
     existing_data_volume: DataVolume | None = None,
     check_running_vm: bool = True,
+    dv_wait_timeout: int = TIMEOUT_50MIN,
 ) -> Generator[VirtualMachineForTests]:
     """
     Creates a Windows Server 2022 VM with vTPM using existing DataVolume.
@@ -743,7 +745,7 @@ def create_windows2022_vm_using_existing_dv(
         cpu_model=cpu_model,
     ) as vm:
         if check_running_vm:
-            running_vm(vm=vm)
+            running_vm(vm=vm, dv_wait_timeout=dv_wait_timeout)
             wait_for_windows_vm(vm=vm, version="2022")
         yield vm
 
@@ -756,6 +758,7 @@ def create_windows2022_vm_with_data_volume_template(
     cpu_model: str | None = None,
     dv_template: dict | None = None,
     check_running_vm: bool = True,
+    dv_wait_timeout: int = TIMEOUT_50MIN,
 ) -> Generator[VirtualMachineForTests]:
     """
     Creates a Windows Server 2022 VM with vTPM with dv template.
@@ -783,6 +786,6 @@ def create_windows2022_vm_with_data_volume_template(
         cpu_model=cpu_model,
     ) as vm:
         if check_running_vm:
-            running_vm(vm=vm)
+            running_vm(vm=vm, dv_wait_timeout=dv_wait_timeout)
             wait_for_windows_vm(vm=vm, version="2022")
         yield vm


### PR DESCRIPTION
##### What this PR does / why we need it:
Tests are failing on "hostpath-csi-pvc-block" storage class. Increasing the timeout and adding option to adjust it for the individual tests.

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-94592

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows Server 2022 virtual machine startup reliability by allowing more time for DataVolumes created from templates to become ready.
  * Existing DataVolume startup behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->