### PR TITLE
net, tests, upgrade: Verify primary-UDN connectivity across upgrade

### DIFF
--- a/tests/network/upgrade/conftest.py
+++ b/tests/network/upgrade/conftest.py
@@ -1,7 +1,8 @@
 from ipaddress import IPv4Interface, IPv6Interface
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import pytest
+from ocp_resources.user_defined_network import Layer2UserDefinedNetwork
 from ocp_resources.virtual_machine import VirtualMachine
 
 if TYPE_CHECKING:
@@ -15,7 +16,12 @@ if TYPE_CHECKING:
 
 from libs.net import nodenetworkconfigurationpolicy as libnncp
 from libs.net.cluster import cluster_vlans, ipv4_supported_cluster, ipv6_supported_cluster
-from libs.net.ip import filter_link_local_addresses, random_ipv4_address, random_ipv6_address
+from libs.net.ip import (
+    filter_link_local_addresses,
+    random_ipv4_address,
+    random_ipv6_address,
+)
+from libs.net.udn import UDN_BINDING_DEFAULT_PLUGIN_NAME, create_udn_namespace
 from libs.net.vmspec import lookup_iface_status
 from libs.vm.oper import run_vms
 from libs.vm.spec import Interface, Multus, Network
@@ -35,6 +41,7 @@ from tests.network.libs.localnet import (
     localnet_cudn,
     localnet_vm,
 )
+from tests.network.libs.vm_factory import udn_vm
 from tests.network.upgrade.libupgrade import KMP_DISABLED_LABEL
 from utilities.constants.cluster import WORKER_NODE_LABEL_KEY
 from utilities.constants.networking import KMP_VM_ASSIGNMENT_LABEL, LINUX_BRIDGE
@@ -44,6 +51,7 @@ from utilities.network import cloud_init, network_nad
 from utilities.virt import VirtualMachineForTests, fedora_vm_body
 
 NAD_MAC_SPOOF_NAME = "brspoofupgrade"
+UDN_UPGRADE_VM_ANTI_AFFINITY_LABEL: Final[dict[str, str]] = {"upgrade-udn-vm": "true"}
 
 
 @pytest.fixture(scope="session")
