### PR TITLE
net, tests, udn: Verify VM connectivity via ClusterIP service on P-UDN

### DIFF
--- a/tests/network/libs/connectivity.py
+++ b/tests/network/libs/connectivity.py
@@ -40,6 +40,7 @@ def poll_tcp_connectivity(
     server_ip: str,
     client_bind_dev: str | None = None,
     server_bind_dev: str | None = None,
+    client_target_ip: str | None = None,
     expect_connectivity: bool = True,
 ) -> bool:
     """Poll TCP connectivity (or its absence) between two VMs, retrying until the expected state is reached.
@@ -52,6 +53,9 @@ def poll_tcp_connectivity(
             Bypasses ECMP routing when both secondary interfaces share the same subnet.
         server_bind_dev: Guest network device name to force the server responses out (e.g. "eth1").
             Bypasses ECMP routing on the server VM when it has multiple secondary interfaces.
+        client_target_ip: IP address the client connects to. Set this to reach the server through
+            an intermediary address (e.g. a ClusterIP service VIP) while the server still binds to
+            its own IP.
         expect_connectivity: When True polls until connectivity exists; when False polls until it does not.
 
     Returns:
@@ -60,7 +64,10 @@ def poll_tcp_connectivity(
     try:
         with TcpServer(vm=server_vm, port=IPERF_SERVER_PORT, bind_ip=server_ip, bind_dev=server_bind_dev):
             with VMTcpClient(
-                vm=client_vm, server_ip=server_ip, server_port=IPERF_SERVER_PORT, bind_dev=client_bind_dev
+                vm=client_vm,
+                server_ip=server_ip if client_target_ip is None else client_target_ip,
+                server_port=IPERF_SERVER_PORT,
+                bind_dev=client_bind_dev,
             ):
                 reachable = True
     except TimeoutExpiredError:

--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.pod import Pod
+from ocp_resources.service import Service
 from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
 from libs.net.ip import random_ipv4_address
@@ -167,3 +168,18 @@ def udn_pod(
     ) as pod:
         pod.wait_for_status(status=Pod.Status.RUNNING)
         yield pod
+
+
+@pytest.fixture()
+def clusterip_service_for_vmb_udn(
+    admin_client: DynamicClient, udn_namespace: Namespace, vmb_udn: BaseVirtualMachine
+) -> Generator[Service]:
+    """A ClusterIP service targeting the primary-UDN server VM."""
+    with Service(
+        name="udn-clusterip-svc",
+        namespace=udn_namespace.name,
+        selector={"vmi.kubevirt.io/id": vmb_udn.name},
+        ports=[{"port": IPERF_SERVER_PORT}],
+        client=admin_client,
+    ) as svc:
+        yield svc

--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -53,7 +53,7 @@ def udn_affinity_label():
     return affinity.new_label(key_prefix="udn")
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
     with udn_vm(
         namespace_name=udn_namespace.name,
@@ -67,7 +67,7 @@ def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_
         yield vm
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="module")
 def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
     with udn_vm(
         namespace_name=udn_namespace.name,

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -2,7 +2,7 @@
 Tests for virtual machines connected to a primary user-defined network (UDN).
 
 Preconditions:
-    - UDN namespace (with UDN annotation).
+    - UDN namespace (with UDN label).
     - Primary UDN resource with an IP range defined.
 """
 
@@ -16,6 +16,7 @@ from ocp_resources.utils.constants import TIMEOUT_1MINUTE
 
 from libs.net.traffic_generator import is_tcp_connection
 from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
+from tests.network.libs.connectivity import poll_tcp_connectivity
 from tests.network.user_defined_network.libudn import lookup_default_pod_ip
 from utilities.constants.networking import PUBLIC_DNS_SERVER_IP
 from utilities.constants.pytest import QUARANTINED
@@ -24,6 +25,7 @@ from utilities.virt import migrate_vm_and_verify
 
 if TYPE_CHECKING:
     from kubernetes.dynamic import DynamicClient
+    from ocp_resources.service import Service
     from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 
     from libs.net.traffic_generator import TcpServer, VMTcpClient
@@ -42,11 +44,16 @@ class TestPrimaryUdnClusterIpService:
     """
 
     @pytest.mark.polarion("CNV-11462")
-    def test_tcp_connectivity_via_cluster_ip_service_on_primary_udn(self):
+    def test_tcp_connectivity_via_cluster_ip_service_on_primary_udn(
+        self,
+        vma_udn: BaseVirtualMachine,
+        vmb_udn: BaseVirtualMachine,
+        clusterip_service_for_vmb_udn: Service,
+    ):
         """
         Test that a VM's primary UDN interface is reachable through a ClusterIP service.
 
-        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-52879 # <skip-jira-utils-check>
 
         Preconditions:
             - Running server VM attached to the primary UDN network.
