### PR TITLE
Removing must-gather test with long vm name case

### DIFF
--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -461,19 +461,6 @@ def must_gather_stopped_vms(must_gather_vms_from_alternate_namespace):
 
 
 @pytest.fixture(scope="class")
-def must_gather_long_name_vm(node_gather_unprivileged_namespace, unprivileged_client):
-    with VirtualMachineForTests(
-        client=unprivileged_client,
-        namespace=node_gather_unprivileged_namespace.name,
-        name=LONG_VM_NAME,
-        body=fedora_vm_body(name=LONG_VM_NAME),
-        generate_unique_name=False,
-    ) as vm:
-        running_vm(vm=vm)
-        yield vm
-
-
-@pytest.fixture(scope="class")
 def gathered_images(
     request,
     must_gather_tmpdir_scope_module,

--- a/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
+++ b/tests/install_upgrade_operators/must_gather/test_must_gather_vms.py
@@ -25,7 +25,6 @@ from tests.install_upgrade_operators.must_gather.utils import (
     check_list_of_resources,
     check_no_duplicate_and_missing_files_collected_from_migrated_vm,
     extracted_data_from_must_gather_on_vm_node,
-    validate_files_collected,
     validate_guest_console_logs_collected,
     validate_no_empty_files_collected_must_gather_vm,
 )
@@ -274,24 +273,6 @@ class TestGuestConsoleLog:
         validate_guest_console_logs_collected(
             vm=must_gather_vm_scope_class,
             collected_vm_details_must_gather=collected_vm_details_must_gather,
-            admin_client=admin_client,
-        )
-
-
-@pytest.mark.sno
-class TestMustGatherVmLongNameDetails:
-    @pytest.mark.polarion("CNV-9233")
-    def test_data_collected_from_virt_launcher_long(
-        self,
-        admin_client,
-        must_gather_long_name_vm,
-        collected_vm_details_must_gather,
-        nftables_ruleset_from_utility_pods,
-    ):
-        validate_files_collected(
-            base_path=collected_vm_details_must_gather,
-            vm_list=[must_gather_long_name_vm],
-            nftables_ruleset_from_utility_pods=nftables_ruleset_from_utility_pods,
             admin_client=admin_client,
         )
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Removing a must-gather test that was only checks the must gather for a case where the vm name is long which is redundent, it was because of a use case in the past where there was a bug with collecting information for vms with long name, not relevant anymore and not worth holding a test just for it.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-96234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed coverage for must-gather collection from virtual machines with maximum-length names.
  * Removed the associated test fixture and file-collection validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->