### PR TITLE
[Storage] DV stop status function for Restricted Namespace Cloning module

### DIFF
--- a/tests/storage/restricted_namespace_cloning/conftest.py
+++ b/tests/storage/restricted_namespace_cloning/conftest.py
@@ -25,6 +25,7 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VERBS_SRC_SA,
     VM_FOR_TEST,
 )
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from tests.storage.utils import (
     create_cluster_role,
     create_role_binding,
@@ -88,7 +89,7 @@ def dv_cloned_from_datasource(
         storage_class=storage_class_name_scope_module,
         client=namespace.client,
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 
@@ -319,7 +320,7 @@ def dv_destination_cloned_from_pvc(
         consume_wffc=False,
         annotations=BIND_IMMEDIATE_ANNOTATION,
     ) as cdv:
-        cdv.wait_for_dv_success()
+        cdv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=cdv)
         yield cdv
 
 

--- a/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
+++ b/tests/storage/restricted_namespace_cloning/test_restricted_namespace_cloning.py
@@ -22,6 +22,7 @@ from tests.storage.restricted_namespace_cloning.constants import (
     VERBS_SRC,
 )
 from tests.storage.restricted_namespace_cloning.utils import create_dv_negative, verify_snapshot_used_namespace_transfer
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities.constants import Images
 from utilities.constants.images import OS_FLAVOR_FEDORA
 from utilities.storage import create_vm_from_dv
@@ -52,7 +53,10 @@ def test_unprivileged_user_clone_dv_same_namespace_positive(
     permissions_pvc_source,
     dv_cloned_by_unprivileged_user_in_the_same_namespace,
 ):
-    dv_cloned_by_unprivileged_user_in_the_same_namespace.wait_for_dv_success()
+    dv_cloned_by_unprivileged_user_in_the_same_namespace.wait_for_dv_success(
+        stop_status_func=dv_stop_status_restart_threshold,
+        dv=dv_cloned_by_unprivileged_user_in_the_same_namespace,
+    )
 
 
 @pytest.mark.sno


### PR DESCRIPTION
##### What this PR does / why we need it:
Wires the shared `dv_stop_status_restart_threshold` stop-status guard into the
clone DataVolume waits in `tests/storage/restricted_namespace_cloning/`.

These tests clone DataVolumes (from a DataSource, from a PVC cross-namespace,
and within the same namespace) and wait on `wait_for_dv_success()` without any
early-exit guard. When a clone importer restarts excessively, the wait blocks
until the full timeout before failing, wasting CI time and obscuring the real
failure cause. The `cdi_clone` tests already use
`dv_stop_status_restart_threshold` for exactly this reason; this PR reuses the
same shared helper here so these clone waits fail fast on excessive restarts.

##### Which issue(s) this PR fixes:
[CNV-94466](https://redhat.atlassian.net/browse/CNV-94466)

##### Special notes for reviewer:
No new function was added — the existing shared
`tests/storage/stop_status_utils.py:dv_stop_status_restart_threshold` is reused.
Changes are confined to three clone `wait_for_dv_success()` call sites (two
fixtures in `conftest.py`, one assertion in
`test_restricted_namespace_cloning.py`). No behavior change on the success path;
only adds an early stop when a clone DV exceeds the restart threshold.

Co-Authored: Claude Opus 4.8 <noreply@anthropic.com>

##### jira-ticket:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved storage cloning test reliability by using stop-status thresholds when waiting for cloned data volumes to complete.
  * Updated restricted-namespace cloning scenarios to validate completion with the revised readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->