### PR TITLE
[cnv-4.19] Add memory_requests to AAQ allocation methods test fixture

### DIFF
--- a/tests/virt/cluster/aaq/conftest.py
+++ b/tests/virt/cluster/aaq/conftest.py
@@ -312,6 +312,7 @@ def vm_for_aaq_allocation_methods_test(namespace, cpu_for_migration, aaq_allocat
         namespace=namespace.name,
         cpu_limits=1,
         memory_limits="1Gi",
+        memory_requests="1Gi",
         body=fedora_vm_body(name=vm_name),
         cpu_model=cpu_for_migration,
     ) as vm:


### PR DESCRIPTION
##### What this PR does / why we need it:
`vm_for_aaq_allocation_methods_test` only set `memory_limits`, so with the VirtualResources allocation method the ARQ status (which mirrors `vm.vmi.instance.spec.domain.resources`) had no memory request to compare against, failing `test_aaq_with_virtual_resources_allocation_methods`. Adding `memory_requests="1Gi"` fixes it.

##### Which issue(s) this PR fixes:
NONE

##### Special notes for reviewer:
One-line fixture fix in `tests/virt/cluster/aaq/conftest.py`.

##### jira-ticket:
NONE
