### PR TITLE
net, tests, udn: Add VM-to-pod connectivity test

### DIFF
--- a/libs/net/udn.py
+++ b/libs/net/udn.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 from typing import Final
 

--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -1,7 +1,9 @@
 from collections.abc import Generator
+from typing import TYPE_CHECKING
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.pod import Pod
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
 from libs.net.ip import random_ipv4_address
@@ -13,7 +15,11 @@ from libs.vm.oper import run_vms
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs.vm_factory import udn_vm
 from utilities.constants.architecture import AMD_64, ARM_64
+from utilities.constants.networking import POD_CONTAINER_SPEC
 from utilities.infra import create_ns
+
+if TYPE_CHECKING:
+    from ocp_resources.namespace import Namespace
 
 
 @pytest.fixture(scope="module")
@@ -145,3 +151,19 @@ def running_amd_and_arm_vms(
     """
     amd64_vm, arm64_vm = run_vms(vms=(amd64_udn_vm, arm64_udn_vm))
     return amd64_vm, arm64_vm
+
+
+@pytest.fixture(scope="class")
+def udn_pod(
+    admin_client: DynamicClient,
+    udn_namespace: Namespace,
+    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
+) -> Generator[Pod]:
+    with Pod(
+        name="udn-pod",
+        namespace=udn_namespace.name,
+        containers=[{**POD_CONTAINER_SPEC, "name": "udn-container"}],
+        client=admin_client,
+    ) as pod:
+        pod.wait_for_status(status=Pod.Status.RUNNING)
+        yield pod

--- a/tests/network/user_defined_network/libudn.py
+++ b/tests/network/user_defined_network/libudn.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from ocp_resources.resource import Resource
+
+from libs.net.vmspec import IpNotFound
+
+if TYPE_CHECKING:
+    from ocp_resources.pod import Pod
+
+
+def lookup_default_pod_ip(pod: Pod) -> str:
+    """Return the default network IP address of a pod.
+
+    Args:
+        pod: The pod to query.
+
+    Returns:
+        The IP address from the default network attachment.
+    """
+    network_status_annotation = f"{Resource.ApiGroup.K8S_V1_CNI_CNCF_IO}/network-status"
+    network_status = json.loads(pod.instance.metadata.annotations[network_status_annotation])
+    default_entry = next(entry for entry in network_status if entry.get("default"))
+    if not default_entry["ips"]:
+        raise IpNotFound(f"No IPs assigned to default UDN entry on pod {pod.name}")
+    return str(default_entry["ips"][0])

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -8,6 +8,7 @@ from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
 from libs.net.traffic_generator import is_tcp_connection
 from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
+from tests.network.user_defined_network.libudn import lookup_default_pod_ip
 from utilities.constants.networking import PUBLIC_DNS_SERVER_IP
 from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_1MIN
@@ -79,3 +80,9 @@ class TestPrimaryUdn:
     ):
         migrate_vm_and_verify(vm=server.vm, client=admin_client)
         assert is_tcp_connection(server=server, client=client)
+
+    @pytest.mark.polarion("CNV-11432")
+    def test_vm_to_pod_connectivity_on_udn(self, vma_udn, udn_pod):
+        """Jira: https://redhat.atlassian.net/browse/CNV-51404 # <skip-jira-utils-check>"""
+        pod_ip = lookup_default_pod_ip(pod=udn_pod)
+        vma_udn.console(commands=[f"ping -c 3 {pod_ip}"], timeout=TIMEOUT_1MIN)


### PR DESCRIPTION
##### What this PR does / why we need it:
Verify that a VM and a pod, both connected to the same Primary User Defined Network, have connectivity over the UDN interfaces.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-51404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the IP address of pods connected to a user-defined network.
  * Improved visibility into connectivity between virtual machines and pods on user-defined networks.

* **Tests**
  * Added validation that virtual machines can communicate with pods on user-defined networks.
  * Expanded network connectivity coverage for user-defined network scenarios, including pod readiness and default-network IP resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->