### PR TITLE
[Upgrade] Add upgrade_custom support to get_cnv_version_explorer_url

### DIFF
--- a/utilities/pytest_utils.py
+++ b/utilities/pytest_utils.py
@@ -416,7 +416,11 @@ def get_artifactory_server_url(cluster_host_url, session):
 
 
 def get_cnv_version_explorer_url(pytest_config):
-    if pytest_config.getoption("install") or pytest_config.getoption("upgrade") in ("eus", "cnv"):
+    if (
+        pytest_config.getoption("install")
+        or pytest_config.getoption("upgrade") in ("eus", "cnv")
+        or pytest_config.getoption("upgrade_custom") == "cnv"
+    ):
         LOGGER.info("Checking for cnv version explorer url:")
         version_explorer_url = os.environ.get("CNV_VERSION_EXPLORER_URL")
         if not version_explorer_url:

--- a/utilities/unittests/test_pytest_utils.py
+++ b/utilities/unittests/test_pytest_utils.py
@@ -1250,6 +1250,21 @@ class TestGetCnvVersionExplorerUrl:
 
         assert result == "https://version-explorer.com"
 
+    @patch("utilities.pytest_utils.os.environ", {"CNV_VERSION_EXPLORER_URL": "https://version-explorer.com"})
+    @patch("utilities.pytest_utils.LOGGER")
+    def test_get_cnv_version_explorer_url_upgrade_custom_cnv(self, mock_logger):
+        """Test getting CNV version explorer URL with upgrade_custom=cnv"""
+        mock_config = MagicMock()
+        mock_config.getoption.side_effect = lambda option: {
+            "install": False,
+            "upgrade": None,
+            "upgrade_custom": "cnv",
+        }.get(option, False)
+
+        result = get_cnv_version_explorer_url(mock_config)
+
+        assert result == "https://version-explorer.com"
+
     @patch("utilities.pytest_utils.os.environ", {})
     def test_get_cnv_version_explorer_url_missing_env(self):
         """Test error when CNV_VERSION_EXPLORER_URL is missing"""


### PR DESCRIPTION
##### What this PR does / why we need it:
- Add support for --upgrade_custom=cnv flag to retrieve CNV version explorer URL
- Mirrors existing logic for --upgrade eus/cnv flags
- Add unit test for upgrade_custom=cnv scenario

##### Which issue(s) this PR fixes:
Fixes custom upgrade lane version explorer URL retrieval
##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-96592


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CNV Version Explorer URLs are now correctly recognized when using the custom CNV upgrade option.

* **Tests**
  * Added coverage to verify URL handling for custom CNV upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->