### PR TITLE
net, tests, udn: Centralize UDN fixtures and single_nic marker

### DIFF
--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -78,20 +78,22 @@ def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_
 @pytest.fixture(scope="class")
 def server(vmb_udn):
     with TcpServer(vm=vmb_udn, port=IPERF_SERVER_PORT) as server:
-        assert server.is_running()
         yield server
 
 
 @pytest.fixture(scope="class")
-def client(vma_udn, vmb_udn):
+def client(vma_udn, server):
     with VMTcpClient(
         vm=vma_udn,
         server_ip=str(
-            lookup_iface_status_ip(vm=vmb_udn, iface_name=lookup_primary_network(vm=vmb_udn).name, ip_family=4)
+            lookup_iface_status_ip(
+                vm=server.vm,
+                iface_name=lookup_primary_network(vm=server.vm).name,
+                ip_family=4,
+            )
         ),
         server_port=IPERF_SERVER_PORT,
     ) as client:
-        assert client.is_running()
         yield client
 
 

--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -5,7 +5,9 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
 from libs.net.ip import random_ipv4_address
+from libs.net.traffic_generator import IPERF_SERVER_PORT, TcpServer, VMTcpClient
 from libs.net.udn import UDN_BINDING_DEFAULT_PLUGIN_NAME
+from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
 from libs.vm import affinity
 from libs.vm.oper import run_vms
 from libs.vm.vm import BaseVirtualMachine
@@ -43,6 +45,54 @@ def namespaced_layer2_user_defined_network(admin_client, udn_namespace):
 @pytest.fixture(scope="module")
 def udn_affinity_label():
     return affinity.new_label(key_prefix="udn")
+
+
+@pytest.fixture(scope="class")
+def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+    with udn_vm(
+        namespace_name=udn_namespace.name,
+        name="vma-udn",
+        client=admin_client,
+        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
+        template_labels=dict((udn_affinity_label,)),
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+    with udn_vm(
+        namespace_name=udn_namespace.name,
+        name="vmb-udn",
+        client=admin_client,
+        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
+        template_labels=dict((udn_affinity_label,)),
+    ) as vm:
+        vm.start(wait=True)
+        vm.wait_for_agent_connected()
+        yield vm
+
+
+@pytest.fixture(scope="class")
+def server(vmb_udn):
+    with TcpServer(vm=vmb_udn, port=IPERF_SERVER_PORT) as server:
+        assert server.is_running()
+        yield server
+
+
+@pytest.fixture(scope="class")
+def client(vma_udn, vmb_udn):
+    with VMTcpClient(
+        vm=vma_udn,
+        server_ip=str(
+            lookup_iface_status_ip(vm=vmb_udn, iface_name=lookup_primary_network(vm=vmb_udn).name, ip_family=4)
+        ),
+        server_port=IPERF_SERVER_PORT,
+    ) as client:
+        assert client.is_running()
+        yield client
 
 
 @pytest.fixture(scope="class")

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -6,11 +6,8 @@ from typing import TYPE_CHECKING
 import pytest
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
-from libs.net.traffic_generator import TcpServer, is_tcp_connection
-from libs.net.traffic_generator import VMTcpClient as TcpClient
-from libs.net.udn import UDN_BINDING_DEFAULT_PLUGIN_NAME
+from libs.net.traffic_generator import is_tcp_connection
 from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
-from tests.network.libs.vm_factory import udn_vm
 from utilities.constants.networking import PUBLIC_DNS_SERVER_IP
 from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_1MIN
@@ -19,65 +16,15 @@ from utilities.virt import migrate_vm_and_verify
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
 
+    from libs.net.traffic_generator import TcpServer, VMTcpClient
     from libs.vm.vm import BaseVirtualMachine
-
-IP_ADDRESS = "ipAddress"
-SERVER_PORT = 5201
-
-
-@pytest.fixture(scope="class")
-def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
-    with udn_vm(
-        namespace_name=udn_namespace.name,
-        name="vma-udn",
-        client=admin_client,
-        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
-        template_labels=dict((udn_affinity_label,)),
-    ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        yield vm
-
-
-@pytest.fixture(scope="class")
-def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
-    with udn_vm(
-        namespace_name=udn_namespace.name,
-        name="vmb-udn",
-        client=admin_client,
-        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
-        template_labels=dict((udn_affinity_label,)),
-    ) as vm:
-        vm.start(wait=True)
-        vm.wait_for_agent_connected()
-        yield vm
-
-
-@pytest.fixture(scope="class")
-def server(vmb_udn):
-    with TcpServer(vm=vmb_udn, port=SERVER_PORT) as server:
-        assert server.is_running()
-        yield server
-
-
-@pytest.fixture(scope="class")
-def client(vma_udn, vmb_udn):
-    with TcpClient(
-        vm=vma_udn,
-        server_ip=str(
-            lookup_iface_status_ip(vm=vmb_udn, iface_name=lookup_primary_network(vm=vmb_udn).name, ip_family=4)
-        ),
-        server_port=SERVER_PORT,
-    ) as client:
-        assert client.is_running()
-        yield client
 
 
 @pytest.mark.ipv4
 @pytest.mark.s390x
+@pytest.mark.single_nic
 class TestPrimaryUdn:
     @pytest.mark.polarion("CNV-11624")
-    @pytest.mark.single_nic
     def test_ip_address_in_running_vm_matches_udn_subnet(self, namespaced_layer2_user_defined_network, vma_udn):
         ip = str(lookup_iface_status_ip(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name, ip_family=4))
         (subnet,) = namespaced_layer2_user_defined_network.subnets
@@ -86,7 +33,6 @@ class TestPrimaryUdn:
         )
 
     @pytest.mark.polarion("CNV-11674")
-    @pytest.mark.single_nic
     def test_ip_address_is_preserved_after_live_migration(
         self, admin_client: DynamicClient, vma_udn: BaseVirtualMachine
     ):
@@ -104,13 +50,11 @@ class TestPrimaryUdn:
         )
 
     @pytest.mark.polarion("CNV-11434")
