### PR TITLE
CherryPicked: [cnv-4.22] [IUO] Add multiarch golden image automation tests

### DIFF
--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/conftest.py
@@ -1,19 +1,25 @@
 import pytest
+from ocp_resources.data_import_cron import DataImportCron
+from ocp_resources.data_source import DataSource
 from ocp_resources.image_stream import ImageStream
 from ocp_resources.pod import Pod
 from ocp_utilities.infra import get_pods_by_name_prefix
 
-from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME
+from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME, ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
+    COMMON_TEMPLATE,
     CUSTOM_TEMPLATE,
     HCO_CR_DATA_IMPORT_SCHEDULE_KEY,
-    get_modifed_common_template_names,
+    get_modified_common_template_names,
     get_random_minutes_hours_fields_from_data_import_schedule,
     get_templates_by_type_from_hco_status,
+    get_templates_resources_names_dict,
 )
 from utilities.constants import (
     COMMON_TEMPLATES_KEY_NAME,
+    FEATURE_GATES,
     HCO_OPERATOR,
+    KUBERNETES_ARCH_LABEL,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
 )
 from utilities.hco import disable_common_boot_image_import_hco_spec
@@ -102,7 +108,7 @@ def default_custom_templates_scope_session(
 
 @pytest.fixture(scope="session")
 def modified_common_templates_scope_session(hyperconverged_resource_scope_session):
-    return get_modifed_common_template_names(hyperconverged=hyperconverged_resource_scope_session)
+    return get_modified_common_template_names(hyperconverged=hyperconverged_resource_scope_session)
 
 
 @pytest.fixture()
@@ -115,6 +121,60 @@ def ssp_spec_templates_scope_function(ssp_resource_scope_function):
 @pytest.fixture(scope="session")
 def common_templates_scope_session(hyperconverged_status_scope_session):
     return hyperconverged_status_scope_session[SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME]
+
+
+@pytest.fixture(scope="session")
+def workers_architectures(workers):
+    return {worker.labels[KUBERNETES_ARCH_LABEL] for worker in workers}
+
+
+@pytest.fixture(scope="class")
+def common_templates_from_hco_status_scope_class(hyperconverged_status_templates_scope_class):
+    return get_templates_by_type_from_hco_status(
+        hco_status_templates=hyperconverged_status_templates_scope_class, template_type=COMMON_TEMPLATE
+    )
+
+
+@pytest.fixture(scope="class")
+def base_common_templates_related_resources(common_templates_from_hco_status_scope_class):
+    return get_templates_resources_names_dict(templates=common_templates_from_hco_status_scope_class)
+
+
+@pytest.fixture(scope="class")
+def expected_common_templates_related_resources(
+    workers_architectures,
+    base_common_templates_related_resources,
+    hyperconverged_resource_scope_class,
+):
+    """Return expected golden image resource names for the current cluster state.
+
+    Relies on the class-level feature-gate fixture (applied via @pytest.mark.usefixtures
+    on the test class) being resolved before this fixture reads the HCO spec.
+
+    When enableMultiArchBootImageImport is enabled:
+        - DataImportCrons: arch-specific only (base names are replaced)
+        - DataSources: both arch-specific and agnostic pointers
+        - ImageStreams: always base names
+    When disabled: all base names.
+    """
+    feature_gate_enabled = hyperconverged_resource_scope_class.instance.spec.get(FEATURE_GATES, {}).get(
+        ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT, False
+    )
+
+    if not feature_gate_enabled:
+        return {kind: set(names) for kind, names in base_common_templates_related_resources.items()}
+
+    expected_resources = {}
+    for kind, base_names in base_common_templates_related_resources.items():
+        arch_names = {f"{name}-{arch}" for name in base_names for arch in workers_architectures}
+        # only DataImportCrons are replaced, DataSources are kept as pointers
+        if kind == DataImportCron.kind:
+            expected_resources[kind] = arch_names
+        elif kind == DataSource.kind:
+            expected_resources[kind] = base_names | arch_names
+        else:
+            expected_resources[kind] = base_names
+    return expected_resources
 
 
 @pytest.fixture()

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/conftest.py
@@ -1,0 +1,101 @@
+import logging
+
+import pytest
+from ocp_resources.cdi import CDI
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.network_addons_config import NetworkAddonsConfig
+from ocp_resources.ssp import SSP
+
+from tests.install_upgrade_operators.constants import (
+    ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT,
+    FG_DISABLED,
+    FG_ENABLED,
+)
+from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
+    CUSTOM_MULTIARCH_DATASOURCE_NAME,
+    MULTIARCH_MANAGED_CRS,
+)
+from utilities.constants import FEATURE_GATES, KUBERNETES_ARCH_LABEL
+from utilities.hco import ResourceEditorValidateHCOReconcile, update_hco_templates_spec
+from utilities.virt import get_hyperconverged_kubevirt
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="class")
+def disabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_class):
+    with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
+        patches={
+            hyperconverged_resource_scope_class: {
+                "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_DISABLED}}
+            }
+        },
+        list_resource_reconcile=MULTIARCH_MANAGED_CRS,
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+
+
+@pytest.fixture(scope="class")
+def enabled_multiarch_feature_gate(admin_client, hyperconverged_resource_scope_class):
+    feature_gates = hyperconverged_resource_scope_class.instance.spec.get(FEATURE_GATES, {})
+    if feature_gates.get(ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT):
+        LOGGER.info("Multiarch feature gate is already enabled")
+        yield
+    else:
+        with ResourceEditorValidateHCOReconcile(
+            admin_client=admin_client,
+            patches={
+                hyperconverged_resource_scope_class: {
+                    "spec": {FEATURE_GATES: {ENABLE_MULTI_ARCH_BOOT_IMAGE_IMPORT: FG_ENABLED}}
+                }
+            },
+            list_resource_reconcile=MULTIARCH_MANAGED_CRS,
+            wait_for_reconcile_post_update=True,
+        ):
+            yield
+
+
+@pytest.fixture(scope="class")
+def kubevirt_default_architecture(admin_client, hco_namespace):
+    # TODO: Migrate to HCO CR once defaultArchitecture is exposed there.
+    # Currently only available on KubeVirt CR status. See:
+    # https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4329
+    return get_hyperconverged_kubevirt(
+        admin_client=admin_client,
+        hco_namespace=hco_namespace,
+    ).instance.status.defaultArchitecture
+
+
+@pytest.fixture()
+def single_arch_node_placement(admin_client, workers_architectures, hyperconverged_resource_scope_function):
+    single_arch = min(workers_architectures)
+    LOGGER.info(f"Restricting workloads nodePlacement to single architecture: {single_arch}")
+    placement = {"nodePlacement": {"nodeSelector": {KUBERNETES_ARCH_LABEL: single_arch}}}
+    with ResourceEditorValidateHCOReconcile(
+        admin_client=admin_client,
+        patches={hyperconverged_resource_scope_function: {"spec": {"workloads": placement}}},
+        list_resource_reconcile=[SSP, KubeVirt, CDI, NetworkAddonsConfig],
+        wait_for_reconcile_post_update=True,
+    ):
+        yield
+
+
+@pytest.fixture()
+def hco_with_custom_template(
+    request,
+    admin_client,
+    hco_namespace,
+    golden_images_namespace,
+    hyperconverged_resource_scope_function,
+    hyperconverged_status_templates_scope_function,
+):
+    yield from update_hco_templates_spec(
+        admin_client=admin_client,
+        hco_namespace=hco_namespace,
+        hyperconverged_resource=hyperconverged_resource_scope_function,
+        updated_template=request.param(common_templates=hyperconverged_status_templates_scope_function),
+        custom_datasource_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+        golden_images_namespace=golden_images_namespace,
+    )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/test_multiarch_golden_images_support.py
@@ -6,19 +6,30 @@ https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/blob/main
 
 Preconditions:
     - Multi-architecture cluster with AMD64 and ARM64 worker nodes
