### PR TITLE
[Manual Cherry Pick][cnv-4.22][Storage] Fix Validation OS images RBAC issue for Windows tests (#6045)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ from utilities.constants import (
     NODE_TYPE_WORKER_LABEL,
     OC_ADM_LOGS_COMMAND,
     OS_FLAVOR_RHEL,
+    OS_IMAGES_EDIT_CLUSTER_ROLE,
     OVS_BRIDGE,
     POD_SECURITY_NAMESPACE_LABELS,
     PREFERENCE_STR,
@@ -1099,7 +1100,7 @@ def golden_images_cluster_role_edit(
     admin_client,
 ):
     for cluster_role in ClusterRole.get(
-        name="os-images.kubevirt.io:edit",
+        name=OS_IMAGES_EDIT_CLUSTER_ROLE,
         client=admin_client,
     ):
         return cluster_role

--- a/tests/fixtures/images/validation_os_images.py
+++ b/tests/fixtures/images/validation_os_images.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.data_source import DataSource
@@ -13,9 +15,19 @@ from utilities.artifactory import (
     get_artifactory_secret,
     get_test_artifact_server_url,
 )
-from utilities.constants import BIND_IMMEDIATE_ANNOTATION, REGISTRY_STR, TIMEOUT_10MIN, TIMEOUT_50MIN, WIN_2K22, Images
+from utilities.constants import (
+    BIND_IMMEDIATE_ANNOTATION,
+    OS_IMAGES_EDIT_CLUSTER_ROLE,
+    REGISTRY_STR,
+    TIMEOUT_10MIN,
+    TIMEOUT_50MIN,
+    WIN_2K22,
+    Images,
+)
 from utilities.os_utils import get_windows_container_disk_path
 from utilities.storage import construct_datavolume_source_dict, generate_data_source_dict
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
@@ -33,7 +45,11 @@ def validation_os_images_namespace(admin_client):
 
 @pytest.fixture(scope="session")
 def validation_os_images_role_binding(admin_client, validation_os_images_namespace):
-    """Grants view permissions in the namespace so unprivileged clients can clone from it."""
+    """Grants unprivileged clients the same clone permissions as the golden-images namespace.
+
+    Binds the built-in ``os-images.kubevirt.io:edit`` ClusterRole to ``system:authenticated`` in the
+    validation-os-images namespace so cross-namespace clones from this namespace succeed.
+    """
     role_binding = RoleBinding(
         client=admin_client,
         name="validation-os-images-view",
@@ -41,7 +57,7 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
         subjects_kind="Group",
         subjects_name="system:authenticated",
         role_ref_kind=ClusterRole.kind,
-        role_ref_name="view",
+        role_ref_name=OS_IMAGES_EDIT_CLUSTER_ROLE,
     )
 
     if role_binding.exists:
@@ -56,12 +72,16 @@ def validation_os_images_role_binding(admin_client, validation_os_images_namespa
         assert role_ref.kind == ClusterRole.kind, (
             f"RoleBinding {role_binding.name} roleRef kind is {role_ref.kind}, expected {ClusterRole.kind}"
         )
-        assert role_ref.name == "view", (
-            f"RoleBinding {role_binding.name} roleRef name is {role_ref.name}, expected view"
+        assert role_ref.name == OS_IMAGES_EDIT_CLUSTER_ROLE, (
+            f"RoleBinding {role_binding.name} roleRef name is {role_ref.name}, expected {OS_IMAGES_EDIT_CLUSTER_ROLE}"
         )
         yield role_binding
         return
 
+    LOGGER.info(
+        f"Creating RoleBinding {role_binding.name} in {role_binding.namespace} "
+        f"binding {OS_IMAGES_EDIT_CLUSTER_ROLE} to system:authenticated"
+    )
     with role_binding as rb:
         yield rb
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -813,6 +813,8 @@ CREATE_STR = "create"
 DELETE_STR = "delete"
 WILDCARD_CRON_EXPRESSION = "* * * * *"
 OUTDATED = "Outdated"
+# Built-in CNV ClusterRole granting create/clone permissions in an OS-images namespace
+OS_IMAGES_EDIT_CLUSTER_ROLE = "os-images.kubevirt.io:edit"
 
 RHEL_WITH_INSTANCETYPE_AND_PREFERENCE = "rhel-with-instancetype-and-preference"
 CENTOS_STREAM9_PREFERENCE = "centos.stream9"


### PR DESCRIPTION
Manual cherry-pick: https://github.com/RedHatQE/openshift-virtualization-tests/pull/6045

There's a problem with RBAC role on HPP lane for Tier3 test, link below. It seems like cloning permission from `validation-os-images` namespace needs to be different from OCS where it works just fine.

Probably caused by
https://github.com/kubevirt/containerized-data-importer/pull/4219

https://redhat.atlassian.net/browse/CNV-95483

Co-Authored: Sonnet 5 <noreply@anthropic.com>

This is Manual Cherry pick from changes merged in main.

<!-- full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged If the task is not tracked by a Jira ticket, just write "NONE". -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

* **Bug Fixes**
  * Improved validation of permissions used by OS image workflows.
* Updated role binding checks to ensure authenticated access receives the intended image-editing permissions.
* Improved diagnostic logging when permissions are configured, making configuration issues easier to identify.
* Standardized references to the built-in OS image editing role across image-related validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
