### PR TITLE
CherryPicked: [cnv-4.18] Remove test_no_new_prometheus_rules test

### DIFF
--- a/tests/observability/runbook_url/conftest.py
+++ b/tests/observability/runbook_url/conftest.py
@@ -7,11 +7,6 @@ from pytest_testconfig import config as py_config
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.fixture(scope="module")
-def cnv_prometheus_rules_names(hco_namespace):
-    return [prometheus_rule.name for prometheus_rule in PrometheusRule.get(namespace=hco_namespace.name)]
-
-
 @pytest.fixture()
 def cnv_alerts_runbook_urls_from_prometheus_rule(cnv_prometheus_rules_matrix__function__):
     cnv_prometheus_rule_by_name = PrometheusRule(

--- a/tests/observability/runbook_url/test_runbook_url.py
+++ b/tests/observability/runbook_url/test_runbook_url.py
@@ -3,22 +3,12 @@ import logging
 import pytest
 
 from tests.utils import validate_runbook_url_exists
-from utilities.constants import CNV_PROMETHEUS_RULES, QUARANTINED
+from utilities.constants import QUARANTINED
 
 LOGGER = logging.getLogger(__name__)
 
 
 class TestRunbookUrlsAndPrometheusRules:
-    @pytest.mark.polarion("CNV-10081")
-    def test_no_new_prometheus_rules(self, cnv_prometheus_rules_names):
-        """
-        Since validations for runbook url of all cnv alerts are done via polarion parameterization of prometheusrules,
-        this test has been added to catch any new cnv prometheusrules that is not part of cnv_prometheus_rules_matrix
-        """
-        assert sorted(CNV_PROMETHEUS_RULES) == sorted(cnv_prometheus_rules_names), (
-            f"New cnv prometheusrule found: {set(cnv_prometheus_rules_names) - set(CNV_PROMETHEUS_RULES)}"
-        )
-
     @pytest.mark.xfail(
         reason=f"{QUARANTINED}: New alerts runbooks added to upstream and not merged yet for downstream, CNV-67890",
         run=False,


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove the test_no_new_prometheus_rules test and cnv_prometheus_rules_names fixture. The hardcoded list caused false failures; runbook URL validation is already covered per-rule via cnv_prometheus_rules_matrix.

Original PR: #6130
assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-96121
