### PR TITLE
[Storage] Fix the artifactiory cleanup for Validation OS Images Windows DV + other fixes

### DIFF
--- a/tests/fixtures/images/validation_os_images.py
+++ b/tests/fixtures/images/validation_os_images.py
@@ -118,13 +118,15 @@ def windows_validation_os_images_data_volume_scope_session(
     win_dv.api_name = "storage"
     win_dv.annotations = BIND_IMMEDIATE_ANNOTATION
 
-    with win_dv as wdv:
-        wdv.wait_for_dv_success(timeout=TIMEOUT_50MIN)
-        yield wdv
-    cleanup_artifactory_secret_and_config_map(
-        artifactory_secret=artifactory_secret,
-        artifactory_config_map=artifactory_config_map,
-    )
+    try:
+        with win_dv as wdv:
+            wdv.wait_for_dv_success(timeout=TIMEOUT_50MIN)
+            yield wdv
+    finally:
+        cleanup_artifactory_secret_and_config_map(
+            artifactory_secret=artifactory_secret,
+            artifactory_config_map=artifactory_config_map,
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/storage/cdi_clone/test_clone.py
+++ b/tests/storage/cdi_clone/test_clone.py
@@ -11,7 +11,7 @@ from tests.storage.utils import (
     assert_pvc_snapshot_clone_annotation,
     assert_use_populator,
 )
-from tests.utils import create_windows2022_vm_using_existing_dv
+from tests.utils import create_windows2022_vm
 from utilities.constants import Images
 from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_WINDOWS
 from utilities.constants.timeouts import TIMEOUT_1MIN
@@ -164,12 +164,12 @@ class TestWindowsClonedDv:
         Expected:
             - VM OS info reported by VMI matches the expected Windows OS parameters
         """
-        with create_windows2022_vm_using_existing_dv(
+        with create_windows2022_vm(
             namespace=namespace.name,
             client=unprivileged_client,
             vm_name=f"vm-{WIN_2K22}",
             cpu_model=modern_cpu_for_migration,
-            existing_data_volume=cloned_windows_dv_multi_storage_scope_class,
+            data_volume=cloned_windows_dv_multi_storage_scope_class,
         ) as vm:
             validate_os_info_vmi_vs_windows_os(vm=vm)
 

--- a/tests/storage/memory_dump/conftest.py
+++ b/tests/storage/memory_dump/conftest.py
@@ -8,7 +8,7 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import config as py_config
 
 from tests.storage.memory_dump.utils import wait_for_memory_dump_status_completed
-from tests.utils import create_windows2022_vm_with_data_volume_template
+from tests.utils import create_windows2022_vm
 from utilities.constants import Images
 from utilities.constants.timeouts import TIMEOUT_2MIN
 from utilities.constants.virt import WIN_2K22
@@ -27,8 +27,8 @@ def windows_vm_with_vtpm_for_memory_dump(
     modern_cpu_for_migration,
     windows_validation_os_images_data_source_scope_session,
 ):
-    with create_windows2022_vm_with_data_volume_template(
-        dv_template=data_volume_template_with_source_ref_dict(
+    with create_windows2022_vm(
+        data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=windows_validation_os_images_data_source_scope_session,
             storage_class=py_config["default_storage_class"],
         ),

--- a/tests/storage/snapshots/conftest.py
+++ b/tests/storage/snapshots/conftest.py
@@ -18,7 +18,7 @@ from tests.storage.utils import (
     create_windows_directory,
     set_permissions,
 )
-from tests.utils import create_windows2022_vm_with_data_volume_template
+from tests.utils import create_windows2022_vm
 from utilities.constants.pytest import UNPRIVILEGED_USER
 from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
@@ -59,8 +59,8 @@ def windows_vm_with_vtpm_for_snapshot(
     windows_validation_os_images_data_source_scope_session,
     storage_class_matrix_snapshot_matrix__module__,
 ):
-    with create_windows2022_vm_with_data_volume_template(
-        dv_template=data_volume_template_with_source_ref_dict(
+    with create_windows2022_vm(
+        data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=windows_validation_os_images_data_source_scope_session,
             storage_class=next(iter(storage_class_matrix_snapshot_matrix__module__)),
         ),

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -26,7 +26,7 @@ from tests.storage.storage_migration.utils import (
     wait_for_storage_migration_completed,
 )
 from tests.storage.utils import create_windows_directory, get_storage_class_for_storage_migration
-from tests.utils import create_windows2022_vm_with_data_volume_template
+from tests.utils import create_windows2022_vm
 from utilities.constants import Images
 from utilities.constants.images import OS_FLAVOR_FEDORA, OS_FLAVOR_RHEL
 from utilities.constants.instance_types import U1_SMALL
@@ -379,12 +379,12 @@ def windows_vm_with_vtpm_for_storage_migration(
     source_storage_class,
     windows_validation_os_images_data_source_scope_session,
 ):
-    with create_windows2022_vm_with_data_volume_template(
+    with create_windows2022_vm(
         namespace=namespace.name,
         client=unprivileged_client,
         vm_name="windows-2022-vm",
         cpu_model=modern_cpu_for_migration,
-        dv_template=data_volume_template_with_source_ref_dict(
+        data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=windows_validation_os_images_data_source_scope_session,
             storage_class=source_storage_class,
         ),

--- a/tests/storage/test_hotplug.py
+++ b/tests/storage/test_hotplug.py
@@ -15,7 +15,7 @@ from ocp_resources.storage_profile import StorageProfile
 
 from tests.storage.constants import BLANK_DV_SIZE, NUM_HOTPLUG_DISKS
 from tests.storage.utils import assert_disk_bus, expected_hotplug_serials
-from tests.utils import create_windows2022_vm_with_data_volume_template
+from tests.utils import create_windows2022_vm
 from utilities.constants.storage import HOTPLUG_DISK_SCSI_BUS, HOTPLUG_DISK_SERIAL, HOTPLUG_DISK_VIRTIO_BUS
 from utilities.constants.virt import WIN_2K22
 from utilities.storage import (
@@ -75,8 +75,8 @@ def vm_instance_multi_storage_scope_class(
     storage_class_name_scope_class,
 ):
     """Creates a Windows 2022 VM with vTPM from the session-scoped Windows DataSource."""
-    with create_windows2022_vm_with_data_volume_template(
-        dv_template=data_volume_template_with_source_ref_dict(
+    with create_windows2022_vm(
+        data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=windows_validation_os_images_data_source_scope_session,
             storage_class=storage_class_name_scope_class,
         ),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -709,23 +709,25 @@ def verify_rwx_default_storage(client: DynamicClient) -> None:
 
 
 @contextmanager
-def create_windows2022_vm_using_existing_dv(
+def create_windows2022_vm(
     namespace: str,
     client: DynamicClient,
     vm_name: str,
     cpu_model: str | None = None,
-    existing_data_volume: DataVolume | None = None,
+    data_volume: DataVolume | None = None,
+    data_volume_template: dict | None = None,
     check_running_vm: bool = True,
 ) -> Generator[VirtualMachineForTests]:
     """
-    Creates a Windows Server 2022 VM with vTPM using existing DataVolume.
+    Creates a Windows Server 2022 VM with vTPM using an existing DataVolume or a DataVolume template.
 
     Args:
-        existing_data_volume: DataVolume to use for the VM's data volume
         namespace: Kubernetes namespace
         client: Kubernetes client
         vm_name: Name for the VirtualMachine
         cpu_model: CPU model specification (can be None)
+        data_volume: Existing DataVolume to use for the VM's data volume
+        data_volume_template: DataVolume template dictionary with metadata and spec
         check_running_vm: If True, start the VM and wait for Windows boot
 
     Yields:
@@ -739,47 +741,8 @@ def create_windows2022_vm_using_existing_dv(
         os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
         vm_instance_type=VirtualMachineClusterInstancetype(name=U1_LARGE, client=client),
         vm_preference=VirtualMachineClusterPreference(name=WINDOWS_2K22_PREFERENCE, client=client),
-        data_volume=existing_data_volume,
-        cpu_model=cpu_model,
-    ) as vm:
-        if check_running_vm:
-            running_vm(vm=vm)
-            wait_for_windows_vm(vm=vm, version="2022")
-        yield vm
-
-
-@contextmanager
-def create_windows2022_vm_with_data_volume_template(
-    namespace: str,
-    client: DynamicClient,
-    vm_name: str,
-    cpu_model: str | None = None,
-    dv_template: dict | None = None,
-    check_running_vm: bool = True,
-) -> Generator[VirtualMachineForTests]:
-    """
-    Creates a Windows Server 2022 VM with vTPM with dv template.
-
-    Args:
-        dv_template: DataVolume template dictionary with metadata and spec
-        namespace: Kubernetes namespace
-        client: Kubernetes client
-        vm_name: Name for the VirtualMachine
-        cpu_model: CPU model specification (can be None)
-        check_running_vm: If True, start the VM and wait for Windows boot
-
-    Yields:
-        VirtualMachineForTests: Windows 2022 VM with vTPM
-    """
-
-    with VirtualMachineForTests(
-        name=vm_name,
-        namespace=namespace,
-        client=client,
-        os_flavor=OS_FLAVOR_WIN_CONTAINER_DISK,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_LARGE, client=client),
-        vm_preference=VirtualMachineClusterPreference(name=WINDOWS_2K22_PREFERENCE, client=client),
-        data_volume_template=dv_template,
+        data_volume=data_volume,
+        data_volume_template=data_volume_template,
         cpu_model=cpu_model,
     ) as vm:
         if check_running_vm:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -734,6 +734,13 @@ def create_windows2022_vm(
         VirtualMachineForTests: Windows 2022 VM with vTPM
     """
 
+    assert data_volume is not None or data_volume_template is not None, (
+        "Must provide exactly one of data_volume or data_volume_template"
+    )
+    assert data_volume is None or data_volume_template is None, (
+        "Must provide exactly one of data_volume or data_volume_template, not both"
+    )
+
     with VirtualMachineForTests(
         name=vm_name,
         namespace=namespace,


### PR DESCRIPTION
##### What this PR does / why we need it:
There's artifactory issue when the `DataVolume.wait_for_dv_success` method fails, the cleanup doesn't happen, so it needs to be wrapped in `try/finally` block.

Also merged the `create_windows2022_vm...` functions into one function and fixed all the references.

Deduplicated one windows preference constant.

These fixed were flagged by our QE lead in: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5664#pullrequestreview-4949601924

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-51351

##### Special notes for reviewer:
Co-Authored: Claude Code <noreply@anthropic.com>

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary image-related configuration when Windows image setup or readiness checks fail.
  * Increased reliability of Windows VM validation involving cloned, templated, and attached data volumes.

* **Tests**
  * Consolidated Windows VM test setup for storage, snapshot, migration, memory dump, and hot-plug scenarios.
  * Updated coverage to consistently support both existing data volumes and data volume templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->