### PR TITLE
net, tests, udn: Remove KMP enforcement on P-UDN scenario

### DIFF
--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -29,7 +29,7 @@ class TestPrimaryUdn:
     Tests for a VM connected to a primary user-defined network (UDN).
 
     Preconditions:
-        - UDN namespace (with UDN annotation) with KubeMacPool enabled.
+        - UDN namespace (with UDN annotation).
         - Primary UDN resource with an IP range defined.
         - Running under-test VM attached to the primary UDN network.
     """
@@ -133,25 +133,6 @@ class TestPrimaryUdn:
         """
 
     test_tcp_connectivity_via_cluster_ip_service_on_primary_udn.__test__ = False
-
-    @pytest.mark.polarion("CNV-16773")
-    def test_kubemacpool_assigns_mac_on_primary_udn_interface(self):
-        """
-        Test that KubeMacPool assigns a MAC address from its pool to a VM's primary UDN interface.
-
-        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
-
-        Preconditions:
-            - Running under-test VM attached to the primary UDN network.
-
-        Steps:
-            1. Read the MAC address assigned to the VM primary UDN interface from the VM object.
-
-        Expected:
-            - The primary UDN interface MAC address is within the KubeMacPool range.
-        """
-
-    test_kubemacpool_assigns_mac_on_primary_udn_interface.__test__ = False
 
     @pytest.mark.polarion("CNV-11435")
     def test_network_policy_enforcement_on_primary_udn_interface(self):


### PR DESCRIPTION
  ##### What this PR does / why we need it:

  Removes the STD placeholder scenario `test_kubemacpool_assigns_mac_on_primary_udn_interface`
  (CNV-16773), which asserted that KubeMacPool assigns a MAC from its pool to a VM's
  primary UDN interface.

  The scenario is based on an incorrect premise and is not valid to test. KubeMacPool
  does not manage MAC addresses on the primary UDN interface — OVN-Kubernetes does.
  On a primary UDN, IPs are always assigned from the subnet declared in the UDN CR, and
  OVN-K derives the interface MAC deterministically from that IP. Because each IP in the
  subnet is unique, the resulting MACs are inherently unique, so there is no MAC collision
  for KubeMacPool to prevent and no KMP involvement on this interface. Verified on-cluster:
  the realized primary-UDN MAC falls outside the configured KubeMacPool range and matches
  OVN-K's IP-derived address.

  ##### Which issue(s) this PR fixes:

  ##### Special notes for reviewer:
  - Traceability (scenario deletion): Polarion CNV-16773 has been marked as inactive with a 
  comment explaining the reasoning. Same for the Jira task
 (https://redhat.atlassian.net/browse/CNV-76430).
  - The class-level `Preconditions:` no longer references "KubeMacPool enabled", as UDN 
  scenarios do not depend on KMP.

##### jira-ticket:
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated primary user-defined network test prerequisites so they no longer depend on KubeMacPool being enabled.
  * Removed coverage for MAC assignment on primary user-defined network interfaces when KubeMacPool is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->