### PR TITLE
infra, tests: Add unified DataSource volume reference validator

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -18,15 +18,13 @@ from tests.infrastructure.golden_images.constants import (
 from tests.infrastructure.golden_images.update_boot_source.utils import (
     fedora_dv_for_data_source,
     wait_for_data_source_unchanged_referenced_volume,
+    wait_for_data_source_updated_referenced_volume,
 )
 from tests.utils import get_parameters_from_template
 from utilities.constants.hco import DATA_SOURCE_NAME
 from utilities.constants.images import DEFAULT_FEDORA_REGISTRY_URL
 from utilities.constants.pytest import QUARANTINED
-from utilities.constants.timeouts import (
-    TIMEOUT_5MIN,
-    TIMEOUT_10MIN,
-)
+from utilities.constants.timeouts import TIMEOUT_5MIN
 from utilities.ssp import wait_for_condition_message_value
 
 LOGGER = logging.getLogger(__name__)
@@ -40,41 +38,6 @@ pytestmark = pytest.mark.post_upgrade
 
 def opt_in_status_str(opt_in):
     return f"opt-{'in' if opt_in else 'out'}"
-
-
-def wait_for_data_source_reconciliation_after_update(
-    data_source, opt_in, volume_name_before_reconcile=DUMMY_VOLUME_NAME
-):
-    LOGGER.info(f"{opt_in_status_str(opt_in=opt_in)}: Verify DataSource {data_source.name} is reconciled after update.")
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_10MIN,
-            sleep=5,
-            func=lambda: data_source.source.name != volume_name_before_reconcile,
-        ):
-            if sample:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(f"dataSource {data_source.name} was not reconciled")
-        raise
-
-
-def wait_for_data_source_updated_referenced_volume(data_source, volume_name):
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=TIMEOUT_10MIN,
-            sleep=5,
-            func=lambda: data_source.source.name == volume_name,
-        ):
-            if sample:
-                return
-    except TimeoutExpiredError:
-        LOGGER.error(
-            f"dataSource {data_source.name} volume reference was not updated, "
-            f"expected {volume_name}, "
-            f"spec: {data_source.instance.spec}"
-        )
-        raise
 
 
 def delete_data_source_and_wait_for_reconciliation(data_source, opt_in):
@@ -251,6 +214,7 @@ def opted_out_data_source_scope_class(
     ):
         wait_for_data_source_updated_referenced_volume(
             data_source=data_source_by_name_scope_class,
+            match_volume_name=True,
             volume_name=created_dv_for_data_import_cron_managed_data_source_scope_class.name,
         )
         yield
