### PR TITLE
[Storage] Fix WFFC dummy pod creation with unprivileged client in golden image …

### DIFF
--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -7,7 +7,7 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import config as py_config
 
-from utilities.constants.storage import PVC
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, PVC
 from utilities.constants.timeouts import TIMEOUT_20MIN
 from utilities.storage import ErrorMsg, create_dv, get_dv_size_from_datasource
 
@@ -58,6 +58,8 @@ def dv_created_by_unprivileged_user_with_rolebinding(
         namespace=golden_images_namespace.name,
         size=size,
         storage_class=storage_class_name_scope_function,
+        consume_wffc=False,
+        annotations=BIND_IMMEDIATE_ANNOTATION,
         source_ref={
             "kind": fedora_data_source_scope_module.kind,
             "name": fedora_data_source_scope_module.name,


### PR DESCRIPTION
##### What this PR does / why we need it:
The dv_created_by_unprivileged_user_with_rolebinding fixture passes unprivileged_client to create_dv, which forwards it to create_dummy_first_consumer_pod for WFFC storage classes. The unprivileged user lacks pod-creation permissions in the golden images namespace, causing a 403 Forbidden error.

Set consume_wffc=False since CDI's volume populator handles WFFC binding via its own service account.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated golden image storage tests to use immediate volume binding for role-bound, user-created storage volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->