### PR TITLE
Add exclude_from_descheduler parameter to VM test classes

### DIFF
--- a/tests/virt/node/general/test_oom.py
+++ b/tests/virt/node/general/test_oom.py
@@ -49,6 +49,7 @@ def fedora_oom_vm(namespace, unprivileged_client):
         cpu_cores=2,
         cpu_requests="2",
         cpu_limits="2",
+        exclude_from_descheduler=True,
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/tests/virt/node/general/test_windows_vtpm_bitlocker.py
+++ b/tests/virt/node/general/test_windows_vtpm_bitlocker.py
@@ -129,6 +129,7 @@ def windows_vtpm_vm(
         tpm_params=persistent_enabled,
         efi_params=persistent_enabled,
         cpu_model=modern_cpu_for_migration,
+        exclude_from_descheduler=True,
     ) as vm:
         running_vm(vm=vm)
         verify_tpm_in_os(vm=vm)

--- a/tests/virt/node/general/test_wsl2.py
+++ b/tests/virt/node/general/test_wsl2.py
@@ -116,6 +116,7 @@ def windows_wsl2_vm(
         cpu_flags=vm_cpu_flags,
         os_flavor=OS_FLAVOR_WINDOWS,
         disk_type=None,
+        exclude_from_descheduler=True,
     ) as vm:
         running_vm(vm=vm)
         yield vm

--- a/utilities/unittests/test_virt.py
+++ b/utilities/unittests/test_virt.py
@@ -11,7 +11,54 @@ import utilities.virt
 
 importlib.reload(utilities.virt)
 
+from utilities.constants.virt import ES_LIVE_MIGRATE_IF_POSSIBLE, ES_NONE, EVICTIONSTRATEGY
 from utilities.virt import VirtualMachineForTests
+
+PREFER_NO_EVICTION_ANNOTATION = "descheduler.alpha.kubernetes.io/prefer-no-eviction"
+
+
+def _build_vm_stub(exclude_from_descheduler=None, eviction_strategy=None):
+    """Create a minimal VirtualMachineForTests stub with enough state for _set_descheduler_exclusion."""
+    vm = VirtualMachineForTests.__new__(VirtualMachineForTests)
+    vm.name = "test-vm"
+    vm.exclude_from_descheduler = exclude_from_descheduler
+    template_spec = {"domain": {}}
+    if eviction_strategy:
+        template_spec[EVICTIONSTRATEGY] = eviction_strategy
+    vm.res = {"spec": {"template": {"metadata": {}, "spec": template_spec}}}
+    return vm
+
+
+class TestDeschedulerExclusion:
+    def test_explicit_true_sets_annotation(self):
+        vm = _build_vm_stub(exclude_from_descheduler=True)
+        vm._set_descheduler_exclusion()
+        assert vm.res["spec"]["template"]["metadata"]["annotations"][PREFER_NO_EVICTION_ANNOTATION] == "true"
+
+    def test_explicit_false_skips_annotation(self):
+        vm = _build_vm_stub(exclude_from_descheduler=False, eviction_strategy=ES_NONE)
+        vm._set_descheduler_exclusion()
+        assert PREFER_NO_EVICTION_ANNOTATION not in vm.res["spec"]["template"]["metadata"].get("annotations", {})
+
+    def test_auto_exclude_for_es_none(self):
+        vm = _build_vm_stub(eviction_strategy=ES_NONE)
+        vm._set_descheduler_exclusion()
+        assert vm.res["spec"]["template"]["metadata"]["annotations"][PREFER_NO_EVICTION_ANNOTATION] == "true"
+
+    def test_auto_exclude_for_es_live_migrate_if_possible(self):
+        vm = _build_vm_stub(eviction_strategy=ES_LIVE_MIGRATE_IF_POSSIBLE)
+        vm._set_descheduler_exclusion()
+        assert vm.res["spec"]["template"]["metadata"]["annotations"][PREFER_NO_EVICTION_ANNOTATION] == "true"
+
+    def test_no_annotation_without_matching_eviction_strategy(self):
+        vm = _build_vm_stub(eviction_strategy="LiveMigrate")
+        vm._set_descheduler_exclusion()
+        assert PREFER_NO_EVICTION_ANNOTATION not in vm.res["spec"]["template"]["metadata"].get("annotations", {})
+
+    def test_no_annotation_when_no_eviction_strategy(self):
+        vm = _build_vm_stub()
+        vm._set_descheduler_exclusion()
+        assert PREFER_NO_EVICTION_ANNOTATION not in vm.res["spec"]["template"]["metadata"].get("annotations", {})
 
 
 class TestVirtualMachineForTestsLabel:

