### PR TITLE
fix: bump myk-pi-tools to ~=4.3.2 in coderabbit-retry workflow

### DIFF
--- a/.github/workflows/coderabbit-retry-on-rate-limit.yml
+++ b/.github/workflows/coderabbit-retry-on-rate-limit.yml
@@ -48,7 +48,7 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install myk-pi-tools
-        run: pipx install "myk-pi-tools==4.2.1"
+        run: pipx install "myk-pi-tools~=4.3.2"
 
       - name: Scan and retry rate-limited PRs
         env:


### PR DESCRIPTION
##### What this PR does / why we need it:
The `coderabbit-retry-on-rate-limit.yml` GHA workflow pins `myk-pi-tools==4.2.1`, which cannot parse CodeRabbit's current rate-limit comment format (contains Review Change Stack banner + updated markdown). The CLI returns exit 1 with "Could not parse wait time from rate limit message" for every rate-limited PR, causing the retry script to skip all of them.

**Result:** 0 retries across 227 runs since deployment. Currently 7 PRs are rate-limited with long-elapsed waits and have never been retried.

**Fix:** Bump to `~=4.3.2` (compatible release — allows 4.3.x patches, blocks 4.4+).

**Tested locally:**
- `myk-pi-tools==4.2.1`: `exit 1` — "Could not parse wait time from rate limit message"
- `myk-pi-tools==4.3.2`: `exit 0` — `{"rate_limited": true, "wait_seconds": 3120, ...}`
- Full flow trace on PR #6011 confirms retry would trigger correctly with 4.3.2

##### Which issue(s) this PR fixes: -

##### Special notes for reviewer:
One-line version bump. The retry script logic is correct — only the CLI version was too old to parse the current CodeRabbit comment format.

##### jira-ticket: -


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal workflow tool to a compatible newer version range.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->