### PR TITLE
CherryPicked: [cnv-4.20] Fix module name matching for abbreviated ocp_resources modules- #6030

### DIFF
--- a/tests/install_upgrade_operators/conftest.py
+++ b/tests/install_upgrade_operators/conftest.py
@@ -20,7 +20,7 @@ from tests.install_upgrade_operators.constants import (
 from tests.install_upgrade_operators.utils import (
     get_network_addon_config,
     get_resource_by_name,
-    get_resource_from_module_name,
+    get_resource_from_related_object,
 )
 from utilities.constants import HPP_POOL
 from utilities.hco import ResourceEditorValidateHCOReconcile, get_hco_version
@@ -224,7 +224,7 @@ def machine_config_pools_conditions_scope_module(machine_config_pools):
 
 @pytest.fixture()
 def ocp_resource_by_name(admin_client, ocp_resources_submodule_list, related_object_from_hco_status):
-    return get_resource_from_module_name(
+    return get_resource_from_related_object(
         related_obj=related_object_from_hco_status,
         ocp_resources_submodule_list=ocp_resources_submodule_list,
         admin_client=admin_client,

--- a/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
+++ b/tests/install_upgrade_operators/relationship_labels/test_all_cnv_resources.py
@@ -5,8 +5,7 @@ import pytest
 
 from tests.install_upgrade_operators.relationship_labels.constants import ALL_LABEL_KEYS
 from tests.install_upgrade_operators.utils import (
-    get_ocp_resource_module_name,
-    get_resource,
+    get_resource_from_related_object,
 )
 from utilities.exceptions import ResourceValueError
 from utilities.infra import is_jira_open
@@ -107,16 +106,13 @@ def test_relationship_labels_all_cnv_resources(
                 LOGGER.debug(f"{kind}, {name} is allowlisted")
                 continue
             LOGGER.debug(f"Looking at element: {name}, kind: {kind}")
-            resource_obj = get_resource(
+            resource_obj = get_resource_from_related_object(
                 related_obj={
                     "kind": kind,
                     "name": name,
                     "namespace": hco_namespace.name,
                 },
-                module_name=get_ocp_resource_module_name(
-                    related_object_kind=kind,
-                    list_submodules=ocp_resources_submodule_list,
-                ),
+                ocp_resources_submodule_list=ocp_resources_submodule_list,
                 admin_client=admin_client,
             )
             if resource_obj.exists:

--- a/tests/install_upgrade_operators/utils.py
+++ b/tests/install_upgrade_operators/utils.py
@@ -205,74 +205,39 @@ def get_resource_container_env_image_mismatch(container):
     ]
 
 
-def get_ocp_resource_module_name(related_object_kind, list_submodules):
-    """
-    From a list of ocp_resources submodule, based on kubernetes 'kind' name pick the right module name
+def get_resource_from_related_object(
+    related_obj: dict[str, str],
+    ocp_resources_submodule_list: list[str],
+    admin_client: DynamicClient,
+) -> Resource:
+    """Gets a resource object for an HCO related object by finding its ocp_resources class.
+
+    Iterates ocp_resources submodules to find the class matching the related object's kind,
+    then instantiates it with the object's name and namespace.
 
     Args:
-        related_object_kind (str): Kubernetes kind name of a resource
-        list_submodules (list): list of ocp_resources submodule names
+        related_obj: HCO status related object dict with kind, name, namespace keys.
+        ocp_resources_submodule_list: List of ocp_resources submodule names.
+        admin_client: Kubernetes dynamic client.
 
     Returns:
-        str: Name of the ocp_resources submodule
+        Instantiated resource object for the related object.
 
     Raises:
-        ModuleNotFoundError: if a module associated with related object kind is not found
+        ModuleNotFoundError: If no ocp_resources module contains the related object's kind.
     """
-    for module_name in list_submodules:
-        expected_module_name = module_name.replace("_", "")
-        if related_object_kind.lower() == expected_module_name:
-            return module_name
-    raise ModuleNotFoundError(f"{related_object_kind} module not found in ocp_resources")
-
-
-def get_resource(related_obj, admin_client, module_name):
-    """
-    Gets CR based on associated HCO.status.relatedObject entry and ocp_reources module name
-
-    Args:
-        related_obj (dict): Associated HCO.status.relatedObject dict
-        admin_client (DynamicClient): Dynamic client object
-        module_name (str): Associated ocp_reources module name to be used
-
-    Returns:
-        Resource: Associated cr object
-
-    Raises:
-        AssertionError: if a related object kind is not in module name
-    """
-    kwargs = {"client": admin_client, "name": related_obj["name"]}
-    if related_obj["namespace"]:
+    kind = related_obj["kind"]
+    kwargs: dict[str, Any] = {"client": admin_client, "name": related_obj["name"]}
+    if related_obj.get("namespace"):
         kwargs["namespace"] = related_obj["namespace"]
 
-    module = importlib.import_module(f"ocp_resources.{module_name}")
-    cls_related_obj = getattr(module, related_obj["kind"], None)
-    assert cls_related_obj, f"class {related_obj['kind']} is not in {module_name}"
-    LOGGER.debug(f"reading class {related_obj['kind']} from module {module_name}")
-    return cls_related_obj(**kwargs)
+    for module_name in ocp_resources_submodule_list:
+        module = importlib.import_module(f"ocp_resources.{module_name}")
+        resource_class = getattr(module, kind, None)
+        if resource_class and isinstance(resource_class, type) and getattr(resource_class, "kind", None) == kind:
+            return resource_class(**kwargs)
 
-
-def get_resource_from_module_name(related_obj, ocp_resources_submodule_list, admin_client):
-    """
-    Gets resource object based on module name
-
-    Args:
-        related_obj (dict): Related object Dictionary
-        ocp_resources_submodule_list (list): list of submudule names associated with ocp_resources package
-        admin_client (DynamicClient): Dynamic client object
-
-    Returns:
-        Resource: Associated cr object
-    """
-    module_name = get_ocp_resource_module_name(
-        related_object_kind=related_obj["kind"],
-        list_submodules=ocp_resources_submodule_list,
-    )
-    return get_resource(
-        admin_client=admin_client,
-        related_obj=related_obj,
-        module_name=module_name,
-    )
+    raise ModuleNotFoundError(f"{kind} module not found in ocp_resources")
 
 
 def get_resource_by_name(resource_kind, name, namespace=None):


### PR DESCRIPTION
Cherry-pick from main branch, original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5975, PR owner: OhadRevah

<!-- full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged If the task is not tracked by a Jira ticket, just write "NONE". -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

* **Tests**
  * Improved automated coverage for install and upgrade scenarios.
* Test resource discovery now adapts more reliably to related object types.
* Added clearer handling when a matching resource type cannot be found.
* **Chores**
* Simplified test setup and resource lookup behavior for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95552
