### PR TITLE
net, tests, udn: Add STD for P-UDN connectivity upgrade scenario

### DIFF
--- a/tests/network/upgrade/test_udn.py
+++ b/tests/network/upgrade/test_udn.py
@@ -1,0 +1,73 @@
+"""
+Primary UDN upgrade tests
+
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/ip-request.md
+
+Markers:
+    - upgrade
+    - ocp_upgrade
+    - cnv_upgrade
+    - eus_upgrade
+    - single_nic
+
+Preconditions:
+    - UDN namespace (with required annotations).
+    - A primary UDN network.
+    - A running VM with a primary UDN network and an explicit IP address specified.
+"""
+
+import pytest
+
+
+@pytest.mark.polarion("CNV-13118")
+def test_udn_vm_state_before_upgrade():
+    """
+    Test that a VM with:
+    - A primary UDN network.
+    - An explicit IP address specified.
+
+    Can preserve its IP address over a cluster upgrade (VM is in running state).
+
+    Preconditions:
+        - Run before cluster upgrade.
+        - Running under-test VM, with a primary UDN network and an IP address specified
+            (through annotation & cloud-init).
+        - The specified IP address on the under-test VM.
+
+    Steps:
+        1. Execute a ping command from the under-test VM to the external IP address.
+
+    Expected:
+        - IP address reported by VMI status and guest OS is the same as the one specified.
+        - Verify that the ping command succeeds with 0% packet loss.
+    """
+
+
+test_udn_vm_state_before_upgrade.__test__ = False
+
+
+@pytest.mark.polarion("CNV-13119")
+def test_udn_vm_state_after_upgrade():
+    """
+    Test that a VM with:
+    - A primary UDN network.
+    - An explicit IP address specified.
+
+    Can preserve its IP address over a cluster upgrade (VM is in running state).
+
+    Preconditions:
+        - Run after cluster upgrade.
+        - Running under-test VM, with a primary UDN network and an IP address specified
+            (through annotation & cloud-init).
+        - The specified IP address on the under-test VM.
+
+    Steps:
+        1. Execute a ping command from the under-test VM to the external IP address.
+
+    Expected:
+        - IP address reported by VMI status and guest OS is the same as the one specified.
+        - Verify that the ping command succeeds with 0% packet loss.
+    """
+
+
+test_udn_vm_state_after_upgrade.__test__ = False

--- a/tests/network/upgrade/test_udn.py
+++ b/tests/network/upgrade/test_udn.py
@@ -1,8 +1,6 @@
 """
 Primary UDN upgrade tests
 
-STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/ip-request.md
-
 Markers:
     - upgrade
     - ocp_upgrade
@@ -13,7 +11,6 @@ Markers:
 Preconditions:
     - UDN namespace (with required annotations).
     - A primary UDN network.
-    - A running VM with a primary UDN network and an explicit IP address specified.
 """
 
 import pytest
@@ -28,6 +25,8 @@ def test_udn_vm_state_before_upgrade():
 
     Can preserve its IP address over a cluster upgrade (VM is in running state).
 
+    STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/ip-request.md
+
     Preconditions:
         - Run before cluster upgrade.
         - Running under-test VM, with a primary UDN network and an IP address specified
@@ -39,11 +38,33 @@ def test_udn_vm_state_before_upgrade():
 
     Expected:
         - IP address reported by VMI status and guest OS is the same as the one specified.
-        - Verify that the ping command succeeds with 0% packet loss.
+        - Ping command succeeds with 0% packet loss.
     """
 
 
 test_udn_vm_state_before_upgrade.__test__ = False
+
+
+@pytest.mark.polarion("CNV-11617")
+def test_connectivity_between_udn_vms_before_upgrade():
+    """
+    Test that two VMs with a primary UDN network can communicate with each other over the primary UDN network.
+
+    No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+    Preconditions:
+        - Run before cluster upgrade.
+        - Two running under-test VMs, each with a primary UDN network.
+
+    Steps:
+        1. Execute a ping command from one under-test VM to the other under-test VM.
+
+    Expected:
+        - Ping command succeeds with 0% packet loss.
+    """
+
+
+test_connectivity_between_udn_vms_before_upgrade.__test__ = False
 
 
 @pytest.mark.polarion("CNV-13119")
@@ -54,6 +75,8 @@ def test_udn_vm_state_after_upgrade():
     - An explicit IP address specified.
 
     Can preserve its IP address over a cluster upgrade (VM is in running state).
+
+    STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-network/ip-request.md
 
     Preconditions:
         - Run after cluster upgrade.
@@ -66,8 +89,30 @@ def test_udn_vm_state_after_upgrade():
 
     Expected:
         - IP address reported by VMI status and guest OS is the same as the one specified.
-        - Verify that the ping command succeeds with 0% packet loss.
+        - Ping command succeeds with 0% packet loss.
     """
 
 
 test_udn_vm_state_after_upgrade.__test__ = False
