### PR TITLE
[IUO] Add PanicDevices to expected KubeVirt hardcoded featuregates

### DIFF
--- a/tests/install_upgrade_operators/constants.py
+++ b/tests/install_upgrade_operators/constants.py
@@ -38,6 +38,7 @@ EXPECTED_KUBEVIRT_HARDCODED_FEATUREGATES = {
     "HotplugVolumes",
     "DecentralizedLiveMigration",
     "LiveUpdateNADRef",
+    "PanicDevices",
 }
 S390X_SPECIFIC_KUBEVIRT_FEATUREGATES = {"SecureExecution"}
 EXPECTED_CDI_HARDCODED_FEATUREGATES = {


### PR DESCRIPTION
##### What this PR does / why we need it:
HCO added PanicDevices to the mandatory KubeVirt featuregate list for CNV 4.22, but the test constant was never updated, causing 7 consecutive test failures.

##### Which issue(s) this PR fixes:
4.22 tier2 tests alignment
##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-94977
