### PR TITLE
[IUO] remove deprecated cdi featuregate in reconcile test

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -38,7 +38,6 @@ S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
 EXPECTED_CDI_HARDCODED_FEATUREGATES = {
     "DataVolumeClaimAdoption",
     "HonorWaitForFirstConsumer",
-    "WebhookPvcRendering",
 }
 HCO_DEFAULT_FEATUREGATES = {
     DEPLOY_KUBE_SECONDARY_DNS: FG_DISABLED,


### PR DESCRIPTION
##### What this PR does / why we need it:
WebhookPvcRendering was deprecated and removed from CDI default feature gates CDI PR #4172.
##### Which issue(s) this PR fixes:
failing all CI lanes in 5.0/4.23.
##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-96420


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated configuration validation expectations to align with the current set of supported feature gates.
  - No user-facing functionality or behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->