### PR TITLE
fix: Skip arch incompatible preferences from runs

### DIFF
--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -1,13 +1,20 @@
+import logging
+
 import pytest
 from ocp_resources.virtual_machine_cluster_preference import (
     VirtualMachineClusterPreference,
 )
+from pytest_testconfig import config as py_config
 
 from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_label
 from tests.infrastructure.instance_types.vm_preference_list import VM_PREFERENCES_LIST
 from utilities.constants import Images
+from utilities.constants.architecture import SUPPORTED_CPU_ARCHITECTURES
 from utilities.constants.components import VIRT_OPERATOR
+from utilities.constants.virt import VIRTIO
 from utilities.virt import VirtualMachineForTests, running_vm
+
+LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
@@ -54,14 +61,36 @@ def start_vm_with_cluster_preference(client, preference_name, namespace_name):
 
 
 def run_general_vm_preferences(client, namespace, preferences):
+    """Create, start and delete a VM for each preference applicable to the cluster architecture.
+
+    Preferences containing 'virtio' or targeting a different CPU architecture are skipped.
+
+    Args:
+        client: Kubernetes client for resource operations.
+        namespace: Namespace object where VMs are created.
+        preferences: List of VirtualMachineClusterPreference names to validate.
+    """
+    cluster_arch = py_config["cpu_arch"]
+
+    runnable_preferences = []
+    skipped_preferences = []
     for preference_name in preferences:
-        # TODO remove arm64 skip when openshift-virtualization-tests support arm64
-        if all(suffix not in preference_name for suffix in ["virtio", "arm64"]):
-            start_vm_with_cluster_preference(
-                client=client,
-                preference_name=preference_name,
-                namespace_name=namespace.name,
-            )
+        if VIRTIO in preference_name or any(
+            suffix in preference_name for suffix in SUPPORTED_CPU_ARCHITECTURES - {cluster_arch}
+        ):
+            skipped_preferences.append(preference_name)
+        else:
+            runnable_preferences.append(preference_name)
+
+    if skipped_preferences:
+        LOGGER.info(f"Skipping preferences not applicable to cluster arch {cluster_arch}: {skipped_preferences}")
+
+    for preference_name in runnable_preferences:
+        start_vm_with_cluster_preference(
+            client=client,
+            preference_name=preference_name,
+            namespace_name=namespace.name,
+        )
 
 
 @pytest.fixture()


### PR DESCRIPTION
##### What this PR does / why we need it:

Newer KubeVirt preferences (rhel.9.s390x, rhel.10.arm64) now enforce architecture via spec.requirements.architecture, causing ErrorUnschedulable on clusters that lack matching nodes.

refer : https://github.com/kubevirt/common-instancetypes/pull/502
This is currently not available in 4.22 and lower versions so this test will only fail in 4.23/5.0 for now.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine preference handling for clusters with different CPU architectures.
  * Preferences that are incompatible with the configured architecture are now skipped automatically.
  * VIRTIO-related preferences are excluded where appropriate, and only compatible preferences are used to start virtual machines.
  * Added clearer logging for skipped preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->