### PR TITLE
util: update openshift-python-wrapper to 11.0.139 in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1298,7 +1298,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/11/8c/5a03b7c28670dd355
 
 [[package]]
 name = "openshift-python-wrapper"
-version = "11.0.138"
+version = "11.0.139"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cloup" },
@@ -1318,7 +1318,7 @@ dependencies = [
     { name = "timeout-sampler" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e5/6a683c68262f56a13cda611691cd5cda3caadd54decf54d1efec8c1455ab/openshift_python_wrapper-11.0.138.tar.gz", hash = "sha256:a1f073e0217ccab93e671ee569e5b5917eae9d555c194a937994e566b83e932d", size = 8160531, upload-time = "2026-07-22T11:00:19.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/40/55c080ae49440e4e5be1f3f0c7bed5d8df6790c80081a73ff1adf8f8426c/openshift_python_wrapper-11.0.139.tar.gz", hash = "sha256:63baddad7a8880eee3b1b88ada798b242265d96d886277a9b8c32336c8f17102", size = 8167523, upload-time = "2026-08-05T18:34:38.902Z" }
 
 [[package]]
 name = "openshift-python-wrapper-data-collector"


### PR DESCRIPTION
##### What this PR does / why we need it:
util: update openshift-python-wrapper to 11.0.139 in uv.lock, which contain the `process` sub-resource for `VirtualMachineTemplate`

##### Which issue(s) this PR fixes:
#5764 

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
