### PR TITLE
[Storage] Implement CBT push full/incremental backup-success tests

### DIFF
--- a/tests/storage/cbt/conftest.py
+++ b/tests/storage/cbt/conftest.py
@@ -23,6 +23,7 @@ from tests.storage.cbt.utils import (
     cbt_pvc_size_with_headroom,
     wait_for_pull_backup_export_deleted,
     wait_for_pull_backup_export_ready,
+    wait_for_push_backup_complete,
     wait_for_vm_cbt_enabled,
 )
 from utilities.constants.images import OS_FLAVOR_RHEL
@@ -138,6 +139,96 @@ def backup_tracker_source(backup_tracker_for_vm):
         "kind": VirtualMachineBackupTracker.kind,
         "name": backup_tracker_for_vm.name,
     }
+
+
+@pytest.fixture()
+def push_backup_pvc(
+    unprivileged_client,
+    namespace,
+    vm_with_cbt_label,
+    storage_class_name_scope_module,
+    unique_suffix,
+):
+    """
+    PVC for storing push-mode backup output.
+
+    Returns:
+        PersistentVolumeClaim: PVC for push-mode backup storage
+    """
+    boot_disk_size = vm_with_cbt_label.data_volume_template["spec"]["storage"]["resources"]["requests"]["storage"]
+    with PersistentVolumeClaim(
+        name=f"cbt-backup-{unique_suffix}",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        size=cbt_pvc_size_with_headroom(source_disk_size=boot_disk_size),
+        storage_class=storage_class_name_scope_module,
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture()
+def completed_full_backup_push_mode(
+    unprivileged_client,
+    namespace,
+    push_backup_pvc,
+    backup_tracker_source,
+    unique_suffix,
+):
+    """
+    Full push-mode backup after Complete=True.
+
+    Returns:
+        VirtualMachineBackup: Completed full push backup
+    """
+    with VirtualMachineBackup(
+        mode=VirtualMachineBackup.Mode.PUSH,
+        name=f"full-push-{unique_suffix}",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        pvc_name=push_backup_pvc.name,
+        force_full_backup=True,
+        source=backup_tracker_source,
+    ) as backup:
+        wait_for_push_backup_complete(backup=backup)
+        yield backup
+
+
+@pytest.fixture()
+def completed_incremental_backup_push_mode(
+    unprivileged_client,
+    namespace,
+    push_backup_pvc,
+    vm_with_cbt_label,
+    completed_full_backup_push_mode,
+    backup_tracker_source,
+    unique_suffix,
+):
+    """
+    Incremental push-mode backup after Complete=True.
+
+    Depends on a prior full push backup, then writes new guest data before the incremental.
+
+    Returns:
+        VirtualMachineBackup: Completed incremental push backup
+    """
+    write_file_via_ssh(
+        vm=vm_with_cbt_label,
+        filename=CBT_INCREMENTAL_TEST_DATA_FILE,
+        content=CBT_INCREMENTAL_TEST_DATA,
+    )
+    with VirtualMachineBackup(
+        mode=VirtualMachineBackup.Mode.PUSH,
+        name=f"incr-push-{unique_suffix}",
+        namespace=namespace.name,
+        client=unprivileged_client,
+        pvc_name=push_backup_pvc.name,
+        force_full_backup=False,
+        source=backup_tracker_source,
+    ) as backup:
+        wait_for_push_backup_complete(backup=backup)
+        yield backup
 
 
 @pytest.fixture()

--- a/tests/storage/cbt/constants.py
+++ b/tests/storage/cbt/constants.py
@@ -7,3 +7,4 @@ CBT_INCREMENTAL_TEST_DATA_FILE: str = "/tmp/cbt-incremental-test-data.txt"
 CBT_ENABLED_LABEL: dict[str, str] = {"changedBlockTracking": "true"}
 CBT_BACKUP_TYPE_FULL: str = "Full"
 CBT_BACKUP_TYPE_INCREMENTAL: str = "Incremental"
+CBT_BACKUP_CONDITION_FAILED: str = "Failed"

--- a/tests/storage/cbt/constants.py
+++ b/tests/storage/cbt/constants.py
@@ -5,3 +5,5 @@ CBT_INCREMENTAL_TEST_DATA: str = "cbt-incremental-backup-test-data"
 CBT_BOOT_DISK_TEST_DATA_FILE: str = "/tmp/cbt-test-data.txt"
 CBT_INCREMENTAL_TEST_DATA_FILE: str = "/tmp/cbt-incremental-test-data.txt"
 CBT_ENABLED_LABEL: dict[str, str] = {"changedBlockTracking": "true"}
+CBT_BACKUP_TYPE_FULL: str = "Full"
+CBT_BACKUP_TYPE_INCREMENTAL: str = "Incremental"

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -105,7 +105,9 @@ class TestIncrementalBackup:
         Test that an incremental backup in push mode completes successfully.
 
         Preconditions:
+        Preconditions:
             - Backup PVC available
+            - Full backup completed in push mode
 
         Steps:
             1. Perform a full backup in push mode and wait until it completes

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -11,6 +11,7 @@ Preconditions:
 
 import pytest
 
+from tests.storage.cbt.constants import CBT_BACKUP_TYPE_FULL, CBT_BACKUP_TYPE_INCREMENTAL
 from tests.storage.cbt.utils import assert_backup_includes_volumes
 from utilities.constants.virt import DV_DISK
 
@@ -51,7 +52,7 @@ class TestFullBackupRestore:
         assert_backup_includes_volumes(
             backup=completed_full_backup_push_mode,
             expected_volume_names=[DV_DISK],
-            expected_backup_type="Full",
+            expected_backup_type=CBT_BACKUP_TYPE_FULL,
         )
 
     @pytest.mark.polarion("CNV-15996")
@@ -76,7 +77,7 @@ class TestFullBackupRestore:
         assert_backup_includes_volumes(
             backup=ready_full_backup_pull_mode,
             expected_volume_names=[DV_DISK],
-            expected_backup_type="Full",
+            expected_backup_type=CBT_BACKUP_TYPE_FULL,
         )
 
 
@@ -118,7 +119,7 @@ class TestIncrementalBackupRestore:
         assert_backup_includes_volumes(
             backup=completed_incremental_backup_push_mode,
             expected_volume_names=[DV_DISK],
-            expected_backup_type="Incremental",
+            expected_backup_type=CBT_BACKUP_TYPE_INCREMENTAL,
         )
 
     @pytest.mark.polarion("CNV-16000")
@@ -145,7 +146,7 @@ class TestIncrementalBackupRestore:
         assert_backup_includes_volumes(
             backup=ready_incremental_backup_pull_mode,
             expected_volume_names=[DV_DISK],
-            expected_backup_type="Incremental",
+            expected_backup_type=CBT_BACKUP_TYPE_INCREMENTAL,
         )
 
 

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -105,15 +105,13 @@ class TestIncrementalBackup:
         Test that an incremental backup in push mode completes successfully.
 
         Preconditions:
-        Preconditions:
             - Backup PVC available
             - Full backup completed in push mode
 
         Steps:
-            1. Perform a full backup in push mode and wait until it completes
-            2. Write new test data to VM
-            3. Perform an incremental backup in push mode
-            4. Wait for the backup to complete
+            1. Write new test data to VM
+            2. Perform an incremental backup in push mode
+            3. Wait for the backup to complete
 
         Expected:
             - Incremental backup completes and includes the boot disk

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -21,7 +21,7 @@ from utilities.constants.virt import DV_DISK
     [{"name": "cbt-full"}],
     indirect=True,
 )