--- a/utilities/unittests/test_virt.py
+++ b/utilities/unittests/test_virt.py
@@ -18,7 +18,7 @@ PREFER_NO_EVICTION_ANNOTATION = "descheduler.alpha.kubernetes.io/prefer-no-evict
 
 
 def _build_vm_stub(
-    exclude_from_descheduler: bool | None = None, eviction_strategy: str | None = None
+    eviction_strategy: str | None = None, *, exclude_from_descheduler: bool = False
 ) -> VirtualMachineForTests:
     """Create a minimal VirtualMachineForTests stub with enough state for _set_descheduler_exclusion."""
     vm = VirtualMachineForTests.__new__(VirtualMachineForTests)
@@ -38,11 +38,13 @@ class TestDeschedulerExclusion:
         annotations = vm.res["spec"]["template"]["metadata"]["annotations"]
         assert annotations[PREFER_NO_EVICTION_ANNOTATION] == "true", "Annotation not set when explicitly requested"
 
-    def test_explicit_false_skips_annotation(self):
+    def test_explicit_false_does_not_override_eviction_strategy(self):
+        # False is the default (do not force exclusion); it must NOT suppress the
+        # eviction-strategy-driven auto-exclusion for ES_NONE / ES_LIVE_MIGRATE_IF_POSSIBLE.
         vm = _build_vm_stub(exclude_from_descheduler=False, eviction_strategy=ES_NONE)
         vm._set_descheduler_exclusion()
-        annotations = vm.res["spec"]["template"]["metadata"].get("annotations", {})
-        assert PREFER_NO_EVICTION_ANNOTATION not in annotations, "Annotation set despite explicit False"
+        annotations = vm.res["spec"]["template"]["metadata"]["annotations"]
+        assert annotations[PREFER_NO_EVICTION_ANNOTATION] == "true", "Annotation not auto-set for ES_NONE when False"
 
     def test_auto_exclude_for_es_none(self):
         vm = _build_vm_stub(eviction_strategy=ES_NONE)

--- a/utilities/unittests/test_virt.py
+++ b/utilities/unittests/test_virt.py
@@ -17,7 +17,9 @@ from utilities.virt import VirtualMachineForTests
 PREFER_NO_EVICTION_ANNOTATION = "descheduler.alpha.kubernetes.io/prefer-no-eviction"
 
 
-def _build_vm_stub(exclude_from_descheduler=None, eviction_strategy=None):
+def _build_vm_stub(
+    exclude_from_descheduler: bool | None = None, eviction_strategy: str | None = None
+) -> VirtualMachineForTests:
     """Create a minimal VirtualMachineForTests stub with enough state for _set_descheduler_exclusion."""
     vm = VirtualMachineForTests.__new__(VirtualMachineForTests)
     vm.name = "test-vm"
@@ -33,32 +35,40 @@ class TestDeschedulerExclusion:
     def test_explicit_true_sets_annotation(self):
         vm = _build_vm_stub(exclude_from_descheduler=True)
         vm._set_descheduler_exclusion()
