### PR TITLE
CNV-91916:[CNV-4.22] Starlette: request.form() limits silently ignored for application/x-www-form-urlencoded enable DoS

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2285,14 +2285,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
##### What this PR does / why we need it:
  Since the project is using the `starlette` package as a transitive dependency(openshift-python-wrapper → fastmcp → mcp → starlette), it is affected byCVE-2026-54283 (GHSA-82w8-qh3p-5jfq). This vulnerability allows Denial of Service unbounded resource allocation in `request.form()` for URL-encoded requests (CVSS 7.5). This PR bumps starlette to >= 1.3.1 which
contains the fix.

##### Which issue(s) this PR fixes:
CVE-2026-54283 — starlette `request.form()` silently ignores configured limits (max_fields, max_part_size) for application/x-www-form-urlencoded requests, allowing field count and field size attacks.

##### Special notes for reviewer:
The dependency is transitive (4 levels deep) and only the lock file needs updating. No direct code changes are required. Practical risk is low since this is a test framework, but bumping resolves the vulnerability in dependency scanners.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-91916