### PR TITLE
net, localnet: add shared-hostname VM regression tests

### DIFF
--- a/libs/vm/spec.py
+++ b/libs/vm/spec.py
@@ -29,6 +29,7 @@ class Metadata:
 class VMISpec:
     domain: Domain
     architecture: str | None = None
+    hostname: str | None = None
     networks: list[Network] | None = None
     volumes: list[Volume] | None = None
     terminationGracePeriodSeconds: int | None = None  # noqa: N815

--- a/tests/network/libs/localnet.py
+++ b/tests/network/libs/localnet.py
@@ -94,6 +94,7 @@ def localnet_vm(
     cloud_init: CloudInitNoCloud | None = None,
     affinity: Affinity | None = None,
     vm_labels: dict[str, str] | None = None,
+    hostname: str | None = None,
 ) -> BaseVirtualMachine:
     """
     Create a Fedora-based Virtual Machine connected to localnet network(s).
@@ -116,6 +117,9 @@ def localnet_vm(
         vm_labels: Optional labels to apply to the VM template metadata.
             These labels are set on the VMI pod and can be used for affinity/anti-affinity matching.
             If None, no additional labels are applied beyond LOCALNET_TEST_LABEL.
+        hostname: Optional hostname to set on the VMI spec
+            (spec.template.spec.hostname). When set, KubeVirt uses this value for the
+            vm.kubevirt.io/name pod label instead of the VM name.
 
     Returns:
         BaseVirtualMachine: The configured VM object ready for creation.
@@ -138,6 +142,9 @@ def localnet_vm(
 
     if affinity is not None:
         vmi_spec.affinity = copy.deepcopy(affinity)
+
+    if hostname is not None:
+        vmi_spec.hostname = hostname
 
     return fedora_vm(namespace=namespace, name=name, client=client, spec=spec)
 

--- a/tests/network/localnet/conftest.py
+++ b/tests/network/localnet/conftest.py
@@ -41,6 +41,8 @@ from utilities.constants.cluster import WORKER_NODE_LABEL_KEY
 from utilities.infra import create_ns
 from utilities.virt import migrate_vm_and_verify
 
+SHARED_HOSTNAME = "shared-localnet-vm"
+
 
 @pytest.fixture(scope="module")
 def nncp_localnet(
@@ -549,3 +551,123 @@ def ovs_bridge_localnet_running_jumbo_frame_vms(
 ) -> Generator[tuple[BaseVirtualMachine, BaseVirtualMachine]]:
     vm1, vm2 = run_vms(vms=(vm1_ovs_bridge_localnet_jumbo_frame, vm2_ovs_bridge_localnet_jumbo_frame))
     yield vm1, vm2
+
+
+@pytest.fixture(scope="module")
+def shared_hostname_vm_1(
+    unprivileged_client: DynamicClient,
+    ipv4_localnet_address_pool: Generator[str],
+    ipv6_localnet_address_pool: Generator[str],
+    namespace_localnet_1: Namespace,
+    cudn_localnet: libcudn.ClusterUserDefinedNetwork,
+) -> Generator[BaseVirtualMachine]:
+    with localnet_vm(
+        namespace=namespace_localnet_1.name,
+        name="shared-hostname-vm1",
+        client=unprivileged_client,
+        networks=[Network(name=LOCALNET_BR_EX_INTERFACE, multus=Multus(networkName=cudn_localnet.name))],
+        interfaces=[Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={})],
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        ),
+                    )
+                }
+            )
+        ),
+        hostname=SHARED_HOSTNAME,
+    ) as vm:
+        yield vm
+
+
+@pytest.fixture(scope="module")
+def shared_hostname_vm_2(
+    unprivileged_client: DynamicClient,
+    ipv4_localnet_address_pool: Generator[str],
+    ipv6_localnet_address_pool: Generator[str],
+    namespace_localnet_1: Namespace,
+    cudn_localnet: libcudn.ClusterUserDefinedNetwork,
+) -> Generator[BaseVirtualMachine]:
+    with localnet_vm(
+        namespace=namespace_localnet_1.name,
+        name="shared-hostname-vm2",
+        client=unprivileged_client,
+        networks=[Network(name=LOCALNET_BR_EX_INTERFACE, multus=Multus(networkName=cudn_localnet.name))],
+        interfaces=[Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={})],
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        ),
+                    )
+                }
+            )
+        ),
+        hostname=SHARED_HOSTNAME,
+    ) as vm:
+        yield vm
+
+
+@pytest.fixture(scope="module")
+def shared_hostname_vm_3(
+    unprivileged_client: DynamicClient,
+    ipv4_localnet_address_pool: Generator[str],
+    ipv6_localnet_address_pool: Generator[str],
+    namespace_localnet_1: Namespace,
+    cudn_localnet: libcudn.ClusterUserDefinedNetwork,
+) -> Generator[BaseVirtualMachine]:
+    with localnet_vm(
+        namespace=namespace_localnet_1.name,
+        name="shared-hostname-vm3",
+        client=unprivileged_client,
+        networks=[Network(name=LOCALNET_BR_EX_INTERFACE, multus=Multus(networkName=cudn_localnet.name))],
+        interfaces=[Interface(name=LOCALNET_BR_EX_INTERFACE, bridge={})],
+        cloud_init=localnet_cloudinit(
+            network_data=cloudinit.NetworkData(
+                ethernets={
+                    GUEST_1ST_IFACE_NAME: cloudinit.EthernetDevice(
+                        addresses=ip_addresses_from_pool(
+                            ipv4_pool=ipv4_localnet_address_pool,
+                            ipv6_pool=ipv6_localnet_address_pool,
+                        ),
+                    )
+                }
+            )
+        ),
+        hostname=SHARED_HOSTNAME,
+    ) as vm:
+        yield vm
+
+
+@pytest.fixture(scope="module")
+def running_shared_hostname_vms(
+    shared_hostname_vm_1: BaseVirtualMachine,
+    shared_hostname_vm_2: BaseVirtualMachine,
+    shared_hostname_vm_3: BaseVirtualMachine,
+) -> list[BaseVirtualMachine]:
+    running_vms = run_vms(vms=(shared_hostname_vm_1, shared_hostname_vm_2, shared_hostname_vm_3))
+    ip_families = supported_cluster_ip_versions()
+    for vm in running_vms:
+        vmi_hostname = vm.vmi.instance.spec.hostname
+        if vmi_hostname != SHARED_HOSTNAME:
+            raise RuntimeError(f"VM {vm.name} hostname is {vmi_hostname!r}, expected {SHARED_HOSTNAME!r}")
+        lookup_iface_status(
+            vm=vm,
+            iface_name=LOCALNET_BR_EX_INTERFACE,
+            predicate=lambda interface: (
+                len(
+                    filter_cluster_unsupported_addresses(
+                        ip_addresses=filter_link_local_addresses(ip_addresses=interface.get("ipAddresses", []))
+                    )
+                )
+                == len(ip_families)
+            ),
+        )
+    return list(running_vms)

--- a/tests/network/localnet/test_default_bridge.py
+++ b/tests/network/localnet/test_default_bridge.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import ipaddress
+import itertools
 from ipaddress import ip_interface
 from typing import TYPE_CHECKING
 
 import pytest
 
 from libs.net.ip import filter_cluster_unsupported_addresses, filter_link_local_addresses, have_same_ip_families
-from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
+from libs.net.traffic_generator import active_tcp_connections, client_server_active_connection, is_tcp_connection
 from libs.net.vmspec import lookup_iface_status
 from tests.network.libs.localnet import (
     GUEST_2ND_IFACE_NAME,
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
 
     from libs.net.traffic_generator import TcpServer, VMTcpClient
+    from libs.vm.vm import BaseVirtualMachine
 
 
 @pytest.mark.gating
@@ -102,3 +104,88 @@ def test_vmi_reports_ip_on_secondary_interface_without_vlan(
         f"IP addresses mismatch for interface {LOCALNET_BR_EX_INTERFACE_NO_VLAN} on VM {vm.name}, "
         f"Reported: {reported_ips}, Expected: {expected_ips}"
     )
+
+
+@pytest.mark.single_nic
+@pytest.mark.incremental
+@pytest.mark.usefixtures("nncp_localnet")
+class TestSharedHostnameLocalnet:
+    """Tests for VMs sharing the same spec.template.spec.hostname on localnet.
+
+    Jira: https://issues.redhat.com/browse/OCPBUGS-99277 # <skip-jira-utils-check>
+
+    Preconditions:
+        - 3 VMs with identical spec.template.spec.hostname connected to a localnet secondary network
+        - All 3 VMs Running with IPs assigned on the localnet interface
+    """
+
+    @pytest.mark.polarion("CNV-16555")
+    def test_tcp_connectivity_between_shared_hostname_vms(
+        self,
+        subtests: pytest.Subtests,
+        running_shared_hostname_vms: list[BaseVirtualMachine],
+    ):
+        """Test that VMs sharing the same hostname can communicate over localnet.
+
+        Preconditions:
+            - 3 VMs with identical spec.template.spec.hostname connected to a localnet secondary network
+            - All 3 VMs Running with IPs assigned on the localnet interface
+
+        Steps:
+            1. For each pair of VMs, establish a TCP connection over the localnet interface
+
+        Expected:
+            - TCP connectivity succeeds between all VM pairs
+        """
+        for client_vm, server_vm in itertools.combinations(running_shared_hostname_vms, 2):
+            with active_tcp_connections(
+                client_vm=client_vm,
+                server_vm=server_vm,
+                iface_name=LOCALNET_BR_EX_INTERFACE,
+            ) as connections:
+                for client, server in connections:
+                    with subtests.test(
+                        msg=f"{client_vm.name} -> {server_vm.name} IPv{ipaddress.ip_address(client.server_ip).version}"
+                    ):
+                        assert is_tcp_connection(server=server, client=client), (
+                            f"TCP connection failed: {client_vm.name} -> {server_vm.name} ({client.server_ip})"
+                        )
+
+    @pytest.mark.polarion("CNV-16556")
+    def test_tcp_connectivity_after_migration_of_shared_hostname_vm(
+        self,
+        subtests: pytest.Subtests,
+        admin_client: DynamicClient,
+        running_shared_hostname_vms: list[BaseVirtualMachine],
+    ):
+        """Test that connectivity is preserved after migrating a VM that shares its hostname.
+
+        Preconditions:
+            - 3 VMs with identical spec.template.spec.hostname connected to a localnet secondary network
+            - All 3 VMs Running with IPs assigned on the localnet interface
+
+        Steps:
+            1. Migrate one of the shared-hostname VMs
+            2. Establish TCP connections from the migrated VM to each of the other VMs
+
+        Expected:
+            - TCP connectivity succeeds from the migrated VM to all other VMs
+        """
+        migrated_vm = running_shared_hostname_vms[0]
+        migrate_vm_and_verify(vm=migrated_vm, client=admin_client)
+
+        for peer_vm in running_shared_hostname_vms[1:]:
+            with active_tcp_connections(
+                client_vm=migrated_vm,
+                server_vm=peer_vm,
+                iface_name=LOCALNET_BR_EX_INTERFACE,
+            ) as connections:
+                for client, server in connections:
+                    with subtests.test(
+                        msg=f"migrated {migrated_vm.name} -> {peer_vm.name}"
+                        f" IPv{ipaddress.ip_address(client.server_ip).version}"
+                    ):
+                        assert is_tcp_connection(server=server, client=client), (
+                            f"TCP connection failed after migration:"
+                            f" {migrated_vm.name} -> {peer_vm.name} ({client.server_ip})"
+                        )


### PR DESCRIPTION
##### What this PR does / why we need it:
Add regression tests for OCPBUGS-99277 — OVN-Kubernetes failed with
"unexpected live migration state at pods" when 3+ VMs shared the same
`spec.template.spec.hostname`, making the `vm.kubevirt.io/name` pod
label ambiguous during live migration status discovery.

Changes:
- Add `hostname` field to `VMISpec` and `localnet_vm()` factory
- Add 3 shared-hostname VM fixtures reusing the existing localnet
namespace, CUDN, and IP address pools
- Add 2 tests in `test_default_bridge.py`:
    - TCP connectivity between all pairs of shared-hostname VMs
    - Migration succeeds and post-migration connectivity is preserved

##### Which issue(s) this PR fixes:
regression for https://issues.redhat.com/browse/OCPBUGS-99277

##### Special notes for reviewer:
The `hostname` parameter on `localnet_vm()` is a stopgap - a follow-up
PR will introduce a new pattern across all VM factories  so that generic 
VMI spec fields don't grow factory signatures.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-93643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual machines can now be assigned an optional hostname.
  * Local network configurations support hostname assignment for improved VM identification.

* **Bug Fixes**
  * Preserved IPv4 and IPv6 TCP connectivity between virtual machines sharing a hostname.
  * Maintained connectivity after migrating a shared-hostname virtual machine.

* **Tests**
  * Added coverage for shared-hostname networking and post-migration connectivity across multiple virtual machines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->