### PR TITLE
[Storage] Implement CBT push full/incremental backup-success tests

### DIFF
--- a/tests/storage/cbt/conftest.py
+++ b/tests/storage/cbt/conftest.py
@@ -23,6 +23,7 @@ from tests.storage.cbt.utils import (
     cbt_pvc_size_with_headroom,
     wait_for_pull_backup_export_deleted,
     wait_for_pull_backup_export_ready,
+    wait_for_push_backup_complete,
     wait_for_vm_cbt_enabled,
 )
 from utilities.constants.images import OS_FLAVOR_RHEL
@@ -138,6 +139,96 @@ def backup_tracker_source(backup_tracker_for_vm):
         "kind": VirtualMachineBackupTracker.kind,
         "name": backup_tracker_for_vm.name,
     }
+
+
+@pytest.fixture()
+def push_backup_pvc(
+    unprivileged_client,
+    namespace,
+    vm_with_cbt_label,
+    storage_class_name_scope_module,
+    unique_suffix,
+):
+    """
+    PVC for storing push-mode backup output.
+
+    Returns:
+        PersistentVolumeClaim: PVC for push-mode backup storage
+    """
+    boot_disk_size = vm_with_cbt_label.data_volume_template["spec"]["storage"]["resources"]["requests"]["storage"]
+    with PersistentVolumeClaim(
+        name=f"cbt-backup-{unique_suffix}",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        size=cbt_pvc_size_with_headroom(source_disk_size=boot_disk_size),
+        storage_class=storage_class_name_scope_module,
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture()
+def completed_full_backup_push_mode(
+    unprivileged_client,
+    namespace,
+    push_backup_pvc,
+    backup_tracker_source,
+    unique_suffix,
+):
+    """
+    Full push-mode backup after Complete=True.
+
+    Returns:
+        VirtualMachineBackup: Completed full push backup
+    """
+    with VirtualMachineBackup(
+        mode=VirtualMachineBackup.Mode.PUSH,
+        name=f"full-push-{unique_suffix}",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        pvc_name=push_backup_pvc.name,
+        force_full_backup=True,
+        source=backup_tracker_source,
+    ) as backup:
+        wait_for_push_backup_complete(backup=backup)
+        yield backup
+
+
+@pytest.fixture()
+def completed_incremental_backup_push_mode(
+    unprivileged_client,
+    namespace,
+    push_backup_pvc,
+    vm_with_cbt_label,
+    completed_full_backup_push_mode,
+    backup_tracker_source,
+    unique_suffix,
+):
+    """
+    Incremental push-mode backup after Complete=True.
+
+    Depends on a prior full push backup, then writes new guest data before the incremental.
+
+    Returns:
+        VirtualMachineBackup: Completed incremental push backup
+    """
+    write_file_via_ssh(
+        vm=vm_with_cbt_label,
+        filename=CBT_INCREMENTAL_TEST_DATA_FILE,
+        content=CBT_INCREMENTAL_TEST_DATA,
+    )
+    with VirtualMachineBackup(
+        mode=VirtualMachineBackup.Mode.PUSH,
+        name=f"incr-push-{unique_suffix}",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        pvc_name=push_backup_pvc.name,
+        force_full_backup=False,
+        source=backup_tracker_source,
+    ) as backup:
+        wait_for_push_backup_complete(backup=backup)
+        yield backup
 
 
 @pytest.fixture()

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -30,9 +30,12 @@ class TestFullBackupRestore:
     """
 
     @pytest.mark.polarion("CNV-15997")
-    def test_full_backup_push_mode_restore(self):
+    def test_full_backup_push_mode(
+        self,
+        completed_full_backup_push_mode,
+    ):
         """
-        Test that a VM can be backed up (push mode) and restored from a full backup.
+        Test that a full backup in push mode completes successfully.
 
         Preconditions:
             - Backup PVC available
@@ -40,16 +43,16 @@ class TestFullBackupRestore:
         Steps:
             1. Create a backup tracker for the VM
             2. Perform a full backup in push mode
-            3. Wait for backup to complete
-            4. Delete the original VM
-            5. Restore VM from the full backup
-            6. Start the restored VM
+            3. Wait for the backup to complete
 
         Expected:
-            - Restored VM boots successfully and test data is present
+            - Backup completes and includes the boot disk
         """
-
-    test_full_backup_push_mode_restore.__test__ = False  # STD placeholder - not yet implemented
+        assert_backup_includes_volumes(
+            backup=completed_full_backup_push_mode,
+            expected_volume_names=[DV_DISK],
+            expected_backup_type="Full",
+        )
 
     @pytest.mark.polarion("CNV-15996")
     def test_full_backup_pull_mode(
@@ -93,26 +96,30 @@ class TestIncrementalBackupRestore:
     """
 
     @pytest.mark.polarion("CNV-15998")
-    def test_incremental_backup_push_mode_restore(self):
+    def test_incremental_backup_push_mode(
+        self,
+        completed_incremental_backup_push_mode,
+    ):
         """
-        Test that a VM can be backed up (push mode) and restored from an incremental backup.
+        Test that an incremental backup in push mode completes successfully.
 
         Preconditions:
             - Backup PVC available
 
         Steps:
-            1. Write new test data to VM
-            2. Perform an incremental backup in push mode
-            3. Wait for backup to complete
-            4. Delete the original VM
-            5. Restore VM from the incremental backup
-            6. Start the restored VM
+            1. Perform a full backup in push mode and wait until it completes
+            2. Write new test data to VM
+            3. Perform an incremental backup in push mode
+            4. Wait for the backup to complete
 
         Expected:
-            - Restored VM boots successfully and all test data is present
+            - Incremental backup completes and includes the boot disk
         """
-
-    test_incremental_backup_push_mode_restore.__test__ = False  # STD placeholder - not yet implemented
+        assert_backup_includes_volumes(
+            backup=completed_incremental_backup_push_mode,
+            expected_volume_names=[DV_DISK],
+            expected_backup_type="Incremental",
+        )
 
     @pytest.mark.polarion("CNV-16000")
     def test_incremental_backup_pull_mode(

--- a/tests/storage/cbt/utils.py
+++ b/tests/storage/cbt/utils.py
@@ -59,6 +59,17 @@ def wait_for_vm_cbt_enabled(vm: VirtualMachine) -> None:
             return
 
 
+def wait_for_push_backup_complete(backup: VirtualMachineBackup) -> None:
+    """Wait until a push-mode backup completes successfully."""
+    LOGGER.info(f"Waiting for push-mode backup {backup.name} to complete")
+    backup.wait_for_condition(
+        condition="Complete",
+        status=backup.Condition.Status.TRUE,
+        timeout=TIMEOUT_10MIN,
+        sleep_time=TIMEOUT_5SEC,
+    )
+
+
 def wait_for_pull_backup_export_ready(backup: VirtualMachineBackup) -> None:
     """Wait until a pull-mode backup export is ready for collection."""
     # Pull readiness is Progressing=True with reason ExportReady (there is no ExportReady condition type).


### PR DESCRIPTION
##### What this PR does / why we need it:
Implement CBT push-mode full and incremental backup-success tests, matching the pull-mode coverage from #5761.

Validates that push backups reach Complete and include the boot disk. Restore and remaining CBT scenarios stay as STD placeholders.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
- Mirrors pull backup-success approach: fixtures wait for Complete=True, tests assert included volumes + backup type.
- No restore / collect pods in this PR.

##### jira-ticket:
NONE

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for completed full and incremental push-mode backups.
  * Verified that push-mode backups include the boot disk with the expected backup type.
  * Added validation that backups reach completion before assertions run.
  * Replaced disabled push-mode backup/restore placeholders with executable tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->