### PR TITLE
infra: Add client to missing objects

### DIFF
--- a/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
+++ b/tests/infrastructure/golden_images/test_common_templates_data_volumes.py
@@ -25,7 +25,7 @@ def vm_from_golden_image_multi_storage(
         name="vm-from-golden-image",
         namespace=namespace.name,
         client=unprivileged_client,
-        vm_instance_type=VirtualMachineClusterInstancetype(name=U1_SMALL),
+        vm_instance_type=VirtualMachineClusterInstancetype(client=unprivileged_client, name=U1_SMALL),
         data_volume_template=data_volume_template_with_source_ref_dict(
             data_source=golden_image_data_source_multi_storage_scope_function,
             storage_class=storage_class_name_scope_function,

--- a/tests/infrastructure/golden_images/update_boot_source/conftest.py
+++ b/tests/infrastructure/golden_images/update_boot_source/conftest.py
@@ -271,6 +271,7 @@ def created_data_import_cron(
     with DataImportCron(
         name="data-import-cron-for-test",
         namespace=data_import_cron_namespace.name,
+        client=unprivileged_client,
         managed_data_source=golden_images_data_import_cron_spec.managedDataSource,
         schedule=golden_images_data_import_cron_spec.schedule,
         annotations=BIND_IMMEDIATE_ANNOTATION,

--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_import_crons.py
@@ -278,7 +278,9 @@ class TestDataSourceVmCreation:
                     vm_instance_type_infer=True,
                     vm_preference_infer=True,
                     data_volume_template=data_volume_template_with_source_ref_dict(
-                        data_source=DataSource(name=data_source_name, namespace=golden_images_namespace.name)
+                        data_source=DataSource(
+                            client=unprivileged_client, name=data_source_name, namespace=golden_images_namespace.name
+                        )
                     ),
                 ):
                     pass


### PR DESCRIPTION
##### What this PR does / why we need it:
Add client to:
 - `DataImportCron` in `created_data_import_cron`
 - `DataSource` in `test_all_datasources_support_vm_creation`
 - `VirtualMachineClusterInstancetype` in `vm_from_golden_image_multi_storage`

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-68529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved golden-image and data-import testing with unprivileged access checks.
  * Updated VM and data-source scenarios to use the appropriate client context.
  * Enhanced coverage for data import cron and multi-storage workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->