### PR TITLE
network, udn: fix VM pair anti-affinity for multiple migrations

### DIFF
--- a/tests/network/user_defined_network/conftest.py
+++ b/tests/network/user_defined_network/conftest.py
@@ -55,13 +55,26 @@ def udn_affinity_label():
 
 
 @pytest.fixture(scope="module")
-def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+def udn_vm_pair_labels() -> tuple[tuple[str, str], tuple[str, str]]:
+    key, _ = affinity.new_label(key_prefix="udn")
+    return (key, "client"), (key, "server")
+
+
+@pytest.fixture(scope="module")
+def vma_udn(
+    udn_namespace: Namespace,
+    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
+    udn_vm_pair_labels: tuple[tuple[str, str], tuple[str, str]],
+    admin_client: DynamicClient,
+) -> Generator[BaseVirtualMachine]:
+    client_label, server_label = udn_vm_pair_labels
     with udn_vm(
         namespace_name=udn_namespace.name,
         name="vma-udn",
         client=admin_client,
         binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
-        template_labels=dict((udn_affinity_label,)),
+        template_labels=dict((client_label,)),
+        affinity=affinity.new_pod_anti_affinity(label=server_label),
     ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()
@@ -69,13 +82,20 @@ def vma_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_
 
 
 @pytest.fixture(scope="module")
-def vmb_udn(udn_namespace, namespaced_layer2_user_defined_network, udn_affinity_label, admin_client):
+def vmb_udn(
+    udn_namespace: Namespace,
+    namespaced_layer2_user_defined_network: Layer2UserDefinedNetwork,
+    udn_vm_pair_labels: tuple[tuple[str, str], tuple[str, str]],
+    admin_client: DynamicClient,
+) -> Generator[BaseVirtualMachine]:
+    client_label, server_label = udn_vm_pair_labels
     with udn_vm(
         namespace_name=udn_namespace.name,
         name="vmb-udn",
         client=admin_client,
         binding=UDN_BINDING_DEFAULT_PLUGIN_NAME,
-        template_labels=dict((udn_affinity_label,)),
+        template_labels=dict((server_label,)),
+        affinity=affinity.new_pod_anti_affinity(label=client_label),
     ) as vm:
         vm.start(wait=True)
         vm.wait_for_agent_connected()

--- a/tests/network/user_defined_network/test_user_defined_network.py
+++ b/tests/network/user_defined_network/test_user_defined_network.py
@@ -19,7 +19,6 @@ from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
 from tests.network.libs.connectivity import poll_tcp_connectivity
 from tests.network.user_defined_network.libudn import lookup_default_pod_ip
 from utilities.constants.networking import PUBLIC_DNS_SERVER_IP
-from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_1MIN
 from utilities.virt import migrate_vm_and_verify
 
@@ -135,10 +134,6 @@ class TestPrimaryUdn:
         assert is_tcp_connection(server=server, client=client)
 
     @pytest.mark.polarion("CNV-12177")
-    @pytest.mark.xfail(
-        reason=f"{QUARANTINED}: Failed migration of vm in UDN: CNV-72782",
-        run=False,
-    )
     def test_connectivity_is_preserved_during_server_live_migration(
         self, admin_client: DynamicClient, server: TcpServer, client: VMTcpClient
     ):


### PR DESCRIPTION
##### What this PR does / why we need it:
Both UDN connectivity VMs used the same pod anti-affinity label, so migration target pods could not schedule on a 3-worker cluster once Succeeded virt-launchers carried that label on every node (CNV-72782).

After several migrations in `TestPrimaryUdn`, Running and Succeeded virt-launcher pods with that label occupied all three workers, so the migration target pod stayed Pending with
`0/3 nodes didn't match pod anti-affinity rules`.

##### Which issue(s) this PR fixes:
Use client/server role labels with peer pod anti-affinity on `vma_udn` and `vmb_udn` - VMs still land on different nodes, but a migrating VM's own old launchers no longer block its target pod.

##### Special notes for reviewer: -

##### jira-ticket: https://redhat.atlassian.net/browse/CNV-72782
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restored live migration connectivity coverage for primary user-defined networks by enabling the test to run normally.
  * Improved test setup to use distinct client and server pod anti-affinity labels, supporting more accurate network validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->