-    - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     - Prometheus is installed and running
-
-Markers:
-    - multiarch
-    - post_upgrade
 """
 
 import pytest
+from ocp_resources.data_import_cron import DataImportCron
+from ocp_resources.data_source import DataSource
 
-pytestmark = [pytest.mark.multiarch]
+from tests.install_upgrade_operators.hco_enablement_golden_image_updates.multiarch.utils import (
+    CUSTOM_MULTIARCH_DATASOURCE_NAME,
+    CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME,
+    CUSTOM_UNSUPPORTED_ARCH_CRON_NAME,
+    KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY,
+    KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_SUPPORTED_ARCHITECTURES_QUERY,
+    KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED,
+    get_no_arch_annotation_template,
+    get_unsupported_arch_template,
+)
+from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import verify_resource_in_ns
+from utilities.monitoring import validate_metrics_value
+
+pytestmark = [pytest.mark.multiarch, pytest.mark.post_upgrade]
 
 
+@pytest.mark.usefixtures("disabled_multiarch_feature_gate")
 class TestDisabledMultiarchGoldenImagesSupport:
     """
     Tests for boot source state and misconfiguration metrics when
@@ -29,43 +40,96 @@ class TestDisabledMultiarchGoldenImagesSupport:
         - "enableMultiArchBootImageImport" feature gate disabled in HCO CR
     """
 
-    __test__ = False
-
     @pytest.mark.polarion("CNV-15977")
-    def test_only_architecture_agnostic_golden_image_resources_exist(self):
+    @pytest.mark.parametrize(
+        "resource_type",
+        [
+            pytest.param(DataImportCron),
+            pytest.param(DataSource, marks=pytest.mark.jira("CNV-68996", run=False)),
+        ],
+    )
+    def test_only_base_golden_image_resources_exist(
+        self,
+        admin_client,
+        golden_images_namespace,
+        base_common_templates_related_resources,
+        expected_common_templates_related_resources,
+        resource_type,
+    ):
         """
-        Test that only architecture-agnostic golden image resources exist
+        Test that only base golden image resources exist
         after disabling multi-architecture golden images support.
 
         Parametrize:
             - resource_type:
                 - DataImportCron
-                - DataSource
+                - DataSource [Markers: jira(CNV-68996)]
 
         Steps:
-            1. List resources of the parametrized type in the golden images namespace.
-            2. Verify arch-suffix resources are not present.
+            1. Verify expected base resources exist in the golden images namespace.
+            2. Verify no architecture-specific resources exist.
 
         Expected:
-            - No resources exist with architecture suffix.
+            - Only base resources of the parametrized type exist.
         """
+        verify_resource_in_ns(
+            expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=resource_type,
+        )
+        base_names = base_common_templates_related_resources[resource_type.kind]
+        arch_specific_resources = [
+            resource.name
+            for resource in resource_type.get(client=admin_client, namespace=golden_images_namespace.name)
+            if any(resource.name.startswith(f"{base_name}-") for base_name in base_names)
+        ]
+        assert not arch_specific_resources, (
+            f"Architecture-specific {resource_type.kind} resources found when multiarch is disabled: "
+            f"{arch_specific_resources}"
+        )
 
     @pytest.mark.polarion("CNV-15978")
-    def test_architecture_agnostic_data_sources_rollback(self):
+    def test_architecture_agnostic_data_sources_rollback(
+        self,
+        admin_client,
+        golden_images_namespace,
+        expected_common_templates_related_resources,
+        subtests,
+    ):
         """
-        Test that architecture-agnostic (pointer) DataSources remain available after
-        disabling multi-architecture golden images support, and pointing to a pvc/snapshot source.
+        Test that architecture-agnostic DataSources remain available after
+        disabling multi-architecture golden images support, and point to a pvc/snapshot source.
 
         Steps:
             1. Get architecture-agnostic DataSources from golden images namespace.
             2. Wait for them to be in ready condition.
+            3. Check the source reference of each DataSource.
 
         Expected:
             - Architecture-agnostic DataSources reference a pvc/snapshot source.
         """
+        verify_resource_in_ns(
+            expected_resource_names=expected_common_templates_related_resources[DataSource.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=DataSource,
+            ready_condition=DataSource.Condition.READY,
+        )
+        for ds_name in expected_common_templates_related_resources[DataSource.kind]:
+            with subtests.test(msg=ds_name):
+                data_source = DataSource(
+                    name=ds_name,
+                    namespace=golden_images_namespace.name,
+                    client=admin_client,
+                )
+                source = data_source.instance.spec.source
+                assert source.get("pvc") or source.get("snapshot"), (
+                    f"DataSource {ds_name} does not reference a pvc/snapshot source: {source}"
+                )
 
     @pytest.mark.polarion("CNV-15979")
-    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric(self):
+    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric(self, prometheus):
         """
         Test that the metric is indicating that multi-arch
         golden images support is disabled on a multiarch cluster.
@@ -74,14 +138,24 @@ class TestDisabledMultiarchGoldenImagesSupport:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0.
+            - Metric value is 0. This metric is the underlying signal for the
+              corresponding alert.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED,
+            expected_value="0",
+        )
 
