### PR TITLE
Collect VM-scoped must-gather on running_vm timeout

### DIFF
--- a/utilities/data_collector.py
+++ b/utilities/data_collector.py
@@ -2,9 +2,11 @@ import json
 import logging
 import os
 import shlex
+from datetime import UTC, datetime
 from functools import cache
 
 from _pytest.nodes import Collector
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_utilities.monitoring import Prometheus
@@ -13,7 +15,8 @@ from pytest_testconfig import config as py_config
 
 import utilities.hco
 import utilities.infra
-from utilities.constants.timeouts import TIMEOUT_20MIN
+from utilities.cluster import cache_admin_client
+from utilities.constants.timeouts import TIMEOUT_10MIN, TIMEOUT_20MIN
 from utilities.must_gather import run_must_gather
 
 LOGGER = logging.getLogger(__name__)
@@ -131,6 +134,50 @@ def collect_vnc_screenshot_for_vms(vm: VirtualMachine) -> None:
         LOGGER.warning(f"Skipping VNC screenshot for VM {vm.name}, status is '{printable_status}'.")
 
 
+def _get_cnv_must_gather_image(admin_client: DynamicClient) -> str:
+    """Resolve the CNV must-gather image from the installed HCO CSV.
+
+    Args:
+        admin_client: Cluster admin client used to query the CSV.
+
+    Returns:
+        The must-gather container image URL.
+    """
+    cnv_csv = utilities.hco.get_installed_hco_csv(
+        admin_client=admin_client,
+        hco_namespace=Namespace(client=admin_client, name=py_config["hco_namespace"]),
+    )
+    return [image["image"] for image in cnv_csv.instance.spec.relatedImages if "must-gather" in image["name"]][0]
+
+
+def collect_must_gather_for_vm(vm: VirtualMachine, admin_client: DynamicClient | None = None) -> None:
+    """Run CNV must-gather --vm-incident for one VM at the current time.
+
+    Uses the product incident collector which gathers only data pertinent to
+    the VM: virt-launcher logs, node diagnostics, metrics, and storage chain.
+    No cluster-wide noise. Timeboxed to 10 minutes.
+
+    Args:
+        vm (VirtualMachine): VM whose incident data should be collected.
+        admin_client (DynamicClient | None): Optional cluster admin client; falls back to cache_admin_client().
+    """
+    try:
+        admin_client = admin_client or cache_admin_client()
+        must_gather_image = _get_cnv_must_gather_image(admin_client=admin_client)
+        incident_time = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        LOGGER.info(f"Collecting vm-incident must-gather for VM {vm.name} at {incident_time}")
+        run_must_gather(
+            image_url=must_gather_image,
+            target_base_dir=os.path.join(get_data_collector_dir(), "vm_must_gather"),
+            script_name=f"NS={vm.namespace} VM={vm.name} /usr/bin/gather",
+            flag_names=f"vm-incident,incident-time={incident_time}",
+            timeout=f"{TIMEOUT_10MIN}s",
+            command_timeout=TIMEOUT_10MIN,
+        )
+    except Exception:
+        LOGGER.exception(f"[DATA_COLLECTOR] Failed to collect must-gather for VM {vm.name}")
+
+
 def collect_ocp_must_gather(since_time):
     base_directory = get_data_collector_dir()
     LOGGER.info(f"Collecting OCP must-gather data under: {base_directory}, for time {since_time} seconds.")
@@ -138,13 +185,8 @@ def collect_ocp_must_gather(since_time):
 
 
 def collect_default_cnv_must_gather_with_vm_gather(since_time, target_dir, admin_client):
