### PR TITLE
[cnv-4.21] fix(gpu): give second vGPU test VMs their own cloned disk 

### DIFF
--- a/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_rhel_vm_with_vgpu.py
@@ -20,6 +20,7 @@ from tests.virt.node.gpu.utils import (
 )
 from tests.virt.utils import (
     build_node_affinity_dict,
+    get_data_volume_template_dict_with_default_storage_class,
     get_num_gpu_devices_in_rhel_vm,
     running_sleep_in_linux,
     verify_gpu_device_exists_in_vm,
@@ -48,7 +49,7 @@ TESTS_CLASS_NAME = "TestVGPURHELGPUSSpec"
 def gpu_vmb(
     unprivileged_client,
     namespace,
-    golden_image_data_volume_template_for_test_scope_class,
+    golden_image_data_source_for_test_scope_class,
     supported_gpu_device,
     gpu_vma,
 ):
@@ -60,7 +61,9 @@ def gpu_vmb(
         namespace=namespace.name,
         client=unprivileged_client,
         labels=Template.generate_template_labels(**RHEL_LATEST_LABELS),
-        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class,
+        ),
         vm_affinity=gpu_vma.vm_affinity,
         gpu_name=supported_gpu_device[VGPU_DEVICE_NAME_STR],
     ) as vm:
@@ -73,7 +76,7 @@ def node_mdevtype_gpu_vm(
     request,
     unprivileged_client,
     namespace,
-    golden_image_data_volume_template_for_test_scope_class,
+    golden_image_data_source_for_test_scope_class,
     nodes_with_supported_gpus,
     supported_gpu_device,
 ):
@@ -88,7 +91,9 @@ def node_mdevtype_gpu_vm(
         request=request,
         namespace=namespace,
         unprivileged_client=unprivileged_client,
-        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class,
+        ),
         vm_affinity=build_node_affinity_dict(values=[[*nodes_with_supported_gpus][1].name]),
         gpu_name=supported_gpu_device[VGPU_GRID_NAME_STR],
     ) as vm:

--- a/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
+++ b/tests/virt/node/gpu/vgpu/test_windows_vm_with_vgpu.py
@@ -14,6 +14,7 @@ from tests.virt.node.gpu.utils import (
     restart_and_check_gpu_exists,
 )
 from tests.virt.utils import (
+    get_data_volume_template_dict_with_default_storage_class,
     get_gpu_device_name_from_windows_vm,
     validate_pause_unpause_windows_vm,
     verify_gpu_device_exists_in_vm,
@@ -42,7 +43,7 @@ TESTS_CLASS_NAME = "TestVGPUWindowsGPUSSpec"
 def gpu_vmc(
     unprivileged_client,
     namespace,
-    golden_image_data_volume_template_for_test_scope_class,
+    golden_image_data_source_for_test_scope_class,
     supported_gpu_device,
     gpu_vma,
 ):
@@ -54,7 +55,9 @@ def gpu_vmc(
         namespace=namespace.name,
         client=unprivileged_client,
         labels=Template.generate_template_labels(**WINDOWS_10_TEMPLATE_LABELS),
-        data_volume_template=golden_image_data_volume_template_for_test_scope_class,
+        data_volume_template=get_data_volume_template_dict_with_default_storage_class(
+            data_source=golden_image_data_source_for_test_scope_class,
+        ),
         node_selector=gpu_vma.node_selector,
         gpu_name=supported_gpu_device[VGPU_DEVICE_NAME_STR],
         cloned_dv_size=DV_SIZE,


### PR DESCRIPTION


##### What this PR does / why we need it:
`gpu_vmb`, `node_mdevtype_gpu_vm`, and `gpu_vmc` all reused the class-scoped `golden_image_data_volume_template_for_test_scope_class` fixture, the same one `gpu_vma` already consumes. Since that fixture is cached once per test class, the "second" VM in each concurrent-vGPU test unintentionally shared `gpu_vma`'s DataVolume/PVC instead of getting its own disk. Two VMs booting from the same underlying disk concurrently caused the guest agent to never come up on the second VM, failing these tests. This PR makes each second VM build its own data volume template from the underlying data source at fixture setup time, so it gets a uniquely named clone.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
