### PR TITLE
Storage: STD for online/offline VM storage migration

### DIFF
--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -5,6 +5,8 @@ STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob
 Jira: https://issues.redhat.com/browse/CNV-77501 # <skip-jira-utils-check>
 """
 
+import pytest
+
 __test__ = False
 
 
@@ -28,6 +30,7 @@ class TestOfflineVMStorageMigrationVolumeModes:
         - File written to the VM data disk with known content
     """
 
+    @pytest.mark.polarion("CNV-16796")
     def test_offline_vm_storage_migration_across_volume_modes(self):
         """
         Test that offline VM storage migration completes successfully and preserves data
@@ -60,6 +63,7 @@ class TestMixedOfflineOnlineStorageMigration:
         - Running VM on the source storage class, boot time recorded before migration
     """
 
+    @pytest.mark.polarion("CNV-16797")
     def test_mixed_offline_online_vm_storage_migration(self):
         """
         Test that storage migration completes for a plan containing both offline and running VMs
@@ -94,6 +98,7 @@ class TestOfflineStorageMigrationCleanupPolicy:
         - Source volume identifier recorded before migration
     """
 
+    @pytest.mark.polarion("CNV-16798")
     def test_source_volumes_retained_after_offline_migration(self):
         """
         Test that source volumes are retained after offline VM storage migration
@@ -112,6 +117,7 @@ class TestOfflineStorageMigrationCleanupPolicy:
             - Source volumes exist after migration completes
         """
 
+    @pytest.mark.polarion("CNV-16799")
     def test_source_volumes_deleted_after_offline_migration(self):
         """
         Test that source volumes are deleted after offline VM storage migration
@@ -141,6 +147,7 @@ class TestOfflineVMStorageMigrationWithHotplugDisks:
         - File written to each disk with known content
     """
 
+    @pytest.mark.polarion("CNV-16800")
     def test_offline_vm_with_hotplug_disks_storage_migration(self):
         """
         Test that offline VM storage migration migrates all disks including hotplug disks.
@@ -176,6 +183,7 @@ class TestOfflineVMStorageMigrationSameStorageClass:
         - VM disk volume references recorded before migration
     """
 
+    @pytest.mark.polarion("CNV-16801")
     def test_offline_vm_same_storage_class_migration(self):
         """
         Test that offline VM storage migration completes for same-storage class (HPP to HPP) migration.
@@ -207,6 +215,7 @@ class TestOfflineVMStorageMigrationFailureRollback:
         - Storage migration configured to trigger a failure during migration
     """
 
+    @pytest.mark.polarion("CNV-16802")
     def test_offline_vm_rollback_on_migration_failure(self):
         """
         [NEGATIVE] Test that offline VM disk references remain unchanged when storage migration fails.
@@ -236,6 +245,7 @@ class TestVMStartDuringStorageMigration:
         - Stopped VM with a data disk on the source storage class
     """
 
+    @pytest.mark.polarion("CNV-16803")
     def test_vm_start_during_offline_storage_migration(self):
         """
         Test that starting a stopped VM during storage migration succeeds
@@ -269,6 +279,7 @@ class TestCancelInProgressStorageMigration:
         - VM disk references recorded before migration
     """
 
+    @pytest.mark.polarion("CNV-16804")
     def test_cancel_in_progress_storage_migration(self):
         """
         Test that cancelling an in-progress storage migration preserves original VM state

--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -7,8 +7,6 @@ Jira: https://issues.redhat.com/browse/CNV-77501 # <skip-jira-utils-check>
 
 import pytest
 
-__test__ = False
-
 
 class TestOfflineVMStorageMigrationVolumeModes:
     """
@@ -29,6 +27,8 @@ class TestOfflineVMStorageMigrationVolumeModes:
         - Stopped VM with a data disk on the source storage class using the source volume mode
         - File written to the VM data disk with known content
     """
+
+    __test__ = False
 
     @pytest.mark.polarion("CNV-16796")
     def test_offline_vm_storage_migration_across_volume_modes(self):
@@ -62,6 +62,8 @@ class TestMixedOfflineOnlineStorageMigration:
         - Stopped VM on the source storage class
         - Running VM on the source storage class, boot time recorded before migration
     """
+
+    __test__ = False
 
     @pytest.mark.polarion("CNV-16797")
     def test_mixed_offline_online_vm_storage_migration(self):
