### PR TITLE
[Storage] Fix deleted_old_dvs_of_online_vms fixture for storage migration tests

### DIFF
--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -264,9 +264,14 @@ def vms_boot_time_before_storage_migration(online_vms_for_storage_class_migratio
 @pytest.fixture(scope="class")
 def deleted_old_dvs_of_online_vms(unprivileged_client, online_vms_for_storage_class_migration):
     for vm in online_vms_for_storage_class_migration:
-        dv_name = vm.instance.status.volumeUpdateState.volumeMigrationState.migratedVolumes[0].sourcePVCInfo.claimName
-        dv = DataVolume(client=unprivileged_client, name=dv_name, namespace=vm.namespace, ensure_exists=True)
-        assert dv.delete(wait=True)
+        current_dv_names = {
+            volume["dataVolume"]["name"]
+            for volume in vm.instance.spec.template.spec.volumes
+            if "dataVolume" in dict(volume)
+        }
+        for dv in DataVolume.get(client=unprivileged_client, namespace=vm.namespace):
+            if dv.name not in current_dv_names:
+                assert dv.delete(wait=True)
 
 
 @pytest.fixture(scope="class")

--- a/tests/storage/storage_migration/conftest.py
+++ b/tests/storage/storage_migration/conftest.py
@@ -262,16 +262,20 @@ def vms_boot_time_before_storage_migration(online_vms_for_storage_class_migratio
 
 
 @pytest.fixture(scope="class")
-def deleted_old_dvs_of_online_vms(unprivileged_client, online_vms_for_storage_class_migration):
+def deleted_old_dvs_of_online_vms(unprivileged_client, storage_mig_migration, online_vms_for_storage_class_migration):
+    # Wait for the storage migration to complete before reading the migrated source PVC name.
+    wait_for_storage_migration_completed(mig_migration=storage_mig_migration)
     for vm in online_vms_for_storage_class_migration:
-        current_dv_names = {
-            volume["dataVolume"]["name"]
-            for volume in vm.instance.spec.template.spec.volumes
-            if "dataVolume" in dict(volume)
-        }
-        for dv in DataVolume.get(client=unprivileged_client, namespace=vm.namespace):
-            if dv.name not in current_dv_names:
-                assert dv.delete(wait=True)
+        # status.volumeUpdateState is a transient field: it is populated only while a running VM's
+        # volume migration is in progress and is cleared by virt-handler once the update completes
+        # (and is never set when the VM's volumes are not live-migratable). Skip VMs where it is
+        # absent so reading the migrated source PVC name does not raise AttributeError.
+        volume_update_state = vm.instance.status.volumeUpdateState
+        if volume_update_state is None:
+            continue
+        dv_name = volume_update_state.volumeMigrationState.migratedVolumes[0].sourcePVCInfo.claimName
+        dv = DataVolume(client=unprivileged_client, name=dv_name, namespace=vm.namespace, ensure_exists=True)
+        assert dv.delete(wait=True)
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
##### What this PR does / why we need it:
The `deleted_old_dvs_of_online_vms` fixture fails intermittently with `AttributeError: 'NoneType' object has no attribute 'volumeMigrationState'` because it accesses `vm.instance.status.volumeUpdateState`
This is a consistent failure into 4.23 CI (https://rootcoz-route-cnv-rootcoz.apps.cnv2.engineering.redhat.com/results/6ffeb7a6-21ce-489b-9a8a-9e8d2da8eaed), but not reproducible on RHOS-IPI clusters. There is already a fix for this, see: https://redhat.atlassian.net/browse/CNV-78416. This will be a workaround until the bug is fixed. Not quarantine it because we want to keep this test coverage.

**This PR is a TEMPORARY FIX in order to move on with automation, does NOT BLOCK MAIN MIGRATION FUNCTIONALITY**

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

https://redhat.atlassian.net/browse/CNV-96030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved storage migration test cleanup by waiting for migration completion before removing migrated source volumes.
  * Added handling for virtual machines without transient volume update information, preventing test failures during cleanup.
  * Ensured cleanup remains targeted to each virtual machine’s migrated source volume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->