### PR TITLE
net, hotplug: fix flaky console errors

### DIFF
--- a/tests/network/l2_bridge/libl2bridge.py
+++ b/tests/network/l2_bridge/libl2bridge.py
@@ -9,6 +9,8 @@ from typing import Final, cast
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.client import ResourceField
 from ocp_resources.resource import ResourceEditor
+from ocp_utilities.exceptions import CommandExecFailed
+from pexpect.exceptions import EOF
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from libs.net.ip import random_ipv4_address
@@ -275,12 +277,14 @@ def hot_plug_interface_and_set_address(
 
 @retry(
     wait_timeout=120,
-    sleep=5,
+    sleep=10,
     exceptions_dict={
         VMInterfaceStatusNotFoundError: [],
         GuestInterfaceNotFoundError: [],
         json.JSONDecodeError: [],
         IndexError: [],
+        CommandExecFailed: [],
+        EOF: [],
     },
 )
 def _lookup_hotplugged_iface_via_console(


### PR DESCRIPTION
##### What this PR does / why we need it:
Console executions can be unstable and raise errors when retrying.
These errors were not caught by `_lookup_hotplugged_iface_via_console` leading to helper not retry or exhausting the console, due to frequent login.

Add EOF and CommandExecFailed errors of vm_console_run_commands into the exceptions_dict for proper retrying.
Increment retry timeout to prevent console exhaustion.


##### Which issue(s) this PR fixes:
The following errors occured in CI in hotplug tests:
- (abnormal closure): unexpected EOF
- CommandExecFailed: Command: [] - exec failed. Error: EOF

##### Special notes for reviewer: -

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for network command failures and unexpected connection termination.
  * Test operations are now more resilient to transient execution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->