### PR TITLE
[4.21, net, hot-plug]: W/A guest-agent deadlock on hot-plugged interfaces

### DIFF
--- a/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
+++ b/tests/network/l2_bridge/test_bridge_nic_hot_plug.py
@@ -120,7 +120,7 @@ def hot_plugged_interface_with_address(running_vm_for_nic_hot_plug, index_number
     set_secondary_static_ip_address(
         vm=running_vm_for_nic_hot_plug,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
-        vmi_interface=hot_plugged_interface.name,
+        vmi_interface=hot_plugged_interface,
     )
 
 
@@ -161,7 +161,7 @@ def hot_plugged_second_interface_with_address(
     set_secondary_static_ip_address(
         vm=running_vm_with_secondary_and_hot_plugged_interfaces,
         ipv4_address=random_ipv4_address(net_seed=0, host_address=next(index_number)),
-        vmi_interface=hot_plugged_interface_on_vm_created_with_secondary_interface.name,
+        vmi_interface=hot_plugged_interface_on_vm_created_with_secondary_interface,
     )
 
 

--- a/tests/network/l2_bridge/utils.py
+++ b/tests/network/l2_bridge/utils.py
@@ -1,13 +1,27 @@
 import contextlib
+import json
 import logging
 import re
 import time
+from ipaddress import IPv4Address
+from typing import cast
 
+from kubernetes.dynamic.client import ResourceField
 from ocp_resources.resource import ResourceEditor
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+from ocp_utilities.exceptions import CommandExecFailed
+from pexpect.exceptions import EOF
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from libs.net.ip import random_ipv4_address
-from libs.net.vmspec import lookup_iface_status, lookup_iface_status_ip, wait_for_missing_iface_status
+from libs.net.vmspec import (
+    IpNotFound,
+    VMInterfaceStatusNotFoundError,
+    lookup_iface_status,
+    lookup_iface_status_ip,
+    wait_for_missing_iface_status,
+)
+from libs.vm.vm import BaseVirtualMachine
+from tests.network.libs.guest import read_guest_interface_ipv4
 from tests.network.utils import update_cloud_init_extra_user_data
 from utilities import console
 from utilities.constants import (
@@ -20,14 +34,20 @@ from utilities.constants import (
     TIMEOUT_5SEC,
 )
 from utilities.infra import get_pod_by_name_prefix
+from utilities.jira import is_jira_open
 from utilities.network import (
     IfaceNotFound,
     compose_cloud_init_data_dict,
     network_device,
 )
-from utilities.virt import VirtualMachineForTests, fedora_vm_body
+from utilities.virt import VirtualMachineForTests, fedora_vm_body, vm_console_run_commands
 
 LOGGER = logging.getLogger(__name__)
+
+
+class GuestInterfaceNotFoundError(Exception):
+    pass
+
 
 NETWORK_MANAGER_UNMANAGE_RUNCMD = [
     'sudo echo -e "[main]\nno-auto-default=*\nignore-carrier=*" > /etc/NetworkManager/conf.d/no-nm-ownership.conf',
@@ -124,6 +144,9 @@ def hot_plug_interface(
 
     update_hot_plug_config_in_vm(vm=vm, interfaces=interfaces, networks=networks)
 
+    if is_jira_open(jira_id="CNV-96648"):
+        return _lookup_hotplugged_iface_via_console(vm=vm, spec_interface_name=hot_plugged_interface_name)
+
     return lookup_iface_status(
         vm=vm,
         iface_name=hot_plugged_interface_name,
@@ -187,12 +210,12 @@ def create_bridge_interface_for_hot_plug(
         yield br
 
 
-def set_secondary_static_ip_address(vm, ipv4_address, vmi_interface):
-    guest_vm_interface = get_guest_vm_interface_name_by_vmi_interface_name(
-        vm=vm,
-        vm_interface_name=vmi_interface,
+def set_secondary_static_ip_address(
+    vm: VirtualMachineForTests, ipv4_address: str, vmi_interface: ResourceField
+) -> None:
+    console_command = (
+        f"sudo ip addr add {ipv4_address}/{IPV4_ADDRESS_SUBNET_PREFIX_LENGTH} dev {vmi_interface.interfaceName}"
     )
-    console_command = f"sudo ip addr add {ipv4_address}/{IPV4_ADDRESS_SUBNET_PREFIX_LENGTH} dev {guest_vm_interface}"
     LOGGER.info(f"Sending command to {vm.name} console: '{console_command}'")
     with console.Console(vm=vm) as vm_console:
         vm_console.sendline(console_command)
@@ -200,8 +223,26 @@ def set_secondary_static_ip_address(vm, ipv4_address, vmi_interface):
     # Verify the IP address was set successfully.
     # The function fails on timeout if the interface or its address are not found,
     # so there's no need to check its return code.
-    hot_plugged_interface_ip = lookup_iface_status_ip(vm=vm, iface_name=vmi_interface, ip_family=4)
-    LOGGER.info(f"{vm.name}/{vmi_interface} set with IP address {hot_plugged_interface_ip}")
+    expected_ipv4_address = IPv4Address(address=ipv4_address)
+    if is_jira_open(jira_id="CNV-96648"):
+        hot_plugged_interface_ip = read_guest_interface_ipv4(
+            vm=vm, interface_name=vmi_interface.interfaceName, expected_ip=expected_ipv4_address
+        ).ip
+        LOGGER.warning(
+            f"CNV-96648: Verified IP {hot_plugged_interface_ip} on {vmi_interface.name} via console "
+            f"(guest-agent not reporting on VM {vm.name})."
+        )
+    else:
+        hot_plugged_interface_ip = cast(
+            IPv4Address, lookup_iface_status_ip(vm=vm, iface_name=vmi_interface.name, ip_family=4)
+        )
+    if hot_plugged_interface_ip != expected_ipv4_address:
+        raise IpNotFound(
+            f"Expected IPv4 address {expected_ipv4_address} was not found on "
+            f"{vmi_interface.interfaceName} in VM {vm.name} (interface's "
+            f"actual IP is {hot_plugged_interface_ip})."
+        )
+    LOGGER.info(f"{vm.name}/{vmi_interface.name} set with IP address {hot_plugged_interface_ip}")
 
 
 def hot_plug_interface_and_set_address(
@@ -221,18 +262,65 @@ def hot_plug_interface_and_set_address(
     set_secondary_static_ip_address(
         vm=vm,
         ipv4_address=ipv4_address,
-        vmi_interface=iface.name,
+        vmi_interface=iface,
     )
 
     return iface
 
 
-def get_guest_vm_interface_name_by_vmi_interface_name(vm, vm_interface_name):
-    vmi_interfaces = vm.vmi.interfaces
-    for interface in vmi_interfaces:
-        if interface["name"] == vm_interface_name:
-            return interface["interfaceName"]
-    raise IfaceNotFound(name=vm_interface_name)
+@retry(
+    wait_timeout=120,
+    sleep=10,
+    exceptions_dict={
+        VMInterfaceStatusNotFoundError: [],
+        GuestInterfaceNotFoundError: [],
+        json.JSONDecodeError: [],
+        IndexError: [],
+        CommandExecFailed: [],
+        EOF: [],
+    },
+)
+def _lookup_hotplugged_iface_via_console(
+    vm: VirtualMachineForTests | BaseVirtualMachine,
+    spec_interface_name: str,
+) -> ResourceField:
+    """Look up a hot-plugged interface via console when guest-agent is dead (CNV-96648).
+
+    Args:
+        vm: The virtual machine to query.
+        spec_interface_name: The spec-level interface name.
+
+    Returns:
+        A ResourceField with interface data gathered from the guest.
+
+    Raises:
+        VMInterfaceStatusNotFoundError: If the interface has not yet appeared in the VMI spec.
+        GuestInterfaceNotFoundError: If no guest interface with the expected MAC is found.
+    """
+    vmi_iface = _lookup_vmi_interface(vmi=vm.vmi, interface_name=spec_interface_name)
+    if not vmi_iface:
+        raise VMInterfaceStatusNotFoundError(f"Interface {spec_interface_name} not in VMI spec of {vm.name}")
+
+    LOGGER.warning(
+        f"CNV-96648: Guest agent did not report interface {spec_interface_name} on VM {vm.name}, "
+        f"falling back to console lookup by MAC {vmi_iface['macAddress']}."
+    )
+    cmd = "ip -j addr show"
+    output = vm_console_run_commands(vm=vm, commands=[cmd])
+    guest_interfaces = json.loads(output[cmd][1])
+
+    visible_ifaces = [{"ifname": iface.get("ifname"), "address": iface.get("address")} for iface in guest_interfaces]
+    LOGGER.info(
+        f"CNV-96648: looking for MAC {vmi_iface['macAddress']} in guest {vm.name}, visible interfaces: {visible_ifaces}"
+    )
+    for guest_iface in guest_interfaces:
+        if guest_iface.get("address", "").lower() == vmi_iface["macAddress"].lower():
+            LOGGER.info(
+                f"Console fallback found interface {guest_iface['ifname']} for {spec_interface_name} on VM {vm.name}."
+            )
+            return ResourceField(params={"name": spec_interface_name, "interfaceName": guest_iface["ifname"]})
+
+    raise GuestInterfaceNotFoundError(f"No interface associated with {spec_interface_name} found in VM guest {vm.name}")
 
 
 @contextlib.contextmanager

--- a/tests/network/libs/guest.py
+++ b/tests/network/libs/guest.py
@@ -1,0 +1,56 @@
+import ipaddress
+import json
+import logging
+from typing import TYPE_CHECKING, Final
+
+from libs.net.vmspec import IpNotFound
+from libs.vm.vm import BaseVirtualMachine
+from utilities.virt import vm_console_run_commands
+
+if TYPE_CHECKING:
+    from utilities.virt import VirtualMachineForTests
+
+LOGGER = logging.getLogger(__name__)
+
+
+def read_guest_interface_ipv4(
+    vm: VirtualMachineForTests | BaseVirtualMachine,
+    interface_name: str,
+    expected_ip: ipaddress.IPv4Address | None = None,
+) -> ipaddress.IPv4Interface:
+    """Retrieve the IPv4 address and prefix length of an interface from the VM guest OS.
+
+    Args:
+        vm: The virtual machine to query.
+        interface_name: The name of the network interface (e.g., "eth0").
+        expected_ip: When provided, the command filters to this specific host address
+            using 'ip addr show to <expected_ip>', which returns output only when
+            that address is configured on the interface. Useful when the interface
+            may carry multiple addresses.
+
+    Returns:
+        IPv4 address with prefix length (e.g., 192.168.1.5/24).
+
+    Raises:
+        IpNotFound: If no matching IPv4 address is found or console output cannot be parsed.
+    """
+    to_filter: Final[str] = f" to {expected_ip}" if expected_ip is not None else ""
+    cmd: Final[str] = f"ip -j -4 addr show {interface_name}{to_filter}"
+
+    output = vm_console_run_commands(vm=vm, commands=[cmd], timeout=30)
+    LOGGER.info(f"Command {cmd} output: {output[cmd]}")
+
+    try:
+        iface_info = json.loads(output[cmd][1])
+    except (IndexError, json.JSONDecodeError) as err:
+        raise IpNotFound(f"Failed to parse console JSON from VM {vm.name} for '{cmd}': {output[cmd]}") from err
+
+    if iface_info and "addr_info" in iface_info[0]:
+        for addr in iface_info[0]["addr_info"]:
+            if addr.get("family") == "inet":
+                if expected_ip is None or ipaddress.IPv4Address(addr["local"]) == expected_ip:
+                    return ipaddress.IPv4Interface(address=f"{addr['local']}/{addr['prefixlen']}")
+
+    raise IpNotFound(
+        f"{'No IPv4 address' if expected_ip is None else str(expected_ip)} found on {interface_name} in VM {vm.name}"
+    )

--- a/tests/network/user_defined_network/ip_specification/libipspec.py
+++ b/tests/network/user_defined_network/ip_specification/libipspec.py
@@ -1,20 +1,12 @@
 import ipaddress
 import json
-import logging
-from typing import Final
-
-from libs.net.vmspec import IpNotFound
-from libs.vm.vm import BaseVirtualMachine
-
-LOGGER = logging.getLogger(__name__)
 
 
 def ip_address_annotation(
     network_name: str,
     ip_address: ipaddress.IPv4Interface | ipaddress.IPv6Interface,
 ) -> dict[str, str]:
-    """
-    Generate VM annotation for specifying IP address on a network interface.
+    """Generate VM annotation for specifying IP address on a network interface.
 
     Args:
         network_name: The name of the network interface.
@@ -26,38 +18,3 @@ def ip_address_annotation(
     """
     ip_addresses_spec = {network_name: [str(ip_address.ip)]}
     return {"network.kubevirt.io/addresses": json.dumps(ip_addresses_spec)}
-
-
-def read_guest_interface_ipv4(
-    vm: BaseVirtualMachine,
-    interface_name: str,
-) -> ipaddress.IPv4Interface:
-    """
-    Retrieve the IPv4 address and prefix length of an interface from the VM guest OS.
-
-    Args:
-        vm: The virtual machine to query.
-        interface_name: The name of the network interface (e.g., "eth0").
-
-    Returns:
-        IPv4 address with prefix length (e.g., 192.168.1.5/24).
-
-    Raises:
-        RuntimeError: If command execution fails.
-        IpNotFound: If no IPv4 address is found on the specified interface.
-    """
-    cmd: Final[str] = f"ip -j -4 addr show {interface_name}"
-    if not (out := vm.console(commands=[cmd], timeout=10)):
-        raise RuntimeError(f"Failed to retrieve IP address from {interface_name}")
-
-    LOGGER.info(f"Command {cmd} output: {out}")
-
-    iface_info = json.loads(out[cmd][1])
-    if iface_info and "addr_info" in iface_info[0]:
-        for addr in iface_info[0]["addr_info"]:
-            if addr["family"] == "inet":
-                ip_str = addr["local"]
-                prefix_len = addr["prefixlen"]
-                return ipaddress.IPv4Interface(address=f"{ip_str}/{prefix_len}")
-
-    raise IpNotFound(f"No IPv4 address found on {interface_name}")

--- a/tests/network/user_defined_network/ip_specification/test_ip_specification.py
+++ b/tests/network/user_defined_network/ip_specification/test_ip_specification.py
@@ -17,10 +17,8 @@ from libs.net.traffic_generator import VMTcpClient as TcpClient
 from libs.net.vmspec import lookup_iface_status_ip, lookup_primary_network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs import cloudinit
-from tests.network.user_defined_network.ip_specification.libipspec import (
-    ip_address_annotation,
-    read_guest_interface_ipv4,
-)
+from tests.network.libs.guest import read_guest_interface_ipv4
+from tests.network.user_defined_network.ip_specification.libipspec import ip_address_annotation
 from utilities.constants import PUBLIC_DNS_SERVER_IP
 from utilities.virt import migrate_vm_and_verify
 


### PR DESCRIPTION
CNV-96648 causes guest-agent to stop reporting newly hot-plugged interfaces, failing tests that depend on interface data from VMI status. Work around the bug so tests continue to run until the fix is released. As part of this change, functionality from another package (user_defined_network/ip_specification) was re-used, therefore this package is handled here as well.

The cherry-pick is combined from PRs that were all required for this, and after they are merged in main, it makes the most sense to group them together for cherry-picking:
 #5578
 #5584
 #5970
 #6002
All these PRs were later combined in the [4.22 cherry-pick](https://github.com/RedHatQE/openshift-virtualization-tests/pull/6204), which became the source for this PR.
Includes  Avoid redundant VMI interface lookup:
hot_plug_interface() already returns the full interface status including interfaceName. Pass it through to set_secondary_static_ip_address() instead of re-querying VMI status for the same value.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-95230