@@ -60,8 +67,15 @@ class TestPrimaryUdnClusterIpService:
         Expected:
             - The TCP connection to the server VM through the ClusterIP service succeeds.
         """
-
-    test_tcp_connectivity_via_cluster_ip_service_on_primary_udn.__test__ = False
+        server_ip = str(
+            lookup_iface_status_ip(vm=vmb_udn, iface_name=lookup_primary_network(vm=vmb_udn).name, ip_family=4)
+        )
+        poll_tcp_connectivity(
+            client_vm=vma_udn,
+            server_vm=vmb_udn,
+            server_ip=server_ip,
+            client_target_ip=clusterip_service_for_vmb_udn.instance.spec.clusterIP,
+        )
 
 
 @pytest.mark.ipv4

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -1,3 +1,11 @@
+"""
+Tests for virtual machines connected to a primary user-defined network (UDN).
+
+Preconditions:
+    - UDN namespace (with UDN annotation).
+    - Primary UDN resource with an IP range defined.
+"""
+
 from __future__ import annotations
 
 import ipaddress
@@ -23,6 +31,40 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.ipv4
+@pytest.mark.single_nic
+class TestPrimaryUdnClusterIpService:
+    """
+    Tests for reaching a VM on a primary user-defined network (UDN) through a ClusterIP service.
+
+    Preconditions:
+        - Running server VM attached to the primary UDN network.
+        - Running client VM attached to the same primary UDN network.
+    """
+
+    @pytest.mark.polarion("CNV-11462")
+    def test_tcp_connectivity_via_cluster_ip_service_on_primary_udn(self):
+        """
+        Test that a VM's primary UDN interface is reachable through a ClusterIP service.
+
+        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
+
+        Preconditions:
+            - Running server VM attached to the primary UDN network.
+            - ClusterIP service targeting the server VM primary UDN interface.
+            - Running client VM attached to the same primary UDN network.
+
+        Steps:
+            1. Start a TCP server on the server VM.
+            2. Establish a TCP connection from the client VM to the ClusterIP service address.
+
+        Expected:
+            - The TCP connection to the server VM through the ClusterIP service succeeds.
+        """
+
+    test_tcp_connectivity_via_cluster_ip_service_on_primary_udn.__test__ = False
+
+
+@pytest.mark.ipv4
 @pytest.mark.s390x
 @pytest.mark.single_nic
 class TestPrimaryUdn:
@@ -30,8 +72,6 @@ class TestPrimaryUdn:
     Tests for a VM connected to a primary user-defined network (UDN).
 
     Preconditions:
-        - UDN namespace (with UDN annotation).
-        - Primary UDN resource with an IP range defined.
         - Running under-test VM attached to the primary UDN network.
     """
 
@@ -112,28 +152,6 @@ class TestPrimaryUdn:
         """
         pod_ip = lookup_default_pod_ip(pod=udn_pod)
         vma_udn.console(commands=[f"ping -c 3 {pod_ip}"], timeout=TIMEOUT_1MIN)
-
-    @pytest.mark.polarion("CNV-11462")
-    def test_tcp_connectivity_via_cluster_ip_service_on_primary_udn(self):
-        """
-        Test that a VM's primary UDN interface is reachable through a ClusterIP service.
-
-        No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
-
-        Preconditions:
-            - Running server VM attached to the primary UDN network.
-            - ClusterIP service targeting the server VM primary UDN interface.
-            - Running client VM attached to the same primary UDN network.
-
-        Steps:
-            1. Start a TCP server on the server VM.
-            2. Establish a TCP connection from the client VM to the ClusterIP service address.
-
-        Expected:
-            - The TCP connection to the server VM through the ClusterIP service succeeds.
-        """
-
-    test_tcp_connectivity_via_cluster_ip_service_on_primary_udn.__test__ = False
 
     @pytest.mark.polarion("CNV-11435")
     def test_network_policy_enforcement_on_primary_udn_interface(self):


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds coverage for reaching a virtual machine on a primary user-defined
network (UDN) through a ClusterIP service. This validates that
service traffic is correctly directed into a UDN backend.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
The scenario runs in its own test class, on shared VMs. The migration tests in the other class keep a single TCP connection open for the whole class. The ClusterIP test should be tested on a clean connection, so it has to run outside that window. The connection's lifetime is tied to the class-scoped server/client fixtures, not to the VMs, so sharing the VMs is safe.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-52879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for TCP connectivity through a ClusterIP service on the primary user-defined network.
  - Enabled validation that one virtual machine can reach another through its assigned service IP.
  - Expanded connectivity checks to support connections through an address different from the server’s bound IP.
  - Improved test setup efficiency by reusing virtual machine fixtures across related tests.
  - Added validation for service-based connectivity through the service endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->