### PR TITLE
[cnv-4.20] Remove migration memory transfer rate metric and CNV-84890 bug marker

### DIFF
--- a/tests/observability/metrics/constants.py
+++ b/tests/observability/metrics/constants.py
@@ -17,9 +17,6 @@ KUBEVIRT_VM_INFO = "kubevirt_vm_info{{name='{vm_name}'}}"
 KUBEVIRT_VMI_STATUS_ADDRESSES = "kubevirt_vmi_status_addresses{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_PROCESSED_BYTES = "kubevirt_vmi_migration_data_processed_bytes{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES = "kubevirt_vmi_migration_data_remaining_bytes{{name='{vm_name}'}}"
-KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES = (
-    "kubevirt_vmi_migration_memory_transfer_rate_bytes{{name='{vm_name}'}}"
-)
 KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES = "kubevirt_vmi_migration_dirty_memory_rate_bytes{{name='{vm_name}'}}"
 KUBEVIRT_VM_DISK_ALLOCATED_SIZE_BYTES = "kubevirt_vm_disk_allocated_size_bytes{{name='{vm_name}'}}"
 KUBEVIRT_VMI_MIGRATIONS_IN_SCHEDULING_PHASE = "kubevirt_vmi_migrations_in_scheduling_phase"

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -7,14 +7,12 @@ from tests.observability.metrics.constants import (
     KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES,
     KUBEVIRT_VMI_MIGRATION_DATA_TOTAL_BYTES,
     KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
-    KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES,
 )
 from tests.observability.metrics.utils import (
     timestamp_to_seconds,
     wait_for_non_empty_metrics_value,
 )
 from tests.observability.utils import validate_metrics_value
-from utilities.infra import is_jira_open
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,10 +25,6 @@ class TestKubevirtVmiMigrationMetrics:
             pytest.param(
                 KUBEVIRT_VMI_MIGRATION_DATA_REMAINING_BYTES,
                 marks=(pytest.mark.polarion("CNV-11600")),
-            ),
-            pytest.param(
-                KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES,
-                marks=(pytest.mark.polarion("CNV-11598")),
             ),
             pytest.param(
                 KUBEVIRT_VMI_MIGRATION_DIRTY_MEMORY_RATE_BYTES,
@@ -53,8 +47,6 @@ class TestKubevirtVmiMigrationMetrics:
         vm_migration_metrics_vmim_scope_function,
         query,
     ):
-        if query == KUBEVIRT_VMI_MIGRATION_MEMORY_TRANSFER_RATE_BYTES and is_jira_open(jira_id="CNV-84890"):
-            pytest.xfail(f"Bug is still open for metric {query}")
         wait_for_non_empty_metrics_value(
             prometheus=prometheus,
             metric_name=query.format(vm_name=vm_for_migration_metrics_test.name),


### PR DESCRIPTION

##### What this PR does / why we need it:
The kubevirt_vmi_migration_memory_transfer_rate_bytes metric does not belong to 4.20. Remove the constant, its test parametrize entry, and the CNV-84890 xfail guard.

assisted by: claude code claude-opus-4-6

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95501