### PR TITLE
Update expected KubeVirt hardcoded feature gates for CNV 5.0

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -27,10 +27,12 @@ EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
     "CPUManager",
     "DecentralizedLiveMigration",
     "DeclarativeHotplugVolumes",
+    "ExternalNetResourceInjection",
     "HostDevices",
     "HypervStrictCheck",
     "KubevirtSeccompProfile",
     "Snapshot",
+    "Template",
 }
 S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
 EXPECTED_CDI_HARDCODED_FEATUREGATES = {


### PR DESCRIPTION

##### What this PR does / why we need it:

On CNV 5.0, HCO reconciles `Template` and `ExternalNetResourceInjection` as hardcoded KubeVirt feature gates. This updates `EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES` so IUO featuregate reconcile tests match HCO.


##### Which issue(s) this PR fixes:

test_managed_cr_featuregate_reconcile[delete_featuregates_kubevirt_cr] (CNV-6427) for CNV 5.0

##### Special notes for reviewer:

- Only updates `EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES` in `tests/install_upgrade_operators/constants.py`.
- Adds `Template` and `ExternalNetResourceInjection`.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated feature gate validation to include external network resource injection and template support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->