### PR TITLE
net, tests, udn: Verify network policy enforcement on primary UDN interface

### DIFF
--- a/tests/network/network_policy/libnetpolicy.py
+++ b/tests/network/network_policy/libnetpolicy.py
@@ -15,9 +15,14 @@ class ApplyNetworkPolicy(NetworkPolicy):
         client: DynamicClient,
         ports: list[int] | None = None,
         teardown: bool = True,
+        pod_selector: dict | None = None,
+        ingress_from_pod_selector: dict | None = None,
     ) -> None:
-        super().__init__(name=name, namespace=namespace, client=client, teardown=teardown, pod_selector={})
+        super().__init__(
+            name=name, namespace=namespace, client=client, teardown=teardown, pod_selector=pod_selector or {}
+        )
         self.ports = ports
+        self.ingress_from_pod_selector = ingress_from_pod_selector
 
     def to_dict(self) -> None:
         super().to_dict()
@@ -28,8 +33,14 @@ class ApplyNetworkPolicy(NetworkPolicy):
 
         self.res["spec"]["policyTypes"] = ["Ingress"]
 
-        # Default deny all ingress traffic if no ports specified
-        self.res["spec"]["ingress"] = [{"ports": _ports}] if _ports else []
+        ingress_rule: dict = {}
+        if self.ingress_from_pod_selector is not None:
+            ingress_rule["from"] = [{"podSelector": {"matchLabels": self.ingress_from_pod_selector}}]
+        if _ports:
+            ingress_rule["ports"] = _ports
+
+        # Default deny all ingress traffic if no source selector or ports specified
+        self.res["spec"]["ingress"] = [ingress_rule] if ingress_rule else []
 
 
 def format_curl_command(ip_address: str, port: int, head: bool = False) -> str:

--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -1,8 +1,9 @@
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.network_policy import NetworkPolicy
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
@@ -15,12 +16,16 @@ from libs.vm import affinity
 from libs.vm.oper import run_vms
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs.vm_factory import udn_vm
+from tests.network.user_defined_network.libudn import ALLOWED_POD_CONTAINER_NAME
 from utilities.constants.architecture import AMD_64, ARM_64
 from utilities.constants.networking import POD_CONTAINER_SPEC
 from utilities.infra import create_ns
 
 if TYPE_CHECKING:
     from ocp_resources.namespace import Namespace
+
+ALLOWED_POD_LABEL: Final[dict[str, str]] = {"udn": "allowed"}
+VMI_ID_LABEL: Final[str] = "vmi.kubevirt.io/id"
 
 
 @pytest.fixture(scope="module")
