### PR TITLE
net, 4.18: remove closed jira

### DIFF
--- a/tests/network/connectivity/test_ovs_linux_bridge.py
+++ b/tests/network/connectivity/test_ovs_linux_bridge.py
@@ -50,7 +50,6 @@ class TestConnectivityLinuxBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11125")
     @pytest.mark.ipv6
-    @pytest.mark.jira("CNV-58530", run=True)
     def test_ipv6_linux_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,
@@ -145,7 +144,6 @@ class TestConnectivityOVSBridge:
     @pytest.mark.post_upgrade
     @pytest.mark.polarion("CNV-11128")
     @pytest.mark.ipv6
-    @pytest.mark.jira("CNV-58530", run=True)
     def test_ipv6_ovs_bridge(
         self,
         fail_if_not_ipv6_supported_cluster,

--- a/tests/network/connectivity/test_pod_network.py
+++ b/tests/network/connectivity/test_pod_network.py
@@ -91,7 +91,6 @@ def cloud_init_ipv6_network_data(dual_stack_network_data):
             marks=[
                 pytest.mark.polarion("CNV-11845"),
                 pytest.mark.ipv6,
-                pytest.mark.jira("CNV-58530 ", run=True),
             ],
         ),
     ],


### PR DESCRIPTION


##### What this PR does / why we need it:
CNV-58530 is resolved

These tests will run in 4.18 lanes:
Gating will run on PSI, as all old versions (limited resources) Upgrade tests will run IPv6 scenarios on full-cap lane (Dual-stack BM)

##### Which issue(s) this PR fixes:
Fixes CI failure in `cnv-4.18` branch due to resolved ticket

##### Special notes for reviewer:
The relevant lanes are already marked to run with `not ipv6`, and `and ipv6` on full-cap lane

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
