### PR TITLE
[4.19]: Manual cherry-pick: handle console reconnect to already-logged-in session (#6049)

### DIFF
--- a/utilities/console.py
+++ b/utilities/console.py
@@ -69,13 +69,23 @@ class Console(object):
     def _connect(self):
         self.child.send("\n\n")
         if self.username:
-            self.child.expect(self.login_prompt)
-            LOGGER.info(f"{self.vm.name}: Using username {self.username}")
-            self.child.sendline(self.username)
-            if self.password:
-                self.child.expect("Password:")
-                LOGGER.info(f"{self.vm.name}: Using password {self.password}")
-                self.child.sendline(self.password)
+            # Wait for either "login:" or a shell prompt (e.g., "$" or "#")
+            patterns = [self.login_prompt] + (self.prompt if isinstance(self.prompt, list) else [self.prompt])
+            matched_index = self.child.expect(patterns)
+
+            # Index 0 = login prompt, other indices = shell prompt
+            if matched_index == 0:
+                # Need to login
+                LOGGER.info(f"{self.vm.name}: Using username {self.username}")
+                self.child.sendline(self.username)
+                if self.password:
+                    self.child.expect("Password:")
+                    LOGGER.info(f"{self.vm.name}: Using password {self.password}")
+                    self.child.sendline(self.password)
+            else:
+                # Already logged in, skip login sequence
+                LOGGER.info(f"{self.vm.name}: Already at shell prompt, skipping login")
+                return
 
         LOGGER.info(f"{self.vm.name}: waiting for terminal prompt '{self.prompt}'")
         self.child.expect(self.prompt)


### PR DESCRIPTION
##### What this PR does / why we need it:
Manual backport of #6049 to 4.19
Auto cherry-pick failed due to conflict of missing `utilities/unittests/test_console.py`

##### Which issue(s) this PR fixes:
When virtctl console reconnects after VM migration, the guest TTY may still show a shell prompt instead of "login:". The old code waited only for "login:" and timed out after 300s.

_connect() now detects either login prompt or shell prompt. When reconnecting to an existing session, it skips the login sequence and returns immediately.

Fixes: SR-IOV hot-plug triggered live
migration, virtctl console dropped (websocket 1006), reconnect landed on "[fedora@... ~]$" shell prompt, pexpect waited for "login:" until timeout. VMI status showed interface correctly attached with guest-agent reporting - product worked, harness could not reconnect to console.

Also fixes: migration tests using console, hot-plug tests with CNV-77961 workaround, and any scenario where console reconnects to a still-logged-in VM session.

##### Special notes for reviewer: -

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