@@ -98,6 +100,8 @@ class TestOfflineStorageMigrationCleanupPolicy:
         - File written to the VM data disk with known content
         - Source volume identifier recorded before migration
     """
+
+    __test__ = False
 
     @pytest.mark.polarion("CNV-16798")
     def test_source_volumes_retained_after_offline_migration(self):
@@ -156,6 +160,8 @@ class TestOfflineVMStorageMigrationWithHotplugDisks:
         - File written to each disk with known content
     """
 
+    __test__ = False
+
     @pytest.mark.polarion("CNV-16800")
     def test_offline_vm_with_hotplug_disks_storage_migration(self):
         """
@@ -189,6 +195,8 @@ class TestOfflineVMStorageMigrationFailureRollback:
         - Storage migration configured to trigger a failure during migration
     """
 
+    __test__ = False
+
     @pytest.mark.polarion("CNV-16802")
     def test_offline_vm_rollback_on_migration_failure(self):
         """
@@ -219,6 +227,8 @@ class TestVMStartDuringStorageMigration:
         - Stopped VM with a data disk on the source storage class
         - File written to the VM data disk with known content
     """
+
+    __test__ = False
 
     @pytest.mark.polarion("CNV-16803")
     def test_vm_start_during_offline_storage_migration(self):
@@ -256,6 +266,8 @@ class TestCancelInProgressStorageMigration:
         - Running VM on the source storage class with a sufficiently large disk
         - VM disk references recorded before migration
     """
+
+    __test__ = False
 
     @pytest.mark.polarion("CNV-16804")
     def test_cancel_in_progress_storage_migration(self):

--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -178,7 +178,6 @@ class TestOfflineVMStorageMigrationWithHotplugDisks:
         """
 
 
-
 class TestOfflineVMStorageMigrationFailureRollback:
     """
     Tests for offline VM rollback behavior on storage migration failure.

--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -12,12 +12,12 @@ __test__ = False
 
 class TestOfflineVMStorageMigrationVolumeModes:
     """
-    Tests for offline VM storage migration between ODF and HPP across volume mode combinations.
+    Tests for offline VM storage migration across volume mode combinations.
 
     Parametrize:
         - storage_class_direction:
-            - ODF to HPP
-            - HPP to ODF
+            - Storage class A to storage class B
+            - Storage class B to storage class A
         - volume_mode:
             - Block-to-Block
             - File-to-File
@@ -25,7 +25,7 @@ class TestOfflineVMStorageMigrationVolumeModes:
             - File-to-Block
 
     Preconditions:
-        - Source and target storage classes available (ODF and HPP)
+        - Source and target storage classes available on the cluster
         - Stopped VM with a data disk on the source storage class using the source volume mode
         - File written to the VM data disk with known content
     """
@@ -34,7 +34,7 @@ class TestOfflineVMStorageMigrationVolumeModes:
     def test_offline_vm_storage_migration_across_volume_modes(self):
         """
         Test that offline VM storage migration completes successfully and preserves data
-        across volume mode combinations between ODF and HPP.
+        across volume mode combinations between different storage classes.
 
         Preconditions:
             - Stopped VM with a data disk on the source storage class using the source volume mode
@@ -95,6 +95,7 @@ class TestOfflineStorageMigrationCleanupPolicy:
     Preconditions:
         - Source and target storage classes available
         - Stopped VM with a data disk on the source storage class
+        - File written to the VM data disk with known content
         - Source volume identifier recorded before migration
     """
 
@@ -106,15 +107,19 @@ class TestOfflineStorageMigrationCleanupPolicy:
 
         Preconditions:
             - Stopped VM with a data disk on the source storage class
+            - File written to the VM data disk with known content
             - Source volume identifier recorded before migration
 
         Steps:
             1. Create a storage migration plan with cleanup policy set to retain
             2. Execute the storage migration and wait for completion
             3. Check whether the source volumes still exist
+            4. Start the VM after migration completes
+            5. Read the file content from the VM data disk
 
         Expected:
             - Source volumes exist after migration completes
+            - File content equals the pre-migration written data
         """
 
     @pytest.mark.polarion("CNV-16799")
@@ -125,15 +130,19 @@ class TestOfflineStorageMigrationCleanupPolicy:
 
         Preconditions:
             - Stopped VM with a data disk on the source storage class
