### PR TITLE
[Storage] Fix Validation OS images RBAC issue for Windows tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ from utilities.constants.instance_types import (
     PREFERENCE_STR,
 )
 from utilities.constants.networking import LINUX_BRIDGE
-from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, StorageClassNames
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, OS_IMAGES_EDIT_CLUSTER_ROLE, StorageClassNames
 from utilities.constants.timeouts import (
     TIMEOUT_3MIN,
     TIMEOUT_5MIN,
@@ -374,7 +374,7 @@ def golden_images_cluster_role_edit(
     admin_client,
 ):
     for cluster_role in ClusterRole.get(
-        name="os-images.kubevirt.io:edit",
+        name=OS_IMAGES_EDIT_CLUSTER_ROLE,
         client=admin_client,
     ):
         return cluster_role

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ from utilities.constants.instance_types import (
     PREFERENCE_STR,
 )
 from utilities.constants.networking import LINUX_BRIDGE
-from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, OS_IMAGES_EDIT_CLUSTER_ROLE, StorageClassNames
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, StorageClassNames
 from utilities.constants.timeouts import (
     TIMEOUT_3MIN,
     TIMEOUT_5MIN,
@@ -374,7 +374,7 @@ def golden_images_cluster_role_edit(
     admin_client,
 ):
     for cluster_role in ClusterRole.get(
-        name=OS_IMAGES_EDIT_CLUSTER_ROLE,
+        name="os-images.kubevirt.io:edit",
         client=admin_client,
     ):
         return cluster_role

--- a/tests/fixtures/images/golden_images.py
+++ b/tests/fixtures/images/golden_images.py
@@ -9,6 +9,7 @@ from pytest_testconfig import config as py_config
 
 from utilities.constants.components import RHEL9_STR
 from utilities.constants.hco import DATA_SOURCE_NAME
+from utilities.constants.storage import OS_IMAGES_EDIT_CLUSTER_ROLE
 from utilities.ssp import get_data_import_crons
 from utilities.storage import create_or_update_data_source, data_volume
 
@@ -31,7 +32,7 @@ def golden_images_cluster_role_edit(
     admin_client,
 ):
     for cluster_role in ClusterRole.get(
-        name="os-images.kubevirt.io:edit",
+        name=OS_IMAGES_EDIT_CLUSTER_ROLE,
         client=admin_client,
     ):
         return cluster_role

--- a/tests/fixtures/images/validation_os_images.py
+++ b/tests/fixtures/images/validation_os_images.py
@@ -1,3 +1,5 @@
+from contextlib import ExitStack
+
 import pytest
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.data_source import DataSource
@@ -72,18 +74,19 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
         role_ref_name=VALIDATION_OS_IMAGES_CLONE_ROLE,
     )
 
-    if clone_role.exists and role_binding.exists:
-        role_ref = role_binding.instance.roleRef
-        assert role_ref.name == VALIDATION_OS_IMAGES_CLONE_ROLE, (
-            f"RoleBinding {role_binding.name} roleRef name is {role_ref.name},"
-            f" expected {VALIDATION_OS_IMAGES_CLONE_ROLE}"
-        )
-        yield role_binding
-        return
+    # A RoleBinding created by an older revision of this fixture may still point to a different
+    # ClusterRole. Remove it (independently of the clone_role state) so it can be recreated with
+    # the correct roleRef; otherwise recreating it below fails with a 409 AlreadyExists conflict.
+    if role_binding.exists and role_binding.instance.roleRef.name != VALIDATION_OS_IMAGES_CLONE_ROLE:
+        role_binding.clean_up(wait=True)
 
-    with clone_role:
-        with role_binding as rb:
-            yield rb
+    # Create only the resources that are missing so pre-existing ones are left untouched.
+    with ExitStack() as stack:
+        if not clone_role.exists:
+            stack.enter_context(clone_role)
+        if not role_binding.exists:
+            stack.enter_context(role_binding)
+        yield role_binding
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/images/validation_os_images.py
+++ b/tests/fixtures/images/validation_os_images.py
@@ -43,7 +43,7 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
     """Grants unprivileged clients the same clone permissions as the golden-images namespace.
 
     Binds the built-in ``os-images.kubevirt.io:edit`` ClusterRole to ``system:authenticated`` in the
-    validation-os-images namespace so cross-namespace (host-assisted) clones from this namespace succeed.
+    validation-os-images namespace so cross-namespace clones from this namespace succeed.
     """
     role_binding = RoleBinding(
         client=admin_client,
@@ -55,26 +55,20 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
         role_ref_name=OS_IMAGES_EDIT_CLUSTER_ROLE,
     )
 
-    # A RoleBinding created by an older revision of this fixture may still point to a different
-    # ClusterRole (e.g. "view"). A RoleBinding's roleRef is immutable, so a stale binding must be
-    # deleted and recreated with the correct roleRef; otherwise recreating it below fails with a
-    # 409 AlreadyExists conflict.
-    if role_binding.exists and role_binding.instance.roleRef.name != OS_IMAGES_EDIT_CLUSTER_ROLE:
-        LOGGER.info(
-            f"Deleting stale RoleBinding {role_binding.name} in {role_binding.namespace} "
-            f"pointing to {role_binding.instance.roleRef.name}, expected {OS_IMAGES_EDIT_CLUSTER_ROLE}"
-        )
-        role_binding.clean_up(wait=True)
-
     if role_binding.exists:
-        # roleRef is guaranteed correct here (a mismatch was cleaned up above); validate the subjects
-        # of the pre-existing binding so a misconfigured one fails fast instead of silently not granting.
         subjects = next(iter(role_binding.instance.subjects))
         assert subjects.kind == "Group", (
             f"RoleBinding {role_binding.name} subjects kind is {subjects.kind}, expected Group"
         )
         assert subjects.name == "system:authenticated", (
             f"RoleBinding {role_binding.name} subjects name is {subjects.name}, expected system:authenticated"
+        )
+        role_ref = role_binding.instance.roleRef
+        assert role_ref.kind == ClusterRole.kind, (
+            f"RoleBinding {role_binding.name} roleRef kind is {role_ref.kind}, expected {ClusterRole.kind}"
+        )
+        assert role_ref.name == OS_IMAGES_EDIT_CLUSTER_ROLE, (
+            f"RoleBinding {role_binding.name} roleRef name is {role_ref.name}, expected {OS_IMAGES_EDIT_CLUSTER_ROLE}"
         )
         yield role_binding
         return

--- a/tests/fixtures/images/validation_os_images.py
+++ b/tests/fixtures/images/validation_os_images.py
@@ -1,5 +1,3 @@
-from contextlib import ExitStack
-
 import pytest
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.data_source import DataSource
@@ -16,7 +14,7 @@ from utilities.artifactory import (
     get_test_artifact_server_url,
 )
 from utilities.constants import Images
-from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, REGISTRY_STR
+from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, OS_IMAGES_EDIT_CLUSTER_ROLE, REGISTRY_STR
 from utilities.constants.timeouts import TIMEOUT_10MIN, TIMEOUT_50MIN
 from utilities.constants.virt import WIN_2K22
 from utilities.os_utils import get_windows_container_disk_path
@@ -36,34 +34,13 @@ def validation_os_images_namespace(admin_client):
             yield ns
 
 
-VALIDATION_OS_IMAGES_CLONE_ROLE = "validation-os-images-clone"
-
-
 @pytest.fixture(scope="session")
 def validation_os_images_role_binding(admin_client, validation_os_images_namespace):
-    """Grants view and datavolumes/source permissions so unprivileged clients can clone from this namespace."""
-    clone_role = ClusterRole(
-        client=admin_client,
-        name=VALIDATION_OS_IMAGES_CLONE_ROLE,
-        rules=[
-            {
-                "apiGroups": [""],
-                "resources": ["pods", "persistentvolumeclaims", "services", "endpoints", "configmaps", "secrets"],
-                "verbs": ["get", "list", "watch"],
-            },
-            {
-                "apiGroups": [DataVolume.api_group],
-                "resources": ["datavolumes", "datasources"],
-                "verbs": ["get", "list", "watch"],
-            },
-            {
-                "apiGroups": [DataVolume.api_group],
-                "resources": ["datavolumes/source"],
-                "verbs": ["create"],
-            },
-        ],
-    )
+    """Grants unprivileged clients the same clone permissions as the golden-images namespace.
 
+    Binds the built-in ``os-images.kubevirt.io:edit`` ClusterRole to ``system:authenticated`` in the
+    validation-os-images namespace so cross-namespace (host-assisted) clones from this namespace succeed.
+    """
     role_binding = RoleBinding(
         client=admin_client,
         name="validation-os-images-view",
@@ -71,22 +48,22 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
         subjects_kind="Group",
         subjects_name="system:authenticated",
         role_ref_kind=ClusterRole.kind,
-        role_ref_name=VALIDATION_OS_IMAGES_CLONE_ROLE,
+        role_ref_name=OS_IMAGES_EDIT_CLUSTER_ROLE,
     )
 
     # A RoleBinding created by an older revision of this fixture may still point to a different
-    # ClusterRole. Remove it (independently of the clone_role state) so it can be recreated with
-    # the correct roleRef; otherwise recreating it below fails with a 409 AlreadyExists conflict.
-    if role_binding.exists and role_binding.instance.roleRef.name != VALIDATION_OS_IMAGES_CLONE_ROLE:
+    # ClusterRole (e.g. "view"). A RoleBinding's roleRef is immutable, so a stale binding must be
+    # deleted and recreated with the correct roleRef; otherwise recreating it below fails with a
+    # 409 AlreadyExists conflict.
+    if role_binding.exists and role_binding.instance.roleRef.name != OS_IMAGES_EDIT_CLUSTER_ROLE:
         role_binding.clean_up(wait=True)
 
-    # Create only the resources that are missing so pre-existing ones are left untouched.
-    with ExitStack() as stack:
-        if not clone_role.exists:
-            stack.enter_context(clone_role)
-        if not role_binding.exists:
-            stack.enter_context(role_binding)
+    if role_binding.exists:
         yield role_binding
+        return
+
+    with role_binding as rb:
+        yield rb
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/images/validation_os_images.py
+++ b/tests/fixtures/images/validation_os_images.py
@@ -34,9 +34,34 @@ def validation_os_images_namespace(admin_client):
             yield ns
 
 
+VALIDATION_OS_IMAGES_CLONE_ROLE = "validation-os-images-clone"
+
+
 @pytest.fixture(scope="session")
 def validation_os_images_role_binding(admin_client, validation_os_images_namespace):
-    """Grants view permissions in the namespace so unprivileged clients can clone from it."""
+    """Grants view and datavolumes/source permissions so unprivileged clients can clone from this namespace."""
+    clone_role = ClusterRole(
+        client=admin_client,
+        name=VALIDATION_OS_IMAGES_CLONE_ROLE,
+        rules=[
+            {
+                "apiGroups": [""],
+                "resources": ["pods", "persistentvolumeclaims", "services", "endpoints", "configmaps", "secrets"],
+                "verbs": ["get", "list", "watch"],
+            },
+            {
+                "apiGroups": [DataVolume.api_group],
+                "resources": ["datavolumes", "datasources"],
+                "verbs": ["get", "list", "watch"],
+            },
+            {
+                "apiGroups": [DataVolume.api_group],
+                "resources": ["datavolumes/source"],
+                "verbs": ["create"],
+            },
+        ],
+    )
+
     role_binding = RoleBinding(
         client=admin_client,
         name="validation-os-images-view",
@@ -44,29 +69,21 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
         subjects_kind="Group",
         subjects_name="system:authenticated",
         role_ref_kind=ClusterRole.kind,
-        role_ref_name="view",
+        role_ref_name=VALIDATION_OS_IMAGES_CLONE_ROLE,
     )
 
-    if role_binding.exists:
-        subjects = next(iter(role_binding.instance.subjects))
-        assert subjects.kind == "Group", (
-            f"RoleBinding {role_binding.name} subjects kind is {subjects.kind}, expected Group"
-        )
-        assert subjects.name == "system:authenticated", (
-            f"RoleBinding {role_binding.name} subjects name is {subjects.name}, expected system:authenticated"
-        )
+    if clone_role.exists and role_binding.exists:
         role_ref = role_binding.instance.roleRef
-        assert role_ref.kind == ClusterRole.kind, (
-            f"RoleBinding {role_binding.name} roleRef kind is {role_ref.kind}, expected {ClusterRole.kind}"
-        )
-        assert role_ref.name == "view", (
-            f"RoleBinding {role_binding.name} roleRef name is {role_ref.name}, expected view"
+        assert role_ref.name == VALIDATION_OS_IMAGES_CLONE_ROLE, (
+            f"RoleBinding {role_binding.name} roleRef name is {role_ref.name},"
+            f" expected {VALIDATION_OS_IMAGES_CLONE_ROLE}"
         )
         yield role_binding
         return
 
-    with role_binding as rb:
-        yield rb
+    with clone_role:
+        with role_binding as rb:
+            yield rb
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/images/validation_os_images.py
+++ b/tests/fixtures/images/validation_os_images.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.data_source import DataSource
@@ -19,6 +21,8 @@ from utilities.constants.timeouts import TIMEOUT_10MIN, TIMEOUT_50MIN
 from utilities.constants.virt import WIN_2K22
 from utilities.os_utils import get_windows_container_disk_path
 from utilities.storage import construct_datavolume_source_dict, generate_data_source_dict
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
@@ -56,12 +60,29 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
     # deleted and recreated with the correct roleRef; otherwise recreating it below fails with a
     # 409 AlreadyExists conflict.
     if role_binding.exists and role_binding.instance.roleRef.name != OS_IMAGES_EDIT_CLUSTER_ROLE:
+        LOGGER.info(
+            f"Deleting stale RoleBinding {role_binding.name} in {role_binding.namespace} "
+            f"pointing to {role_binding.instance.roleRef.name}, expected {OS_IMAGES_EDIT_CLUSTER_ROLE}"
+        )
         role_binding.clean_up(wait=True)
 
     if role_binding.exists:
+        # roleRef is guaranteed correct here (a mismatch was cleaned up above); validate the subjects
+        # of the pre-existing binding so a misconfigured one fails fast instead of silently not granting.
+        subjects = next(iter(role_binding.instance.subjects))
+        assert subjects.kind == "Group", (
+            f"RoleBinding {role_binding.name} subjects kind is {subjects.kind}, expected Group"
+        )
+        assert subjects.name == "system:authenticated", (
+            f"RoleBinding {role_binding.name} subjects name is {subjects.name}, expected system:authenticated"
+        )
         yield role_binding
         return
 
+    LOGGER.info(
+        f"Creating RoleBinding {role_binding.name} in {role_binding.namespace} "
+        f"binding {OS_IMAGES_EDIT_CLUSTER_ROLE} to system:authenticated"
+    )
     with role_binding as rb:
         yield rb
 

--- a/utilities/constants/storage.py
+++ b/utilities/constants/storage.py
@@ -84,6 +84,8 @@ REGISTRY_STR = "registry"
 # DataImportCron / golden image constants
 WILDCARD_CRON_EXPRESSION = "* * * * *"
 OUTDATED = "Outdated"
+# Built-in CNV ClusterRole granting create/clone permissions in an OS-images namespace
+OS_IMAGES_EDIT_CLUSTER_ROLE = "os-images.kubevirt.io:edit"
 
 # Storage capacity metric field names
 CAPACITY = "capacity"


### PR DESCRIPTION
##### What this PR does / why we need it:
There's a problem with RBAC role on HPP lane for Tier3 test, link below. It seems like cloning permission from `validation-os-images` namespace needs to be different from OCS where it works just fine.

Probably caused by https://github.com/kubevirt/containerized-data-importer/pull/4219

##### Which issue(s) this PR fixes:
https://redhat.atlassian.net/browse/CNV-95483

##### Special notes for reviewer:
Co-Authored: Opus 4.8 <noreply@anthropic.com>

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of permissions used by OS image workflows.
  * Updated role binding checks to ensure authenticated access receives the intended image-editing permissions.
  * Improved diagnostic logging when permissions are configured, making configuration issues easier to identify.
  * Standardized references to the built-in OS image editing role across image-related validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->