@@ -381,3 +389,71 @@ def ipv4_dedicated_nic_bridge_localnet_address_pool_upgrade() -> Generator[IPv4I
 @pytest.fixture(scope="session")
 def ipv6_dedicated_nic_bridge_localnet_address_pool_upgrade() -> Generator[IPv6Interface]:
     return (random_ipv6_address(net_seed=1, host_address=host) for host in range(1, 254))
+
+
+@pytest.fixture(scope="session")
+def namespace_udn_upgrade(admin_client: DynamicClient) -> Generator[Namespace]:
+    yield from create_udn_namespace(name="upgrade-udn-ns", client=admin_client)
+
+
+@pytest.fixture(scope="session")
+def primary_udn_upgrade(
+    admin_client: DynamicClient,
+    namespace_udn_upgrade: Namespace,
+) -> Generator[Layer2UserDefinedNetwork]:
+    with Layer2UserDefinedNetwork(
+        name="upgrade-udn",
+        namespace=namespace_udn_upgrade.name,
+        role="Primary",
+        subnets=[str(random_ipv4_address(net_seed=2, host_address=0))],
+        ipam={"lifecycle": "Persistent"},
+        client=admin_client,
+    ) as udn:
+        udn.wait_for_condition(
+            condition="NetworkAllocationSucceeded",
+            status=udn.Condition.Status.TRUE,
+        )
+        yield udn
+
+
+@pytest.fixture(scope="session")
+def vm_udn_upgrade_a(
+    admin_client: DynamicClient,
+    namespace_udn_upgrade: Namespace,
+    primary_udn_upgrade: Layer2UserDefinedNetwork,
+) -> Generator[BaseVirtualMachine]:
+    with udn_vm(
+        namespace_name=namespace_udn_upgrade.name,
+        name="upgrade-udn-vm-a",
+        client=admin_client,
+        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
+        template_labels=UDN_UPGRADE_VM_ANTI_AFFINITY_LABEL,
+        anti_affinity_namespaces=[namespace_udn_upgrade.name],
+    ) as vm:
+        yield vm
+
+
+@pytest.fixture(scope="session")
+def vm_udn_upgrade_b(
+    admin_client: DynamicClient,
+    namespace_udn_upgrade: Namespace,
+    primary_udn_upgrade: Layer2UserDefinedNetwork,
+) -> Generator[BaseVirtualMachine]:
+    with udn_vm(
+        namespace_name=namespace_udn_upgrade.name,
+        name="upgrade-udn-vm-b",
+        client=admin_client,
+        binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
+        template_labels=UDN_UPGRADE_VM_ANTI_AFFINITY_LABEL,
+        anti_affinity_namespaces=[namespace_udn_upgrade.name],
+    ) as vm:
+        yield vm
+
+
+@pytest.fixture(scope="session")
+def running_udn_vms_upgrade(
+    vm_udn_upgrade_a: BaseVirtualMachine,
+    vm_udn_upgrade_b: BaseVirtualMachine,
+) -> tuple[BaseVirtualMachine, BaseVirtualMachine]:
+    vm_a, vm_b = run_vms(vms=(vm_udn_upgrade_a, vm_udn_upgrade_b))
+    return vm_a, vm_b

--- a/tests/network/upgrade/test_udn.py
+++ b/tests/network/upgrade/test_udn.py
@@ -1,19 +1,34 @@
 """
 Primary UDN upgrade tests
 
-Markers:
-    - upgrade
-    - ocp_upgrade
-    - cnv_upgrade
-    - eus_upgrade
-    - single_nic
-
 Preconditions:
     - UDN namespace (with required annotations).
     - A primary UDN network.
 """
 
+import os
+
 import pytest
+
+from libs.net.traffic_generator import client_server_active_connection, is_tcp_connection
+from libs.net.vmspec import lookup_primary_network
+from tests.upgrade_params import (
+    IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
+    IUO_UPGRADE_TEST_ORDERING_NODE_ID,
+)
+from utilities.constants.pytest import DEPENDENCY_SCOPE_SESSION
+
+BEFORE_UPGRADE_UDN_CONNECTIVITY_TEST_ID = (
+    f"{os.path.abspath(__file__)}::test_connectivity_between_udn_vms_before_upgrade"
+)
+
+pytestmark = [
+    pytest.mark.upgrade,
+    pytest.mark.ocp_upgrade,
+    pytest.mark.cnv_upgrade,
+    pytest.mark.eus_upgrade,
+    pytest.mark.single_nic,
+]
 
 
 @pytest.mark.polarion("CNV-13118")
@@ -45,10 +60,14 @@ def test_udn_vm_state_before_upgrade():
 test_udn_vm_state_before_upgrade.__test__ = False
 
 
+@pytest.mark.ipv4
 @pytest.mark.polarion("CNV-11617")
-def test_connectivity_between_udn_vms_before_upgrade():
+@pytest.mark.order(before=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
+# Post-upgrade test depends on this to skip if pre-upgrade connectivity already fails.
+@pytest.mark.dependency(name=BEFORE_UPGRADE_UDN_CONNECTIVITY_TEST_ID, scope=DEPENDENCY_SCOPE_SESSION)
+def test_connectivity_between_udn_vms_before_upgrade(running_udn_vms_upgrade):
     """
-    Test that two VMs with a primary UDN network can communicate with each other over the primary UDN network.
+    Test that two VMs with a primary UDN network can communicate with each other over IPv4.
 
     No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
 
@@ -57,14 +76,20 @@ def test_connectivity_between_udn_vms_before_upgrade():
         - Two running under-test VMs, each with a primary UDN network.
 
     Steps:
-        1. Execute a ping command from one under-test VM to the other under-test VM.
+        1. Establish TCP connection between the VMs over the primary UDN network.
 
     Expected:
-        - Ping command succeeds with 0% packet loss.
+        - TCP connection succeeds.
     """
-
-
-test_connectivity_between_udn_vms_before_upgrade.__test__ = False
+    client_vm, server_vm = running_udn_vms_upgrade
+    with client_server_active_connection(
+        client_vm=client_vm,
+        server_vm=server_vm,
+        spec_logical_network=lookup_primary_network(vm=server_vm).name,
+    ) as (client, server):
+        assert is_tcp_connection(server=server, client=client), (
+            f"Pre-upgrade TCP connection from {client_vm.name} to {server_vm.name} over primary UDN failed"
+        )
 
 
 @pytest.mark.polarion("CNV-13119")
@@ -96,10 +121,20 @@ def test_udn_vm_state_after_upgrade():
 test_udn_vm_state_after_upgrade.__test__ = False
 
 
+@pytest.mark.ipv4
 @pytest.mark.polarion("CNV-16774")
-def test_connectivity_between_udn_vms_after_upgrade():
+@pytest.mark.order(after=IUO_UPGRADE_TEST_ORDERING_NODE_ID)
+# Requires upgrade completion and pre-upgrade baseline connectivity.
+@pytest.mark.dependency(
+    depends=[
+        IUO_UPGRADE_TEST_DEPENDENCY_NODE_ID,
+        BEFORE_UPGRADE_UDN_CONNECTIVITY_TEST_ID,
+    ],
+    scope=DEPENDENCY_SCOPE_SESSION,
+)
+def test_connectivity_between_udn_vms_after_upgrade(running_udn_vms_upgrade):
     """
-    Test that two VMs with a primary UDN network can communicate with each other over the primary UDN network.
+    Test that two VMs with a primary UDN network can communicate with each other over IPv4.
 
     No STP exists for this scenario - tracked via Jira: https://redhat.atlassian.net/browse/CNV-94228 # <skip-jira-utils-check>
 
@@ -108,11 +143,17 @@ def test_connectivity_between_udn_vms_after_upgrade():
         - Two running under-test VMs, each with a primary UDN network.
 
     Steps:
-        1. Execute a ping command from one under-test VM to the other under-test VM.
+        1. Establish TCP connection between the VMs over the primary UDN network.
 
     Expected:
-        - Ping command succeeds with 0% packet loss.
+        - TCP connection succeeds, connectivity preserved after upgrade.
     """
-
-
-test_connectivity_between_udn_vms_after_upgrade.__test__ = False
+    client_vm, server_vm = running_udn_vms_upgrade
+    with client_server_active_connection(
+        client_vm=client_vm,
+        server_vm=server_vm,
+        spec_logical_network=lookup_primary_network(vm=server_vm).name,
+    ) as (client, server):
+        assert is_tcp_connection(server=server, client=client), (
+            f"Post-upgrade TCP connection from {client_vm.name} to {server_vm.name} over primary UDN failed"
+        )


### PR DESCRIPTION
##### What this PR does / why we need it:
Primary user-defined networks (P-UDN) must keep east-west VM connectivity working across a cluster upgrade. This PR adds before/after-upgrade connectivity coverage for two VMs on a primary Layer2 UDN over IPv4: the pre-upgrade test establishes a connectivity baseline, and the post-upgrade test re-verifies it once the CNV upgrade completes, so an issue introduced by the upgrade is caught.
  
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
 - IPv6 connectivity coverage is intentionally out of scope here and will follow in a separate change while adding IPv6 support for the entire tier2 UDN coverage.
 - RBAC for creating resources inside the UDN namespace will be added later - after first applying it to the UDN module (tracked in https://redhat.atlassian.net/browse/CNV-96105).

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-96144


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded upgrade coverage for user-defined networks.
  - Added validation for persistent IP address management and connectivity between virtual machines before and after upgrades.
  - Improved test setup with anti-affinity placement and IPv4 TCP connectivity checks over the primary network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->