### PR TITLE
WIP: utils: Promote RBAC helpers to a shared module

### DIFF
--- a/tests/storage/data_import_cron/conftest.py
+++ b/tests/storage/data_import_cron/conftest.py
@@ -7,12 +7,12 @@ from ocp_resources.data_source import DataSource
 from ocp_resources.resource import Resource
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
-from tests.storage.utils import create_role_binding
 from utilities.constants import Images
 from utilities.constants.images import OS_FLAVOR_FEDORA
 from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, REGISTRY_STR
 from utilities.constants.timeouts import TIMEOUT_10MIN
 from utilities.infra import create_ns
+from utilities.rbac import create_role_binding
 from utilities.storage import create_dv, data_volume_template_with_source_ref_dict
 from utilities.virt import VirtualMachineForTests, running_vm
 

--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -25,16 +25,16 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VERBS_SRC_SA,
     VM_FOR_TEST,
 )
-from tests.storage.utils import (
-    create_cluster_role,
-    create_role_binding,
-    set_permissions,
-)
 from utilities.constants import Images
 from utilities.constants.images import OS_FLAVOR_FEDORA
 from utilities.constants.pytest import UNPRIVILEGED_USER
 from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, PVC
 from utilities.infra import create_ns
+from utilities.rbac import (
+    create_cluster_role,
+    create_role_binding,
+    set_permissions,
+)
 from utilities.storage import construct_datavolume_source_dict, create_dv, get_dv_size_from_datasource
 from utilities.virt import VirtualMachineForTests, running_vm
 

--- a/tests/storage/snapshots/conftest.py
+++ b/tests/storage/snapshots/conftest.py
@@ -16,7 +16,6 @@ from tests.storage.snapshots.constants import WINDOWS_DIRECTORY_PATH
 from tests.storage.utils import (
     assert_windows_directory_existence,
     create_windows_directory,
-    set_permissions,
 )
 from tests.utils import create_windows2022_vm
 from utilities.constants.pytest import UNPRIVILEGED_USER
@@ -25,6 +24,7 @@ from utilities.constants.timeouts import (
     TIMEOUT_5SEC,
     TIMEOUT_10MIN,
 )
+from utilities.rbac import set_permissions
 from utilities.storage import data_volume_template_with_source_ref_dict
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/storage/utils.py
+++ b/tests/storage/utils.py
@@ -1,19 +1,15 @@
 import ast
 import logging
 import shlex
-from collections.abc import Generator
 from contextlib import contextmanager
 
 import pytest
 import requests
-from kubernetes.dynamic import DynamicClient
-from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.daemonset import DaemonSet
 from ocp_resources.datavolume import DataVolume
 from ocp_resources.hostpath_provisioner import HostPathProvisioner
 from ocp_resources.resource import Resource
-from ocp_resources.role_binding import RoleBinding
 from ocp_resources.route import Route
 from ocp_resources.service import Service
 from ocp_resources.storage_class import StorageClass
@@ -160,91 +156,6 @@ class HttpService(Service):
 
 def get_file_url_https_server(images_https_server, file_name):
     return f"{images_https_server}{Images.Cirros.DIR}/{file_name}"
