### PR TITLE
Quarantine: Upgrade snapshot restore tests (CNV-95012)

### DIFF
--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -90,10 +90,6 @@ class TestUpgradeStorage:
                 expected_result="file not found",
             )
 
-    @pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Flaky UEFI boot failure after DV clone on upgrade cluster; CNV-95012",
-        run=False,
-    )
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5995")
     @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
@@ -128,10 +124,6 @@ class TestUpgradeStorage:
 
     """ Post-upgrade tests """
 
-    @pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Depends on quarantined pre-upgrade snapshot test; CNV-95012",
-        run=False,
-    )
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5994")
     @pytest.mark.order(after=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
@@ -162,10 +154,6 @@ class TestUpgradeStorage:
             expected_result="file not found",
         )
 
-    @pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Depends on quarantined pre-upgrade snapshot test; CNV-95012",
-        run=False,
-    )
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5996")
     @pytest.mark.order(after=IUO_UPGRADE_TEST_ORDERING_NODE_ID)

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -20,7 +20,7 @@ from tests.upgrade_params import (
     SNAPSHOT_RESTORE_CREATE_AFTER_UPGRADE,
     STORAGE_NODE_ID_PREFIX,
 )
-from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
+from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION, QUARANTINED
 from utilities.constants.storage import HOTPLUG_DISK_VIRTIO_BUS
 from utilities.storage import (
     assert_disk_serial,
@@ -50,6 +50,10 @@ pytestmark = [
 class TestUpgradeStorage:
     """Pre-upgrade tests"""
 
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Flaky UEFI boot failure after DV clone on upgrade cluster; CNV-95012",
+        run=False,
+    )
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5993")
     @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
@@ -86,6 +90,10 @@ class TestUpgradeStorage:
                 expected_result="file not found",
             )
 
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Flaky UEFI boot failure after DV clone on upgrade cluster; CNV-95012",
+        run=False,
+    )
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5995")
     @pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
@@ -120,6 +128,10 @@ class TestUpgradeStorage:
 
     """ Post-upgrade tests """
 
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Depends on quarantined pre-upgrade snapshot test; CNV-95012",
+        run=False,
+    )
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5994")
     @pytest.mark.order(after=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
@@ -150,6 +162,10 @@ class TestUpgradeStorage:
             expected_result="file not found",
         )
 
+    @pytest.mark.xfail(
+        reason=f"{QUARANTINED}: Depends on quarantined pre-upgrade snapshot test; CNV-95012",
+        run=False,
+    )
     @pytest.mark.sno
     @pytest.mark.polarion("CNV-5996")
     @pytest.mark.order(after=IUO_UPGRADE_TEST_ORDERING_NODE_ID)


### PR DESCRIPTION
##### What this PR does / why we need it:
Quarantine snapshot upgrade tests in `TestUpgradeStorage` due to flaky UEFI boot failure after DV clone on upgrade cluster `c01-cnv4220-upg` (fails 3/5 builds on `test-upgrade-cnv-to-4.22.z`). Root cause is under investigation — both VMs show `ProvisioningFailed` during clone.

Quarantined tests:
- `test_vm_snapshot_restore_before_upgrade` — directly affected by UEFI boot failure

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-95012

##### Special notes for reviewer:
Uses `@pytest.mark.xfail` quarantine (not `@pytest.mark.jira`) because root cause is unidentified — could be infra or product bug, under investigation.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Quarantined a flaky pre-upgrade snapshot restore test affected by intermittent UEFI boot failures after DV cloning.
  * Marked the test as non-running until the reliability issue is resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->