+    @pytest.mark.usefixtures("single_arch_node_placement")
     @pytest.mark.polarion("CNV-15980")
-    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric_single_arch_node_placement(self):
+    def test_kubevirt_hco_multi_arch_boot_images_enabled_metric_single_arch_node_placement(
+        self,
+        prometheus,
+    ):
         """
-        Test that the metric is indicating that multi-arch support is enabled
-        when nodePlacement restricts workloads to a single architecture.
+        Test that the metric is not emitted when nodePlacement restricts
+        workloads to a single architecture.
 
         Preconditions:
             - nodePlacement restricts workloads to a single architecture in HCO CR.
@@ -90,10 +164,17 @@ class TestDisabledMultiarchGoldenImagesSupport:
             1. Query the metric.
 
         Expected:
-            - Metric value is 1.
+            - Metric is not emitted. This metric is the underlying signal for the
+              corresponding alert.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED,
+            expected_value=0,
+        )
 
 
+@pytest.mark.usefixtures("enabled_multiarch_feature_gate")
 class TestEnabledMultiarchGoldenImagesSupport:
     """
     Tests for architecture-specific golden image boot sources availability
@@ -103,8 +184,21 @@ class TestEnabledMultiarchGoldenImagesSupport:
         - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     """
 
-    @pytest.mark.polarion("CNV-15981")
-    def test_architecture_specific_golden_image_resources(self):
+    @pytest.mark.parametrize(
+        "resource_type, expected_condition",
+        [
+            pytest.param(DataImportCron, DataImportCron.Condition.UP_TO_DATE, marks=pytest.mark.polarion("CNV-15981")),
+            pytest.param(DataSource, DataSource.Condition.READY, marks=pytest.mark.polarion("CNV-15982")),
+        ],
+    )
+    def test_architecture_specific_golden_image_resources(
+        self,
+        admin_client,
+        golden_images_namespace,
+        expected_common_templates_related_resources,
+        resource_type,
+        expected_condition,
+    ):
         """
         Test that architecture-specific golden image resources are created
         for each common DataImportCronTemplate and each supported cluster architecture.
@@ -120,25 +214,64 @@ class TestEnabledMultiarchGoldenImagesSupport:
 
         Expected:
             - Architecture-specific golden image resources exist for each supported
-              architecture matching the workers architectures and in expected condition.
+              architecture matching the workers architectures and in the expected condition.
+              For DataImportCrons, only arch-specific names are expected (base names are replaced).
+              For DataSources, both architecture-agnostic pointers and arch-specific names are expected.
         """
+        verify_resource_in_ns(
+            expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=resource_type,
+            ready_condition=expected_condition,
+        )
 
-    @pytest.mark.polarion("CNV-15982")
-    def test_architecture_agnostic_data_sources(self):
+    @pytest.mark.polarion("CNV-16020")
+    def test_architecture_agnostic_data_sources(
+        self,
+        admin_client,
+        golden_images_namespace,
+        base_common_templates_related_resources,
+        kubevirt_default_architecture,
+        subtests,
+    ):
         """
         Test that architecture-agnostic (pointer) DataSources are referencing
         the default architecture-specific DataSource.
 
         Steps:
             1. Get architecture-agnostic DataSources from golden images namespace.
-            2. Get control-plane architecture.
+            2. Get Kubevirt default architecture.
 
         Expected:
-            - DataSources in ready condition and referencing the control-plane
-              architecture-specific DataSource.
+            - DataSource is referencing architecture-specific DataSource matching the Kubevirt default architecture.
         """
+        verify_resource_in_ns(
+            expected_resource_names=base_common_templates_related_resources[DataSource.kind],
+            namespace=golden_images_namespace.name,
+            client=admin_client,
+            resource_type=DataSource,
+            ready_condition=DataSource.Condition.READY,
+        )
+        for ds_name in base_common_templates_related_resources[DataSource.kind]:
+            expected_arch_ds = f"{ds_name}-{kubevirt_default_architecture}"
+            with subtests.test(msg=ds_name):
+                data_source = DataSource(
+                    name=ds_name,
+                    namespace=golden_images_namespace.name,
+                    client=admin_client,
+                )
+                assert (source := data_source.instance.spec.source.get("dataSource")), (
+                    f"DataSource {ds_name} does not reference an architecture-specific DataSource."
+                )
+                assert source.name == expected_arch_ds, (
+                    f"DataSource {ds_name} does not reference a Kubevirt default "
+                    f"architecture-specific DataSource (expected: {expected_arch_ds}). "
+                    f"Actual source: {source.name}"
+                )
 
 
+@pytest.mark.usefixtures("enabled_multiarch_feature_gate")
 class TestMultiarchGoldenImageAnnotationMetrics:
     """
     Tests for misconfiguration metrics on golden image annotation issues
@@ -148,11 +281,20 @@ class TestMultiarchGoldenImageAnnotationMetrics:
         - "enableMultiArchBootImageImport" feature gate enabled in HCO CR
     """
 
+    @pytest.mark.parametrize(
+        "hco_with_custom_template",
+        [pytest.param(get_unsupported_arch_template, id="unsupported_arch")],
+        indirect=True,
+    )
     @pytest.mark.polarion("CNV-15983")
-    def test_kubevirt_hco_dataimportcrontemplate_with_supported_architectures_metric(self):
+    def test_kubevirt_hco_dataimportcrontemplate_with_supported_architectures_metric(
+        self,
+        hco_with_custom_template,
+        prometheus,
+    ):
         """
-        [NEGATIVE] Test that a misconfiguration metric is reported when a golden
-        image is annotated with an architecture not supported by the cluster.
+        [NEGATIVE] Test that a misconfiguration metric indicates an unsupported
+        architecture annotation on a golden image.
 
         Preconditions:
             - HCO CR is patched with a custom DataImportCronTemplate annotated
@@ -162,22 +304,49 @@ class TestMultiarchGoldenImageAnnotationMetrics:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0.
+            - Metric is emitted with value 0, indicating the misconfiguration is
+              detected. This metric is the underlying signal for the corresponding alert.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_SUPPORTED_ARCHITECTURES_QUERY.format(
+                cron_name=CUSTOM_UNSUPPORTED_ARCH_CRON_NAME,
+                ds_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+            ),
+            expected_value="0",
+        )
 