-class TestFullBackupRestore:
+class TestFullBackup:
     """
     Full backup validation for push and pull modes (backup success only).
 
@@ -47,7 +47,7 @@ class TestFullBackupRestore:
             3. Wait for the backup to complete
 
         Expected:
-            - Backup completes and includes the boot disk
+            - Full backup completes and includes the boot disk
         """
         assert_backup_includes_volumes(
             backup=completed_full_backup_push_mode,
@@ -86,7 +86,7 @@ class TestFullBackupRestore:
     [{"name": "cbt-incr"}],
     indirect=True,
 )
-class TestIncrementalBackupRestore:
+class TestIncrementalBackup:
     """
     Incremental backup validation for push and pull modes (backup success only).
 

--- a/tests/storage/cbt/test_cbt.py
+++ b/tests/storage/cbt/test_cbt.py
@@ -30,9 +30,12 @@ class TestFullBackupRestore:
     """
 
     @pytest.mark.polarion("CNV-15997")
-    def test_full_backup_push_mode_restore(self):
+    def test_full_backup_push_mode(
+        self,
+        completed_full_backup_push_mode,
+    ):
         """
-        Test that a VM can be backed up (push mode) and restored from a full backup.
+        Test that a full backup in push mode completes successfully.
 
         Preconditions:
             - Backup PVC available
@@ -40,16 +43,16 @@ class TestFullBackupRestore:
         Steps:
             1. Create a backup tracker for the VM
             2. Perform a full backup in push mode
-            3. Wait for backup to complete
-            4. Delete the original VM
-            5. Restore VM from the full backup
-            6. Start the restored VM
+            3. Wait for the backup to complete
 
         Expected:
-            - Restored VM boots successfully and test data is present
+            - Backup completes and includes the boot disk
         """
