### PR TITLE
[Storage] STD: concurrent 20 VM boot with 4 disks per VM

### DIFF
--- a/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
+++ b/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
@@ -1,0 +1,39 @@
+"""
+Concurrent VM boot with multiple disks per VM.
+
+Validates the ability to spin up 20 VMs simultaneously, each with 1 golden image
+boot volume (PVC clone) + 1 cloud-init disk + 3 blank data volumes
+(5 disk devices total in the VMI spec).
+
+Jira: https://redhat.atlassian.net/browse/CNV-88906  # <skip-jira-utils-check>
+
+Preconditions:
+    - Fedora golden image DataSource available in openshift-virtualization-os-images
+    - Storage class supporting dynamic provisioning and CSI volume cloning
+    - Sufficient cluster resources to schedule 20 VMs simultaneously
+"""
+
+import pytest
+
+
+@pytest.mark.tier3
+@pytest.mark.conformance
+@pytest.mark.polarion("CNV-16335")
+def test_concurrent_vms_boot_with_four_disks():
+    """
+    Test that 20 VMs boot simultaneously, each reporting the expected number of disk devices.
+
+    Preconditions:
+        - 20 VMs created, each with 1 golden image boot volume, 1 cloud-init disk,
+          and 3 blank data volumes
+        - All 20 VMs started simultaneously and reached Running state
+
+    Steps:
+        1. For each VM, verify the number of disk devices reported in the VMI spec
+
+    Expected:
+        - All 20 VMs report 5 disk devices each in the VMI spec
+    """
+
+
+test_concurrent_vms_boot_with_four_disks.__test__ = False

--- a/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
+++ b/tests/storage/concurrent_vm_boot/test_concurrent_vm_boot.py
@@ -1,39 +1,51 @@
 """
-Concurrent VM boot with multiple disks per VM.
+Concurrent VM Boot Tests
 
-Validates the ability to spin up 20 VMs simultaneously, each with 1 golden image
-boot volume (PVC clone) + 1 cloud-init disk + 3 blank data volumes
-(5 disk devices total in the VMI spec).
+Validates booting 20 virtual machines simultaneously, each with a multi-disk
+configuration: one cloned boot volume, one cloud-init disk, and three blank
+data volumes (five disk devices total in the VMI spec).
 
 Jira: https://redhat.atlassian.net/browse/CNV-88906  # <skip-jira-utils-check>
 
-Preconditions:
-    - Fedora golden image DataSource available in openshift-virtualization-os-images
-    - Storage class supporting dynamic provisioning and CSI volume cloning
-    - Sufficient cluster resources to schedule 20 VMs simultaneously
+Markers:
+    - tier3
+    - conformance
 """
 
 import pytest
 
+__test__ = False
 
-@pytest.mark.tier3
-@pytest.mark.conformance
-@pytest.mark.polarion("CNV-16335")
-def test_concurrent_vms_boot_with_four_disks():
+
+class TestConcurrentVMBoot:
     """
-    Test that 20 VMs boot simultaneously, each reporting the expected number of disk devices.
+    Tests for booting multiple VMs simultaneously with multi-disk configurations.
 
     Preconditions:
-        - 20 VMs created, each with 1 golden image boot volume, 1 cloud-init disk,
-          and 3 blank data volumes
-        - All 20 VMs started simultaneously and reached Running state
-
-    Steps:
-        1. For each VM, verify the number of disk devices reported in the VMI spec
-
-    Expected:
-        - All 20 VMs report 5 disk devices each in the VMI spec
+        - Fedora golden image DataSource available in the openshift-virtualization-os-images namespace
+        - Storage class supporting dynamic provisioning and CSI volume cloning
+        - Sufficient cluster resources to schedule 20 VMs simultaneously
     """
 
+    @pytest.mark.tier3
+    @pytest.mark.conformance
+    @pytest.mark.polarion("CNV-16335")
+    def test_concurrent_vms_boot_with_five_disks(self):
+        """
+        Test that 20 VMs boot simultaneously with five disk devices each and all reach Running state.
 
-test_concurrent_vms_boot_with_four_disks.__test__ = False
+        Preconditions:
+            - Fedora golden image DataSource available in the openshift-virtualization-os-images namespace
+            - Storage class supporting dynamic provisioning and CSI volume cloning
+            - Sufficient cluster resources to schedule 20 VMs simultaneously
+
+        Steps:
+            1. Create 20 VMs, each with one golden image boot volume (PVC clone via DataSource),
+               one cloud-init disk, and three blank data volumes
+            2. Start all 20 VMs simultaneously
+            3. Wait for all 20 VMs to reach Running state
+            4. For each VM, inspect the disk devices reported in the VMI spec
+
+        Expected:
+            - All 20 VMs report exactly five disk devices each in the VMI spec
+        """


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds the STD (Software Test Description) for the concurrent VM boot test before the implementation PR (#5768) is merged.

The test validates that 20 VMs boot simultaneously, each with:
- 1 golden image boot volume (PVC clone via DataSource)
- 1 cloud-init disk
- 3 blank data volumes

= 5 disk devices total in the VMI spec

##### Which issue(s) this PR fixes:
Jira: CNV-88906

##### Special notes for reviewer:
- This is the **STD-only PR** (Phase 1). Implementation is in #5768.
- `__test__ = False` prevents collection until the implementation PR lands.
- Docstring uses natural language only — no variable names or code identifiers per STD rules.
- Markers (`@pytest.mark.tier3`, `@pytest.mark.conformance`, `@pytest.mark.polarion`) are on the test function; `pytestmark` is intentionally absent (Phase 2 addition per STD workflow docs).

##### jira-ticket:
CNV-88906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a tier-3 conformance test scaffold for booting 20 virtual machines concurrently.
  - Documents a configuration with cloned boot volumes, cloud-init disks, and blank data volumes.
  - Includes storage and cluster prerequisites along with tracking references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->