### PR TITLE
Add HTTPError to _download_file retry exceptions

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -689,6 +689,7 @@ def get_all_console_links(console_cli_downloads_spec_links):
         requests.exceptions.SSLError: [],
         requests.exceptions.ConnectionError: [],
         requests.exceptions.Timeout: [],
+        requests.exceptions.HTTPError: [],
     },
 )
 def _download_file(url: str, local_file_name: str) -> str:


### PR DESCRIPTION
##### What this PR does / why we need it:
The retry decorator on _download_file only retried on SSLError, ConnectionError, and Timeout. HTTPError (e.g. 503 Service Unavailable) was not retried, causing immediate failure instead of waiting for the service to become available.


assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File downloads now automatically retry when an HTTP error occurs, improving resilience against temporary request failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->