### PR TITLE
CherryPicked: [cnv-4.21] Remove test_no_new_prometheus_rules test

### DIFF
--- a/tests/observability/runbook_url/conftest.py
+++ b/tests/observability/runbook_url/conftest.py
@@ -7,11 +7,6 @@ from pytest_testconfig import config as py_config
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module")
-def cnv_prometheus_rules_names(hco_namespace):
-    return [prometheus_rule.name for prometheus_rule in PrometheusRule.get(namespace=hco_namespace.name)]
-
-
 @pytest.fixture()
 def cnv_alerts_runbook_urls_from_prometheus_rule(cnv_prometheus_rules_matrix__function__, hpp_cr_installed):
     rule_name = cnv_prometheus_rules_matrix__function__

--- a/tests/observability/runbook_url/test_runbook_url.py
+++ b/tests/observability/runbook_url/test_runbook_url.py
@@ -1,12 +1,9 @@
 import http
-import logging
 
 import pytest
 import requests
 
-from utilities.constants import CNV_PROMETHEUS_RULES, TIMEOUT_10SEC
-
-LOGGER = logging.getLogger(__name__)
+from utilities.constants import TIMEOUT_10SEC
 
 
 def validate_downstream_runbook_url(
@@ -33,20 +30,6 @@ def validate_downstream_runbook_url(
 
 
 class TestRunbookUrlsAndPrometheusRules:
-    @pytest.mark.polarion("CNV-10081")
-    def test_no_new_prometheus_rules(self, cnv_prometheus_rules_names, hpp_cr_installed):
-        """
-        Since validations for runbook url of all cnv alerts are done via polarion parameterization of prometheusrules,
-        this test has been added to catch any new cnv prometheusrules that is not part of cnv_prometheus_rules_matrix
-        """
-        expected_prometheus_rules_names = CNV_PROMETHEUS_RULES.copy()
-        if not hpp_cr_installed:
-            LOGGER.warning("HPP CR is not installed, removing prometheus-hpp-rules from the list of prometheus rules")
-            expected_prometheus_rules_names.remove("prometheus-hpp-rules")
-        assert sorted(cnv_prometheus_rules_names) == sorted(expected_prometheus_rules_names), (
-            f"New cnv prometheusrule found: {set(cnv_prometheus_rules_names) - set(expected_prometheus_rules_names)}"
-        )
-
     @pytest.mark.polarion("CNV-10084")
     def test_runbook_downstream_urls(self, cnv_alerts_runbook_urls_from_prometheus_rule, subtests):
         validate_downstream_runbook_url(


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove the test_no_new_prometheus_rules test and cnv_prometheus_rules_names fixture. The hardcoded list caused false failures; runbook URL validation is already covered per-rule via cnv_prometheus_rules_matrix.

Original PR: #6130
assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-96118
