### PR TITLE
fix(coderabbit): correct unresolve false-positive and retry log noise

### DIFF
--- a/.github/workflows/unresolve-coderabbit-threads.yml
+++ b/.github/workflows/unresolve-coderabbit-threads.yml
@@ -49,23 +49,26 @@ jobs:
             thread_id=$(echo "$thread_data" | jq -r '.id')
 
             # Check if the opening comment is from CodeRabbit — if not, skip
-            local opener_login opener_type
+            local opener_login opener_type opener_id
             opener_login=$(echo "$thread_data" | jq -r '.opening_comment.nodes[0].author.login // ""')
             opener_type=$(echo "$thread_data" | jq -r '.opening_comment.nodes[0].author.__typename // ""')
+            opener_id=$(echo "$thread_data" | jq -r '.opening_comment.nodes[0].id // ""')
             if [ "$opener_login" != "$BOT_LOGIN" ] || [ "$opener_type" != "$BOT_TYPE" ]; then
               echo "Thread $thread_id not opened by CodeRabbit (opener: $opener_login, type: $opener_type). Skipping."
               return
             fi
 
-            # Check for a substantive reply from PR author (>= 15 chars) or CodeRabbit verification
+            # Check for a substantive reply from PR author (>= 15 chars) or CodeRabbit verification.
+            # The opening comment is excluded so CodeRabbit's original finding text (which may itself
+            # contain words like "addressed"/"resolved") is never mistaken for a verification reply.
             local has_response