@@ -352,8 +316,10 @@ def test_opt_in_data_source_reconciles_after_deletion(
 def test_opt_in_data_source_reconciles_after_update(
     updated_opted_in_data_source_scope_function,
 ):
-    wait_for_data_source_reconciliation_after_update(
-        data_source=updated_opted_in_data_source_scope_function, opt_in=True
+    wait_for_data_source_updated_referenced_volume(
+        data_source=updated_opted_in_data_source_scope_function,
+        match_volume_name=False,
+        volume_name=DUMMY_VOLUME_NAME,
     )
 
 
@@ -405,8 +371,10 @@ def test_opt_out_data_source_reconciles_after_update(
     disabled_common_boot_image_import_hco_spec_scope_function,
     updated_opted_out_data_source_scope_function,
 ):
-    wait_for_data_source_reconciliation_after_update(
-        data_source=updated_opted_out_data_source_scope_function, opt_in=False
+    wait_for_data_source_updated_referenced_volume(
+        data_source=updated_opted_out_data_source_scope_function,
+        match_volume_name=False,
+        volume_name=DUMMY_VOLUME_NAME,
     )
 
 
@@ -513,6 +481,7 @@ class TestDataSourcesOptInLabel:
         LOGGER.info("Verify DataSource is managed by DataImportCron after labelled and a PVC exists.")
         wait_for_data_source_updated_referenced_volume(
             data_source=data_source_by_name_scope_class,
+            match_volume_name=True,
             volume_name=data_source_referenced_volume_scope_class,
         )
 
@@ -521,9 +490,10 @@ class TestDataSourcesOptInLabel:
     def test_opt_in_label_data_source_reconciles_after_update_with_existing_pvc(
         self, updated_data_source_with_existing_pvc_scope_function
     ):
-        wait_for_data_source_reconciliation_after_update(
+        wait_for_data_source_updated_referenced_volume(
             data_source=updated_data_source_with_existing_pvc_scope_function,
-            opt_in=True,
+            match_volume_name=False,
+            volume_name=DUMMY_VOLUME_NAME,
         )
         wait_for_data_import_cron_label_in_data_source_when_opt_in(
             data_source=updated_data_source_with_existing_pvc_scope_function,
@@ -578,9 +548,10 @@ class TestDataSourcesOptOutLabel:
     def test_opt_out_label_data_source_reconciles_after_update_with_existing_pvc(
         self, updated_data_source_with_existing_pvc_scope_function
     ):
-        wait_for_data_source_reconciliation_after_update(
+        wait_for_data_source_updated_referenced_volume(
             data_source=updated_data_source_with_existing_pvc_scope_function,
-            opt_in=False,
+            match_volume_name=False,
+            volume_name=DUMMY_VOLUME_NAME,
         )
         wait_for_data_import_cron_label_in_data_source_when_opt_in(
             data_source=updated_data_source_with_existing_pvc_scope_function,
@@ -608,8 +579,8 @@ class TestDataSourcesOptOutLabel:
         wait_for_data_import_cron_label_in_data_source_when_opt_in(
             data_source=data_source_by_name_scope_class, opt_in=True
         )
-        wait_for_data_source_reconciliation_after_update(
+        wait_for_data_source_updated_referenced_volume(
             data_source=data_source_by_name_scope_class,
-            opt_in=True,
-            volume_name_before_reconcile=created_dv_for_data_import_cron_managed_data_source_scope_class.name,
+            match_volume_name=False,
+            volume_name=created_dv_for_data_import_cron_managed_data_source_scope_class.name,
         )

--- a/tests/infrastructure/golden_images/update_boot_source/utils.py
+++ b/tests/infrastructure/golden_images/update_boot_source/utils.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 from packaging.version import Version
 from pytest_testconfig import py_config
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from tests.infrastructure.golden_images.constants import DATA_SOURCE_READY_FOR_CONSUMPTION_MESSAGE
 from utilities.constants import Images
@@ -28,6 +28,7 @@ from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,
     TIMEOUT_5SEC,
+    TIMEOUT_10MIN,
     TIMEOUT_30SEC,
 )
 from utilities.exceptions import ResourceValueError
@@ -313,3 +314,37 @@ def wait_for_data_source_unchanged_referenced_volume(data_source: DataSource, vo
                 )
     except TimeoutExpiredError:
         return
+
+
+@retry(wait_timeout=TIMEOUT_10MIN, sleep=TIMEOUT_5SEC)
+def wait_for_data_source_updated_referenced_volume(
+    data_source: DataSource,
+    match_volume_name: bool,
+    volume_name: str,
+) -> bool:
+    """Wait for DataSource volume reference to update within a 10-minute window.
+
+    This function polls the DataSource resource to verify its volume reference
+    updates as expected, either by checking for an exact match or verifying
+    that reconciliation occurred (any change from previous value).
+
+    Args:
+        data_source: The DataSource resource to monitor.
+        match_volume_name: If True, wait for volume reference to match volume_name exactly.
+            If False, wait for volume reference to change from volume_name (the previous value).
+        volume_name: When match_volume_name=True, the expected volume name.
+            When match_volume_name=False, the previous volume name that should change.
+
+    Returns:
+        bool: True when the selected volume-reference condition is met.
+            False when the selected volume-reference condition is not met.
+            The `retry` decorator uses this value to stop polling.
+
+    Raises:
+        TimeoutExpiredError: If the expected condition is not met within 10 minutes.
+    """
+
+    if match_volume_name:
+        return data_source.source.name == volume_name
+    else:
+        return data_source.source.name != volume_name


### PR DESCRIPTION
Consolidate DataSource reconciliation wait functions into a single unified validator

##### What this PR does / why we need it:
Merges `wait_for_data_source_reconciliation_after_update()` and
`wait_for_data_source_updated_referenced_volume()`
into a single unified `wait_for_data_source_updated_referenced_volume()` function controlled by a
`check_exact_match`
boolean parameter.

This provides a cleaner, more maintainable API for tests that verify DataSource reconciliation behavior:
- `check_exact_match=True`: Waits for volume reference to match a specific expected name
- `check_exact_match=False`: Waits for volume reference to change from previous value (reconciliation
occurred)

Reduces code duplication and simplifies future test development in opt-in and opt-out scenarios.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
--> 
https://redhat.atlassian.net/browse/CNV-94886



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Improved validation of boot-source data source updates.
- Added checks for exact volume-reference matches and expected changes from previous references.
- Standardized update verification across related test scenarios.
- Improved synchronization and retry handling for updates that take longer to complete.
- Expanded coverage for newly assigned references and transitions away from previous references.
- Consolidated update checks to provide more consistent test results across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->