### PR TITLE
CherryPicked: [cnv-4.22] net, evpn: fix EVPN test infrastructure for OVN-K VTEP BGP advertisement

### DIFF
--- a/tests/network/bgp/evpn/conftest.py
+++ b/tests/network/bgp/evpn/conftest.py
@@ -6,6 +6,7 @@ from typing import Final
 import ocp_resources.network_operator_openshift_io as openshift_no
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.cluster_operator import ClusterOperator
 from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
@@ -29,6 +30,7 @@ from tests.network.bgp.evpn.libevpn import (
     deploy_evpn_l3_endpoint,
     deploy_evpn_l3_vrf,
     evpn_workloads_active_connections,
+    node_primary_ipv4_interface,
     teardown_evpn_bridge,
     teardown_evpn_l2_endpoint,
     teardown_evpn_l3_endpoint,
@@ -44,6 +46,8 @@ from tests.network.libs.bgp import (
 )
 from tests.network.libs.label_selector import LabelSelector
 from tests.network.libs.vm_factory import udn_vm
+from utilities.constants.hco import DEFAULT_RESOURCE_CONDITIONS
+from utilities.infra import wait_for_consistent_resource_conditions
 
 EVPN_ADVERTISE_LABEL: Final[dict] = {"advertise": "evpn"}
 APP_EVPN_CUDN_LABEL: Final[dict] = {**EVPN_ADVERTISE_LABEL, "app": "cudn-evpn"}
@@ -61,6 +65,7 @@ EVPN_IP_VRF_VNI: Final[int] = 20102
 
 @pytest.fixture(scope="module")
 def ovn_local_gateway_mode(
+    admin_client: DynamicClient,
     network_operator: openshift_no.Network,
 ) -> Generator[None]:
     patch = {
@@ -75,7 +80,19 @@ def ovn_local_gateway_mode(
         }
     }
     with ResourceEditor(patches=patch):
+        wait_for_consistent_resource_conditions(
+            dynamic_client=admin_client,
+            resource_kind=ClusterOperator,
+            resource_name="network",
+            expected_conditions=DEFAULT_RESOURCE_CONDITIONS,
+        )
         yield
+    wait_for_consistent_resource_conditions(
+        dynamic_client=admin_client,
+        resource_kind=ClusterOperator,
+        resource_name="network",
+        expected_conditions=DEFAULT_RESOURCE_CONDITIONS,
+    )
 
 
 @pytest.fixture(scope="module")
@@ -88,9 +105,7 @@ def vtep(
     admin_client: DynamicClient,
     workers: list[Node],
 ) -> Generator[VTEP]:
-    host_cidrs = json.loads(workers[0].instance.metadata.annotations["k8s.ovn.org/host-cidrs"])
-    host_cidr = next(cidr for cidr in host_cidrs if "." in cidr)
-    vtep_cidr = str(ipaddress.ip_network(host_cidr, strict=False))
+    vtep_cidr = str(node_primary_ipv4_interface(workers[0]).network)
     with VTEP(
         name="evpn-vtep",
         cidrs=[vtep_cidr],
@@ -217,11 +232,7 @@ def evpn_bridge(
     frr_external_pod: ExternalFrrPodInfo,
     workers: list[Node],
 ) -> Generator[None]:
-    worker_ips = []
-    for worker in workers:
-        host_cidrs = json.loads(worker.instance.metadata.annotations["k8s.ovn.org/host-cidrs"])
-        host_ip = next(cidr.split("/")[0] for cidr in host_cidrs if "." in cidr)
-        worker_ips.append(host_ip)
+    worker_ips = [str(node_primary_ipv4_interface(worker).ip) for worker in workers]
 
     deploy_evpn_bridge(
         pod=frr_external_pod.pod,

--- a/tests/network/bgp/evpn/conftest.py
+++ b/tests/network/bgp/evpn/conftest.py
@@ -11,6 +11,7 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.vtep import VTEP
+from utilities.constants.hco import DEFAULT_RESOURCE_CONDITIONS
 
 from libs.net.ip import random_ipv4_address
 from libs.net.traffic_generator import TcpServer
@@ -46,7 +47,6 @@ from tests.network.libs.bgp import (
 )
 from tests.network.libs.label_selector import LabelSelector
 from tests.network.libs.vm_factory import udn_vm
-from utilities.constants.hco import DEFAULT_RESOURCE_CONDITIONS
 from utilities.infra import wait_for_consistent_resource_conditions
 
 EVPN_ADVERTISE_LABEL: Final[dict] = {"advertise": "evpn"}

--- a/tests/network/bgp/evpn/conftest.py
+++ b/tests/network/bgp/evpn/conftest.py
@@ -11,7 +11,6 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.vtep import VTEP
-from utilities.constants.hco import DEFAULT_RESOURCE_CONDITIONS
 
 from libs.net.ip import random_ipv4_address
 from libs.net.traffic_generator import TcpServer
@@ -47,6 +46,7 @@ from tests.network.libs.bgp import (
 )
 from tests.network.libs.label_selector import LabelSelector
 from tests.network.libs.vm_factory import udn_vm
+from utilities.constants import DEFAULT_RESOURCE_CONDITIONS
 from utilities.infra import wait_for_consistent_resource_conditions
 
 EVPN_ADVERTISE_LABEL: Final[dict] = {"advertise": "evpn"}

--- a/tests/network/bgp/evpn/libevpn.py
+++ b/tests/network/bgp/evpn/libevpn.py
@@ -1,10 +1,12 @@
 import contextlib
 import ipaddress
+import json
 import logging
 import shlex
 import uuid
 from collections.abc import Generator
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from ocp_resources.pod import Pod
 from pytest import Subtests
@@ -22,6 +24,9 @@ from libs.net.traffic_generator import (
 from libs.net.vmspec import lookup_iface_status, lookup_primary_network
 from libs.vm.vm import BaseVirtualMachine
 from tests.network.libs.bgp import CLUSTER_FRR_ASN, EXTERNAL_FRR_ASN, NET_TOOLS_CONTAINER_NAME
+
+if TYPE_CHECKING:
+    from ocp_resources.node import Node
 
 LOGGER = logging.getLogger(__name__)
 
@@ -466,3 +471,16 @@ def assert_evpn_workloads_connectivity(
         for l3_client, l3_server in l3_connections:
             with subtests.test(f"routed-L3 IPv{ipaddress.ip_address(l3_client.server_ip).version}"):
                 assert is_tcp_connection(server=l3_server, client=l3_client)
+
+
+def node_primary_ipv4_interface(node: Node) -> ipaddress.IPv4Interface:
+    """Return the primary IPv4 interface of a node.
+
+    Args:
+        node: The node to get the primary IPv4 interface of.
+
+    Returns:
+        The primary IPv4 interface of the node as an ipaddress.IPv4Interface object.
+    """
+    primary_ifaddr = json.loads(node.instance.metadata.annotations["k8s.ovn.org/node-primary-ifaddr"])
+    return ipaddress.IPv4Interface(address=primary_ifaddr["ipv4"])

--- a/tests/network/libs/bgp.py
+++ b/tests/network/libs/bgp.py
@@ -192,16 +192,15 @@ def generate_frr_conf(
 
     evpn_route_map = "evpn-to-ocp"
 
-    # Route-map: strips cluster ASN from AS_PATH for eBGP EVPN re-advertisement
+    # Route-map: preserve next-hop for EVPN re-advertisement
     lines = [
         f"route-map {evpn_route_map} permit 10",
-        f" set as-path exclude {CLUSTER_FRR_ASN}",
         " set ip next-hop unchanged",
         "exit",
         "",
     ]
 
-    # BGP router and neighbor definitions
+    # BGP router and neighbor definitions (eBGP: external AS)
     lines.extend([
         f"router bgp {EXTERNAL_FRR_ASN}",
         " no bgp ebgp-requires-policy",
@@ -212,7 +211,7 @@ def generate_frr_conf(
     lines.extend([f" neighbor {ip} remote-as {CLUSTER_FRR_ASN}" for ip in nodes_ipv4_list])
     lines.append("")
 
-    # IPv4 unicast: advertise external subnet, activate neighbors
+    # IPv4 unicast: advertise external subnet to nodes
     lines.extend([
         " address-family ipv4 unicast",
         f"  network {external_subnet_ipv4}",
@@ -220,12 +219,11 @@ def generate_frr_conf(
     for ip in nodes_ipv4_list:
         lines.extend([
             f"  neighbor {ip} activate",
-            f"  neighbor {ip} next-hop-self",
-            f"  neighbor {ip} route-reflector-client",
+            f"  neighbor {ip} attribute-unchanged next-hop",
         ])
     lines.extend([" exit-address-family", ""])
 
-    # EVPN: activate neighbors with route-map to handle AS-path loop prevention
+    # EVPN: activate neighbors for L2VPN EVPN route exchange
     lines.append(" address-family l2vpn evpn")
     for ip in nodes_ipv4_list:
         lines.extend([


### PR DESCRIPTION
Cherry-pick from `main` branch, original PR: https://github.com/RedHatQE/openshift-virtualization-tests/pull/6208

Replaces https://github.com/RedHatQE/openshift-virtualization-tests/pull/6240 which failed tox due to missing `utilities/constants/hco.py` on cnv-4.22.

##### What this PR does / why we need it:
Fix the external FRR pod nexthop advertisement to be compatible with the VTEP host IP BGP advertisement introduced in recent OVN-K versions, and strengthen the overall EVPN test setup. See original PR #6208 for full details.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Fixes tox failure in #6240 caused by importing from `utilities.constants.hco` which does not exist on cnv-4.22.

##### jira-ticket:
NONE