+            - File written to the VM data disk with known content
             - Source volume identifier recorded before migration
 
         Steps:
             1. Create a storage migration plan with cleanup policy set to delete
             2. Execute the storage migration and wait for completion
             3. Check whether the source volumes still exist
+            4. Start the VM after migration completes
+            5. Read the file content from the VM data disk
 
         Expected:
             - Source volumes do not exist after migration completes
+            - File content equals the pre-migration written data
         """
 
 
@@ -168,40 +177,6 @@ class TestOfflineVMStorageMigrationWithHotplugDisks:
             - VM boots successfully with all disks accessible and file content unchanged
         """
 
-
-class TestOfflineVMStorageMigrationSameStorageClass:
-    """
-    Tests for offline VM storage migration within the same storage class (HPP to HPP)
-    for node-to-node migration.
-
-    Markers:
-        - hpp
-
-    Preconditions:
-        - HPP storage class available
-        - Stopped VM with a data disk on HPP storage class
-        - VM disk volume references recorded before migration
-    """
-
-    @pytest.mark.polarion("CNV-16801")
-    def test_offline_vm_same_storage_class_migration(self):
-        """
-        Test that offline VM storage migration completes for same-storage class (HPP to HPP) migration.
-
-        Preconditions:
-            - Stopped VM with a data disk on HPP storage class
-            - VM disk volume references recorded before migration
-
-        Steps:
-            1. Create a storage migration plan targeting the same HPP storage class
-            2. Execute the storage migration and wait for completion
-            3. Start the VM after migration completes
-
-        Expected:
-            - Migration plan status is "Succeeded"
-            - VM disk references point to a new volume different from the original
-            - VM boots successfully after migration
-        """
 
 
 class TestOfflineVMStorageMigrationFailureRollback:
@@ -243,6 +218,7 @@ class TestVMStartDuringStorageMigration:
     Preconditions:
         - Source and target storage classes available
         - Stopped VM with a data disk on the source storage class
+        - File written to the VM data disk with known content
     """
 
     @pytest.mark.polarion("CNV-16803")
@@ -253,6 +229,7 @@ class TestVMStartDuringStorageMigration:
 
         Preconditions:
             - Stopped VM with a data disk on the source storage class
+            - File written to the VM data disk with known content
 
         Steps:
             1. Create a storage migration plan for the stopped VM
@@ -260,11 +237,13 @@ class TestVMStartDuringStorageMigration:
             3. Start the VM while migration is in progress
             4. Verify VM state during migration
             5. Wait for migration to complete
+            6. Read the file content from the VM data disk
 
         Expected:
             - Migration plan status is "Succeeded"
             - VM remains in a pending state during migration and becomes ready only after migration completes
             - VM disk references point to the target storage class
+            - File content equals the pre-migration written data
         """
 
 

--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -57,26 +57,30 @@ class TestMixedOfflineOnlineStorageMigration:
     Preconditions:
         - Source and target storage classes available
         - Stopped VM on the source storage class
-        - Running VM on the source storage class
+        - Running VM on the source storage class, boot time recorded before migration
     """
 
     def test_mixed_offline_online_vm_storage_migration(self):
         """
-        Test that storage migration completes for a plan containing both offline and running VMs.
+        Test that storage migration completes for a plan containing both offline and running VMs
+        while each VM preserves its original state.
 
         Preconditions:
             - Stopped VM on the source storage class
-            - Running VM on the source storage class
+            - Running VM on the source storage class, boot time recorded before migration
 
         Steps:
             1. Create a storage migration plan including both the stopped VM and the running VM
-            2. Execute the storage migration and wait for completion
-            3. Verify all VMs point to the target storage class
+            2. Execute the storage migration
+            3. Verify the running VM remains running while migration is in progress
+            4. Wait for migration to complete
+            5. Verify all VMs point to the target storage class
+            6. Verify each VM preserved its original state after migration
 
         Expected:
             - Migration plan status is "Succeeded"
-            - Stopped VM disk references point to the target storage class
-            - Running VM disk references point to the target storage class and VM remains running
+            - Stopped VM disk references point to the target storage class and VM remains stopped
+            - Running VM disk references point to the target storage class and VM remained running throughout without restart
         """
 
 
@@ -169,6 +173,7 @@ class TestOfflineVMStorageMigrationSameStorageClass:
     Preconditions:
         - HPP storage class available
         - Stopped VM with a data disk on HPP storage class
+        - VM disk volume references recorded before migration
     """
 
     def test_offline_vm_same_storage_class_migration(self):
