### PR TITLE
[Storage] Remove DeclarativeHotplugVolumes feature gate enablement

### DIFF
--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -10,14 +10,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 from ocp_resources.datavolume import DataVolume
-from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
 
 from tests.storage.utils import assert_disk_bus
 from tests.utils import create_windows2022_vm_with_data_volume_template
 from utilities.constants.storage import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.constants.virt import WIN_2K22
-from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import (
     assert_disk_serial,
     assert_hotplugvolume_nonexist,
@@ -38,29 +36,12 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.usefixtures("enabled_feature_gate_for_declarative_hotplug_volumes"),
     pytest.mark.post_upgrade,
 ]
 
 
 def is_dv_migratable(dv):
     return StorageProfile(name=dv.storage_class).first_claim_property_set_access_modes()[0] == DataVolume.AccessMode.RWX
-
-
-@pytest.fixture(scope="module")
-def enabled_feature_gate_for_declarative_hotplug_volumes(
-    admin_client,
-    hyperconverged_resource_scope_module,
-):
-    with ResourceEditorValidateHCOReconcile(
-        admin_client=admin_client,
-        patches={
-            hyperconverged_resource_scope_module: {"spec": {"featureGates": {"declarativeHotplugVolumes": True}}},
-        },
-        list_resource_reconcile=[KubeVirt],
-        wait_for_reconcile_post_update=True,
-    ):
-        yield
 
 
 @pytest.fixture(scope="class")

--- a/tests/storage/upgrade/conftest.py
+++ b/tests/storage/upgrade/conftest.py
@@ -2,7 +2,6 @@ import logging
 
 import pytest
 from ocp_resources.datavolume import DataVolume
-from ocp_resources.kubevirt import KubeVirt
 from ocp_resources.storage_profile import StorageProfile
 from pytest_testconfig import py_config
 
@@ -11,7 +10,6 @@ from tests.storage.upgrade.utils import (
     create_vm_for_snapshot_upgrade_tests,
 )
 from utilities.constants.storage import HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
-from utilities.hco import ResourceEditorValidateHCOReconcile
 from utilities.storage import create_dv, virtctl_volume
 from utilities.virt import (
     VirtualMachineForTests,
@@ -91,22 +89,6 @@ def blank_disk_dv_with_default_sc(upgrade_namespace_scope_session):
         client=upgrade_namespace_scope_session.client,
     ) as dv:
         yield dv
-
-
-@pytest.fixture(scope="session")
-def enabled_feature_gate_for_declarative_hotplug_volumes_upg(
-    admin_client,
-    hyperconverged_resource_scope_session,
-):
-    with ResourceEditorValidateHCOReconcile(
-        admin_client=admin_client,
-        patches={
-            hyperconverged_resource_scope_session: {"spec": {"featureGates": {"declarativeHotplugVolumes": True}}},
-        },
-        list_resource_reconcile=[KubeVirt],
-        wait_for_reconcile_post_update=True,
-    ):
-        yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/upgrade/test_upgrade_storage.py
+++ b/tests/storage/upgrade/test_upgrade_storage.py
@@ -103,7 +103,6 @@ class TestUpgradeStorage:
     def test_vm_with_hotplug_before_upgrade(
         self,
         skip_if_config_default_storage_class_access_mode_rwo,
-        enabled_feature_gate_for_declarative_hotplug_volumes_upg,
         upgrade_namespace_scope_session,
         blank_disk_dv_with_default_sc,
         fedora_vm_for_hotplug_upg,


### PR DESCRIPTION
##### What this PR does / why we need it:

The DeclarativeHotplugVolumes feature gate is now enabled by default, so explicit enablement via HCO patching is no longer needed.

Jira: https://redhat.atlassian.net/browse/CNV-84681

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed obsolete declarative hotplug feature-gate setup from storage and upgrade test coverage.
  * Updated the pre-upgrade hotplug test to run without the removed setup.
  * No changes to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->