### PR TITLE
Use rpm for local guest agent version query

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1183,8 +1183,9 @@ def get_node_selector_dict(node_selector):
 
 
 def get_linux_guest_agent_version(ssh_exec):
-    ssh_exec.sudo = True
-    return guest_agent_version_parser(version_string=ssh_exec.package_manager.info("qemu-guest-agent"))
+    return guest_agent_version_parser(
+        version_string=ssh_exec.executor().run_cmd(cmd=shlex.split("rpm -q qemu-guest-agent"))[1]
+    )
 
 
 def get_linux_os_info(ssh_exec):


### PR DESCRIPTION
##### What this PR does / why we need it:

Replace package_manager.info() (auto-detects dnf) with direct rpm -q for querying qemu-guest-agent version. dnf refreshes remote repo metadata even for local queries, causing failures when VM DNS is unavailable.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of the installed Linux guest agent version.
  - Version checks now use the system’s package query output directly, helping provide more accurate results across supported Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->