### PR TITLE
infra: Remove quarantine CNV-86273 from DataSourceOptOut test

### DIFF
--- a/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
+++ b/tests/infrastructure/golden_images/update_boot_source/test_ssp_data_sources.py
@@ -23,7 +23,6 @@ from tests.infrastructure.golden_images.update_boot_source.utils import (
 from tests.utils import get_parameters_from_template
 from utilities.constants.hco import DATA_SOURCE_NAME
 from utilities.constants.images import DEFAULT_FEDORA_REGISTRY_URL
-from utilities.constants.pytest import QUARANTINED
 from utilities.constants.timeouts import TIMEOUT_5MIN
 from utilities.ssp import wait_for_condition_message_value
 
@@ -525,10 +524,6 @@ class TestDataSourcesOptInLabel:
     "enabled_common_boot_image_import_feature_gate_scope_class",
     "opted_in_data_source_scope_class",
     "opted_out_data_source_scope_class",
-)
-@pytest.mark.xfail(
-    reason=f"{QUARANTINED}: Flaky opt-out label / DataSource volume update; tracked in CNV-86273",
-    run=False,
 )
 class TestDataSourcesOptOutLabel:
     @pytest.mark.polarion("CNV-8244")


### PR DESCRIPTION
##### What this PR does / why we need it:
Remove quarantine for CNV-92714 after it was fixed.
 - Skipped this reference by mistake after https://github.com/RedHatQE/openshift-virtualization-tests/pull/6210 was merged

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Will move the Jira ticket to verify once this is merged, so it won't block CI.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->
https://redhat.atlassian.net/browse/CNV-86273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Restored normal execution for the data source opt-out label test, removing its quarantined and expected-failure status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->