-        assert vm.res["spec"]["template"]["metadata"]["annotations"][PREFER_NO_EVICTION_ANNOTATION] == "true"
+        annotations = vm.res["spec"]["template"]["metadata"]["annotations"]
+        assert annotations[PREFER_NO_EVICTION_ANNOTATION] == "true", "Annotation not set when explicitly requested"
 
     def test_explicit_false_skips_annotation(self):
         vm = _build_vm_stub(exclude_from_descheduler=False, eviction_strategy=ES_NONE)
         vm._set_descheduler_exclusion()
-        assert PREFER_NO_EVICTION_ANNOTATION not in vm.res["spec"]["template"]["metadata"].get("annotations", {})
+        annotations = vm.res["spec"]["template"]["metadata"].get("annotations", {})
+        assert PREFER_NO_EVICTION_ANNOTATION not in annotations, "Annotation set despite explicit False"
 
     def test_auto_exclude_for_es_none(self):
         vm = _build_vm_stub(eviction_strategy=ES_NONE)
         vm._set_descheduler_exclusion()
-        assert vm.res["spec"]["template"]["metadata"]["annotations"][PREFER_NO_EVICTION_ANNOTATION] == "true"
+        annotations = vm.res["spec"]["template"]["metadata"]["annotations"]
+        assert annotations[PREFER_NO_EVICTION_ANNOTATION] == "true", "Annotation not auto-set for ES_NONE"
 
     def test_auto_exclude_for_es_live_migrate_if_possible(self):
         vm = _build_vm_stub(eviction_strategy=ES_LIVE_MIGRATE_IF_POSSIBLE)
         vm._set_descheduler_exclusion()
-        assert vm.res["spec"]["template"]["metadata"]["annotations"][PREFER_NO_EVICTION_ANNOTATION] == "true"
+        annotations = vm.res["spec"]["template"]["metadata"]["annotations"]
+        assert annotations[PREFER_NO_EVICTION_ANNOTATION] == "true", (
+            "Annotation not auto-set for ES_LIVE_MIGRATE_IF_POSSIBLE"
+        )
 
     def test_no_annotation_without_matching_eviction_strategy(self):
         vm = _build_vm_stub(eviction_strategy="LiveMigrate")
         vm._set_descheduler_exclusion()
-        assert PREFER_NO_EVICTION_ANNOTATION not in vm.res["spec"]["template"]["metadata"].get("annotations", {})
+        annotations = vm.res["spec"]["template"]["metadata"].get("annotations", {})
+        assert PREFER_NO_EVICTION_ANNOTATION not in annotations, "Annotation set for non-excluded eviction strategy"
 
     def test_no_annotation_when_no_eviction_strategy(self):
         vm = _build_vm_stub()
         vm._set_descheduler_exclusion()
-        assert PREFER_NO_EVICTION_ANNOTATION not in vm.res["spec"]["template"]["metadata"].get("annotations", {})
+        annotations = vm.res["spec"]["template"]["metadata"].get("annotations", {})
+        assert PREFER_NO_EVICTION_ANNOTATION not in annotations, "Annotation set when no eviction strategy specified"
 
 
 class TestVirtualMachineForTestsLabel:

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -102,6 +102,8 @@ from utilities.constants.virt import (
     CLOUD_INIT_NO_CLOUD,
     CNV_VM_SSH_KEY_PATH,
     DV_DISK,
+    ES_LIVE_MIGRATE_IF_POSSIBLE,
+    ES_NONE,
     EVICTIONSTRATEGY,
     OS_PROC_NAME,
     ROOTDISK,
@@ -297,6 +299,7 @@ class VirtualMachineForTests(VirtualMachine):
         vm_affinity=None,
         annotations=None,
         label=None,
+        exclude_from_descheduler=None,
     ):
         """
         Virtual machine creation
@@ -379,6 +382,9 @@ class VirtualMachineForTests(VirtualMachine):
             vm_affinity (dict, optional): If affinity is specifies, obey all the affinity rules
             annotations (dict, optional): annotations to be added to the VM
             label (dict, optional): labels to be added to VM metadata (not the VMI template)
+            exclude_from_descheduler (bool | None, optional): controls descheduler exclusion annotation on VMI template.
+                True: always set. False: never set. None (default): auto-set when eviction_strategy is "None"
+                or "LiveMigrateIfPossible".
         """
         # Sets VM unique name - replaces "." with "-" in the name to handle valid values.
 
