### PR TITLE
net, tests, mnp: Quarantine negative ingress multi-network-policy test

### DIFF
--- a/tests/network/flat_overlay/test_multi_network_policy.py
+++ b/tests/network/flat_overlay/test_multi_network_policy.py
@@ -27,6 +27,7 @@ def test_positive_egress_multi_network_policy(
     )
 
 
+@pytest.mark.jira("CNV-88747", run=False)
 @pytest.mark.polarion("CNV-10645")
 @pytest.mark.s390x
 def test_negative_ingress_multi_network_policy(


### PR DESCRIPTION
##### What this PR does / why we need it:
Quarantine _test_negative_ingress_multi_network_policy_ due to a product bug.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
Bug: https://redhat.atlassian.net/browse/CNV-88747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a skipped Jira marker for `CNV-88747` to the negative ingress multi-network policy test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->