-            has_response=$(echo "$thread_data" | jq -r --arg pr_author "$PR_AUTHOR" --arg bot_login "$BOT_LOGIN" --arg bot_type "$BOT_TYPE" '
-              any(.recent_comments.nodes[];
+            has_response=$(echo "$thread_data" | jq -r --arg pr_author "$PR_AUTHOR" --arg bot_login "$BOT_LOGIN" --arg bot_type "$BOT_TYPE" --arg opener_id "$opener_id" '
+              any(.recent_comments.nodes[] | select(.id != $opener_id);
                 (
                   # PR author posted a substantive reply (>= 15 chars)
                   (.author.login == $pr_author and ((.body // "") | length) >= 15)
                   or
-                  # CodeRabbit verified the fix
+                  # CodeRabbit verified the fix in a reply (not the original finding)
                   (.author.login == $bot_login and .author.__typename == $bot_type and ((.body // "") | test("\\b(addressed|verified|resolved)\\b|✅|concern is fully"; "i")))
                 )
               )
@@ -121,6 +124,7 @@ jobs:
                         isResolved
                         opening_comment: comments(first: 1) {
                           nodes {
+                            id
                             author {
                               login
                               __typename
@@ -129,6 +133,7 @@ jobs:
                         }
                         recent_comments: comments(last: 5) {
                           nodes {
+                            id
                             author {
                               login
                               __typename

--- a/scripts/coderabbit_retry/coderabbit_retry.py
+++ b/scripts/coderabbit_retry/coderabbit_retry.py
@@ -150,7 +150,20 @@ def check_rate_limit(repo_name: str, pr_number: int) -> dict[str, Any] | None:
         return None
 
     if result.returncode != 0:
-        LOGGER.warning(f"PR #{pr_number}: rate-limit check exited {result.returncode}: {result.stderr.strip()}")
+        stderr = result.stderr.strip()
+        stdout = result.stdout.strip()
+        # A missing CodeRabbit summary comment is a normal, expected state (CodeRabbit
+        # has not engaged with the PR yet) — there is nothing to retry. The CLI emits
+        # this message on stdout, so check both streams. Whitespace is collapsed before
+        # matching so the phrase is still detected if it spans a stream boundary, and
+        # the match is case-insensitive so minor upstream wording/casing drift does not
+        # resurrect the false alarm. Logged at INFO so it is not a false-alarm warning.
+        combined_output = " ".join(f"{stdout} {stderr}".casefold().split())
+        if "no coderabbit summary comment found" in combined_output:
+            LOGGER.info(f"PR #{pr_number}: no CodeRabbit summary comment — skipping")
+        else:
+            detail = " | ".join(stream for stream in (stdout, stderr) if stream) or "(no output)"
+            LOGGER.warning(f"PR #{pr_number}: rate-limit check exited {result.returncode}: {detail}")
         return None
 
     try:

--- a/scripts/coderabbit_retry/tests/test_coderabbit_retry.py
+++ b/scripts/coderabbit_retry/tests/test_coderabbit_retry.py
@@ -113,6 +113,58 @@ class TestCheckRateLimit:
         mock_run.return_value = make_completed_process(returncode=1, stderr="error")
         assert check_rate_limit(repo_name=REPO, pr_number=PR_NUMBER) is None
 
+    @patch("scripts.coderabbit_retry.coderabbit_retry.LOGGER")
+    @patch(SUBPROCESS_PATH)
+    def test_benign_missing_summary_logs_info_not_warning(self, mock_run: MagicMock, mock_logger: MagicMock) -> None:
+        mock_run.return_value = make_completed_process(
+            returncode=1, stdout="Error: No CodeRabbit summary comment found on this PR", stderr=""
+        )
+        assert check_rate_limit(repo_name=REPO, pr_number=PR_NUMBER) is None
+        mock_logger.info.assert_called_once()
+        mock_logger.warning.assert_not_called()
+
+    @patch("scripts.coderabbit_retry.coderabbit_retry.LOGGER")
+    @patch(SUBPROCESS_PATH)
+    def test_benign_missing_summary_on_stderr_also_handled(self, mock_run: MagicMock, mock_logger: MagicMock) -> None:
+        mock_run.return_value = make_completed_process(
+            returncode=1, stdout="", stderr="Error: No CodeRabbit summary comment found on this PR"
+        )
+        assert check_rate_limit(repo_name=REPO, pr_number=PR_NUMBER) is None
+        mock_logger.info.assert_called_once()
+        mock_logger.warning.assert_not_called()
+
+    @patch("scripts.coderabbit_retry.coderabbit_retry.LOGGER")
+    @patch(SUBPROCESS_PATH)
+    def test_genuine_error_logs_warning(self, mock_run: MagicMock, mock_logger: MagicMock) -> None:
+        mock_run.return_value = make_completed_process(returncode=1, stderr="some other real error")
+        assert check_rate_limit(repo_name=REPO, pr_number=PR_NUMBER) is None
+        mock_logger.warning.assert_called_once()
+        mock_logger.info.assert_not_called()
+
+    @patch("scripts.coderabbit_retry.coderabbit_retry.LOGGER")
+    @patch(SUBPROCESS_PATH)
+    def test_genuine_error_includes_both_streams(self, mock_run: MagicMock, mock_logger: MagicMock) -> None:
+        mock_run.return_value = make_completed_process(returncode=1, stdout="stdout detail", stderr="stderr detail")
+        assert check_rate_limit(repo_name=REPO, pr_number=PR_NUMBER) is None
+        mock_logger.warning.assert_called_once()
+        logged_message = mock_logger.warning.call_args.args[0]
+        assert "stdout detail" in logged_message
+        assert "stderr detail" in logged_message
+
+    @patch("scripts.coderabbit_retry.coderabbit_retry.LOGGER")
+    @patch(SUBPROCESS_PATH)
+    def test_benign_missing_summary_split_across_streams(self, mock_run: MagicMock, mock_logger: MagicMock) -> None:
+        # The benign phrase is split across stdout and stderr; whitespace
+        # normalization must still detect it and log INFO, not WARNING.
+        mock_run.return_value = make_completed_process(
+            returncode=1,
+            stdout="Error: No CodeRabbit summary",
+            stderr="comment found on this PR",
+        )
+        assert check_rate_limit(repo_name=REPO, pr_number=PR_NUMBER) is None
+        mock_logger.info.assert_called_once()
+        mock_logger.warning.assert_not_called()
+
     @patch(SUBPROCESS_PATH)
     def test_returns_none_on_invalid_json(self, mock_run: MagicMock) -> None:
         mock_run.return_value = make_completed_process(stdout="not json")


### PR DESCRIPTION
##### What this PR does / why we need it:

Two fixes to the CodeRabbit review-automation workflows, both found while auditing why they were not behaving as expected:

1. **`unresolve-coderabbit-threads.yml` — false positive that defeated the workflow's purpose.** The `has_response` jq check scanned `recent_comments(last: 5)`, which *includes CodeRabbit's own opening finding comment*. When the finding text itself contained words like "addressed", "verified", or "resolved" (very common), the check false-positived and **wrongly kept an unaddressed thread resolved** — exactly the case this workflow exists to catch. Fix: fetch each comment's node `id` and exclude the opening comment from the verification scan, so only genuine *replies* count as verification. Verified with synthetic thread payloads: the CodeRabbit-finding-text case now correctly unresolves, while genuine author replies and genuine CodeRabbit verification replies are still kept resolved.

2. **`coderabbit_retry.py` — false-alarm warning noise.** When a PR has no CodeRabbit summary comment (a normal, expected state — nothing to retry), the `myk-pi-tools coderabbit check` CLI exits non-zero and prints `No CodeRabbit summary comment found` on **stdout**. The script only inspected `stderr`, so it logged a `WARNING` with empty text on every such PR (9 of 42 PRs in a recent run). Fix: check both streams with a whitespace-normalized, case-insensitive match and log the benign case at `INFO`; genuine errors still log at `WARNING` and now include both streams. Behavior (returns `None`, fail-safe) is unchanged. Verified live against real PRs: benign PRs now log INFO "skipping"; a PR with a summary returns proper JSON.

New unit tests cover the stdout, stderr, split-stream, and genuine-error paths (54 tests pass).

**Known limitation (follow-up):** the unresolve check still evaluates only the last 5 comments, so legitimate evidence older than that window can be missed on long threads. This is pre-existing behavior, orthogonal to the false-positive fixed here, and deferred to a separate PR.

##### Which issue(s) this PR fixes:

NONE

##### Special notes for reviewer:

- The two fixes are independent but both target the CodeRabbit review-automation and are small, so they are combined in one PR.
- `scripts/coderabbit_retry/` is a standalone CI tool (not part of the pytest suite); its unit tests live under `scripts/coderabbit_retry/tests/` and all pass.
- Async CI note: no functional test-suite changes beyond the script's own unit tests.

##### jira-ticket:

NONE

---
*Assisted-by: PI (gemini-3.5-flash)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request comment checks to ignore the original thread-opening comment when evaluating follow-up activity.
  * Enhanced rate-limit error handling with clearer logging and correct classification of expected versus unexpected results.

* **Tests**
  * Added coverage for split output streams, expected missing-summary responses, and genuine subprocess errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->