@@ -459,6 +465,7 @@ class VirtualMachineForTests(VirtualMachine):
         self.hugepages_page_size = hugepages_page_size
         self.vm_affinity = vm_affinity
         self.annotations = annotations
+        self.exclude_from_descheduler = exclude_from_descheduler
 
         # Must be here to apply on existing VMs
         self.set_login_params()
@@ -526,6 +533,18 @@ class VirtualMachineForTests(VirtualMachine):
                     template_spec = self.enable_ssh_in_cloud_init_data(template_spec=template_spec)
                 if self.ssh_secret:
                     template_spec = self.update_vm_ssh_secret_configuration(template_spec=template_spec)
+
+        self._set_descheduler_exclusion()
+
+    def _set_descheduler_exclusion(self):
+        if self.exclude_from_descheduler is False:
+            return
+
+        effective_eviction_strategy = self.res["spec"]["template"]["spec"].get(EVICTIONSTRATEGY)
+        if self.exclude_from_descheduler or effective_eviction_strategy in (ES_NONE, ES_LIVE_MIGRATE_IF_POSSIBLE):
+            LOGGER.info(f"Setting descheduler exclusion annotation on VM {self.name}")
+            template_annotations = self.res["spec"]["template"].setdefault("metadata", {}).setdefault("annotations", {})
+            template_annotations["descheduler.alpha.kubernetes.io/prefer-no-eviction"] = "true"
 
     def set_hugepages_page_size(self, template_spec):
         if self.hugepages_page_size:
@@ -1286,6 +1305,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         tpm_params=None,
         additional_labels=None,
         vm_affinity=None,
+        exclude_from_descheduler=None,
     ):
         """VM creation using common templates.
 
@@ -1359,6 +1379,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
             additional_labels=additional_labels,
             vm_affinity=vm_affinity,
             os_flavor=self.os_flavor,
+            exclude_from_descheduler=exclude_from_descheduler,
         )
         self.admin_client = admin_client
         self.data_source = data_source
@@ -1444,6 +1465,8 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
                 ).storage_profile.first_claim_property_set_access_modes()
             if DataVolume.AccessMode.RWX not in self.access_modes:
                 spec[EVICTIONSTRATEGY] = "None"
+
+        self._set_descheduler_exclusion()
 
     def _update_vm_storage_config(self, spec, name):
         # volume name should be updated

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -299,7 +299,7 @@ class VirtualMachineForTests(VirtualMachine):
         vm_affinity=None,
         annotations=None,
         label=None,
-        exclude_from_descheduler: bool | None = None,
+        exclude_from_descheduler: bool = False,
     ):
         """
         Virtual machine creation
@@ -382,9 +382,9 @@ class VirtualMachineForTests(VirtualMachine):
             vm_affinity (dict, optional): If affinity is specifies, obey all the affinity rules
             annotations (dict, optional): annotations to be added to the VM
             label (dict, optional): labels to be added to VM metadata (not the VMI template)
