### PR TITLE
[Storage] Wait for prompt and sync after writing file to VM console

### DIFF
--- a/utilities/storage.py
+++ b/utilities/storage.py
@@ -767,8 +767,10 @@ def write_file(
     """
     if not vm.ready:
         vm.start(wait=True)
-    with console.Console(vm=vm, kubeconfig=kubeconfig) as vm_console:
-        vm_console.sendline(f"echo '{content}' >> {filename}")
+    prompt = r"\$ "
+    with console.Console(vm=vm, prompt=prompt, kubeconfig=kubeconfig) as vm_console:
+        vm_console.sendline(f"echo '{content}' >> {filename} && sync")
+        vm_console.expect(prompt)
     if stop_vm:
         vm.stop(wait=True)
 


### PR DESCRIPTION
##### What this PR does / why we need it:
1. `vm_console.expect(prompt)` — waits for the shell to return to its prompt, which only happens after echo has actually run. This is the missing synchronization; without it, the console tears down before the command executes.
2.` && sync` — flushes the write to disk, so the file survives when the VM is later stopped/migrated (relevant for the CCLM flow).

##### Which issue(s) this PR fixes:
Without it, the test gets flaky on some storages

##### Special notes for reviewer:
coverage-omitted storage.py; thin console-sync wiring

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-writing reliability by ensuring data is synchronized before the operation completes.
  * Added more consistent confirmation handling after files are written, reducing the risk of reporting completion before the write has fully finished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->