### PR TITLE
net, upgrade, tests: Skip Jira reference check

### DIFF
--- a/tests/network/upgrade/test_localnet_connectivity.py
+++ b/tests/network/upgrade/test_localnet_connectivity.py
@@ -3,7 +3,7 @@ Localnet connectivity upgrade tests.
 
 Verifies IPAM-less localnet VM connectivity is preserved across cluster upgrades,
 for both default bridge (br-ex) and dedicated NIC bridge.
-https://redhat.atlassian.net/browse/CNV-85783
+https://redhat.atlassian.net/browse/CNV-85783  # <skip-jira-utils-check>
 
 Preconditions:
     - OVN bridge mapping configured via NNCP for the default bridge (br-ex)


### PR DESCRIPTION
##### What this PR does / why we need it:
The Jira tracking the localnet connectivity upgrade coverage is now
closed. Its reference lives in the test module docstring for
traceability, but the automated jira-utils check flags references to
closed tickets. Skip the Jira reference check.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
None