### PR TITLE
CherryPicked: [cnv-4.18] Remove test_new_operator_in_csv static comparison test

### DIFF
--- a/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
+++ b/tests/install_upgrade_operators/csv/csv_permissions_audit/test_csv_permissions_audit.py
@@ -10,7 +10,6 @@ from tests.install_upgrade_operators.csv.csv_permissions_audit.utils import (
 )
 from utilities.constants import (
     CDI_OPERATOR,
-    CNV_OPERATORS,
     HOSTPATH_PROVISIONER_OPERATOR,
 )
 from utilities.infra import is_jira_open
@@ -33,22 +32,10 @@ def global_permission_from_csv(cnv_operators_matrix__function__, csv_permissions
 
 
 @pytest.fixture(scope="module")
-def operators_from_csv(csv_permissions):
-    return {service_account_name for service_account_name, all_permissions in csv_permissions.items()}
-
-
-@pytest.fixture(scope="module")
 def csv_permissions():
     return get_csv_permissions(
         namespace=py_config["hco_namespace"],
         csv_name_starts_with=py_config["hco_cr_name"],
-    )
-
-
-@pytest.mark.polarion("CNV-9805")
-def test_new_operator_in_csv(operators_from_csv):
-    assert sorted(list(operators_from_csv)) == sorted(CNV_OPERATORS), (
-        f"Expected cnv operators:{CNV_OPERATORS} does not match operators {operators_from_csv} "
     )
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove test that compares CSV operators against static CNV_OPERATORS list, causing false failures when new operators are added. Removes the CNV_OPERATORS import, the operators_from_csv fixture, and the test_new_operator_in_csv test.

Jira-Id: CNV-95719
Original PR: #6036
assisted by: claude code claude-opus-4-6

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95713
