### PR TITLE
[net, hot-plug] Keep the default timeout for reading an hot-plugged interface from the guest console

### DIFF
--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -309,7 +309,7 @@ def _lookup_hotplugged_iface_via_console(
         f"falling back to console lookup by MAC {vmi_iface['macAddress']}."
     )
     cmd = "ip -j addr show"
-    output = vm_console_run_commands(vm=vm, commands=[cmd], timeout=30)
+    output = vm_console_run_commands(vm=vm, commands=[cmd])
     guest_interfaces = json.loads(output[cmd][1])
 
     visible_ifaces = [{"ifname": iface.get("ifname"), "address": iface.get("address")} for iface in guest_interfaces]


### PR DESCRIPTION
Network hot-plug tests started failing in the flow of a [recent fix](https://github.com/RedHatQE/openshift-virtualization-tests/pull/5584). The suspect is when accessing the console for reading an hot-plugged interface, there's not enough grace timeout for this action. The default timeout is 60 seconds, while in the fix it was [overriden and set to 30](https://github.com/RedHatQE/openshift-virtualization-tests/blob/main/tests/network/l2_bridge/libl2bridge.py#L312).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when detecting hot-plugged network interfaces by using the console command’s standard timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->