@@ -155,16 +160,17 @@ def running_amd_and_arm_vms(
 
 
 @pytest.fixture(scope="class")
-def udn_pod(
+def allowed_udn_pod(
     admin_client: DynamicClient,
     udn_namespace: Namespace,
     namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
 ) -> Generator[Pod]:
     with Pod(
-        name="udn-pod",
+        name="udn-allowed-pod",
         namespace=udn_namespace.name,
-        containers=[{**POD_CONTAINER_SPEC, "name": "udn-container"}],
+        containers=[{**POD_CONTAINER_SPEC, "name": ALLOWED_POD_CONTAINER_NAME}],
         client=admin_client,
+        label=ALLOWED_POD_LABEL,
     ) as pod:
         pod.wait_for_status(status=Pod.Status.RUNNING)
         yield pod
@@ -178,8 +184,25 @@ def clusterip_service_for_vmb_udn(
     with Service(
         name="udn-clusterip-svc",
         namespace=udn_namespace.name,
-        selector={"vmi.kubevirt.io/id": vmb_udn.name},
+        selector={VMI_ID_LABEL: vmb_udn.name},
         ports=[{"port": IPERF_SERVER_PORT}],
         client=admin_client,
     ) as svc:
         yield svc
+
+
+@pytest.fixture()
+def udn_network_policy(
+    admin_client: DynamicClient,
+    udn_namespace: Namespace,
+    vma_udn: BaseVirtualMachine,
+) -> Generator[NetworkPolicy]:
+    with NetworkPolicy(
+        name="udn-network-policy",
+        namespace=udn_namespace.name,
+        client=admin_client,
+        pod_selector={"matchLabels": {VMI_ID_LABEL: vma_udn.name}},
+        ingress=[{"from": [{"podSelector": {"matchLabels": ALLOWED_POD_LABEL}}]}],
+        policy_types=["Ingress"],
+    ) as network_policy:
+        yield network_policy

--- a/tests/network/user_defined_network/libudn.py
+++ b/tests/network/user_defined_network/libudn.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from ocp_resources.resource import Resource
 
@@ -9,6 +9,8 @@ from libs.net.vmspec import IpNotFound
 
 if TYPE_CHECKING:
     from ocp_resources.pod import Pod
+
+ALLOWED_POD_CONTAINER_NAME: Final[str] = "udn-container"
 
 
 def lookup_default_pod_ip(pod: Pod) -> str:

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -14,10 +14,10 @@ from typing import TYPE_CHECKING
 import pytest
 from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
-from libs.net.traffic_generator import is_tcp_connection
+from libs.net.traffic_generator import IPERF_SERVER_PORT, PodTcpClient, TcpServer, is_tcp_connection
 from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
 from tests.network.libs.connectivity import poll_tcp_connectivity
-from tests.network.user_defined_network.libudn import lookup_default_pod_ip
+from tests.network.user_defined_network.libudn import ALLOWED_POD_CONTAINER_NAME, lookup_default_pod_ip
 from utilities.constants.networking import PUBLIC_DNS_SERVER_IP
 from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_1MIN
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ocp_resources.service import Service
     from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
-    from libs.net.traffic_generator import TcpServer, VMTcpClient
+    from libs.net.traffic_generator import VMTcpClient
     from libs.vm.vm import BaseVirtualMachine
 
 
@@ -146,7 +146,7 @@ class TestPrimaryUdn:
         assert is_tcp_connection(server=server, client=client)
 
     @pytest.mark.polarion("CNV-11432")
-    def test_vm_to_pod_connectivity_on_udn(self, vma_udn, udn_pod):
+    def test_vm_to_pod_connectivity_on_udn(self, vma_udn, allowed_udn_pod):
         """
         Test that a VM reaches a pod on the same primary UDN network (east-west connectivity).
 
@@ -164,36 +164,52 @@ class TestPrimaryUdn:
         Expected:
             - Ping succeeds with 0% packet loss.
         """
-        pod_ip = lookup_default_pod_ip(pod=udn_pod)
+        pod_ip = lookup_default_pod_ip(pod=allowed_udn_pod)
         vma_udn.console(commands=[f"ping -c 3 {pod_ip}"], timeout=TIMEOUT_1MIN)
 
     @pytest.mark.polarion("CNV-11435")
-    def test_network_policy_enforcement_on_primary_udn_interface(self):
+    @pytest.mark.usefixtures("udn_network_policy")
+    def test_network_policy_enforcement_on_primary_udn_interface(self, vma_udn, vmb_udn, allowed_udn_pod):
         """
-        Test that a network policy is enforced on the VM primary UDN interface: traffic from
-        an allowed pod is permitted while traffic from a denied pod is blocked.
+        [NEGATIVE] Test that a network policy is enforced on the VM primary UDN interface: traffic
+        from an allowed source is permitted while traffic from a denied source is blocked.
 
         No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
 
         Preconditions:
             - Running under-test VM attached to the primary UDN network.
-            - Running allowed pod attached to the primary UDN network.
-            - Running denied pod attached to the primary UDN network.
-            - Network policy applied to the primary UDN, allowing traffic from an allowed pod
-              and denying traffic from a denied pod.
+            - Running denied VM attached to the same primary UDN network.
+            - Running allowed pod attached to the same primary UDN network.
+            - Network policy applied to the under-test VM primary UDN interface, allowing ingress
+              only from the allowed pod.
 
         Steps:
-            1. Execute a ping command from the allowed pod to the under-test VM
+            1. Initiate a TCP connection from the denied VM to the under-test VM
                primary UDN interface IP address.
-            2. Execute a ping command from the denied pod to the under-test VM
+            2. Initiate a TCP connection from the allowed pod to the under-test VM
                primary UDN interface IP address.
 
         Expected:
-            - Ping from the allowed pod succeeds with 0% packet loss.
-            - Ping from the denied pod fails with 100% packet loss.
-        """
+            - The TCP connection from the denied VM is blocked.
+            - The TCP connection from the allowed pod is established.
 
-    test_network_policy_enforcement_on_primary_udn_interface.__test__ = False
+        The blocked source is polled to absorb the asynchronous enforcement of the network policy.
+        Once the deny rule is in effect the allow rule is too, so the allowed pod is checked once.
+        """
+        udn_vm_ip = str(
+            lookup_iface_status_ip(vm=vma_udn, iface_name=lookup_primary_network(vm=vma_udn).name, ip_family=4)
+        )
+        poll_tcp_connectivity(client_vm=vmb_udn, server_vm=vma_udn, server_ip=udn_vm_ip, expect_connectivity=False)
+        with TcpServer(vm=vma_udn, port=IPERF_SERVER_PORT, bind_ip=udn_vm_ip) as server:
+            with PodTcpClient(
+                pod=allowed_udn_pod,
+                server_ip=udn_vm_ip,
+                server_port=IPERF_SERVER_PORT,
+                container=ALLOWED_POD_CONTAINER_NAME,
+            ) as client:
+                assert is_tcp_connection(server=server, client=client), (
+                    f"Allowed pod {allowed_udn_pod.name} failed to reach {udn_vm_ip}:{IPERF_SERVER_PORT}"
+                )
 
     @pytest.mark.order("last")
     @pytest.mark.usefixtures("vma_udn")


### PR DESCRIPTION
##### What this PR does / why we need it:
A VM's primary UDN interface must honor Kubernetes NetworkPolicy so that ingress
traffic can be restricted to approved sources.

This adds a test that applies a NetworkPolicy to the under-test VM's primary UDN
interface, permitting ingress only from a labelled source, and confirms that
traffic from the allowed pod reaches the VM while traffic from a non-selected
source is blocked. The allowed source is a pod carrying the policy's selector
label; the blocked source reuses the existing non-selected VM on the same UDN.
Allow and deny are two facets of a single policy's enforcement, so they are verified
together in one test.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Enforcement is asynchronous, so the blocked source is polled until traffic is
dropped; the allowed source is then checked once (no poll), since the allow rule is
programmed together with the deny rule.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-52883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for network policy enforcement on primary user-defined network interfaces.
  - Verified that TCP traffic from unauthorized virtual machines is blocked.
  - Verified that permitted pods can successfully connect to the virtual machine.
  - Updated user-defined network connectivity tests to use consistent pod labels, container configuration, and network policy fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->