### PR TITLE
Xfail virt-platform-autopilot-metrics in PQC test (CNV-96287)

### DIFF
--- a/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
+++ b/tests/install_upgrade_operators/crypto_policy/test_pqc_tls_audit.py
@@ -8,8 +8,11 @@ import logging
 
 import pytest
 
+from utilities.jira import is_jira_open
+
 LOGGER = logging.getLogger(__name__)
 pytestmark = pytest.mark.post_upgrade
+VIRT_PLATFORM_AUTOPILOT_METRICS = "virt-platform-autopilot-metrics"
 
 
 @pytest.mark.polarion("CNV-15222")
@@ -36,6 +39,8 @@ def test_cnv_services_pqc_key_exchange(subtests, fips_enabled_cluster, pqc_statu
     """
     for service_name, accepted in pqc_status_by_service.items():
         with subtests.test(msg=service_name):
+            if service_name == VIRT_PLATFORM_AUTOPILOT_METRICS and is_jira_open(jira_id="CNV-96287"):
+                pytest.xfail(f"{service_name} serves plain HTTP, not TLS (CNV-96287)")
             assert accepted is not None, f"Service {service_name} is unreachable"
             if fips_enabled_cluster:
                 runtime = services_tls_runtime.get(service_name, "go")


### PR DESCRIPTION
##### What this PR does / why we need it:
Service serves plain HTTP on port 8080 instead of HTTPS. All other CNV metrics services use TLS (port 443/8443).

assisted by: claude code claude-opus-4-6
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PQC TLS audit coverage to account for a service that currently serves plain HTTP instead of TLS.
  * The affected check is temporarily marked as an expected failure while the related issue remains open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->