-    @pytest.mark.single_nic
     def test_vm_egress_connectivity(self, vmb_udn):
         assert str(lookup_iface_status_ip(vm=vmb_udn, iface_name=lookup_primary_network(vm=vmb_udn).name, ip_family=4))
         vmb_udn.console(commands=[f"ping -c 3 {PUBLIC_DNS_SERVER_IP}"], timeout=TIMEOUT_1MINUTE)
 
     @pytest.mark.polarion("CNV-11418")
-    @pytest.mark.single_nic
     def test_basic_connectivity_between_udn_vms(self, vma_udn, vmb_udn):
         target_vm_ip = str(
             lookup_iface_status_ip(vm=vmb_udn, iface_name=lookup_primary_network(vm=vmb_udn).name, ip_family=4)
@@ -118,22 +62,20 @@ class TestPrimaryUdn:
         vma_udn.console(commands=[f"ping -c 3 {target_vm_ip}"], timeout=TIMEOUT_1MIN)
 
     @pytest.mark.polarion("CNV-11427")
-    @pytest.mark.single_nic
     @pytest.mark.gating
     def test_connectivity_is_preserved_during_client_live_migration(
-        self, admin_client: DynamicClient, server: TcpServer, client: TcpClient
+        self, admin_client: DynamicClient, server: TcpServer, client: VMTcpClient
     ):
         migrate_vm_and_verify(vm=client.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)
 
     @pytest.mark.polarion("CNV-12177")
-    @pytest.mark.single_nic
     @pytest.mark.xfail(
         reason=f"{QUARANTINED}: Failed migration of vm in UDN: CNV-72782",
         run=False,
     )
     def test_connectivity_is_preserved_during_server_live_migration(
-        self, admin_client: DynamicClient, server: TcpServer, client: TcpClient
+        self, admin_client: DynamicClient, server: TcpServer, client: VMTcpClient
     ):
         migrate_vm_and_verify(vm=server.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)


### PR DESCRIPTION
##### What this PR does / why we need it:
Move fixtures from test module to conftest.py and rearrange the code.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
This is a cleanup/refactor of test structure and marker placement only.
No new test logic was introduced.

##### jira-ticket:
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Added end-to-end coverage for TCP connectivity between two virtual machines on a user-defined network.
* Added automated setup for launching networked virtual machines and configuring TCP server and client communication.
* Updated migration connectivity tests to use the current TCP client interface.
* Removed outdated test setup and redundant single-network-interface constraints.
* Improved coverage for validating network communication before and after migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->