-
-    test_full_backup_push_mode_restore.__test__ = False  # STD placeholder - not yet implemented
+        assert_backup_includes_volumes(
+            backup=completed_full_backup_push_mode,
+            expected_volume_names=[DV_DISK],
+            expected_backup_type="Full",
+        )
 
     @pytest.mark.polarion("CNV-15996")
     def test_full_backup_pull_mode(
@@ -93,26 +96,30 @@ class TestIncrementalBackupRestore:
     """
 
     @pytest.mark.polarion("CNV-15998")
-    def test_incremental_backup_push_mode_restore(self):
+    def test_incremental_backup_push_mode(
+        self,
+        completed_incremental_backup_push_mode,
+    ):
         """
-        Test that a VM can be backed up (push mode) and restored from an incremental backup.
+        Test that an incremental backup in push mode completes successfully.
 
         Preconditions:
             - Backup PVC available
 
         Steps:
-            1. Write new test data to VM
-            2. Perform an incremental backup in push mode
-            3. Wait for backup to complete
-            4. Delete the original VM
-            5. Restore VM from the incremental backup
-            6. Start the restored VM
+            1. Perform a full backup in push mode and wait until it completes
+            2. Write new test data to VM
+            3. Perform an incremental backup in push mode
+            4. Wait for the backup to complete
 
         Expected:
-            - Restored VM boots successfully and all test data is present
+            - Incremental backup completes and includes the boot disk
         """
-
-    test_incremental_backup_push_mode_restore.__test__ = False  # STD placeholder - not yet implemented
+        assert_backup_includes_volumes(
+            backup=completed_incremental_backup_push_mode,
+            expected_volume_names=[DV_DISK],
+            expected_backup_type="Incremental",
+        )
 
     @pytest.mark.polarion("CNV-16000")
     def test_incremental_backup_pull_mode(

--- a/tests/storage/cbt/utils.py
+++ b/tests/storage/cbt/utils.py
@@ -9,6 +9,7 @@ from kubernetes.utils.quantity import parse_quantity
 from ocp_resources.virtual_machine_export import VirtualMachineExport
 from timeout_sampler import TimeoutSampler
 
+from tests.storage.cbt.constants import CBT_BACKUP_CONDITION_FAILED
 from utilities.constants.timeouts import TIMEOUT_5SEC, TIMEOUT_10MIN
 
 if TYPE_CHECKING:
@@ -74,6 +75,9 @@ def wait_for_push_backup_complete(backup: VirtualMachineBackup) -> None:
 
     Side effects:
         Polls the OpenShift API until the backup reports Complete=True.
+
+    Raises:
+        ConditionError: If the backup reports Failed=True before completing.
     """
     LOGGER.info(f"Waiting for push-mode backup {backup.name} to complete")
     backup.wait_for_condition(
@@ -81,6 +85,8 @@ def wait_for_push_backup_complete(backup: VirtualMachineBackup) -> None:
         status=backup.Condition.Status.TRUE,
         timeout=TIMEOUT_10MIN,
         sleep_time=TIMEOUT_5SEC,
+        stop_condition=CBT_BACKUP_CONDITION_FAILED,
+        stop_status=backup.Condition.Status.TRUE,
     )
 
 
@@ -93,6 +99,9 @@ def wait_for_pull_backup_export_ready(backup: VirtualMachineBackup) -> None:
     Side effects:
         Polls the OpenShift API until the backup reports Progressing=True with reason
         ExportReady (there is no ExportReady condition type).
+
+    Raises:
+        ConditionError: If the backup reports Failed=True before the export becomes ready.
     """
     LOGGER.info(f"Waiting for pull-mode backup {backup.name} export to become ready")
     backup.wait_for_condition(
@@ -101,6 +110,8 @@ def wait_for_pull_backup_export_ready(backup: VirtualMachineBackup) -> None:
         reason="ExportReady",
         timeout=TIMEOUT_10MIN,
         sleep_time=TIMEOUT_5SEC,
+        stop_condition=CBT_BACKUP_CONDITION_FAILED,
+        stop_status=backup.Condition.Status.TRUE,
     )
 
 

--- a/tests/storage/cbt/utils.py
+++ b/tests/storage/cbt/utils.py
@@ -59,6 +59,17 @@ def wait_for_vm_cbt_enabled(vm: VirtualMachine) -> None:
             return
 
 
+def wait_for_push_backup_complete(backup: VirtualMachineBackup) -> None:
+    """Wait until a push-mode backup completes successfully."""
+    LOGGER.info(f"Waiting for push-mode backup {backup.name} to complete")
+    backup.wait_for_condition(
+        condition="Complete",
+        status=backup.Condition.Status.TRUE,
+        timeout=TIMEOUT_10MIN,
+        sleep_time=TIMEOUT_5SEC,
+    )
+
+
 def wait_for_pull_backup_export_ready(backup: VirtualMachineBackup) -> None:
     """Wait until a pull-mode backup export is ready for collection."""
     # Pull readiness is Progressing=True with reason ExportReady (there is no ExportReady condition type).

--- a/tests/storage/cbt/utils.py
+++ b/tests/storage/cbt/utils.py
@@ -48,7 +48,14 @@ def assert_backup_includes_volumes(
 
 
 def wait_for_vm_cbt_enabled(vm: VirtualMachine) -> None:
-    """Wait until changed block tracking is Enabled on the VM."""
+    """Wait until changed block tracking is Enabled on the VM.
+
+    Args:
+        vm: VM to poll for CBT status.
+
+    Side effects:
+        Polls the OpenShift API until the VM reports changedBlockTracking.state == "Enabled".
+    """
     LOGGER.info(f"Waiting for CBT Enabled on VM {vm.name}")
     for cbt_state in TimeoutSampler(
         wait_timeout=TIMEOUT_10MIN,
@@ -60,7 +67,14 @@ def wait_for_vm_cbt_enabled(vm: VirtualMachine) -> None:
 
 
 def wait_for_push_backup_complete(backup: VirtualMachineBackup) -> None:
-    """Wait until a push-mode backup completes successfully."""
+    """Wait until a push-mode backup completes successfully.
+
+    Args:
+        backup: Push-mode backup resource to poll.
+
+    Side effects:
+        Polls the OpenShift API until the backup reports Complete=True.
+    """
     LOGGER.info(f"Waiting for push-mode backup {backup.name} to complete")
     backup.wait_for_condition(
         condition="Complete",
@@ -71,8 +85,15 @@ def wait_for_push_backup_complete(backup: VirtualMachineBackup) -> None:
 
 
 def wait_for_pull_backup_export_ready(backup: VirtualMachineBackup) -> None:
-    """Wait until a pull-mode backup export is ready for collection."""
-    # Pull readiness is Progressing=True with reason ExportReady (there is no ExportReady condition type).
+    """Wait until a pull-mode backup export is ready for collection.
+
+    Args:
+        backup: Pull-mode backup resource to poll.
+
+    Side effects:
+        Polls the OpenShift API until the backup reports Progressing=True with reason
+        ExportReady (there is no ExportReady condition type).
+    """
     LOGGER.info(f"Waiting for pull-mode backup {backup.name} export to become ready")
     backup.wait_for_condition(
         condition="Progressing",
@@ -84,7 +105,16 @@ def wait_for_pull_backup_export_ready(backup: VirtualMachineBackup) -> None:
 
 
 def wait_for_pull_backup_export_deleted(name: str, namespace: str, client: DynamicClient) -> None:
-    """Wait until the VirtualMachineExport owned by a pull-mode backup is gone."""
+    """Wait until the VirtualMachineExport owned by a pull-mode backup is gone.
+
+    Args:
+        name: Name of the VirtualMachineExport (matches the owning pull-mode backup name).
+        namespace: Namespace of the VirtualMachineExport.
+        client: Client used to poll the VirtualMachineExport.
+
+    Side effects:
+        Polls the OpenShift API until the VirtualMachineExport is deleted.
+    """
     export = VirtualMachineExport(name=name, namespace=namespace, client=client)
     LOGGER.info(f"Waiting for VirtualMachineExport {namespace}/{name} to be deleted")
     export.wait_deleted(timeout=TIMEOUT_10MIN)


### PR DESCRIPTION
##### What this PR does / why we need it:
Implement CBT push-mode full and incremental backup-success tests, matching the pull-mode coverage from #5761.

Validates that push backups reach Complete=True and include the boot disk. Remaining CBT scenarios (restore, multi-disk, migration, hotplug, negative, concurrent, Windows) stay as STD placeholders.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
- Mirrors pull backup-success approach: fixtures wait for Complete=True, tests assert included volumes + backup type.
- No restore / collect pods in this PR.
- Even though the STD covers backup and restore, to avoid PRs that are too long it will be split: this PR (and #5761) add the backup tests only; restore PRs will follow once the backup PRs are merged, same plan as pull mode.
- Added Args/Side effects docstring sections to the CBT wait helpers and extracted "Full"/"Incremental" backup type literals into named constants.

##### jira-ticket:
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for successful full and incremental push-mode backups.
  - Added validation for backup completion status, volume configuration, and backup types.
  - Standardized full and incremental backup type handling across CBT scenarios.
  - Improved backup readiness checks to detect both completed and failed operations.
  - Expanded test documentation for backup polling, readiness behavior, and export deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->