-            exclude_from_descheduler (bool | None, optional): controls descheduler exclusion annotation on VMI template.
-                True: always set. False: never set. None (default): auto-set when eviction_strategy is "None"
-                or "LiveMigrateIfPossible".
+            exclude_from_descheduler (bool, optional): if True, exclude the VM from the descheduler.
+                Non-migratable VMs (eviction_strategy "None" or "LiveMigrateIfPossible") are always
+                excluded. Defaults to False.
         """
         # Sets VM unique name - replaces "." with "-" in the name to handle valid values.
 
@@ -537,9 +537,6 @@ class VirtualMachineForTests(VirtualMachine):
         self._set_descheduler_exclusion()
 
     def _set_descheduler_exclusion(self) -> None:
-        if self.exclude_from_descheduler is False:
-            return
-
         effective_eviction_strategy = self.res["spec"]["template"]["spec"].get(EVICTIONSTRATEGY)
         if self.exclude_from_descheduler or effective_eviction_strategy in (ES_NONE, ES_LIVE_MIGRATE_IF_POSSIBLE):
             LOGGER.info(f"Setting descheduler exclusion annotation on VM {self.name}")
@@ -1305,7 +1302,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         tpm_params=None,
         additional_labels=None,
         vm_affinity=None,
-        exclude_from_descheduler: bool | None = None,
+        exclude_from_descheduler: bool = False,
     ):
         """VM creation using common templates.
 

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -299,7 +299,7 @@ class VirtualMachineForTests(VirtualMachine):
         vm_affinity=None,
         annotations=None,
         label=None,
-        exclude_from_descheduler=None,
+        exclude_from_descheduler: bool | None = None,
     ):
         """
         Virtual machine creation
@@ -536,7 +536,7 @@ class VirtualMachineForTests(VirtualMachine):
 
         self._set_descheduler_exclusion()
 
-    def _set_descheduler_exclusion(self):
+    def _set_descheduler_exclusion(self) -> None:
         if self.exclude_from_descheduler is False:
             return
 
@@ -1305,7 +1305,7 @@ class VirtualMachineForTestsFromTemplate(VirtualMachineForTests):
         tpm_params=None,
         additional_labels=None,
         vm_affinity=None,
-        exclude_from_descheduler=None,
+        exclude_from_descheduler: bool | None = None,
     ):
         """VM creation using common templates.
 


### PR DESCRIPTION
##### What this PR does / why we need it:

Descheduler is enabled by default by autopilot and can automatically migrate VMs between nodes to balance cluster load. This interferes with tests that:

- **Use evictionStrategy "None" or "LiveMigrateIfPossible"** — these VMs can be restarted instead of live-migrated by descheduler, which is destructive for running tests
- **Run long-running tier3 tests** (OOM, WSL2, BitLocker/vTPM) — descheduler can trigger unwanted migration mid-test

**Changes:**

1. Add `exclude_from_descheduler` parameter to `VirtualMachineForTests` and `VirtualMachineForTestsFromTemplate` that sets the `descheduler.alpha.kubernetes.io/prefer-no-eviction` annotation on the VMI template metadata.

2. **Auto-exclusion:** When `exclude_from_descheduler` is `None` (default), the annotation is automatically set when the effective `evictionStrategy` is `"None"` or `"LiveMigrateIfPossible"`. This covers all existing VMs using `ES_NONE` or `ES_LIVE_MIGRATE_IF_POSSIBLE` without modifying their call sites.

3. **Explicit exclusion on tier3 tests:**
   - `fedora_oom_vm` — stress-ng at 100% memory for OOM testing
   - `windows_wsl2_vm` — class-scoped Windows VM with WSL2, used across dependent tests including intentional migration
   - `windows_vtpm_vm` — Windows VM with persistent TPM and BitLocker encryption, descheduler migration mid-encryption would be destructive

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

The `_set_descheduler_exclusion` method is called at the end of both `VirtualMachineForTests.to_dict()` and `VirtualMachineForTestsFromTemplate.to_dict()` because the latter can override evictionStrategy to `"None"` based on storage access modes after `super().to_dict()` runs. The method is idempotent so the double call is harmless.

##### jira-ticket:

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for excluding virtual machines from descheduler evictions during creation.
  * Exclusion can be explicitly enabled or disabled, with automatic handling for compatible eviction strategies.

* **Bug Fixes**
  * Updated selected Fedora and Windows virtual machines to remain protected from descheduler evictions.

* **Tests**
  * Added coverage for explicit, automatic, disabled, and unsupported exclusion scenarios.
  * Verified that exclusion settings are correctly applied across supported virtual machine creation options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->