### PR TITLE
[Storage] replace OCS-Virt runtime skip with ocs marker 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -58,6 +58,7 @@ from utilities.pytest_utils import (
     deploy_run_in_progress_namespace,
     filter_hpp_tests,
     filter_multiarch_tests,
+    filter_ocs_tests,
     get_artifactory_server_url,
     get_base_matrix_name,
     get_cnv_version_explorer_url,
@@ -672,6 +673,7 @@ def pytest_collection_modifyitems(session, config, items):
     items[:] = filter_sno_only_tests(items=items, config=config)
     items[:] = filter_multiarch_tests(items=items, config=config)
     items[:] = filter_hpp_tests(items=items, config=config)
+    items[:] = filter_ocs_tests(items=items, config=config)
     items[:] = mark_nmstate_dependent_tests(items=items)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -78,6 +78,7 @@ markers =
 
     ## Required operators
     hpp: Tests that require the HostPath Provisioner operator to be installed
+    ocs: Tests that require OCS (ODF storage) to be installed
     mtv: Tests that require the MTV operator to be installed
     nmstate: Tests that require the K-NMState operator to be installed (marker added dynamically based on fixture dependencies)
     service_mesh: Tests that require the service mesh operator to be installed

--- a/tests/storage/checkups/conftest.py
+++ b/tests/storage/checkups/conftest.py
@@ -200,12 +200,6 @@ def updated_default_storage_profile(default_sc, admin_client):
 
 
 @pytest.fixture()
-def skip_if_no_ocs_rbd_non_virt_sc(cluster_storage_classes_names):
-    if StorageClassNames.CEPH_RBD not in cluster_storage_classes_names:
-        pytest.skip(f"Skip due to no storageclass  {StorageClassNames.CEPH_RBD} in the cluster")
-
-
-@pytest.fixture()
 def ocs_rbd_non_virt_vm_for_checkups_test(admin_client, checkups_namespace):
     with create_cirros_vm(
         storage_class=StorageClassNames.CEPH_RBD,

--- a/tests/storage/checkups/test_checkups.py
+++ b/tests/storage/checkups/test_checkups.py
@@ -66,10 +66,10 @@ class TestCheckupPositive:
             result_entry="storageProfileMissingVolumeSnapshotClass",
         )
 
+    @pytest.mark.ocs
     @pytest.mark.polarion("CNV-10709")
     def test_ocs_rbd_non_virt_vm_exist(
         self,
-        skip_if_no_ocs_rbd_non_virt_sc,
         ocs_rbd_non_virt_vm_for_checkups_test,
         checkup_configmap,
         checkup_job,

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -45,6 +45,7 @@ from utilities.constants.cluster import (
     POD_SECURITY_NAMESPACE_LABELS,
 )
 from utilities.constants.pytest import SANITY_TESTS_FAILURE
+from utilities.constants.storage import StorageClassNames
 from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
     TIMEOUT_5MIN,
@@ -565,6 +566,33 @@ def filter_hpp_tests(items: list[pytest.Item], config: pytest.Config) -> list[py
         return items_to_return
 
     return items
+
+
+def ocs_storage_class_in_matrix() -> bool:
+    """Check whether the OCS storage class is configured in the storage class matrix.
+
+    ``py_config["storage_class_matrix"]`` is populated from the ``--storage-class-matrix`` CLI
+    option. Presence of the OCS storage class in the matrix means OCS is available in the cluster,
+    so OCS-marked tests should run automatically without requiring an explicit ``-m ocs``.
+
+    Returns:
+        True if the OCS storage class is present in the storage class matrix, False otherwise.
+    """
+    return any(
+        StorageClassNames.CEPH_RBD_VIRTUALIZATION in storage_class
+        for storage_class in py_config.get("storage_class_matrix", [])
+    )
+
+
+def filter_ocs_tests(items: list[pytest.Item], config: pytest.Config) -> list[pytest.Item]:
+    marker_expression = config.getoption("-m")
+    ocs_marker_requested = bool(marker_expression) and "ocs" in marker_expression
+    if ocs_marker_requested or ocs_storage_class_in_matrix():
+        return items
+
+    discard_tests, items_to_return = remove_tests_from_list(items=items, filter_str="ocs")
+    config.hook.pytest_deselected(items=discard_tests)
+    return items_to_return
 
 
 def mark_nmstate_dependent_tests(items: list[pytest.Item]) -> list[pytest.Item]:

--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -585,6 +585,18 @@ def ocs_storage_class_in_matrix() -> bool:
 
 
 def filter_ocs_tests(items: list[pytest.Item], config: pytest.Config) -> list[pytest.Item]:
+    """Deselect OCS-marked tests when OCS is not selected or configured.
+
+    Args:
+        items: Collected pytest items.
+        config: Pytest configuration used for marker selection and deselection reporting.
+
+    Returns:
+        The retained pytest items.
+
+    Side Effects:
+        Reports removed OCS-marked items through ``pytest_deselected``.
+    """
     marker_expression = config.getoption("-m")
     ocs_marker_requested = bool(marker_expression) and "ocs" in marker_expression
     if ocs_marker_requested or ocs_storage_class_in_matrix():

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -2795,17 +2795,17 @@ OCS_STORAGE_CLASS = "ocs-storagecluster-ceph-rbd-virtualization"
 class TestOcsStorageClassInMatrix:
     """Test cases for ocs_storage_class_in_matrix function."""
 
-    @patch("utilities.pytest_utils.py_config", {"storage_class_matrix": [{OCS_STORAGE_CLASS: {}}]})
+    @patch(target="utilities.pytest_utils.py_config", new={"storage_class_matrix": [{OCS_STORAGE_CLASS: {}}]})
     def test_true_when_ocs_storage_class_in_matrix(self):
         """Returns True when the OCS storage class is in the storage class matrix."""
         assert ocs_storage_class_in_matrix() is True
 
-    @patch("utilities.pytest_utils.py_config", {"storage_class_matrix": [{"some-other-sc": {}}]})
+    @patch(target="utilities.pytest_utils.py_config", new={"storage_class_matrix": [{"some-other-sc": {}}]})
     def test_false_when_ocs_storage_class_not_in_matrix(self):
         """Returns False when the OCS storage class is not in the storage class matrix."""
         assert ocs_storage_class_in_matrix() is False
 
-    @patch("utilities.pytest_utils.py_config", {})
+    @patch(target="utilities.pytest_utils.py_config", new={})
     def test_false_when_matrix_missing(self):
         """Returns False when the storage class matrix is not configured."""
         assert ocs_storage_class_in_matrix() is False
@@ -2814,7 +2814,7 @@ class TestOcsStorageClassInMatrix:
 class TestFilterOcsTests:
     """Test cases for filter_ocs_tests function."""
 
-    @patch("utilities.pytest_utils.py_config", {})
+    @patch(target="utilities.pytest_utils.py_config", new={})
     def test_removes_ocs_tests_when_no_marker_expression(self):
         """OCS tests are filtered out when no -m option is set and OCS storage class is absent."""
         item_ocs = MagicMock()
@@ -2829,7 +2829,7 @@ class TestFilterOcsTests:
         assert result == [item_other]
         config.hook.pytest_deselected.assert_called_once_with(items=[item_ocs])
 
-    @patch("utilities.pytest_utils.py_config", {})
+    @patch(target="utilities.pytest_utils.py_config", new={})
     def test_removes_ocs_tests_when_marker_does_not_include_ocs(self):
         """OCS tests are filtered out when -m is set but does not contain 'ocs'."""
         item_ocs = MagicMock()
@@ -2844,7 +2844,7 @@ class TestFilterOcsTests:
         assert result == [item_other]
         config.hook.pytest_deselected.assert_called_once_with(items=[item_ocs])
 
-    @patch("utilities.pytest_utils.py_config", {})
+    @patch(target="utilities.pytest_utils.py_config", new={})
     def test_keeps_ocs_tests_when_marker_includes_ocs(self):
         """All tests are kept when -m includes 'ocs'."""
         item_ocs = MagicMock()
@@ -2860,7 +2860,7 @@ class TestFilterOcsTests:
         assert result == items
         config.hook.pytest_deselected.assert_not_called()
 
-    @patch("utilities.pytest_utils.py_config", {})
+    @patch(target="utilities.pytest_utils.py_config", new={})
     def test_keeps_ocs_tests_when_marker_contains_ocs_in_expression(self):
         """All tests are kept when -m contains 'ocs' as part of a larger expression."""
         item_ocs = MagicMock()
@@ -2874,7 +2874,7 @@ class TestFilterOcsTests:
         assert result == items
         config.hook.pytest_deselected.assert_not_called()
 
-    @patch("utilities.pytest_utils.py_config", {})
+    @patch(target="utilities.pytest_utils.py_config", new={})
     def test_empty_marker_expression_filters_ocs(self):
         """OCS tests are filtered out when -m is an empty string and OCS storage class is absent."""
         item_ocs = MagicMock()
@@ -2887,7 +2887,7 @@ class TestFilterOcsTests:
         assert result == []
         config.hook.pytest_deselected.assert_called_once_with(items=[item_ocs])
 
-    @patch("utilities.pytest_utils.py_config", {"storage_class_matrix": [{OCS_STORAGE_CLASS: {}}]})
+    @patch(target="utilities.pytest_utils.py_config", new={"storage_class_matrix": [{OCS_STORAGE_CLASS: {}}]})
     def test_keeps_ocs_tests_when_ocs_storage_class_in_matrix(self):
         """All tests are kept when the OCS storage class is in the matrix, even without -m ocs."""
         item_ocs = MagicMock()

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -32,6 +32,7 @@ from utilities.pytest_utils import (
     exit_pytest_execution,
     filter_hpp_tests,
     filter_multiarch_tests,
+    filter_ocs_tests,
     generate_common_template_matrix_dicts,
     generate_instance_type_matrix_dicts,
     get_artifactory_server_url,
@@ -41,6 +42,7 @@ from utilities.pytest_utils import (
     get_matrix_params,
     get_tests_cluster_markers,
     mark_nmstate_dependent_tests,
+    ocs_storage_class_in_matrix,
     remove_tests_from_list,
     reorder_early_fixtures,
     run_in_progress_config_map,
@@ -2785,6 +2787,121 @@ class TestFilterHppTests:
 
         assert result == []
         config.hook.pytest_deselected.assert_called_once_with(items=[item_hpp])
+
+
+OCS_STORAGE_CLASS = "ocs-storagecluster-ceph-rbd-virtualization"
+
+
+class TestOcsStorageClassInMatrix:
+    """Test cases for ocs_storage_class_in_matrix function."""
+
+    @patch("utilities.pytest_utils.py_config", {"storage_class_matrix": [{OCS_STORAGE_CLASS: {}}]})
+    def test_true_when_ocs_storage_class_in_matrix(self):
+        """Returns True when the OCS storage class is in the storage class matrix."""
+        assert ocs_storage_class_in_matrix() is True
+
+    @patch("utilities.pytest_utils.py_config", {"storage_class_matrix": [{"some-other-sc": {}}]})
+    def test_false_when_ocs_storage_class_not_in_matrix(self):
+        """Returns False when the OCS storage class is not in the storage class matrix."""
+        assert ocs_storage_class_in_matrix() is False
+
+    @patch("utilities.pytest_utils.py_config", {})
+    def test_false_when_matrix_missing(self):
+        """Returns False when the storage class matrix is not configured."""
+        assert ocs_storage_class_in_matrix() is False
+
+
+class TestFilterOcsTests:
+    """Test cases for filter_ocs_tests function."""
+
+    @patch("utilities.pytest_utils.py_config", {})
+    def test_removes_ocs_tests_when_no_marker_expression(self):
+        """OCS tests are filtered out when no -m option is set and OCS storage class is absent."""
+        item_ocs = MagicMock()
+        item_ocs.keywords = {"ocs": True}
+        item_other = MagicMock()
+        item_other.keywords = {"storage": True}
+        config = MagicMock()
+        config.getoption.return_value = None
+
+        result = filter_ocs_tests(items=[item_ocs, item_other], config=config)
+
+        assert result == [item_other]
+        config.hook.pytest_deselected.assert_called_once_with(items=[item_ocs])
+
+    @patch("utilities.pytest_utils.py_config", {})
+    def test_removes_ocs_tests_when_marker_does_not_include_ocs(self):
+        """OCS tests are filtered out when -m is set but does not contain 'ocs'."""
+        item_ocs = MagicMock()
+        item_ocs.keywords = {"ocs": True}
+        item_other = MagicMock()
+        item_other.keywords = {"storage": True}
+        config = MagicMock()
+        config.getoption.return_value = "smoke"
+
+        result = filter_ocs_tests(items=[item_ocs, item_other], config=config)
+
+        assert result == [item_other]
+        config.hook.pytest_deselected.assert_called_once_with(items=[item_ocs])
+
+    @patch("utilities.pytest_utils.py_config", {})
+    def test_keeps_ocs_tests_when_marker_includes_ocs(self):
+        """All tests are kept when -m includes 'ocs'."""
+        item_ocs = MagicMock()
+        item_ocs.keywords = {"ocs": True}
+        item_other = MagicMock()
+        item_other.keywords = {"storage": True}
+        items = [item_ocs, item_other]
+        config = MagicMock()
+        config.getoption.return_value = "ocs"
+
+        result = filter_ocs_tests(items=items, config=config)
+
+        assert result == items
+        config.hook.pytest_deselected.assert_not_called()
+
+    @patch("utilities.pytest_utils.py_config", {})
+    def test_keeps_ocs_tests_when_marker_contains_ocs_in_expression(self):
+        """All tests are kept when -m contains 'ocs' as part of a larger expression."""
+        item_ocs = MagicMock()
+        item_ocs.keywords = {"ocs": True}
+        items = [item_ocs]
+        config = MagicMock()
+        config.getoption.return_value = "ocs and storage"
+
+        result = filter_ocs_tests(items=items, config=config)
+
+        assert result == items
+        config.hook.pytest_deselected.assert_not_called()
+
+    @patch("utilities.pytest_utils.py_config", {})
+    def test_empty_marker_expression_filters_ocs(self):
+        """OCS tests are filtered out when -m is an empty string and OCS storage class is absent."""
+        item_ocs = MagicMock()
+        item_ocs.keywords = {"ocs": True}
+        config = MagicMock()
+        config.getoption.return_value = ""
+
+        result = filter_ocs_tests(items=[item_ocs], config=config)
+
+        assert result == []
+        config.hook.pytest_deselected.assert_called_once_with(items=[item_ocs])
+
+    @patch("utilities.pytest_utils.py_config", {"storage_class_matrix": [{OCS_STORAGE_CLASS: {}}]})
+    def test_keeps_ocs_tests_when_ocs_storage_class_in_matrix(self):
+        """All tests are kept when the OCS storage class is in the matrix, even without -m ocs."""
+        item_ocs = MagicMock()
+        item_ocs.keywords = {"ocs": True}
+        item_other = MagicMock()
+        item_other.keywords = {"storage": True}
+        items = [item_ocs, item_other]
+        config = MagicMock()
+        config.getoption.return_value = None
+
+        result = filter_ocs_tests(items=items, config=config)
+
+        assert result == items
+        config.hook.pytest_deselected.assert_not_called()
 
 
 class TestFilterMultiarchTests:


### PR DESCRIPTION
##### What this PR does / why we need it:
Replace the `skip_if_no_ocs_rbd_non_virt_sc` fixture with an ocs marker that is deselected deterministically at collection time.

OCS tests are auto-selected when the OCS storage class (ocs-storagecluster-ceph-rbd-virtualization) is present in py_config["storage_class_matrix"] (via --storage-class-matrix), or when -m ocs is passed explicitly.

- Register ocs marker in pytest.ini
- Add ocs_storage_class_in_matrix() and filter_ocs_tests() in pytest_utils
- Wire filter_ocs_tests() into pytest_collection_modifyitems
- Mark test_ocs_rbd_non_virt_vm_exist with @pytest.mark.ocs
- Remove skip_if_no_ocs_rbd_non_virt_sc fixture
- Add unit tests for the new functions

Assisted-by: Claude <noreply@anthropic.com>

##### Which issue(s) this PR fixes:
Jira: https://redhat.atlassian.net/browse/CNV-92159

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying and filtering OCS-specific tests based on the configured storage classes.
  * Added an `ocs` test marker for explicitly selecting OCS tests.

* **Bug Fixes**
  * Prevented OCS tests from running when the required OCS storage configuration is unavailable, while allowing explicit selection.

* **Tests**
  * Added coverage for OCS storage detection, test filtering, and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->