### PR TITLE
net, tests, udn: Add STDs for additional scenarios

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -25,6 +25,15 @@ if TYPE_CHECKING:
 @pytest.mark.s390x
 @pytest.mark.single_nic
 class TestPrimaryUdn:
+    """
+    Tests for a VM connected to a primary user-defined network (UDN).
+
+    Preconditions:
+        - UDN namespace (with UDN annotation) with KubeMacPool enabled.
+        - Primary UDN resource with an IP range defined.
+        - Running under-test VM attached to the primary UDN network.
+    """
+
     @pytest.mark.polarion("CNV-11624")
     def test_ip_address_in_running_vm_matches_udn_subnet(self, namespaced_layer2_user_defined_network, vma_udn):
         ip = str(lookup_iface_status_ip(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name, ip_family=4))
@@ -83,6 +92,110 @@ class TestPrimaryUdn:
 
     @pytest.mark.polarion("CNV-11432")
     def test_vm_to_pod_connectivity_on_udn(self, vma_udn, udn_pod):
-        """Jira: https://redhat.atlassian.net/browse/CNV-51404 # <skip-jira-utils-check>"""
+        """
+        Test that a VM reaches a pod on the same primary UDN network (east-west connectivity).
+
+        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running under-test VM attached to the primary UDN network.
+            - Running reference pod attached to the same primary UDN network.
+
+        Steps:
+            1. Get the reference pod IP address, allocated from the UDN subnet.
+            2. Execute a ping command from the under-test VM to the reference pod IP address
+               over the primary UDN interface.
+
+        Expected:
+            - Ping succeeds with 0% packet loss.
+        """
         pod_ip = lookup_default_pod_ip(pod=udn_pod)
         vma_udn.console(commands=[f"ping -c 3 {pod_ip}"], timeout=TIMEOUT_1MIN)
+
+    @pytest.mark.polarion("CNV-11462")
+    def test_tcp_connectivity_via_cluster_ip_service_on_primary_udn(self):
+        """
+        Test that a VM's primary UDN interface is reachable through a ClusterIP service.
+
+        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running server VM attached to the primary UDN network.
+            - ClusterIP service targeting the server VM primary UDN interface.
+            - Running client VM attached to the same primary UDN network.
+
+        Steps:
+            1. Start a TCP server on the server VM.
+            2. Establish a TCP connection from the client VM to the ClusterIP service address.
+
+        Expected:
+            - The TCP connection to the server VM through the ClusterIP service succeeds.
+        """
+
+    test_tcp_connectivity_via_cluster_ip_service_on_primary_udn.__test__ = False
+
+    @pytest.mark.polarion("CNV-16773")
+    def test_kubemacpool_assigns_mac_on_primary_udn_interface(self):
+        """
+        Test that KubeMacPool assigns a MAC address from its pool to a VM's primary UDN interface.
+
+        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running under-test VM attached to the primary UDN network.
+
+        Steps:
+            1. Read the MAC address assigned to the VM primary UDN interface from the VM object.
+
+        Expected:
+            - The primary UDN interface MAC address is within the KubeMacPool range.
+        """
+
+    test_kubemacpool_assigns_mac_on_primary_udn_interface.__test__ = False
+
+    @pytest.mark.polarion("CNV-11435")
+    def test_network_policy_enforcement_on_primary_udn_interface(self):
+        """
+        Test that a network policy is enforced on the VM primary UDN interface: traffic from
+        an allowed pod is permitted while traffic from a denied pod is blocked.
+
+        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running under-test VM attached to the primary UDN network.
+            - Running allowed pod attached to the primary UDN network.
+            - Running denied pod attached to the primary UDN network.
+            - Network policy applied to the primary UDN, allowing traffic from an allowed pod
+              and denying traffic from a denied pod.
+
+        Steps:
+            1. Execute a ping command from the allowed pod to the under-test VM
+               primary UDN interface IP address.
+            2. Execute a ping command from the denied pod to the under-test VM
+               primary UDN interface IP address.
+
+        Expected:
+            - Ping from the allowed pod succeeds with 0% packet loss.
+            - Ping from the denied pod fails with 100% packet loss.
+        """
+
+    test_network_policy_enforcement_on_primary_udn_interface.__test__ = False
+
+    @pytest.mark.polarion("CNV-11451")
+    def test_udn_cannot_be_deleted_while_vm_connected(self):
+        """
+        [NEGATIVE] Test that a primary UDN cannot be removed while a VM is connected to it.
+
+        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running under-test VM attached to the primary UDN network.
+
+        Steps:
+            1. Attempt to delete the primary UDN resource.
+
+        Expected:
+            - The primary UDN resource still exists (deletion is blocked while the VM is connected).
+        """
+
+    test_udn_cannot_be_deleted_while_vm_connected.__test__ = False


### PR DESCRIPTION
##### What this PR does / why we need it:
  Adds STDs for the remaining primary UDN capabilities that lack coverage:
  VM-to-pod connectivity, ClusterIP service exposure, network policy
  enforcement, KubeMacPool MAC assignment, and UDN deletion protection.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
  STD-only PR; automation follows separately (except for _test_vm_to_pod_connectivity_on_udn_, which automation was merged in https://github.com/RedHatQE/openshift-virtualization-tests/pull/5940).
  No STP exists for these scenarios (this is tech debt - the feature is long existing). Tests link the Jira epic for traceability.

##### jira-ticket:
  https://redhat.atlassian.net/browse/CNV-94228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Expanded primary user-defined network prerequisites and clarified VM-to-pod connectivity test scope, setup steps, and expected results.

## Tests

- Added disabled placeholders covering network deletion protection, ClusterIP service connectivity, MAC assignment, and network-policy enforcement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->