### PR TITLE
[4.20][Storage] Manual Cherry-Pick: Add Velero backup hooks opt-out tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ from utilities.constants import (
     PREFERENCE_STR,
     RHEL9_PREFERENCE,
     RHEL9_STR,
+    RHEL10_STR,
     RHEL_WITH_INSTANCETYPE_AND_PREFERENCE,
     RHSM_SECRET_NAME,
     S390X,
@@ -899,6 +900,16 @@ def rhel9_data_source_scope_session(golden_images_namespace):
         client=golden_images_namespace.client,
         name=RHEL9_STR,
         namespace=golden_images_namespace.name,
+        ensure_exists=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def rhel10_data_source_scope_session(golden_images_namespace):
+    return DataSource(
+        namespace=golden_images_namespace.name,
+        name=RHEL10_STR,
+        client=golden_images_namespace.client,
         ensure_exists=True,
     )
 

--- a/tests/data_protection/oadp/conftest.py
+++ b/tests/data_protection/oadp/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.namespace import Namespace
+from ocp_resources.virtual_machine_cluster_instancetype import VirtualMachineClusterInstancetype
+from ocp_resources.virtual_machine_cluster_preference import VirtualMachineClusterPreference
 
 from tests.data_protection.oadp.utils import (
     VeleroRestore,
@@ -10,9 +12,12 @@ from utilities.constants import (
     BACKUP_STORAGE_LOCATION,
     FILE_NAME_FOR_BACKUP,
     OS_FLAVOR_RHEL,
+    RHEL10_PREFERENCE,
+    SKIP_BACKUP_HOOKS_ANNOTATION,
     TEXT_TO_TEST,
     TIMEOUT_8MIN,
     TIMEOUT_15MIN,
+    U1_SMALL,
     Images,
 )
 from utilities.infra import create_ns
@@ -24,11 +29,12 @@ from utilities.storage import (
     check_upload_virtctl_result,
     create_dv,
     create_vm_from_dv,
+    data_volume_template_with_source_ref_dict,
     get_downloaded_artifact,
     virtctl_upload_dv,
     write_file,
 )
-from utilities.virt import running_vm
+from utilities.virt import VirtualMachineForTests, running_vm
 
 
 @pytest.fixture()
@@ -254,3 +260,58 @@ def velero_restore_second_namespace_with_datamover(
         timeout=TIMEOUT_15MIN,
     ) as restore:
         yield restore
+
+
+@pytest.fixture()
+def namespace_for_hooks_backup(admin_client, unprivileged_client):
+    """Namespace for hooks opt-out tests, created with unprivileged RBAC."""
+    yield from create_ns(admin_client=admin_client, unprivileged_client=unprivileged_client, name="velero-hooks-ns")
+
+
+@pytest.fixture()
+def rhel_vm_with_hooks_opt_out(
+    unprivileged_client,
+    rhel10_data_source_scope_session,
+    snapshot_storage_class_name_scope_module,
+    namespace_for_hooks_backup,
+):
+    """Running RHEL VM with kubevirt.io/skip-backup-hooks annotation set to 'true'.
+
+    Creates a RHEL VM with the skip-backup-hooks annotation, waits for it to
+    reach a running state, and verifies the annotation is present before yielding.
+
+    Yields:
+        VirtualMachineForTests: Running VM with backup hooks opt-out annotation.
+    """
+    with VirtualMachineForTests(
+        name="vm-hooks-opt-out",
+        namespace=namespace_for_hooks_backup.name,
+        client=unprivileged_client,
+        os_flavor=OS_FLAVOR_RHEL,
+        vm_instance_type=VirtualMachineClusterInstancetype(client=unprivileged_client, name=U1_SMALL),
+        vm_preference=VirtualMachineClusterPreference(client=unprivileged_client, name=RHEL10_PREFERENCE),
+        data_volume_template=data_volume_template_with_source_ref_dict(
+            data_source=rhel10_data_source_scope_session,
+            storage_class=snapshot_storage_class_name_scope_module,
+        ),
+        annotations={SKIP_BACKUP_HOOKS_ANNOTATION: "true"},
+    ) as vm:
+        running_vm(vm=vm)
+        assert vm.instance.metadata.annotations[SKIP_BACKUP_HOOKS_ANNOTATION] == "true", (
+            f"VM {vm.name} missing {SKIP_BACKUP_HOOKS_ANNOTATION} annotation"
+        )
+        yield vm
+
+
+@pytest.fixture()
+def paused_rhel_vm_with_hooks_opt_out(rhel_vm_with_hooks_opt_out):
+    """Paused RHEL VM with kubevirt.io/skip-backup-hooks annotation set to 'true'.
+
+    Pauses the running VM from rhel_vm_with_hooks_opt_out and yields it
+    in the paused state.
+
+    Yields:
+        VirtualMachineForTests: Paused VM with backup hooks opt-out annotation.
+    """
+    rhel_vm_with_hooks_opt_out.vmi.pause(wait=True)
+    yield rhel_vm_with_hooks_opt_out

--- a/tests/data_protection/oadp/test_velero_backup_hooks.py
+++ b/tests/data_protection/oadp/test_velero_backup_hooks.py
@@ -1,0 +1,91 @@
+"""
+Velero Backup Hook Opt-Out Tests
+
+STP:
+https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/
+sig-storage/remove-velero-hooks-stp.md
+Jira: https://redhat.atlassian.net/browse/CNV-79727 # <skip-jira-utils-check>
+"""
+
+import logging
+
+import pytest
+
+from tests.data_protection.oadp.utils import assert_velero_backup_hooks_not_injected
+from utilities.oadp import VeleroBackup
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TestVeleroBackupHookOptOut:
+    """
+    Tests for Velero backup hook opt-out.
+
+    The skip-backup-hooks annotation is intended for metadata-only backup workflows where
+    third-party solutions handle the actual data protection. These tests verify that
+    freeze/unfreeze hooks are not injected and that Velero backup completes when the
+    annotation is set.
+
+    Preconditions:
+        - Under-test VM with ``kubevirt.io/skip-backup-hooks`` set to ``"true"``
+    """
+
+    @pytest.mark.polarion("CNV-16267")
+    def test_backup_paused_vm_hooks_disabled(
+        self,
+        admin_client,
+        namespace_for_hooks_backup,
+        paused_rhel_vm_with_hooks_opt_out,
+    ):
+        """
+        Test that backup of paused VM completes with hooks disabled.
+
+        Preconditions:
+            - Under-test VM with ``kubevirt.io/skip-backup-hooks`` set to ``"true"``, paused
+
+        Steps:
+            1. Run Velero backup
+            2. Inspect virt-launcher pod for Velero hook annotations
+
+        Expected:
+            - No freeze/unfreeze hooks are injected on the virt-launcher pod
+            - Backup completes successfully
+        """
+        with VeleroBackup(
+            name="backup-paused-optout",
+            client=admin_client,
+            included_namespaces=[namespace_for_hooks_backup.name],
+            teardown=True,
+        ) as backup:
+            assert_velero_backup_hooks_not_injected(vm=paused_rhel_vm_with_hooks_opt_out, admin_client=admin_client)
+            LOGGER.info(f"Backup {backup.name} completed for paused VM with opt-out annotation")
+
+    @pytest.mark.polarion("CNV-16268")
+    def test_backup_running_vm_hooks_disabled(
+        self,
+        admin_client,
+        namespace_for_hooks_backup,
+        rhel_vm_with_hooks_opt_out,
+    ):
+        """
+        Test that backup of a running VM completes with hooks disabled.
+
+        Preconditions:
+            - Under-test VM with ``kubevirt.io/skip-backup-hooks`` set to ``"true"``, running
+
+        Steps:
+            1. Run Velero backup
+            2. Inspect virt-launcher pod for Velero hook annotations
+
+        Expected:
+            - No freeze/unfreeze hooks are injected on the virt-launcher pod
+            - Backup completes successfully
+        """
+        with VeleroBackup(
+            name="backup-hooks-opt-out",
+            client=admin_client,
+            included_namespaces=[namespace_for_hooks_backup.name],
+            teardown=True,
+        ) as backup:
+            assert_velero_backup_hooks_not_injected(vm=rhel_vm_with_hooks_opt_out, admin_client=admin_client)
+            LOGGER.info(f"Backup {backup.name} completed for running VM with opt-out annotation")

--- a/tests/data_protection/oadp/utils.py
+++ b/tests/data_protection/oadp/utils.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.restore import Restore
 from ocp_resources.storage_profile import StorageProfile
+from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 from utilities import console
 from utilities.constants import (
@@ -14,11 +18,17 @@ from utilities.constants import (
     TIMEOUT_10SEC,
     TIMEOUT_15SEC,
     TIMEOUT_20SEC,
+    VELERO_BACKUP_HOOK_ANNOTATIONS,
 )
 from utilities.infra import (
     unique_name,
 )
 from utilities.oadp import delete_velero_resource
+
+if TYPE_CHECKING:
+    from kubernetes.dynamic import DynamicClient
+
+    from utilities.virt import VirtualMachineForTests
 
 LOGGER = logging.getLogger(__name__)
 
@@ -81,3 +91,31 @@ def is_storage_class_support_volume_mode(storage_class_name, requested_volume_mo
 def wait_for_restored_dv(dv):
     dv.pvc.wait_for_status(status=PersistentVolumeClaim.Status.BOUND, timeout=TIMEOUT_15SEC)
     dv.wait_for_dv_success(timeout=TIMEOUT_10SEC)
+
+
+def assert_velero_backup_hooks_not_injected(vm: VirtualMachineForTests, admin_client: DynamicClient) -> None:
+    """Assert virt-launcher has no Velero freeze/unfreeze hook annotations.
+
+    Absence of these annotations means Velero will not execute filesystem
+    freeze/unfreeze during backup.
+
+    Args:
+        vm: VirtualMachine whose virt-launcher pod is checked.
+        admin_client: Privileged client used to access the virt-launcher pod.
+
+    Raises:
+        AssertionError: If any Velero hook annotations are found on the virt-launcher pod.
+    """
+    virt_launcher_pod = VirtualMachineInstance(
+        client=admin_client,
+        name=vm.name,
+        namespace=vm.namespace,
+    ).virt_launcher_pod
+    pod_annotations = virt_launcher_pod.instance.metadata.annotations or {}
+    present_hook_annotations = [
+        annotation_key for annotation_key in VELERO_BACKUP_HOOK_ANNOTATIONS if annotation_key in pod_annotations
+    ]
+    assert not present_hook_annotations, (
+        f"VM {vm.name} virt-launcher pod has Velero hook annotations {present_hook_annotations} "
+        f"but backup hooks should be disabled"
+    )

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -527,16 +527,6 @@ def fedora_data_source_scope_module(golden_images_namespace):
     )
 
 
-@pytest.fixture(scope="session")
-def rhel10_data_source_scope_session(golden_images_namespace):
-    return DataSource(
-        namespace=golden_images_namespace.name,
-        name="rhel10",
-        client=golden_images_namespace.client,
-        ensure_exists=True,
-    )
-
-
 @pytest.fixture(scope="class")
 def storage_class_name_scope_class(storage_class_matrix__class__):
     return [*storage_class_matrix__class__][0]

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -404,6 +404,7 @@ CREATING_VIRTUAL_MACHINE_FROM_VOLUME = "creating-virtual-machine-from-volume"
 UPLOAD_BOOT_SOURCE = "upload-boot-source"
 GRAFANA_DASHBOARD_KUBEVIRT_TOP_CONSUMERS = "grafana-dashboard-kubevirt-top-consumers"
 RHEL9_STR = "rhel9"
+RHEL10_STR = "rhel10"
 RHEL8_GUEST = "rhel8-guest"
 RHEL9_GUEST = "rhel9-guest"
 RHEL10_GUEST = "rhel10-guest"
@@ -953,6 +954,17 @@ ADP_NAMESPACE = "openshift-adp"
 FILE_NAME_FOR_BACKUP = "file_before_backup.txt"
 TEXT_TO_TEST = "text"
 BACKUP_STORAGE_LOCATION = "dpa-1"
+SKIP_BACKUP_HOOKS_ANNOTATION = "kubevirt.io/skip-backup-hooks"
+
+# Velero hook annotations injected on virt-launcher when backup hooks are enabled.
+# See kubevirt pkg/storage/velero and pkg/storage/pod/annotations/generator.go
+VELERO_BACKUP_HOOK_ANNOTATIONS = (
+    "pre.hook.backup.velero.io/container",
+    "pre.hook.backup.velero.io/command",
+    "pre.hook.backup.velero.io/timeout",
+    "post.hook.backup.velero.io/container",
+    "post.hook.backup.velero.io/command",
+)
 
 # AAQ
 AAQ_NAMESPACE_LABEL = {"application-aware-quota/enable-gating": ""}


### PR DESCRIPTION
##### What this PR does / why we need it:
This is a manual cherry-pick of https://github.com/RedHatQE/openshift-virtualization-tests/pull/5478.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

- includes `from __future__ import annotations` in OADP utils to fix the tox collection NameError on TYPE_CHECKING hints that blocked [#5961](https://github.com/RedHatQE/openshift-virtualization-tests/pull/5961).
- `rhel10_data_source_scope_session` is added to global tests/conftest.py so OADP can resolve it (it previously lived only under tests/storage/).

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-85597