### PR TITLE
[4.22] Add trident-csi-iscsi-economy StorageClass and global config

### DIFF
--- a/libs/storage/config.py
+++ b/libs/storage/config.py
@@ -71,6 +71,14 @@ class StorageClassConfig:
                 wffc=False,
             ),
             StorageClass(
+                name=StorageClassNames.TRIDENT_CSI_ISCSI_ECONOMY,
+                volume_mode=DataVolume.VolumeMode.BLOCK,
+                access_mode=DataVolume.AccessMode.RWX,
+                snapshot=True,
+                online_resize=True,
+                wffc=False,
+            ),
+            StorageClass(
                 name=StorageClassNames.GCP,
                 volume_mode=DataVolume.VolumeMode.BLOCK,
                 access_mode=DataVolume.AccessMode.RWX,

--- a/tests/global_config_trident_iscsi_economy.py
+++ b/tests/global_config_trident_iscsi_economy.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+import pytest_testconfig
+from ocp_resources.datavolume import DataVolume
+
+from utilities.constants import StorageClassNames
+
+global config
+global_config = pytest_testconfig.load_python(py_file="tests/global_config.py", encoding="utf-8")
+storage_class_matrix = [
+    {
+        StorageClassNames.TRIDENT_CSI_ISCSI_ECONOMY: {
+            "volume_mode": DataVolume.VolumeMode.BLOCK,
+            "access_mode": DataVolume.AccessMode.RWX,
+            "snapshot": True,
+            "online_resize": True,
+            "wffc": False,
+            "default": True,
+        }
+    },
+]
+
+storage_class_a = StorageClassNames.TRIDENT_CSI_ISCSI_ECONOMY
+storage_class_b = StorageClassNames.TRIDENT_CSI_ISCSI_ECONOMY
+
+for _dir in dir():
+    if not config:
+        config: dict[str, Any] = {}
+    val = locals()[_dir]
+    if type(val) not in [bool, list, dict, str]:
+        continue
+
+    if _dir in ["encoding", "py_file"]:
+        continue
+
+    config[_dir] = locals()[_dir]

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -743,6 +743,7 @@ class StorageClassNames:
     RH_INTERNAL_NFS = "rh-internal-nfs"
     TRIDENT_CSI_FSX = "trident-csi-fsx"
     TRIDENT_CSI_NFS = "trident-csi-nfs"
+    TRIDENT_CSI_ISCSI_ECONOMY = "trident-csi-iscsi-economy"
     IO2_CSI = "io2-csi"
     GPFS = "ibm-spectrum-scale-sample"
     OCI = "oci-bv"


### PR DESCRIPTION
##### What this PR does / why we need it:
Add a new global config file and StorageClassNames constant for the trident-csi-iscsi-economy storage class. 

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