@@ -177,6 +182,7 @@ class TestOfflineVMStorageMigrationSameStorageClass:
 
         Preconditions:
             - Stopped VM with a data disk on HPP storage class
+            - VM disk volume references recorded before migration
 
         Steps:
             1. Create a storage migration plan targeting the same HPP storage class
@@ -185,7 +191,7 @@ class TestOfflineVMStorageMigrationSameStorageClass:
 
         Expected:
             - Migration plan status is "Succeeded"
-            - VM disk references point to a new volume on the target node
+            - VM disk references point to a new volume different from the original
             - VM boots successfully after migration
         """
 

--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -1,0 +1,287 @@
+"""
+Offline VM Storage Migration Tests
+
+STP: https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main/stps/sig-storage/storage_mig_offline.md
+Jira: https://issues.redhat.com/browse/CNV-77501 # <skip-jira-utils-check>
+"""
+
+__test__ = False
+
+
+class TestOfflineVMStorageMigrationVolumeModes:
+    """
+    Tests for offline VM storage migration between ODF and HPP across volume mode combinations.
+
+    Parametrize:
+        - storage_class_direction:
+            - ODF to HPP
+            - HPP to ODF
+        - volume_mode:
+            - Block-to-Block
+            - File-to-File
+            - Block-to-File
+            - File-to-Block
+
+    Preconditions:
+        - Source and target storage classes available (ODF and HPP)
+        - Stopped VM with a data disk on the source storage class using the source volume mode
+        - File written to the VM data disk with known content
+    """
+
+    def test_offline_vm_storage_migration_across_volume_modes(self):
+        """
+        Test that offline VM storage migration completes successfully and preserves data
+        across volume mode combinations between ODF and HPP.
+
+        Preconditions:
+            - Stopped VM with a data disk on the source storage class using the source volume mode
+            - File written to the VM data disk with known content
+
+        Steps:
+            1. Create a storage migration plan for the stopped VM targeting the destination storage class and volume mode
+            2. Execute the storage migration and wait for completion
+            3. Start the VM after migration completes
+            4. Read the file content from the VM data disk
+
+        Expected:
+            - Migration plan status is "Succeeded"
+            - VM boots successfully after migration
+            - File content equals the pre-migration written data
+        """
+
+
+class TestMixedOfflineOnlineStorageMigration:
+    """
+    Tests for storage migration with a migration plan containing both offline and running VMs.
+
+    Preconditions:
+        - Source and target storage classes available
+        - Stopped VM on the source storage class
+        - Running VM on the source storage class
+    """
+
+    def test_mixed_offline_online_vm_storage_migration(self):
+        """
+        Test that storage migration completes for a plan containing both offline and running VMs.
+
+        Preconditions:
+            - Stopped VM on the source storage class
+            - Running VM on the source storage class
+
+        Steps:
+            1. Create a storage migration plan including both the stopped VM and the running VM
+            2. Execute the storage migration and wait for completion
+            3. Verify all VMs point to the target storage class
+
+        Expected:
+            - Migration plan status is "Succeeded"
+            - Stopped VM disk references point to the target storage class
+            - Running VM disk references point to the target storage class and VM remains running
+        """
+
+
+class TestOfflineStorageMigrationCleanupPolicy:
+    """
+    Tests for source volume cleanup policy during offline VM storage migration.
+
+    Preconditions:
+        - Source and target storage classes available
+        - Stopped VM with a data disk on the source storage class
+        - Source volume identifier recorded before migration
+    """
+
+    def test_source_volumes_retained_after_offline_migration(self):
+        """
+        Test that source volumes are retained after offline VM storage migration
+        when cleanup policy is set to retain.
+
+        Preconditions:
+            - Stopped VM with a data disk on the source storage class
+            - Source volume identifier recorded before migration
+
+        Steps:
+            1. Create a storage migration plan with cleanup policy set to retain
+            2. Execute the storage migration and wait for completion
+            3. Check whether the source volumes still exist
+
+        Expected:
+            - Source volumes exist after migration completes
+        """
+
+    def test_source_volumes_deleted_after_offline_migration(self):
+        """
+        Test that source volumes are deleted after offline VM storage migration
+        when cleanup policy is set to delete.
+
+        Preconditions:
+            - Stopped VM with a data disk on the source storage class
+            - Source volume identifier recorded before migration
+
+        Steps:
+            1. Create a storage migration plan with cleanup policy set to delete
+            2. Execute the storage migration and wait for completion
+            3. Check whether the source volumes still exist
+
+        Expected:
+            - Source volumes do not exist after migration completes
+        """
+
+
+class TestOfflineVMStorageMigrationWithHotplugDisks:
+    """
+    Tests for offline VM storage migration with hotplug disks attached.
+
+    Preconditions:
+        - Source and target storage classes available
+        - Stopped VM with boot disk and hotplug disks on the source storage class
+        - File written to each disk with known content
+    """
+
+    def test_offline_vm_with_hotplug_disks_storage_migration(self):
+        """
+        Test that offline VM storage migration migrates all disks including hotplug disks.
+
+        Preconditions:
+            - Stopped VM with boot disk and hotplug disks on the source storage class
+            - File written to each disk with known content
+
+        Steps:
+            1. Create a storage migration plan for the stopped VM targeting the destination storage class
+            2. Execute the storage migration and wait for completion
+            3. Start the VM after migration completes
+            4. Verify all disks including hotplug disks are accessible and data is intact
+
+        Expected:
+            - Migration plan status is "Succeeded"
+            - All disks including hotplug disks are migrated to the target storage class
+            - VM boots successfully with all disks accessible and file content unchanged
+        """
+
+
+class TestOfflineVMStorageMigrationSameStorageClass:
+    """
+    Tests for offline VM storage migration within the same storage class (HPP to HPP)
+    for node-to-node migration.
+
+    Markers:
+        - hpp
+
+    Preconditions:
+        - HPP storage class available
+        - Stopped VM with a data disk on HPP storage class
+    """
+
+    def test_offline_vm_same_storage_class_migration(self):
+        """
+        Test that offline VM storage migration completes for same-storage class (HPP to HPP) migration.
+
+        Preconditions:
+            - Stopped VM with a data disk on HPP storage class
+
+        Steps:
+            1. Create a storage migration plan targeting the same HPP storage class
+            2. Execute the storage migration and wait for completion
+            3. Start the VM after migration completes
+
+        Expected:
+            - Migration plan status is "Succeeded"
+            - VM disk references point to a new volume on the target node
+            - VM boots successfully after migration
+        """
+
+
+class TestOfflineVMStorageMigrationFailureRollback:
+    """
+    Tests for offline VM rollback behavior on storage migration failure.
+
+    Preconditions:
+        - Source and target storage classes available
+        - Stopped VM with a data disk on the source storage class
+        - VM disk references recorded before migration
+        - Storage migration configured to trigger a failure during migration
+    """
+
+    def test_offline_vm_rollback_on_migration_failure(self):
+        """
+        [NEGATIVE] Test that offline VM disk references remain unchanged when storage migration fails.
+
+        Preconditions:
+            - Stopped VM with a data disk on the source storage class
+            - VM disk references recorded before migration
+            - Storage migration configured to trigger a failure during migration
+
+        Steps:
+            1. Create a storage migration plan for the stopped VM
+            2. Execute the storage migration and wait for it to fail
+            3. Verify VM disk references after migration failure
+
+        Expected:
+            - Migration plan status is "Failed"
+            - VM disk references remain unchanged pointing to the original storage
+        """
+
+
+class TestVMStartDuringStorageMigration:
+    """
+    Tests for VM start behavior during an in-progress offline storage migration.
+
+    Preconditions:
+        - Source and target storage classes available
+        - Stopped VM with a data disk on the source storage class
+    """
+
+    def test_vm_start_during_offline_storage_migration(self):
+        """
+        Test that starting a stopped VM during storage migration succeeds
+        and the VM waits for migration completion before becoming ready.
+
+        Preconditions:
+            - Stopped VM with a data disk on the source storage class
+
+        Steps:
+            1. Create a storage migration plan for the stopped VM
+            2. Execute the storage migration
+            3. Start the VM while migration is in progress
+            4. Verify VM state during migration
+            5. Wait for migration to complete
+
+        Expected:
+            - Migration plan status is "Succeeded"
+            - VM remains in a pending state during migration and becomes ready only after migration completes
+            - VM disk references point to the target storage class
+        """
+
+
+class TestCancelInProgressStorageMigration:
+    """
+    Tests for cancellation of in-progress storage migration for offline and online VMs.
+
+    Preconditions:
+        - Source and target storage classes available
+        - Stopped VM on the source storage class with a sufficiently large disk
+        - Running VM on the source storage class with a sufficiently large disk
+        - VM disk references recorded before migration
+    """
+
+    def test_cancel_in_progress_storage_migration(self):
+        """
+        Test that cancelling an in-progress storage migration preserves original VM state
+        for both offline and online VMs.
+
+        Preconditions:
+            - Stopped VM on the source storage class with a sufficiently large disk
+            - Running VM on the source storage class with a sufficiently large disk
+            - VM disk references recorded before migration
+
+        Steps:
+            1. Create a storage migration plan with default cleanup policy (keepSource) for both VMs
+            2. Execute the storage migration
+            3. Cancel the migration while it is actively in progress
+            4. Verify VM state and disk references after cancellation
+
+        Expected:
+            - Migration plan status is "Canceled"
+            - VM disk references remain unchanged pointing to the original storage
+            - Running VM remains running throughout the cancellation
+            - Source volumes are preserved
+        """

--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -43,11 +43,13 @@ class TestOfflineVMStorageMigrationVolumeModes:
         Steps:
             1. Create a storage migration plan for the stopped VM targeting the destination storage class and volume mode
             2. Execute the storage migration and wait for completion
-            3. Start the VM after migration completes
-            4. Read the file content from the VM data disk
+            3. Verify the migrated disk uses the target volume mode
+            4. Start the VM after migration completes
+            5. Read the file content from the VM data disk
 
         Expected:
             - Migration plan status is "Succeeded"
+            - Migrated disk volume mode equals the target volume mode
             - VM boots successfully after migration
             - File content equals the pre-migration written data
         """