+    @pytest.mark.parametrize(
+        "hco_with_custom_template",
+        [pytest.param(get_no_arch_annotation_template, id="no_arch_annotation")],
+        indirect=True,
+    )
     @pytest.mark.polarion("CNV-15984")
-    def test_kubevirt_hco_dataimportcrontemplate_with_architecture_annotation_metric(self):
+    def test_kubevirt_hco_dataimportcrontemplate_with_architecture_annotation_metric(
+        self,
+        hco_with_custom_template,
+        prometheus,
+    ):
         """
-        [NEGATIVE] Test that a misconfiguration metric is reported when a golden
-        image lacks an architecture annotation on a multi-architecture cluster.
+        [NEGATIVE] Test that a misconfiguration metric indicates a missing
+        architecture annotation on a golden image.
 
         Preconditions:
-            - HCO CR is patched with a custom DataImportCronTemplate annotated without
+            - HCO CR is patched with a custom DataImportCronTemplate without
               architecture annotation.
 
         Steps:
             1. Query the metric.
 
         Expected:
-            - Metric value is 0.
+            - Metric is emitted with value 0, indicating the misconfiguration is
+              detected. This metric is the underlying signal for the corresponding alert.
         """
+        validate_metrics_value(
+            prometheus=prometheus,
+            metric_name=KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY.format(
+                cron_name=CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME,
+                ds_name=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+            ),
+            expected_value="0",
+        )

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/multiarch/utils.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+from ocp_resources.cdi import CDI
+from ocp_resources.kubevirt import KubeVirt
+from ocp_resources.ssp import SSP
+
+KUBEVIRT_HCO_MULTI_ARCH_BOOT_IMAGES_ENABLED = "kubevirt_hco_multi_arch_boot_images_enabled"
+MULTIARCH_DICT_ANNOTATION = "ssp.kubevirt.io/dict.architectures"
+MULTIARCH_MANAGED_CRS = [SSP, KubeVirt, CDI]
+
+CUSTOM_MULTIARCH_DATASOURCE_NAME = "custom-multiarch-datasource"
+CUSTOM_UNSUPPORTED_ARCH_CRON_NAME = "custom-unsupported-arch-cron"
+CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME = "custom-no-arch-annotation-cron"
+
+KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_SUPPORTED_ARCHITECTURES_QUERY = (
+    "kubevirt_hco_dataimportcrontemplate_with_supported_architectures"
+    "{{data_import_cron_name='{cron_name}', managed_data_source_name='{ds_name}'}}"
+)
+KUBEVIRT_HCO_DATAIMPORTCRONTEMPLATE_WITH_ARCHITECTURE_ANNOTATION_QUERY = (
+    "kubevirt_hco_dataimportcrontemplate_with_architecture_annotation"
+    "{{data_import_cron_name='{cron_name}', managed_data_source_name='{ds_name}'}}"
+)
+
+
+def get_modified_data_import_cron_template(
+    common_templates: list[dict[str, Any]],
+    name: str,
+    managed_data_source: str,
+    annotations: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Create a custom DataImportCronTemplate based on the first common template.
+
+    Args:
+        common_templates: List of common templates from HCO status.
+        name: Name for the custom template.
+        managed_data_source: DataSource name this template manages.
+        annotations: Optional annotations to merge into the template metadata.
+
+    Returns:
+        dict[str, Any]: A deep copy of the first common template with customized name,
+            managed data source, status removed, and optional annotations.
+    """
+    template = deepcopy(common_templates[0])
+    del template["status"]
+    template["metadata"]["name"] = name
+    template["spec"]["managedDataSource"] = managed_data_source
+    if annotations is not None:
+        template["metadata"].setdefault("annotations", {}).update(annotations)
+    return template
+
+
+def get_unsupported_arch_template(common_templates: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return a custom template annotated with an architecture unsupported by the cluster."""
+    return get_modified_data_import_cron_template(
+        common_templates=common_templates,
+        name=CUSTOM_UNSUPPORTED_ARCH_CRON_NAME,
+        managed_data_source=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+        annotations={MULTIARCH_DICT_ANNOTATION: "arm42"},
+    )
+
+
+def get_no_arch_annotation_template(common_templates: list[dict[str, Any]]) -> dict[str, Any]:
+    """Return a custom template with the architecture annotation removed."""
+    template = get_modified_data_import_cron_template(
+        common_templates=common_templates,
+        name=CUSTOM_NO_ARCH_ANNOTATION_CRON_NAME,
+        managed_data_source=CUSTOM_MULTIARCH_DATASOURCE_NAME,
+    )
+    # annotations is optional in Kubernetes metadata
+    template["metadata"].get("annotations", {}).pop(MULTIARCH_DICT_ANNOTATION, None)
+    return template

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_custom_golden_images_namespace.py
@@ -9,15 +9,14 @@ from ocp_resources.image_stream import ImageStream
 from ocp_resources.resource import Resource
 from ocp_resources.ssp import SSP
 from ocp_resources.volume_snapshot import VolumeSnapshot
+from pytest_testconfig import config as py_config
 
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
-    COMMON_TEMPLATE,
-    get_templates_by_type_from_hco_status,
+    verify_common_template_namespace_updated,
+    verify_resource_in_ns,
+    verify_resource_not_in_ns,
 )
