### PR TITLE
Quarantine: upgrade observability tests CNV-84508

### DIFF
--- a/tests/observability/upgrade/test_upgrade_observability.py
+++ b/tests/observability/upgrade/test_upgrade_observability.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.observability.constants import KUBEVIRT_VMI_NUMBER_OF_OUTDATED
 from tests.upgrade_params import IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID
-from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
+from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION, QUARANTINED
 from utilities.monitoring import validate_metrics_value
 
 
@@ -17,6 +17,10 @@ class TestUpgradeObservability:
     @pytest.mark.order(before=IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID)
     @pytest.mark.dependency(name=TEST_METRIC_KUBEVIRT_VMI_NUMBER_OF_OUTDATED_BEFORE_UPGRADE)
     @pytest.mark.polarion("CNV-11749")
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: pre-upgrade setup for quarantined post-upgrade tests; CNV-84508",
+        run=False,
+    )
     def test_metric_kubevirt_vmi_number_of_outdated_before_upgrade(self, prometheus, vm_with_node_selector_for_upgrade):
         validate_metrics_value(
             prometheus=prometheus,
@@ -32,6 +36,10 @@ class TestUpgradeObservability:
         name=TEST_OUTDATED_VMIS_COUNT_MATCHES,
         depends=[IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID],
         scope=DEPENDENCY_SCOPE_SESSION,
+    )
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: runs before opt-in migration completes, causing outdated VMI count mismatch; CNV-84508",
+        run=False,
     )
     def test_outdated_vmis_count_matches_kubevirt_status_after_upgrade(
         self, outdated_vmis_count, kubevirt_resource_outdated_vmi_workloads_count
@@ -55,6 +63,10 @@ class TestUpgradeObservability:
             TEST_OUTDATED_VMIS_COUNT_MATCHES,
         ],
         scope=DEPENDENCY_SCOPE_SESSION,
+    )
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: invalid namespace filter on kubevirt_vmi_number_of_outdated metric; CNV-84508",
+        run=False,
     )
     def test_metric_kubevirt_vmi_number_of_outdated_after_upgrade(
         self, prometheus, kubevirt_resource_outdated_vmi_workloads_count, vm_with_node_selector_for_upgrade


### PR DESCRIPTION
##### What this PR does / why we need it:
Quarantines two failing tests in `TestUpgradeObservability`:

- **`test_outdated_vmis_count_matches_kubevirt_status_after_upgrade`**: Runs before `test_vmi_pod_image_updates_after_upgrade_optin` which calls `wait_for_automatic_vm_migrations()`. At this point migrations are still in progress, so the `outdatedLauncherImage` label count and `KubeVirt.status.outdatedVirtualMachineInstanceWorkloads` are temporarily out of sync, causing consistent off-by-one failures (e.g. 8 vs 9, 11 vs 12).

- **`test_metric_kubevirt_vmi_number_of_outdated_after_upgrade`**: Queries `kubevirt_vmi_number_of_outdated{namespace='<vmi-namespace>'}` but the metric's namespace label is `openshift-cnv` (virt-controller's namespace), not the VMI namespace. Always returns empty results and times out after 240s.

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-84508

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-84508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Quarantined two post-upgrade observability checks that are currently not executed.
  * Added tracking context for known validation issues involving VMI counts and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->