### PR TITLE
[cnv-4.18] Remove migration memory transfer rate metric and CNV-84901 bug marker

### DIFF
--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -43,9 +43,6 @@ KUBEVIRT_VMI_INFO = "kubevirt_vmi_info{{name='{vm_name}'}}"
 KUBEVIRT_VMI_STATUS_ADDRESSES = "kubevirt_vmi_status_addresses{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES = "kubevirt_vmi_migration_data_processed_bytes{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES = "kubevirt_vmi_migration_data_remaining_bytes{{name='{vm_name}'}}"
-KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES = (
-    "kubevirt_vmi_migration_memory_transfer_rate_bytes{{name='{vm_name}'}}"
-)
 KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES = "kubevirt_vmi_migration_dirty_memory_rate_bytes{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES = "kubevirt_vmi_migration_data_total_bytes{{name='{vm_name}'}}"
 BINDING_NAME = "binding_name"

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -10,7 +10,6 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES,
     KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES,
     KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
-    KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES,
 )
 from tests.observability.metrics.utils import (
     get_metric_sum_value,
@@ -19,7 +18,6 @@ from tests.observability.metrics.utils import (
 )
 from tests.observability.utils import validate_metrics_value
 from utilities.constants import MIGRATION_POLICY_VM_LABEL, TIMEOUT_2MIN, TIMEOUT_3MIN, TIMEOUT_5MIN
-from utilities.infra import is_jira_open
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 
@@ -183,10 +181,6 @@ class TestKubevirtVmiMigrationMetrics:
                 marks=(pytest.mark.polarion("CNV-11600")),
             ),
             pytest.param(
-                KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES,
-                marks=(pytest.mark.polarion("CNV-11598")),
-            ),
-            pytest.param(
                 KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
                 marks=(pytest.mark.polarion("CNV-11599")),
             ),
@@ -202,8 +196,6 @@ class TestKubevirtVmiMigrationMetrics:
         vm_migration_metrics_vmim_scope_function,
         query,
     ):
-        if query == KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES and is_jira_open(jira_id="CNV-84901"):
-            pytest.xfail(f"CNV-84901: metric {query} not triggered")
         wait_for_non_empty_metrics_value(
             prometheus=prometheus,
             metric_name=query.format(vm_name=vm_for_migration_metrics_test.name),


### PR DESCRIPTION
##### What this PR does / why we need it:
The kubevirt_vmi_migration_memory_transfer_rate_bytes metric does not belong to 4.18. Remove the constant, its test parametrize entry, and the CNV-84901 xfail guard.

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95500
