### PR TITLE
CI: Add github-webhook-server.yaml to omit the needs-rebase label

### DIFF
--- a/.github-webhook-server.yaml
+++ b/.github-webhook-server.yaml
@@ -1,0 +1,17 @@
+# Repository-local configuration for the openshift-virtualization-qe-bot
+# (https://github.com/myk-org/github-webhook-server).
+#
+# `labels.enabled-labels` is an allow-list: when set, only the listed label
+# categories are applied. All categories are listed below except
+# "needs-rebase", which is intentionally omitted to disable it.
+labels:
+  enabled-labels:
+    - verified
+    - hold
+    - wip
+    - has-conflicts
+    - can-be-merged
+    - size
+    - branch
+    - cherry-pick
+    - automerge


### PR DESCRIPTION
##### What this PR does / why we need it:
Adds a `.github-webhook-server.yaml` config file to disable the `needs-rebase` label that openshift-virtualization-qe-bot was auto-applying to nearly every open PR. 
The bot's labels.enabled-labels setting is an allow-list, so all other label categories are explicitly listed to preserve current behavior, with `needs-rebase` intentionally omitted.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
Relies on [myk-org/github-webhook-server#1217](https://github.com/myk-org/github-webhook-server/pull/1217) to be merged upstream

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added repository configuration for automated label management.
  - Enabled supported labels for verification, workflow status, conflicts, merge readiness, sizing, branches, cherry-picks, and automatic merging.
  - The rebase-needed label is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->