-from utilities.constants import (
-    TIMEOUT_3MIN,
-    TIMEOUT_10MIN,
-)
+from utilities.constants import MULTIARCH, TIMEOUT_3MIN, TIMEOUT_10MIN
 from utilities.hco import (
     ResourceEditorValidateHCOReconcile,
     wait_for_hco_conditions,
@@ -31,68 +30,9 @@ COMMON_BOOT_IMAGE_NAMESPACE_STR = "commonBootImageNamespace"
 pytestmark = [pytest.mark.arm64, pytest.mark.s390x]
 
 
-def get_templates_resources_names_dict(templates):
-    resource_dict = {}
-    for template in templates:
-        image_stream_name = template["spec"]["template"]["spec"]["source"]["registry"].get("imageStream")
-        if image_stream_name:
-            resource_dict.setdefault(ImageStream.kind, set()).add(image_stream_name)
-        resource_dict.setdefault(DataImportCron.kind, set()).add(template["metadata"]["name"])
-        resource_dict.setdefault(DataSource.kind, set()).add(template["spec"]["managedDataSource"])
-    return resource_dict
-
-
-def verify_resource_not_in_ns(resource_type, namespace, client):
-    resources = resource_type.get(client=client, namespace=namespace)
-    resources_names = {resource.name for resource in resources}
-    assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
-
-
-def verify_resource_in_ns(expected_resource_names, namespace, client, resource_type, ready_condition=None):
-    """
-    Verify that resources exist in expected_namespace and in ready status.
-    """
-    resources = list(resource_type.get(client=client, namespace=namespace))
-    resources_names = {resource.name for resource in resources}
-    missing_resources_names = expected_resource_names - resources_names
-    assert not missing_resources_names, f"Missing {resource_type.kind} in {namespace}: {missing_resources_names}"
-
-    if ready_condition:
-        LOGGER.info(f"Verify that {expected_resource_names} are in {ready_condition} condition")
-        for resource in resources:
-            resource.wait_for_condition(
-                condition=ready_condition,
-                status=resource.Condition.Status.TRUE,
-                timeout=TIMEOUT_10MIN,
-            )
-
-
-def verify_common_template_namespace_updated(common_templates, namespace_name):
-    non_updated_templates = []
-    for template in common_templates:
-        if template["metadata"].get("namespace") != namespace_name:
-            non_updated_templates.append(
-                f"{template['metadata']['name']} expected namespace: {namespace_name} "
-                f"actual: {template['metadata'].get('namespace')}\n"
-            )
-    assert not non_updated_templates, non_updated_templates
-
-
 @pytest.fixture(scope="module")
 def custom_golden_images_namespace(admin_client):
     yield from create_ns(admin_client=admin_client, name="custom-golden-images-namespace")
-
-
-@pytest.fixture(scope="class")
-def default_common_template_hco_status(hyperconverged_status_templates_scope_class):
-    return get_templates_by_type_from_hco_status(
-        hco_status_templates=hyperconverged_status_templates_scope_class, template_type=COMMON_TEMPLATE
-    )
-
-
-@pytest.fixture(scope="class")
-def default_common_templates_related_resources(default_common_template_hco_status):
-    return get_templates_resources_names_dict(templates=default_common_template_hco_status)
 
 
 @pytest.fixture(scope="class")
@@ -146,7 +86,7 @@ class TestDefaultCommonTemplates:
     @pytest.mark.parametrize(
         "common_templates",
         [
-            pytest.param("default_common_template_hco_status", marks=pytest.mark.polarion("CNV-11473")),
+            pytest.param("common_templates_from_hco_status_scope_class", marks=pytest.mark.polarion("CNV-11473")),
             pytest.param("ssp_spec_templates_scope_function", marks=pytest.mark.polarion("CNV-11677")),
         ],
     )
@@ -165,20 +105,27 @@ class TestDefaultCommonTemplates:
         "resource_type, ready_condition",
         [
             pytest.param(ImageStream, None, marks=pytest.mark.polarion("CNV-11474")),
-            pytest.param(DataImportCron, "UpToDate", marks=pytest.mark.polarion("CNV-11475")),
-            pytest.param(DataSource, DataSource.Condition.READY, marks=pytest.mark.polarion("CNV-11476")),
+            pytest.param(DataImportCron, DataImportCron.Condition.UP_TO_DATE, marks=pytest.mark.polarion("CNV-11475")),
+            pytest.param(
+                DataSource,
+                DataSource.Condition.READY,
+                marks=(
+                    pytest.mark.polarion("CNV-11476"),
+                    *((pytest.mark.jira("CNV-86247", run=False),) if py_config["cluster_type"] == MULTIARCH else ()),
+                ),
+            ),
         ],
     )
     def test_resources_in_custom_ns(
         self,
         admin_client,
         custom_golden_images_namespace,
-        default_common_templates_related_resources,
+        expected_common_templates_related_resources,
         resource_type,
         ready_condition,
     ):
         verify_resource_in_ns(
-            expected_resource_names=default_common_templates_related_resources[resource_type.kind],
+            expected_resource_names=expected_common_templates_related_resources[resource_type.kind],
             namespace=custom_golden_images_namespace.name,
             client=admin_client,
             resource_type=resource_type,

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/test_modify_common_templates.py
@@ -10,8 +10,8 @@ from ocp_resources.ssp import SSP
 
 from tests.install_upgrade_operators.constants import KEY_PATH_SEPARATOR
 from tests.install_upgrade_operators.hco_enablement_golden_image_updates.utils import (
-    get_data_import_cron_by_name,
-    get_modifed_common_template_names,
+    get_data_import_crons_by_prefix,
+    get_modified_common_template_names,
     get_template_dict_by_name,
 )
 from utilities.constants import (
@@ -111,7 +111,9 @@ def updated_common_template(
     ):
         yield updated_templates
 
-    modified_common_templates = get_modifed_common_template_names(hyperconverged=hyperconverged_resource_scope_function)
+    modified_common_templates = get_modified_common_template_names(
+        hyperconverged=hyperconverged_resource_scope_function
+    )
     assert not modified_common_templates, f"Following templates were not reverted back: {modified_common_templates}"
 
 
@@ -211,19 +213,23 @@ class TestModifyCommonTemplateSpec:
             if ssp_error:
                 errors.append(f"Mismatch for template in ssp.spec: {template_name}: {''.join(ssp_error)}.\n")
 
-            data_import_cron_error = validate_template_change(
-                template_dict=benedict(
-                    get_data_import_cron_by_name(
-                        cron_name=template_name, namespace=golden_images_namespace.name, admin_client=admin_client
-                    ).instance.to_dict(),
-                    keypath_separator=KEY_PATH_SEPARATOR,
-                ),
-                expected_dict=expected_value,
-            )
-            if data_import_cron_error:
-                errors.append(
-                    f"Mismatch for template: {template_name} in dataimportcron.spec: {''.join(data_import_cron_error)}."
+            for data_import_cron in get_data_import_crons_by_prefix(
+                cron_prefix=template_name,
+                namespace=golden_images_namespace.name,
+                admin_client=admin_client,
+            ):
+                data_import_cron_error = validate_template_change(
+                    template_dict=benedict(
+                        data_import_cron.instance.to_dict(),
+                        keypath_separator=KEY_PATH_SEPARATOR,
+                    ),
+                    expected_dict=expected_value,
                 )
+                if data_import_cron_error:
+                    errors.append(
+                        f"Mismatch for {data_import_cron.name} in dataimportcron.spec: "
+                        f"{''.join(data_import_cron_error)}."
+                    )
         assert not errors, "".join(errors)
 
 
@@ -292,8 +298,10 @@ class TestCommonTemplatesEnableDisable:
                 )
 
             with pytest.raises(ResourceNotFoundError):
-                get_data_import_cron_by_name(
-                    cron_name=template_name, namespace=golden_images_namespace.name, admin_client=admin_client
+                get_data_import_crons_by_prefix(
+                    cron_prefix=template_name,
+                    namespace=golden_images_namespace.name,
+                    admin_client=admin_client,
                 )
         assert not errors, (
             f"Enabling/Disabling common templates via HCO failed with following reasons: {' '.join(errors)}"

--- a/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
+++ b/tests/install_upgrade_operators/hco_enablement_golden_image_updates/utils.py
@@ -1,14 +1,19 @@
 import logging
 import re
+from typing import Any
 
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.data_import_cron import DataImportCron
+from ocp_resources.data_source import DataSource
+from ocp_resources.image_stream import ImageStream
+from ocp_resources.resource import Resource
 
 from tests.install_upgrade_operators.constants import CUSTOM_DATASOURCE_NAME
 from utilities.constants import (
     OUTDATED,
     SSP_CR_COMMON_TEMPLATES_LIST_KEY_NAME,
+    TIMEOUT_10MIN,
     WILDCARD_CRON_EXPRESSION,
 )
 
@@ -74,7 +79,7 @@ def get_random_minutes_hours_fields_from_data_import_schedule(target_string):
     return re_result.group(RE_NAMED_GROUP_MINUTES), re_result.group(RE_NAMED_GROUP_HOURS)
 
 
-def get_modifed_common_template_names(hyperconverged):
+def get_modified_common_template_names(hyperconverged):
     return [
         template["metadata"]["name"]
         for template in get_templates_by_type_from_hco_status(
@@ -93,14 +98,139 @@ def get_templates_by_type_from_hco_status(hco_status_templates, template_type=CO
     ]
 
 
-def get_data_import_cron_by_name(namespace: str, cron_name: str, admin_client: DynamicClient) -> DataImportCron:
-    data_import_cron = DataImportCron(name=cron_name, namespace=namespace, client=admin_client)
-    if data_import_cron.exists:
-        return data_import_cron
-    raise ResourceNotFoundError(f"DataImportCron: {data_import_cron} not found in namespace: {namespace}")
+def get_data_import_crons_by_prefix(
+    namespace: str,
+    cron_prefix: str,
+    admin_client: DynamicClient,
+) -> list[DataImportCron]:
+    """Return all DataImportCrons matching a template base name prefix.
+
+    Matches exact name or name with architecture suffix (e.g. prefix "fedora"
+    matches "fedora", "fedora-amd64", "fedora-arm64").
+
+    Args:
+        namespace: Namespace to search in.
+        cron_prefix: HCO template base name to match against.
+        admin_client: Kubernetes client.
+
+    Returns:
+        List of matching DataImportCron resources.
+
+    Raises:
+        ResourceNotFoundError: If no matching DataImportCrons are found.
+    """
+    matching = [
+        data_import_cron
+        for data_import_cron in DataImportCron.get(client=admin_client, namespace=namespace)
+        if data_import_cron.name == cron_prefix or data_import_cron.name.startswith(f"{cron_prefix}-")
+    ]
+    if not matching:
+        raise ResourceNotFoundError(f"No DataImportCron with prefix '{cron_prefix}' found in namespace: {namespace}")
+    return matching
 
 
-def get_template_dict_by_name(template_name, templates):
+def verify_common_template_namespace_updated(common_templates: list[dict[str, Any]], namespace_name: str) -> None:
+    """Assert that all templates have the expected namespace in their metadata.
+
+    Args:
+        common_templates: List of common templates from HCO status.
+        namespace_name: Expected namespace name.
+
+    Raises:
+        AssertionError: If any template has a different namespace.
+    """
+    non_updated_templates = []
+    for template in common_templates:
+        if template["metadata"].get("namespace") != namespace_name:
+            non_updated_templates.append(
+                f"{template['metadata']['name']} expected namespace: {namespace_name} "
+                f"actual: {template['metadata'].get('namespace')}\n"
+            )
+    assert not non_updated_templates, non_updated_templates
+
+
+def get_template_dict_by_name(template_name: str, templates: list[dict[str, Any]]) -> dict[str, Any] | None:
     for template in templates:
         if template["metadata"]["name"] == template_name:
             return template
+    return None
+
+
+def get_templates_resources_names_dict(templates: list[dict[str, Any]]) -> dict[str, set[str]]:
+    """Extract resource names from HCO DataImportCronTemplates, grouped by kind.
+
+    Returns:
+        dict[str, set[str]]: Mapping of resource kind to set of names.
+            Keys: DataImportCron.kind and DataSource.kind are always present;
+                  ImageStream.kind is present only when templates contain an image stream.
+    """
+    resource_dict: dict[str, set[str]] = {}
+    for template in templates:
+        image_stream_name = template["spec"]["template"]["spec"]["source"]["registry"].get("imageStream")
+        if image_stream_name:
+            resource_dict.setdefault(ImageStream.kind, set()).add(image_stream_name)
+        resource_dict.setdefault(DataImportCron.kind, set()).add(template["metadata"]["name"])
+        resource_dict.setdefault(DataSource.kind, set()).add(template["spec"]["managedDataSource"])
+    return resource_dict
+
+
+def verify_resource_not_in_ns(resource_type: type[Resource], namespace: str, client: DynamicClient) -> None:
+    """Assert that no resources of the given type exist in the namespace.
+
+    Args:
+        resource_type: OCP resource class to query.
+        namespace: Namespace to check.
+        client: OpenShift client.
+
+    Raises:
+        AssertionError: If any resources of the given type exist.
+    """
+    resources = resource_type.get(client=client, namespace=namespace)
+    resources_names = {resource.name for resource in resources}
+    assert not resources_names, f"{resource_type.kind} resources shouldn't exist in {namespace}: {resources_names}"
+
+
+def verify_resource_in_ns(
+    expected_resource_names: set[str],
+    namespace: str,
+    client: DynamicClient,
+    resource_type: type[Resource],
+    ready_condition: str | None = None,
+) -> None:
+    """Assert that expected resources exist in the namespace and optionally wait for readiness.
+
+    DataSources use a subset check (expected ⊆ actual) because they retain
+    architecture-agnostic pointers alongside arch-specific entries.
+    All other resource types use an exact-match check (expected == actual).
+
+    Args:
+        expected_resource_names: Set of resource names that must be present.
+        namespace: Namespace to check.
+        client: OpenShift client.
+        resource_type: OCP resource class to query.
+        ready_condition: If provided, waits up to 10 minutes for each expected
+            resource to reach this condition with status True.
+
+    Raises:
+        AssertionError: If any expected resources are missing, or if unexpected
+            resources exist (for non-DataSource types).
+        TimeoutExpiredError: If a resource does not reach the ready condition in time.
+    """
+    resources = list(resource_type.get(client=client, namespace=namespace))
+    resources_names = {resource.name for resource in resources}
+    missing_resources_names = expected_resource_names - resources_names
+    assert not missing_resources_names, f"Missing {resource_type.kind} in {namespace}: {missing_resources_names}"
+
+    if resource_type is not DataSource:
+        extra_resources_names = resources_names - expected_resource_names
+        assert not extra_resources_names, f"Unexpected {resource_type.kind} in {namespace}: {extra_resources_names}"
+
+    if ready_condition:
+        LOGGER.info(f"Verify that {expected_resource_names} are in {ready_condition} condition")
+        for resource in resources:
+            if resource.name in expected_resource_names:
+                resource.wait_for_condition(
+                    condition=ready_condition,
+                    status=resource.Condition.Status.TRUE,
+                    timeout=TIMEOUT_10MIN,
+                )

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -36,7 +36,6 @@ from tests.observability.metrics.utils import (
     network_packets_received,
     vnic_info_from_vm_or_vmi,
 )
-from tests.observability.utils import validate_metrics_value
 from tests.utils import create_vms, start_stress_on_vm
 from utilities import console
 from utilities.constants import (
@@ -72,7 +71,7 @@ from utilities.infra import (
     get_pod_by_name_prefix,
     unique_name,
 )
-from utilities.monitoring import get_metrics_value
+from utilities.monitoring import get_metrics_value, validate_metrics_value
 from utilities.network import assert_ping_successful, get_ip_from_vm_or_virt_handler_pod, ping
 from utilities.ssp import verify_ssp_pod_is_running
 from utilities.storage import (

--- a/tests/observability/metrics/test_aaq_metrics.py
+++ b/tests/observability/metrics/test_aaq_metrics.py
@@ -4,7 +4,7 @@ from tests.observability.metrics.utils import (
     timestamp_to_seconds,
     validate_values_from_kube_application_aware_resourcequota_metric,
 )
-from tests.observability.utils import validate_metrics_value
+from utilities.monitoring import validate_metrics_value
 
 pytestmark = [
     pytest.mark.usefixtures(

--- a/tests/observability/metrics/test_general_metrics.py
+++ b/tests/observability/metrics/test_general_metrics.py
@@ -7,7 +7,7 @@ from ocp_resources.virtual_machine import VirtualMachine
 from libs.net.cluster import is_ipv6_single_stack_cluster
 from tests.observability.metrics.constants import KUBEVIRT_VMI_NODE_CPU_AFFINITY
 from tests.observability.metrics.utils import validate_vmi_node_cpu_affinity_with_prometheus
-from tests.observability.utils import validate_metrics_value
+from utilities.monitoring import validate_metrics_value
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 KUBEVIRT_VM_TAG = f"{Resource.ApiGroup.KUBEVIRT_IO}/vm"

--- a/tests/observability/metrics/test_metrics.py
+++ b/tests/observability/metrics/test_metrics.py
@@ -9,10 +9,10 @@ from tests.observability.metrics.utils import (
     assert_vm_metric_virt_handler_pod,
     compare_kubevirt_vmi_info_metric_with_vm_info,
 )
-from tests.observability.utils import validate_metrics_value
 from utilities.constants import (
     KUBEVIRT_HCO_HYPERCONVERGED_CR_EXISTS,
 )
+from utilities.monitoring import validate_metrics_value
 
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 

--- a/tests/observability/metrics/test_migration_metrics.py
+++ b/tests/observability/metrics/test_migration_metrics.py
@@ -13,7 +13,7 @@ from tests.observability.metrics.utils import (
     timestamp_to_seconds,
     wait_for_non_empty_metrics_value,
 )
-from tests.observability.utils import validate_metrics_value
+from utilities.monitoring import validate_metrics_value
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/observability/metrics/test_ssp_metrics.py
+++ b/tests/observability/metrics/test_ssp_metrics.py
@@ -7,12 +7,12 @@ from tests.observability.metrics.utils import (
     validate_metric_value_with_round_down,
     validate_metric_value_within_range,
 )
-from tests.observability.utils import validate_metrics_value
 from utilities.constants import (
     SSP_OPERATOR,
     VIRT_TEMPLATE_VALIDATOR,
 )
 from utilities.hco import ResourceEditorValidateHCOReconcile
+from utilities.monitoring import validate_metrics_value
 from utilities.virt import VirtualMachineForTests
 
 KUBEVIRT_SSP_OPERATOR_UP = "kubevirt_ssp_operator_up"

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -27,7 +27,6 @@ from tests.observability.metrics.utils import (
     validate_metric_value_greater_than_initial_value,
     validate_vnic_info,
 )
-from tests.observability.utils import validate_metrics_value
 from utilities.constants import (
     CAPACITY,
     MIGRATION_POLICY_VM_LABEL,
@@ -38,7 +37,7 @@ from utilities.constants import (
     USED,
 )
 from utilities.infra import get_node_selector_dict
-from utilities.monitoring import get_metrics_value
+from utilities.monitoring import get_metrics_value, validate_metrics_value
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/observability/upgrade/test_upgrade_observability.py
+++ b/tests/observability/upgrade/test_upgrade_observability.py
@@ -1,9 +1,9 @@
 import pytest
 
 from tests.observability.constants import KUBEVIRT_VMI_NUMBER_OF_OUTDATED
-from tests.observability.utils import validate_metrics_value
 from tests.upgrade_params import IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID
 from utilities.constants import DEPENDENCY_SCOPE_SESSION, QUARANTINED
+from utilities.monitoring import validate_metrics_value
 
 
 @pytest.mark.cnv_upgrade

--- a/tests/observability/utils.py
+++ b/tests/observability/utils.py
@@ -1,44 +1,11 @@
-import datetime
 import logging
 
 from ocp_utilities.monitoring import Prometheus
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.observability.constants import SSP_COMMON_TEMPLATES_MODIFICATION_REVERTED
-from utilities.constants import (
-    TIMEOUT_4MIN,
-    TIMEOUT_15SEC,
-)
-from utilities.monitoring import get_metrics_value
 
 LOGGER = logging.getLogger(__name__)
 ALLOW_ALERTS_ON_HEALTHY_CLUSTER_LIST = [SSP_COMMON_TEMPLATES_MODIFICATION_REVERTED]
-
-
-def validate_metrics_value(
-    prometheus: Prometheus, metric_name: str, expected_value: str, timeout: int = TIMEOUT_4MIN
-) -> None:
-    samples = TimeoutSampler(
-        wait_timeout=timeout,
-        sleep=TIMEOUT_15SEC,
-        func=get_metrics_value,
-        prometheus=prometheus,
-        metrics_name=metric_name,
-    )
-    sample = None
-    comparison_values_log = {}
-    try:
-        for sample in samples:
-            if sample:
-                comparison_values_log[datetime.datetime.now()] = (
-                    f"metric: {metric_name} value is: {sample}, the expected value is {expected_value}"
-                )
-                if sample == expected_value:
-                    LOGGER.info("Metrics value matches the expected value!")
-                    return
-    except TimeoutExpiredError:
-        LOGGER.error(f"Metrics value: {sample}, expected: {expected_value}, comparison log: {comparison_values_log}")
-        raise
 
 
 def verify_no_listed_alerts_on_cluster(prometheus: Prometheus, alerts_list: list[str]) -> None:

--- a/utilities/monitoring.py
+++ b/utilities/monitoring.py
@@ -1,6 +1,11 @@
+import datetime
 import logging
+from typing import TYPE_CHECKING
 
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+if TYPE_CHECKING:
+    from ocp_utilities.monitoring import Prometheus
 
 from utilities.constants import (
     FIRING_STATE,
@@ -173,6 +178,43 @@ def get_metrics_value(prometheus, metrics_name):
         return metric_values_list[1]
     LOGGER.warning(f"For Query {metrics_name}, empty results found.")
     return 0
+
+
+def validate_metrics_value(
+    prometheus: Prometheus, metric_name: str, expected_value: str | int, timeout: int = TIMEOUT_5MIN
+) -> None:
+    """Wait until the metric matches the expected value.
+
+    Args:
+        prometheus: Prometheus instance.
+        metric_name: Name of the metric to query.
+        expected_value: Expected value to match. Use str for emitted values (e.g. "0"),
+            int 0 for absent/not-emitted metrics (get_metrics_value returns int 0 when absent).
+        timeout: Maximum wait time in seconds.
+
+    Raises:
+        TimeoutExpiredError: If the metric does not match within timeout.
+    """
+    samples = TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=TIMEOUT_5SEC,
+        func=get_metrics_value,
+        prometheus=prometheus,
+        metrics_name=metric_name,
+    )
+    sample = None
+    comparison_values_log = {}
+    try:
+        for sample in samples:
+            comparison_values_log[datetime.datetime.now()] = (
+                f"metric: {metric_name} value is: {sample}, the expected value is {expected_value}"
+            )
+            if sample == expected_value:
+                LOGGER.info(f"Metrics value matches the expected value: {expected_value}")
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(f"Metrics value: {sample}, expected: {expected_value}, comparison log: {comparison_values_log}")
+        raise
 
 
 def wait_for_gauge_metrics_value(prometheus, query, expected_value, timeout=TIMEOUT_5MIN):

--- a/utilities/unittests/test_monitoring.py
+++ b/utilities/unittests/test_monitoring.py
@@ -13,6 +13,7 @@ from utilities.monitoring import (
     get_metrics_value,
     validate_alert_cnv_labels,
     validate_alerts,
+    validate_metrics_value,
     wait_for_alert,
     wait_for_firing_alert_clean_up,
     wait_for_gauge_metrics_value,
@@ -349,6 +350,52 @@ class TestGetMetricsValue:
         result = get_metrics_value(mock_prometheus, "test_metric")
 
         assert result == 0
+
+
+class TestValidateMetricsValue:
+    """Test cases for validate_metrics_value function"""
+
+    @patch("utilities.monitoring.TimeoutSampler")
+    def test_matches_emitted_string_value(self, mock_sampler_cls):
+        """Test matching when metric is emitted with a string value."""
+        mock_sampler_cls.return_value = iter(["0"])
+        validate_metrics_value(prometheus=MagicMock(), metric_name="test_metric", expected_value="0")
+
+    @patch("utilities.monitoring.TimeoutSampler")
+    def test_matches_absent_metric_with_int_zero(self, mock_sampler_cls):
+        """Test matching absent metric (int 0) with expected_value=0."""
+        mock_sampler_cls.return_value = iter([0])
+        validate_metrics_value(prometheus=MagicMock(), metric_name="test_metric", expected_value=0)
+
+    @patch("utilities.monitoring.TimeoutSampler")
+    def test_absent_metric_does_not_match_string_zero(self, mock_sampler_cls):
+        """Test that absent metric (int 0) does NOT match expected_value='0'."""
+
+        def raise_after_samples(*args, **kwargs):
+            def _iter():
+                yield 0
+                raise TimeoutExpiredError("Timeout")
+
+            return _iter()
+
+        mock_sampler_cls.side_effect = raise_after_samples
+        with pytest.raises(TimeoutExpiredError):
+            validate_metrics_value(prometheus=MagicMock(), metric_name="test_metric", expected_value="0")
+
+    @patch("utilities.monitoring.TimeoutSampler")
+    def test_timeout_when_value_does_not_match(self, mock_sampler_cls):
+        """Test timeout when metric value never matches expected."""
+
+        def raise_after_samples(*args, **kwargs):
+            def _iter():
+                yield "5"
+                raise TimeoutExpiredError("Timeout")
+
+            return _iter()
+
+        mock_sampler_cls.side_effect = raise_after_samples
+        with pytest.raises(TimeoutExpiredError):
+            validate_metrics_value(prometheus=MagicMock(), metric_name="test_metric", expected_value="0")
 
 
 class TestWaitForGaugeMetricsValue:


### PR DESCRIPTION
Cherry-pick from main branch, original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/5719, PR owner: hmeir

this cherry-pick is fauly and should be closed https://github.com/RedHatQE/openshift-virtualization-tests/pull/5997https://github.com/RedHatQE/openshift-virtualization-tests/pull/5997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for multi-architecture golden image resources, including architecture-specific DataImportCrons and DataSources.
  * Added validation for feature-gate states, custom templates, node placement, resource readiness, and Prometheus metrics.
  * Expanded monitoring tests to support string and numeric metric values and timeout handling.

* **Refactor**
  * Consolidated resource and metric validation utilities for more consistent test behavior.
  * Improved support for architecture-suffixed resource names and namespace validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->