-
-
-@contextmanager
-def create_cluster_role(
-    client: DynamicClient, name: str, api_groups: list[str], verbs: list[str], permissions_to_resources: list[str]
-) -> Generator:
-    """
-    Create cluster role
-    """
-    with ClusterRole(
-        client=client,
-        name=name,
-        rules=[
-            {
-                "apiGroups": api_groups,
-                "resources": permissions_to_resources,
-                "verbs": verbs,
-            },
-        ],
-    ) as cluster_role:
-        yield cluster_role
-
-
-@contextmanager
-def create_role_binding(
-    client: DynamicClient,
-    name: str,
-    namespace: str,
-    subjects_kind: str,
-    subjects_name: str,
-    role_ref_kind: str,
-    role_ref_name: str,
-    subjects_namespace: str | None = None,
-    subjects_api_group: str | None = None,
-) -> Generator:
-    """
-    Create role binding
-    """
-    with RoleBinding(
-        client=client,
-        name=name,
-        namespace=namespace,
-        subjects_kind=subjects_kind,
-        subjects_name=subjects_name,
-        subjects_api_group=subjects_api_group,
-        subjects_namespace=subjects_namespace,
-        role_ref_kind=role_ref_kind,
-        role_ref_name=role_ref_name,
-    ) as role_binding:
-        yield role_binding
-
-
-@contextmanager
-def set_permissions(
-    client: DynamicClient,
-    role_name: str,
-    role_api_groups: list[str],
-    verbs: list[str],
-    permissions_to_resources: list[str],
-    binding_name: str,
-    namespace: str,
-    subjects_name: str,
-    subjects_kind: str = "User",
-    subjects_api_group: str | None = None,
-    subjects_namespace: str | None = None,
-) -> Generator:
-    with create_cluster_role(
-        client=client,
-        name=role_name,
-        api_groups=role_api_groups,
-        permissions_to_resources=permissions_to_resources,
-        verbs=verbs,
-    ) as cluster_role:
-        with create_role_binding(
-            client=client,
-            name=binding_name,
-            namespace=namespace,
-            subjects_kind=subjects_kind,
-            subjects_name=subjects_name,
-            subjects_api_group=subjects_api_group,
-            subjects_namespace=subjects_namespace,
-            role_ref_kind=cluster_role.kind,
-            role_ref_name=cluster_role.name,
-        ):
-            yield
 
 
 def get_importer_pod(

--- a/utilities/rbac.py
+++ b/utilities/rbac.py
@@ -1,0 +1,101 @@
+"""RBAC helpers for granting cluster roles and namespaced role bindings.
+
+This module holds shared helpers for creating RBAC resources (ClusterRole,
+RoleBinding) used to grant subjects (users or service accounts) permissions.
+
+It does NOT hold:
+    - Authentication / login helpers (see utilities.infra.login_with_user_password)
+    - Namespace creation (see utilities.infra.create_ns)
+"""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.cluster_role import ClusterRole
+from ocp_resources.role_binding import RoleBinding
+
+
+@contextmanager
+def create_cluster_role(
+    client: DynamicClient, name: str, api_groups: list[str], verbs: list[str], permissions_to_resources: list[str]
+) -> Generator:
+    """
+    Create cluster role
+    """
+    with ClusterRole(
+        client=client,
+        name=name,
+        rules=[
+            {
+                "apiGroups": api_groups,
+                "resources": permissions_to_resources,
+                "verbs": verbs,
+            },
+        ],
+    ) as cluster_role:
+        yield cluster_role
+
+
+@contextmanager
+def create_role_binding(
+    client: DynamicClient,
+    name: str,
+    namespace: str,
+    subjects_kind: str,
+    subjects_name: str,
+    role_ref_kind: str,
+    role_ref_name: str,
+    subjects_namespace: str | None = None,
+    subjects_api_group: str | None = None,
+) -> Generator:
+    """
+    Create role binding
+    """
+    with RoleBinding(
+        client=client,
+        name=name,
+        namespace=namespace,
+        subjects_kind=subjects_kind,
+        subjects_name=subjects_name,
+        subjects_api_group=subjects_api_group,
+        subjects_namespace=subjects_namespace,
+        role_ref_kind=role_ref_kind,
+        role_ref_name=role_ref_name,
+    ) as role_binding:
+        yield role_binding
+
+
+@contextmanager
+def set_permissions(
+    client: DynamicClient,
+    role_name: str,
+    role_api_groups: list[str],
+    verbs: list[str],
+    permissions_to_resources: list[str],
+    binding_name: str,
+    namespace: str,
+    subjects_name: str,
+    subjects_kind: str = "User",
+    subjects_api_group: str | None = None,
+    subjects_namespace: str | None = None,
+) -> Generator:
+    with create_cluster_role(
+        client=client,
+        name=role_name,
+        api_groups=role_api_groups,
+        permissions_to_resources=permissions_to_resources,
+        verbs=verbs,
+    ) as cluster_role:
+        with create_role_binding(
+            client=client,
+            name=binding_name,
+            namespace=namespace,
+            subjects_kind=subjects_kind,
+            subjects_name=subjects_name,
+            subjects_api_group=subjects_api_group,
+            subjects_namespace=subjects_namespace,
+            role_ref_kind=cluster_role.kind,
+            role_ref_name=cluster_role.name,
+        ):
+            yield

--- a/utilities/unittests/test_rbac.py
+++ b/utilities/unittests/test_rbac.py
@@ -1,0 +1,38 @@
+"""Unit tests for rbac module"""
+
+from unittest.mock import MagicMock, patch
+
+from utilities.rbac import set_permissions
+
+
+@patch("utilities.rbac.RoleBinding")
+@patch("utilities.rbac.ClusterRole")
+def test_set_permissions_binds_created_cluster_role(mock_cluster_role_class, mock_role_binding_class):
+    # set_permissions calls create_cluster_role and create_role_binding, so this
+    # single test covers all three helpers in the module.
+    mock_cluster_role = MagicMock(kind="ClusterRole")
+    mock_cluster_role.name = "test-role"
+    mock_cluster_role.__enter__ = MagicMock(return_value=mock_cluster_role)
+    mock_cluster_role.__exit__ = MagicMock(return_value=False)
+    mock_cluster_role_class.return_value = mock_cluster_role
+
+    mock_role_binding = MagicMock()
+    mock_role_binding.__enter__ = MagicMock(return_value=mock_role_binding)
+    mock_role_binding.__exit__ = MagicMock(return_value=False)
+    mock_role_binding_class.return_value = mock_role_binding
+
+    with set_permissions(
+        client=MagicMock(),
+        role_name="test-role",
+        role_api_groups=["kubevirt.io"],
+        verbs=["create"],
+        permissions_to_resources=["virtualmachines"],
+        binding_name="test-binding",
+        namespace="test-namespace",
+        subjects_name="unprivileged-user",
+    ):
+        pass
+
+    role_binding_kwargs = mock_role_binding_class.call_args[1]
+    assert role_binding_kwargs["role_ref_kind"] == mock_cluster_role.kind
+    assert role_binding_kwargs["role_ref_name"] == mock_cluster_role.name


### PR DESCRIPTION
##### What this PR does / why we need it:
The `create_cluster_role`, `create_role_binding`, and `set_permissions` helpers
lived under `tests/storage/utils.py`, but granting an unprivileged user
permissions within a namespace is a cross-team need — the UDN network tests
require the same capability. Importing them from the storage test package into
network tests would be a cross-team dependency on another team's test utilities.

This PR moves the three helpers into a dedicated `utilities/rbac.py` module so
they can be reused across teams. Storage consumers are updated to import from
the new location. No behavior change.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Pure refactor (move + import updates). A minimal mocked unit test is added in
`utilities/unittests/test_rbac.py`; exercising `set_permissions` covers all
three helpers since it composes the other two.

##### jira-ticket:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized role-based access control setup into shared utilities.
  * Updated storage test scenarios to use the centralized RBAC helpers.
  * Preserved existing permission and binding behavior.

* **Tests**
  * Added coverage confirming permissions correctly bind to the created cluster role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->