@@ -192,6 +194,7 @@ class TestOfflineVMStorageMigrationFailureRollback:
         - Source and target storage classes available
         - Stopped VM with a data disk on the source storage class
         - VM disk references recorded before migration
+        - Source volume identifier recorded before migration
         - Storage migration configured to trigger a failure during migration
     """
 
@@ -200,21 +203,25 @@ class TestOfflineVMStorageMigrationFailureRollback:
     @pytest.mark.polarion("CNV-16802")
     def test_offline_vm_rollback_on_migration_failure(self):
         """
-        [NEGATIVE] Test that offline VM disk references remain unchanged when storage migration fails.
+        [NEGATIVE] Test that offline VM disk references remain unchanged and the source volume
+        is preserved when storage migration fails.
 
         Preconditions:
             - Stopped VM with a data disk on the source storage class
             - VM disk references recorded before migration
+            - Source volume identifier recorded before migration
             - Storage migration configured to trigger a failure during migration
 
         Steps:
             1. Create a storage migration plan for the stopped VM
             2. Execute the storage migration and wait for it to fail
             3. Verify VM disk references after migration failure
+            4. Verify the source volume still exists after migration failure
 
         Expected:
             - Migration plan status is "Failed"
-            - VM disk references remain unchanged pointing to the original storage
+            - VM disk references remain unchanged pointing to the original storage and the source
+              volume is preserved regardless of cleanup policy
         """
 
 

--- a/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
+++ b/tests/storage/storage_migration/test_storage_class_online_offline_migration.py
@@ -43,13 +43,13 @@ class TestOfflineVMStorageMigrationVolumeModes:
         Steps:
             1. Create a storage migration plan for the stopped VM targeting the destination storage class and volume mode
             2. Execute the storage migration and wait for completion
-            3. Verify the migrated disk uses the target volume mode
+            3. Verify the migrated disk uses the target storage class and volume mode
             4. Start the VM after migration completes
             5. Read the file content from the VM data disk
 
         Expected:
             - Migration plan status is "Succeeded"
-            - Migrated disk volume mode equals the target volume mode
+            - Migrated disk uses the target storage class and volume mode
             - VM boots successfully after migration
             - File content equals the pre-migration written data
         """


### PR DESCRIPTION
##### What this PR does / why we need it:
Introduce STD for storage online/offline migration feature which allows the system to migrate offline VM between storage classes.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage specifications for offline and mixed online/offline VM storage migrations.
  * Covered volume-mode conversions, hotplug disks, same-storage-class migrations, cleanup policies, cancellation, rollback after failure, and VM startup during migration.
  * Documented expected migration behavior across successful, interrupted, and failure scenarios.
  * Included checks for VM states, disk references, data integrity, migration status, and source-volume outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->