### PR TITLE
fix: handle console reconnect to already-logged-in session

### DIFF
--- a/utilities/console.py
+++ b/utilities/console.py
@@ -88,13 +88,23 @@ class Console:
     def _connect(self):
         self.child.send("\n\n")
         if self.username:
-            self.child.expect(self.login_prompt)
-            LOGGER.info(f"{self.vm.name}: Using username {self.username}")
-            self.child.sendline(self.username)
-            if self.password:
-                self.child.expect("Password:")
-                LOGGER.info(f"{self.vm.name}: Using password {self.password}")
-                self.child.sendline(self.password)
+            # Wait for either "login:" or a shell prompt (e.g., "$" or "#")
+            patterns = [self.login_prompt] + (self.prompt if isinstance(self.prompt, list) else [self.prompt])
+            matched_index = self.child.expect(patterns)
+
+            # Index 0 = login prompt, other indices = shell prompt
+            if matched_index == 0:
+                # Need to login
+                LOGGER.info(f"{self.vm.name}: Using username {self.username}")
+                self.child.sendline(self.username)
+                if self.password:
+                    self.child.expect("Password:")
+                    LOGGER.info(f"{self.vm.name}: Using password {self.password}")
+                    self.child.sendline(self.password)
+            else:
+                # Already logged in, skip login sequence
+                LOGGER.info(f"{self.vm.name}: Already at shell prompt, skipping login")
+                return
 
         LOGGER.info(f"{self.vm.name}: waiting for terminal prompt '{self.prompt}'")
         self.child.expect(self.prompt)

--- a/utilities/unittests/test_console.py
+++ b/utilities/unittests/test_console.py
@@ -215,12 +215,13 @@ class TestConsole:
 
         console = Console(vm=mock_vm)
         console.child = MagicMock()
+        console.child.expect.return_value = 0  # simulate login prompt found
 
         console._connect()
 
         # Verify connection sequence
         console.child.send.assert_any_call("\n\n")
-        console.child.expect.assert_any_call("login:")
+        console.child.expect.assert_any_call(["login:", r"#", r"\$"])
         console.child.sendline.assert_any_call("testuser")
         console.child.expect.assert_any_call("Password:")
         console.child.sendline.assert_any_call("testpass")
@@ -239,16 +240,40 @@ class TestConsole:
 
         console = Console(vm=mock_vm)
         console.child = MagicMock()
+        console.child.expect.return_value = 0  # simulate login prompt found
 
         console._connect()
 
         # Verify connection sequence without password
         console.child.send.assert_any_call("\n\n")
-        console.child.expect.assert_any_call("login:")
+        console.child.expect.assert_any_call(["login:", r"#", r"\$"])
         console.child.sendline.assert_any_call("testuser")
         # Should not expect or send password
         password_calls = [call for call in console.child.expect.call_args_list if "Password:" in str(call)]
         assert len(password_calls) == 0
+
+    @patch("console.get_data_collector_base_directory")
+    def test_console_connect_already_logged_in(self, mock_get_dir):
+        """Test _connect method when reconnecting to already-logged-in session"""
+        mock_get_dir.return_value = "/tmp/data"
+        mock_vm = MagicMock()
+        mock_vm.name = "test-vm"
+        mock_vm.namespace = None
+        mock_vm.username = "testuser"
+        mock_vm.password = "testpass"
+        mock_vm.login_params = {}
+
+        console = Console(vm=mock_vm)
+        console.child = MagicMock()
+        console.child.expect.return_value = 1  # simulate shell prompt found (not login:)
+
+        console._connect()
+
+        # Should detect existing shell prompt and skip login
+        console.child.send.assert_any_call("\n\n")
+        console.child.expect.assert_called_once_with(["login:", r"#", r"\$"])
+        # Should NOT send username or password
+        assert console.child.sendline.call_count == 0
 
     @patch("console.get_data_collector_base_directory")
     def test_console_connect_no_username(self, mock_get_dir):


### PR DESCRIPTION
##### What this PR does / why we need it:
When virtctl console reconnects after VM migration, the guest TTY may still show a shell prompt instead of "login:". The old code waited only for "login:" and timed out after 300s.

_connect() now detects either login prompt or shell prompt. When reconnecting to an existing session, it skips the login sequence and returns immediately.


##### Which issue(s) this PR fixes:

Fixes: SR-IOV hot-plug triggered live
migration, virtctl console dropped (websocket 1006), reconnect landed on "[fedora@... ~]$" shell prompt, pexpect waited for "login:" until timeout. VMI status showed interface correctly attached with guest-agent reporting - product worked, harness could not reconnect to console.

Also fixes: migration tests using console, hot-plug tests with CNV-77961 workaround, and any scenario where console reconnects to a still-logged-in VM session.

Added unit-tests accordingly.


##### Special notes for reviewer: -

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console connections to recognize sessions that are already authenticated.
  * Skips unnecessary username and password prompts when a shell is immediately available.
  * Maintains the existing login flow when authentication is required.

* **Tests**
  * Added coverage for reconnecting to an already-authenticated console session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->