### PR TITLE
[4.19][VIRT] Fix non-migratable PVC in windows guest tools test

### DIFF
--- a/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
+++ b/tests/virt/node/readonly_disk/test_vm_with_windows_guest_tools.py
@@ -91,7 +91,8 @@ def vm_with_guest_tools(
         vm_instance_type=VirtualMachineClusterInstancetype(name="u1.large"),
         vm_preference=VirtualMachineClusterPreference(name="windows.10"),
         data_volume_template=data_volume_template_with_source_ref_dict(
-            data_source=golden_image_data_source_scope_class
+            data_source=golden_image_data_source_scope_class,
+            storage_class=py_config["default_storage_class"],
         ),
         termination_grace_period=TIMEOUT_3MIN,
         os_flavor=OS_FLAVOR_WINDOWS,


### PR DESCRIPTION
Backport of #5693 from cnv-4.20.

Pass storage class explicitly when creating DV template for VM. Without it, CDI defaults to RWO access mode, which makes the PVC non-migratable. This broke after commit b82ac9e removed the storage class fallback from data_volume_template_with_source_ref_dict.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
