### PR TITLE
[Storage] Add missing data_import_cron_source_format field to StorageClass dataclass

### DIFF
--- a/libs/storage/config.py
+++ b/libs/storage/config.py
@@ -22,6 +22,7 @@ class StorageClass:
     snapshot: bool
     online_resize: bool
     wffc: bool
+    data_import_cron_source_format: str = ""
 
 
 class StorageClassConfig:


### PR DESCRIPTION
##### What this PR does / why we need it:

Adds the missing `data_import_cron_source_format` field to the `StorageClass` dataclass in `libs/storage/config.py`.

PR #5867 added `data_import_cron_source_format` to `HPP_CAPABILITIES` dict and all `global_config*.py` files, but did not update the `StorageClass` dataclass. This causes a `TypeError` when `StorageClassConfig.supported_storage_classes()` unpacks `**HPP_CAPABILITIES` into `StorageClass()`:

```
TypeError: StorageClass.__init__() got an unexpected keyword argument 'data_import_cron_source_format'
```

This crashes pytest during `pytest_configure` when `--conformance-storage-class` is used (e.g., self-validation checkup tier2 runs).

##### Which issue(s) this PR fixes:
Fixes the regression introduced in #5867

##### Special notes for reviewer:
One-line fix. No unit tests needed — `StorageClass` is a simple dataclass with no testable behavior, and coverage-omitted `config.py` is exercised by integration tests (self-validation tier2).

##### jira-ticket:
https://redhat.atlassian.net/browse/CNV-92158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the source format used by scheduled data imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->