### PR TITLE
[cnv-4.19] Remove bug CNV-64473 fixtures

### DIFF
--- a/tests/install_upgrade_operators/strict_reconciliation/conftest.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/conftest.py
@@ -16,9 +16,8 @@ from tests.install_upgrade_operators.strict_reconciliation.utils import (
     wait_for_resource_version_update,
 )
 from tests.utils import wait_for_cr_labels_change
-from utilities.constants import HCO_BEARER_AUTH, TIMEOUT_1MIN, VERSION_LABEL_KEY
+from utilities.constants import TIMEOUT_1MIN, VERSION_LABEL_KEY
 from utilities.hco import ResourceEditorValidateHCOReconcile
-from utilities.infra import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 DISABLED_KUBEVIRT_FEATUREGATES_IN_SNO = ["LiveMigration", "SRIOVLiveMigration"]
@@ -191,14 +190,3 @@ def updated_resource_labels(ocp_resource_by_name):
     ):
         wait_for_cr_labels_change(expected_value=expected_labels, component=ocp_resource_by_name, timeout=TIMEOUT_1MIN)
         yield expected_labels
-
-
-@pytest.fixture(scope="package")
-def is_jira_64473_open():
-    return is_jira_open(jira_id="CNV-64473")
-
-
-@pytest.fixture()
-def skip_if_hco_bearer_token_bug_open(is_jira_64473_open, ocp_resource_by_name):
-    if is_jira_64473_open and ocp_resource_by_name.name == HCO_BEARER_AUTH:
-        pytest.skip(f"{HCO_BEARER_AUTH} resource labels doesn't reconcile due to 64473 bug")

--- a/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
+++ b/tests/install_upgrade_operators/strict_reconciliation/test_hco_related_objects.py
@@ -18,7 +18,6 @@ class TestRelatedObjects:
         self,
         admin_client,
         hco_namespace,
-        skip_if_hco_bearer_token_bug_open,
         ocp_resource_by_name,
         pre_update_resource_version,
         updated_resource_labels,


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove is_jira_64473_open and skip_if_hco_bearer_token_bug_open fixtures along with unused HCO_BEARER_AUTH and is_jira_open imports.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95485
