### PR TITLE
WIP: net, tests, udn: Prevent UDN fixture teardown from racing self-deletion

### DIFF
--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import NotFoundError
 from ocp_resources.pod import Pod
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
@@ -33,19 +34,28 @@ def udn_namespace(admin_client):
 
 @pytest.fixture(scope="module")
 def namespaced_layer2_user_defined_network(admin_client, udn_namespace):
-    with Layer2UserDefinedNetwork(
+    udn = Layer2UserDefinedNetwork(
         name="layer2-udn",
         namespace=udn_namespace.name,
         role="Primary",
         subnets=[str(random_ipv4_address(net_seed=0, host_address=0))],
         ipam={"lifecycle": "Persistent"},
         client=admin_client,
-    ) as udn:
+    )
+    try:
+        udn.deploy()
         udn.wait_for_condition(
             condition="NetworkAllocationSucceeded",
             status=udn.Condition.Status.TRUE,
         )
         yield udn
+    finally:
+        # In case an attempt to delete the UDN is triggered while a VM/pod is connected to it, the UDN adds finalizers and
+        # self-deletes once that resource is gone. This can lead to a race condition in clean_up().
+        try:
+            udn.clean_up()
+        except NotFoundError:
+            pass
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### What this PR does / why we need it:
The primary-UDN deletion-protection test (CNV-11451) deletes the module-scoped UDN
while a VM is still connected. That deletion is intentionally held by a
finalizer and only completes on its own once the connected VM is torn down.
During module teardown, after the VM is deleted, the UDN resource continues its
own deletion (the finalizer clears). Afterwards, the shared UDN fixture issues its
own deletion of the same resource, racing the one already in flight. This produces
flaky teardown failures.

This PR makes the UDN fixture teardown tolerant of that in-flight self-deletion.

##### Which issue(s) this PR fixes:
Flaky teardown failures of the UDN fixture.

##### Special notes for reviewer:
- The fixture must still delete the UDN itself on runs where the
  deletion-protection test does not execute, otherwise
  the resource would leak - both paths are preserved intentionally.

##### jira-ticket:
None