### PR TITLE
bump soupsieve to 2.9.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2223,11 +2223,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
##### What this PR does / why we need it:

Fixes **CVE-2026-49477** (Jira CNV-93105). `soupsieve < 2.8.4` contains a
regular expression vulnerable to catastrophic backtracking (ReDoS) when
parsing an attribute selector with an unterminated quoted value in
`soupsieve/css_parser.py`. An attacker who can supply untrusted CSS
selector strings to `soupsieve.compile()` or Beautiful Soup
`.select()` / `.select_one()` can cause CPU exhaustion and denial of
service. Fixed in soupsieve 2.8.4.

This bumps the transitive dependency (via `bs4` -> `beautifulsoup4`) in
`uv.lock` from 2.8.3 to 2.9.2 (>= 2.8.4). Lockfile-only change;
`pyproject.toml` is unchanged since soupsieve is not a direct dependency
and `beautifulsoup4` pins no upper bound on it.

##### Which issue(s) this PR fixes:

CVE-2026-49477

##### Special notes for reviewer:

- soupsieve is a transitive dep only; no `pyproject.toml` change is needed.
- `uv lock --check` passes (lock stays consistent with pyproject.toml).
- sdist/wheel sha256 hashes match the upstream PyPI artifacts for 2.9.2.

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-93105
