### PR TITLE
[4.22] net, l2bridge: remove bridge device (#5834)

### DIFF
--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -22,11 +22,9 @@ from utilities.constants import (
     CNV_PROMETHEUS_RULES,
     HCO_CATALOG_SOURCE,
     HPP_CAPABILITIES,
-    LINUX_BRIDGE,
     MONITORING_METRICS,
     MULTIARCH,
     OS_FLAVOR_FEDORA,
-    OVS_BRIDGE,
     PRODUCTION_CATALOG_SOURCE,
     RHEL8_PREFERENCE,
     RHEL9_PREFERENCE,
@@ -126,8 +124,6 @@ cnv_vm_resource_requests_units_matrix = [
 
 
 cnv_vmi_monitoring_metrics_matrix = MONITORING_METRICS
-
-bridge_device_matrix = [LINUX_BRIDGE, OVS_BRIDGE]
 
 storage_class_matrix = [
     {

--- a/tests/network/l2_bridge/conftest.py
+++ b/tests/network/l2_bridge/conftest.py
@@ -42,11 +42,6 @@ VMB_MPLS_ROUTE_TAG = 200
 
 
 @pytest.fixture(scope="class")
-def bridge_device_type(request):
-    return request.param
-
-
-@pytest.fixture(scope="class")
 def l2_bridge_device_name(index_number):
     yield f"br{next(index_number)}test"
 
@@ -57,11 +52,10 @@ def l2_bridge_device_worker_1(
     admin_client,
     hosts_common_available_ports,
     worker_node1,
-    bridge_device_type,
     l2_bridge_device_name,
 ):
     with network_device(
-        interface_type=bridge_device_type,
+        interface_type=LINUX_BRIDGE,
         nncp_name=f"l2-bridge-{name_prefix(worker_node1.name)}",
         interface_name=l2_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node1.hostname),
@@ -77,11 +71,10 @@ def l2_bridge_device_worker_2(
     admin_client,
     hosts_common_available_ports,
     worker_node2,
-    bridge_device_type,
     l2_bridge_device_name,
 ):
     with network_device(
-        interface_type=bridge_device_type,
+        interface_type=LINUX_BRIDGE,
         nncp_name=f"l2-bridge-{name_prefix(worker_node2.name)}",
         interface_name=l2_bridge_device_name,
         node_selector=get_node_selector_dict(node_selector=worker_node2.hostname),
@@ -98,13 +91,12 @@ def dhcp_nad(
     l2_bridge_device_worker_1,
     l2_bridge_device_worker_2,
     vlan_index_number,
-    bridge_device_type,
     l2_bridge_device_name,
 ):
     vlan_tag = next(vlan_index_number)
     with network_nad(
         namespace=namespace,
-        nad_type=bridge_device_type,
+        nad_type=LINUX_BRIDGE,
         nad_name=f"{l2_bridge_device_name}-dhcp-broadcast-nad-vlan-{vlan_tag}",
         interface_name=l2_bridge_device_name,
         vlan=vlan_tag,
@@ -119,12 +111,11 @@ def custom_eth_type_llpd_nad(
     namespace,
     l2_bridge_device_worker_1,
     l2_bridge_device_worker_2,
-    bridge_device_type,
     l2_bridge_device_name,
 ):
     with network_nad(
         namespace=namespace,
-        nad_type=bridge_device_type,
+        nad_type=LINUX_BRIDGE,
         nad_name=f"{l2_bridge_device_name}-custom-eth-type-icmp-nad",
         interface_name=l2_bridge_device_name,
         client=admin_client,
@@ -138,12 +129,11 @@ def mpls_nad(
     namespace,
     l2_bridge_device_worker_1,
     l2_bridge_device_worker_2,
-    bridge_device_type,
     l2_bridge_device_name,
 ):
     with network_nad(
         namespace=namespace,
-        nad_type=bridge_device_type,
+        nad_type=LINUX_BRIDGE,
         nad_name=f"{l2_bridge_device_name}-mpls-nad",
         interface_name=l2_bridge_device_name,
         client=admin_client,
@@ -157,12 +147,11 @@ def dot1q_nad(
     namespace,
     l2_bridge_device_worker_1,
     l2_bridge_device_worker_2,
-    bridge_device_type,
     l2_bridge_device_name,
 ):
     with network_nad(
         namespace=namespace,
-        nad_type=bridge_device_type,
+        nad_type=LINUX_BRIDGE,
         nad_name=f"{l2_bridge_device_name}-dot1q-nad",
         interface_name=l2_bridge_device_name,
         client=admin_client,


### PR DESCRIPTION
##### What this PR does / why we need it:
Missing backport from #5834

##### Which issue(s) this PR fixes:
Following OVS CNI removal, only Linux bridge is tested in l2bridge - remove bridge device type fixture, and replace with Linux bridge

##### Special notes for reviewer: 
All other changes from the original PR are already merged in 4.22 (#6097)

##### jira-ticket: -
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
