### PR TITLE
Quarantine: test_hco_overriding_apiserver_crypto_policy (CNV-95835)

### DIFF
--- a/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_hco_override_api_server_crypto_policy.py
@@ -12,6 +12,7 @@ from tests.install_upgrade_operators.crypto_policy.utils import (
     set_hco_crypto_policy,
     update_apiserver_crypto_policy,
 )
+from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import (
     TIMEOUT_2MIN,
     TIMEOUT_10SEC,
@@ -54,6 +55,10 @@ def updated_apiserver_with_tls_old_profile(
         yield
 
 
+@pytest.mark.xfail(
+    reason=f"{QUARANTINED}: CNV-91966 — crypto-policy teardown leaves cluster unhealthy on bare metal, CNV-95835",
+    run=False,
+)
 @pytest.mark.jira("RHSTOR-6566", run=False)  # <skip-jira-utils-check>
 @pytest.mark.polarion("CNV-9368")
 def test_hco_overriding_apiserver_crypto_policy(


### PR DESCRIPTION
##### What this PR does / why we need it:
Quarantine test due to reproducible cluster_sanity/teardown failure after APIServer TLS profile revert on bare metal. The test passes but fixture teardown leaves infra nodes unreachable/unschedulable. Root cause investigation in CNV-91966.

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Quarantined the API server crypto-policy override test due to a known issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->