-    cnv_csv = utilities.hco.get_installed_hco_csv(
-        admin_client=admin_client, hco_namespace=Namespace(client=admin_client, name=py_config["hco_namespace"])
-    )
-    LOGGER.info(f"Collecting cnv-must gather using CSV: {cnv_csv.name}")
-    must_gather_image = [
-        image["image"] for image in cnv_csv.instance.spec.relatedImages if "must-gather" in image["name"]
-    ][0]
+    must_gather_image = _get_cnv_must_gather_image(admin_client=admin_client)
+    LOGGER.info("Collecting cnv-must gather for VMs")
     run_must_gather(
         image_url=must_gather_image,
         target_base_dir=target_dir,

--- a/utilities/unittests/test_data_collector.py
+++ b/utilities/unittests/test_data_collector.py
@@ -124,11 +124,13 @@ if "utilities.data_collector" in sys.modules:
 
 from ocp_resources.virtual_machine import VirtualMachine
 
-# Now import the real data_collector module functions
+from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.data_collector import (
     BASE_DIRECTORY_NAME,
+    _get_cnv_must_gather_image,
     collect_alerts_data,
     collect_default_cnv_must_gather_with_vm_gather,
+    collect_must_gather_for_vm,
     collect_ocp_must_gather,
     collect_vnc_screenshot_for_vms,
     get_data_collector_base,
@@ -369,6 +371,114 @@ class TestCollectVncScreenshotForVms:
         mock_run_virtctl.assert_not_called()
 
 
+class TestGetCnvMustGatherImage:
+    """Test cases for _get_cnv_must_gather_image helper"""
+
+    @patch("utilities.data_collector.utilities.hco.get_installed_hco_csv")
+    @patch("utilities.data_collector.Namespace")
+    def test_returns_must_gather_image(self, mock_namespace_class, mock_get_csv):
+        """Test _get_cnv_must_gather_image resolves the correct image URL"""
+        mock_client = MagicMock()
+        mock_csv = MagicMock()
+        mock_csv.instance.spec.relatedImages = [
+            {"name": "some-image", "image": "quay.io/test/some:latest"},
+            {"name": "must-gather-image", "image": "quay.io/test/must-gather:latest"},
+            {"name": "cnv-must-gather-debug", "image": "quay.io/test/debug-gather:latest"},
+        ]
+        mock_get_csv.return_value = mock_csv
+
+        with patch("utilities.data_collector.py_config", {"hco_namespace": "test-hco-ns"}):
+            result = _get_cnv_must_gather_image(admin_client=mock_client)
+
+        assert result == "quay.io/test/must-gather:latest"
+        mock_namespace_class.assert_called_once_with(client=mock_client, name="test-hco-ns")
+
+    @patch("utilities.data_collector.utilities.hco.get_installed_hco_csv")
+    @patch("utilities.data_collector.Namespace")
+    def test_raises_index_error_when_no_must_gather_image(self, mock_namespace_class, mock_get_csv):
+        """Test _get_cnv_must_gather_image raises IndexError when no image matches"""
+        mock_client = MagicMock()
+        mock_csv = MagicMock()
+        mock_csv.instance.spec.relatedImages = [
+            {"name": "some-image", "image": "quay.io/test/some:latest"},
+        ]
+        mock_get_csv.return_value = mock_csv
+
+        with patch("utilities.data_collector.py_config", {"hco_namespace": "test-hco-ns"}):
+            with pytest.raises(IndexError):
+                _get_cnv_must_gather_image(admin_client=mock_client)
+
+
+class TestCollectMustGatherForVm:
+    """Test cases for collect_must_gather_for_vm function"""
+
+    @patch("utilities.data_collector.datetime")
+    @patch("utilities.data_collector._get_cnv_must_gather_image")
+    @patch("utilities.data_collector.cache_admin_client")
+    @patch("utilities.data_collector.get_data_collector_dir")
+    @patch("utilities.data_collector.run_must_gather")
+    def test_collects_vm_incident(
+        self, mock_run_must_gather, mock_get_dir, mock_cache_client, mock_get_image, mock_datetime
+    ):
+        """Test must-gather runs --vm-incident scoped to the VM"""
+        mock_get_dir.return_value = "/collect/dir"
+        mock_client = MagicMock()
+        mock_cache_client.return_value = mock_client
+        mock_get_image.return_value = "quay.io/test/must-gather:latest"
+        mock_datetime.now.return_value.strftime.return_value = "2026-08-26T12:00:00Z"
+        mock_vm = MagicMock()
+        mock_vm.name = "test-vm"
+        mock_vm.namespace = "test-ns"
+
+        collect_must_gather_for_vm(vm=mock_vm)
+
+        mock_cache_client.assert_called_once()
+        mock_get_image.assert_called_once_with(admin_client=mock_client)
+        mock_run_must_gather.assert_called_once_with(
+            image_url="quay.io/test/must-gather:latest",
+            target_base_dir="/collect/dir/vm_must_gather",
+            script_name="NS=test-ns VM=test-vm /usr/bin/gather",
+            flag_names="vm-incident,incident-time=2026-08-26T12:00:00Z",
+            timeout=f"{TIMEOUT_10MIN}s",
+            command_timeout=TIMEOUT_10MIN,
+        )
+
+    @patch("utilities.data_collector.datetime")
+    @patch("utilities.data_collector._get_cnv_must_gather_image")
+    @patch("utilities.data_collector.cache_admin_client")
+    @patch("utilities.data_collector.get_data_collector_dir")
+    @patch("utilities.data_collector.run_must_gather")
+    def test_collects_vm_incident_with_explicit_admin_client(
+        self, mock_run_must_gather, mock_get_dir, mock_cache_client, mock_get_image, mock_datetime
+    ):
+        """Test must-gather uses explicit admin_client instead of cache when provided"""
+        mock_get_dir.return_value = "/collect/dir"
+        explicit_client = MagicMock()
+        mock_get_image.return_value = "quay.io/test/must-gather:latest"
+        mock_datetime.now.return_value.strftime.return_value = "2026-08-26T12:00:00Z"
+        mock_vm = MagicMock()
+        mock_vm.name = "test-vm"
+        mock_vm.namespace = "test-ns"
+
+        collect_must_gather_for_vm(vm=mock_vm, admin_client=explicit_client)
+
+        mock_cache_client.assert_not_called()
+        mock_get_image.assert_called_once_with(admin_client=explicit_client)
+
+    @patch("utilities.data_collector.LOGGER")
+    @patch("utilities.data_collector.cache_admin_client")
+    def test_gather_failure_does_not_raise(self, mock_cache_client, mock_logger):
+        """Test must-gather failures are logged and do not raise"""
+        mock_cache_client.side_effect = RuntimeError("must-gather failed")
+        mock_vm = MagicMock()
+        mock_vm.name = "test-vm"
+
+        collect_must_gather_for_vm(vm=mock_vm)
+
+        mock_logger.exception.assert_called_once()
+        assert "test-vm" in mock_logger.exception.call_args[0][0]
+
+
 class TestCollectOcpMustGather:
     """Test cases for collect_ocp_must_gather function"""
 
@@ -393,46 +503,21 @@ class TestCollectOcpMustGather:
 class TestCollectDefaultCnvMustGatherWithVmGather:
     """Test cases for collect_default_cnv_must_gather_with_vm_gather function"""
 
-    @patch("utilities.data_collector.utilities.hco.get_installed_hco_csv")
-    @patch("utilities.data_collector.Namespace")
-    @patch("utilities.data_collector.py_config", {"hco_namespace": "test-hco-ns"})
+    @patch("utilities.data_collector._get_cnv_must_gather_image")
     @patch("utilities.data_collector.run_must_gather")
     @patch("utilities.data_collector.LOGGER")
-    def test_collect_default_cnv_must_gather_with_vm_gather(
-        self, mock_logger, mock_run_must_gather, mock_namespace_class, mock_get_csv
-    ):
+    def test_collect_default_cnv_must_gather_with_vm_gather(self, mock_logger, mock_run_must_gather, mock_get_image):
         """Test collect_default_cnv_must_gather_with_vm_gather"""
-        # Setup mocks
         mock_client = MagicMock()
+        mock_get_image.return_value = "quay.io/test/must-gather:latest"
 
-        mock_namespace = MagicMock()
-        mock_namespace_class.return_value = mock_namespace
+        collect_default_cnv_must_gather_with_vm_gather(
+            since_time=1800,
+            target_dir="/target/dir",
+            admin_client=mock_client,
+        )
 
-        mock_csv = MagicMock()
-        mock_csv.name = "cnv-csv-v1.0.0"
-        # Setup related images to test must-gather image selection logic
-        # The function filters images where name contains "must-gather" and selects the FIRST match
-        # Expected behavior: "must-gather-image" should be selected (first image with "must-gather" in name)
-        mock_csv.instance.spec.relatedImages = [
-            {"name": "some-image", "image": "quay.io/test/some:latest"},  # Will be ignored (no "must-gather")
-            {
-                "name": "must-gather-image",
-                "image": "quay.io/test/must-gather:latest",
-            },  # EXPECTED: Selected (first match)
-            {"name": "cnv-must-gather-debug", "image": "quay.io/test/debug-gather:latest"},  # Would match but not first
-        ]
-        mock_get_csv.return_value = mock_csv
-
-        collect_default_cnv_must_gather_with_vm_gather(1800, "/target/dir", admin_client=mock_client)
-
-        mock_namespace_class.assert_called_once_with(client=mock_client, name="test-hco-ns")
-        mock_get_csv.assert_called_once_with(admin_client=mock_client, hco_namespace=mock_namespace)
-
-        # ASSERTION: Verify the expected must-gather image selection behavior
-        # The function should select "quay.io/test/must-gather:latest" because:
-        # 1. It filters relatedImages where image["name"] contains "must-gather"
-        # 2. It takes the first ([0]) matching image from the filtered list
-        # 3. "must-gather-image" is the first image in the list with "must-gather" in its name
+        mock_get_image.assert_called_once_with(admin_client=mock_client)
         mock_run_must_gather.assert_called_once_with(
             image_url="quay.io/test/must-gather:latest",
             target_base_dir="/target/dir",

--- a/utilities/virt.py
+++ b/utilities/virt.py
@@ -107,7 +107,7 @@ from utilities.constants.virt import (
     ROOTDISK,
     VIRTCTL,
 )
-from utilities.data_collector import collect_vnc_screenshot_for_vms
+from utilities.data_collector import collect_must_gather_for_vm, collect_vnc_screenshot_for_vms
 from utilities.exceptions import MigrationStuckSchedulingError, ResourceValueError
 from utilities.hco import get_hco_namespace, wait_for_hco_conditions
 from utilities.network import (
@@ -1826,6 +1826,9 @@ def wait_for_running_vm(
     """
     Wait for the VMI to be in Running state.
 
+    On timeout, collects a VNC screenshot and a VM-incident must-gather
+    archive before re-raising the exception.
+
     Args:
         vm (VirtualMachine): VM object.
         wait_until_running_timeout (int): how much time to wait for VMI to reach Running state
@@ -1834,7 +1837,8 @@ def wait_for_running_vm(
         ssh_timeout (int): how much time to wait for SSH connectivity
 
     Raises:
-        TimeoutExpiredError: After timeout is reached for any of the steps
+        TimeoutExpiredError: After timeout is reached for any of the steps.
+            VNC screenshot and must-gather artifacts are collected before re-raising.
     """
     assert_vm_not_error_status(vm=vm)
     try:
@@ -1847,6 +1851,7 @@ def wait_for_running_vm(
             wait_for_ssh_connectivity(vm=vm, timeout=ssh_timeout)
     except TimeoutExpiredError:
         collect_vnc_screenshot_for_vms(vm=vm)
+        collect_must_gather_for_vm(vm=vm)
         raise
 
 
@@ -1979,6 +1984,7 @@ def migrate_vm_and_verify(
         node_before=node_before,
         wait_for_interfaces=wait_for_interfaces,
         check_ssh_connectivity=check_ssh_connectivity,
+        admin_client=client,
     )
     return None
 
@@ -2051,7 +2057,29 @@ def verify_vm_migrated(
     node_before,
     wait_for_interfaces=True,
     check_ssh_connectivity=False,
+    admin_client: DynamicClient | None = None,
 ):
+    """Verify that a VM migrated to a different node.
+
+    Asserts the VMI is on a new node and that migration completed, then
+    optionally waits for network interfaces and SSH connectivity.
+
+    On timeout, collects a VNC screenshot and a VM-incident must-gather
+    archive before re-raising the exception.
+
+    Args:
+        vm: VM object whose migration is being verified.
+        node_before: Node the VM was running on before migration.
+        wait_for_interfaces (bool): Wait for VM interfaces to appear after migration.
+        check_ssh_connectivity (bool): Wait for SSH connectivity after migration.
+        admin_client (DynamicClient | None): Cluster admin client for must-gather
+            collection on timeout. Falls back to cache_admin_client() when None.
+
+    Raises:
+        AssertionError: If the VM is still on the original node or migration did not complete.
+        TimeoutExpiredError: If waiting for interfaces or SSH times out.
+            VNC screenshot and must-gather artifacts are collected before re-raising.
+    """
     vmi_name = vm.vmi.name
     vmi_node_name = vm.vmi.node.name
     assert vmi_node_name != node_before.name, f"VMI: {vmi_name} still running on the same node: {vmi_node_name}"
@@ -2067,6 +2095,7 @@ def verify_vm_migrated(
             wait_for_ssh_connectivity(vm=vm)
     except TimeoutExpiredError:
         collect_vnc_screenshot_for_vms(vm=vm)
+        collect_must_gather_for_vm(vm=vm, admin_client=admin_client)
         raise
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:

When a test fails during setup (VM timeout waiting to reach Running state, or timeout verifying migration completion), the VNC screenshot is captured but virt-launcher logs, guest console output, and node diagnostics are missing from the collected artifacts.

The pytest_exception_interact hook collects must-gather with --vms_details, but on setup failures the VM is already deleted by the time the hook fires:

1. VM wait times out → `TimeoutExpiredError`
2. `with VirtualMachineForTests(...)` context exits → `clean_up()` deletes the VM
3. `pytest_exception_interact` hook fires → no virt-launcher pod → no VM artifacts

The VNC screenshot works because it runs inside the except block, before the context manager unwinds. 

This PR adds `--vm-incident` must-gather collection at the same point (https://github.com/kubevirt/must-gather#vm-incident-collection), scoped to the failing VM. Unlike `--vms_details`, this skips all cluster-wide collectors and gathers only incident-pertinent data: pod logs, serial console, libvirt state, virt-handler logs, node diagnostics (journal, kubelet, dmesg), and time-scoped Prometheus metrics, all within a 10-minute timeout.

The global hook remains unchanged and still collects cluster-wide artifacts (--vms_details) after teardown.

##### Which issue(s) this PR fixes:


##### Special notes for reviewer:

The collection runs unconditionally on timeout (like the screenshot) rather than being gated behind --data-collector. The try/except inside the function prevents any gather failure from masking the original timeout error. 

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-96019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added VM-scoped diagnostic collection using the installed must-gather image.
  - Diagnostic archives now include the VM namespace, name, and incident timestamp.
  - VM startup and migration timeout handling captures diagnostic archives alongside VNC screenshots.

- **Bug Fixes**
  - Diagnostic collection failures are logged without interrupting timeout handling.
  - Must-gather image resolution is now consistent for default and VM-specific collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->