+
+
+@pytest.mark.polarion("CNV-16774")
+def test_connectivity_between_udn_vms_after_upgrade():
+    """
+    Test that two VMs with a primary UDN network can communicate with each other over the primary UDN network.
+
+    No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+    Preconditions:
+        - Run after cluster upgrade.
+        - Two running under-test VMs, each with a primary UDN network.
+
+    Steps:
+        1. Execute a ping command from one under-test VM to the other under-test VM.
+
+    Expected:
+        - Ping command succeeds with 0% packet loss.
+    """
+
+
+test_connectivity_between_udn_vms_after_upgrade.__test__ = False

--- a/tests/network/upgrade/test_upgrade_network.py
+++ b/tests/network/upgrade/test_upgrade_network.py
@@ -113,31 +113,6 @@ class TestUpgradeNetwork:
             ),
         )
 
-    @pytest.mark.polarion("CNV-13118")
-    def test_udn_vm_state_before_upgrade(self):
-        """
-        Test that a VM with:
-        - A primary UDN network.
-        - An explicit IP address specified.
-
-        Can preserve its IP address over a cluster upgrade (VM is in running state).
-
-        Preconditions:
-            - Run before cluster upgrade.
-            - Running under-test VM, with a primary UDN network and an IP address specified
-              (through annotation & cloud-init).
-            - The specified IP address on the under-test VM.
-
-        Steps:
-            1. Execute a ping command from the under-test VM to the external IP address.
-
-        Expected:
-            - IP address reported by VMI status and guest OS is the same as the one specified.
-            - Verify that the ping command succeeds with 0% packet loss.
-        """
-
-    test_udn_vm_state_before_upgrade.__test__ = False
-
     """ Post-upgrade tests """
 
     @pytest.mark.polarion("CNV-2989")
@@ -244,28 +219,3 @@ class TestUpgradeNetwork:
                 ip_family=4,
             ),
         )
-
-    @pytest.mark.polarion("CNV-13119")
-    def test_udn_vm_state_after_upgrade(self):
-        """
-        Test that a VM with:
-        - A primary UDN network.
-        - An explicit IP address specified.
-
-        Can preserve its IP address over a cluster upgrade (VM is in running state).
-
-        Preconditions:
-            - Run after cluster upgrade.
-            - Running under-test VM, with a primary UDN network and an IP address specified
-              (through annotation & cloud-init).
-            - The specified IP address on the under-test VM.
-
-        Steps:
-            1. Execute a ping command from the under-test VM to the external IP address.
-
-        Expected:
-            - IP address reported by VMI status and guest OS is the same as the one specified.
-            - Verify that the ping command succeeds with 0% packet loss.
-        """
-
-    test_udn_vm_state_after_upgrade.__test__ = False


### PR DESCRIPTION
##### What this PR does / why we need it:
  Establishes a dedicated `tests/network/upgrade/test_udn.py` module for
  primary-UDN upgrade scenarios and adds a new connectivity scenario STD to it.

  Two changes, one per commit:

  1. Move the existing UDN IP-preservation upgrade STDs (CNV-13118 /
     CNV-13119) out of `test_upgrade_network.py` into a dedicated module,
     giving new UDN upgrade tests a clear home.
  2. Add an STD pair verifying that east-west connectivity between two VMs
     on a primary UDN survives a cluster upgrade.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
  - STD-only PR; implementation follows in a separate PR.
  - Since the existing UDN scenarios have their own STP, it is linked inside the test's docstrings.
    The new scenario has their Jira links inside their docstrings.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-52880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added documented validation scenarios for preserving VM IP addresses during cluster upgrades.
  * Added checks for VM-to-VM connectivity before and after upgrades.
  * Consolidated UDN upgrade test coverage and removed obsolete duplicate checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->