### PR TITLE
net, tests, udn: Add UDN deletion protection test

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -16,6 +16,7 @@ from utilities.virt import migrate_vm_and_verify
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
+    from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
     from libs.net.traffic_generator import TcpServer, VMTcpClient
     from libs.vm.vm import BaseVirtualMachine
@@ -181,10 +182,18 @@ class TestPrimaryUdn:
 
     test_network_policy_enforcement_on_primary_udn_interface.__test__ = False
 
+    @pytest.mark.order("last")
+    @pytest.mark.usefixtures("vma_udn")
     @pytest.mark.polarion("CNV-11451")
-    def test_udn_cannot_be_deleted_while_vm_connected(self):
+    def test_udn_cannot_be_deleted_while_vm_connected(
+        self, namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork
+    ):
         """
         [NEGATIVE] Test that a primary UDN cannot be removed while a VM is connected to it.
+
+        This test runs last since it issues a DELETE against the primary UDN shared by the other
+        tests. If deletion protection is broken (a bug), running it earlier would remove that
+        network and break the tests sharing it.
 
         No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
 
@@ -197,5 +206,6 @@ class TestPrimaryUdn:
         Expected:
             - The primary UDN resource still exists (deletion is blocked while the VM is connected).
         """
-
-    test_udn_cannot_be_deleted_while_vm_connected.__test__ = False
+        assert not namespaced_layer2_user_defined_network.delete(wait=True, timeout=20), (
+            "UDN was deleted despite having a connected VM."
+        )


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds a negative test (CNV-11451) that verifies a primary user-defined 
network (UDN) cannot be deleted while a VM is connected to it. This guards the
deletion-protection contract for primary UDNs: a network that still has attached
workloads must not be removable.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The finalizers mechanism that prevent the UDN from being deleted while VM/pods are connected to it is specified in the [feature's OKEP](https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/okeps/okep-5193-user-defined-networks.md#api-details):

> There should be a finalizer on the CRDs, so that upon deletion OVN-Kubernetes can validate that there are no pods still using this network. If there are pods still attached to this network, the network will not be removed.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-52884


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for user-defined network test scenarios, including connectivity, ClusterIP access, MAC assignment, network policies, and deletion protection.
  * Updated references with clearer scenario descriptions.

* **Tests**
  * Improved type annotations for deletion-protection coverage.
  * Prevented placeholder tests from being collected until implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->