### PR TITLE
Remove constant leftover from #6164

### DIFF
--- a/tests/install_upgrade_operators/must_gather/conftest.py
+++ b/tests/install_upgrade_operators/must_gather/conftest.py
@@ -40,7 +40,6 @@ from utilities.storage import add_dv_to_vm
 from utilities.virt import VirtualMachineForTests, fedora_vm_body, running_vm
 
 LOGGER = logging.getLogger(__name__)
-LONG_VM_NAME = "v" * 63
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
##### What this PR does / why we need it:
On https://github.com/RedHatQE/openshift-virtualization-tests/pull/6164 there was a constant leftover that needs to be removed, this pr removes the unused LONG_VM_NAME constant
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated must-gather test fixtures by removing an unused constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->