### PR TITLE
fix: use preferredCPUTopology for VM CPU sizing in preference tests

### DIFF
--- a/tests/infrastructure/instance_types/test_common_vm_preference.py
+++ b/tests/infrastructure/instance_types/test_common_vm_preference.py
@@ -6,7 +6,10 @@ from ocp_resources.virtual_machine_cluster_preference import (
 )
 from pytest_testconfig import config as py_config
 
-from tests.infrastructure.instance_types.utils import assert_mismatch_vendor_label
+from tests.infrastructure.instance_types.utils import (
+    assert_mismatch_vendor_label,
+    extract_resources_from_cluster_preference_spec,
+)
 from tests.infrastructure.instance_types.vm_preference_list import VM_PREFERENCES_LIST
 from utilities.constants import Images
 from utilities.constants.architecture import SUPPORTED_CPU_ARCHITECTURES
@@ -19,29 +22,10 @@ LOGGER = logging.getLogger(__name__)
 pytestmark = [pytest.mark.post_upgrade, pytest.mark.sno]
 
 
-def _extract_resources_from_cluster_preference_spec(cluster_preference_spec):
-    memory_guest = (
-        cluster_preference_spec.get("requirements", {}).get("memory", {}).get("guest")
-        or Images.Rhel.DEFAULT_MEMORY_SIZE
-    )
-    spread_options = cluster_preference_spec.get("cpu", {}).get("spreadOptions", {})
-
-    sockets = None
-    cores = None
-    threads = None
-
-    if cpu_guest := cluster_preference_spec.get("requirements", {}).get("cpu", {}).get("guest"):
-        cores = spread_options.get("ratio", 2) if spread_options else 1
-        sockets = max(1, cpu_guest // cores)
-        threads = 1
-
-    return memory_guest, sockets, cores, threads
-
-
 def start_vm_with_cluster_preference(client, preference_name, namespace_name):
     cluster_preference = VirtualMachineClusterPreference(client=client, name=preference_name)
 
-    memory_guest, sockets, cores, threads = _extract_resources_from_cluster_preference_spec(
+    memory_guest, sockets, cores, threads = extract_resources_from_cluster_preference_spec(
         cluster_preference_spec=cluster_preference.instance.spec
     )
 

--- a/tests/infrastructure/instance_types/utils.py
+++ b/tests/infrastructure/instance_types/utils.py
@@ -1,11 +1,68 @@
 import shlex
-from typing import Literal
+from typing import Any, Literal
 
 from ocp_resources.controller_revision import ControllerRevision
 from ocp_resources.resource import Resource
 from pyhelper_utils.shell import run_ssh_commands
 
+from utilities.constants import Images
 from utilities.virt import VirtualMachineForTests
+
+
+def extract_resources_from_cluster_preference_spec(
+    cluster_preference_spec: dict[str, Any],
+) -> tuple[str, int | None, int | None, int | None]:
+    """Derive VM CPU and memory sizing from a cluster preference spec.
+
+    Maps requirements.cpu.guest and cpu.preferredCPUTopology onto sockets,
+    cores, and threads for VirtualMachineForTests. Unset topology defaults
+    to sockets.
+
+    Args:
+        cluster_preference_spec (dict): VirtualMachineClusterPreference.spec
+            content.
+
+    Returns:
+        A tuple (memory_guest, sockets, cores, threads).
+        memory_guest (str): Guest memory from requirements.memory.guest, or
+            Images.Rhel.DEFAULT_MEMORY_SIZE when unset.
+        sockets (int | None): Socket count, or None when the preference has
+            no requirements.cpu.guest.
+        cores (int | None): Core count, or None when the preference has no
+            requirements.cpu.guest.
+        threads (int | None): Thread count, or None when the preference has
+            no requirements.cpu.guest.
+    """
+    memory_guest = (
+        cluster_preference_spec.get("requirements", {}).get("memory", {}).get("guest")
+        or Images.Rhel.DEFAULT_MEMORY_SIZE
+    )
+
+    cpu_guest = cluster_preference_spec.get("requirements", {}).get("cpu", {}).get("guest")
+    if not cpu_guest:
+        return memory_guest, None, None, None
+
+    sockets = cores = threads = 1
+    if cpu_guest > 1:
+        cpu_preferences = cluster_preference_spec.get("cpu", {})
+        topology = cpu_preferences.get("preferredCPUTopology", "sockets").removeprefix("prefer").lower()
+        if topology == "cores":
+            cores = cpu_guest
+        elif topology == "spread":
+            spread_options = cpu_preferences.get("spreadOptions", {})
+            ratio = spread_options.get("ratio", 2)
+            across = spread_options.get("across", "SocketsCores")
+            if across == "SocketsCoresThreads":
+                threads = 2
+                cores = ratio
+                sockets = cpu_guest // 2 // ratio
+            else:
+                cores = ratio
+                sockets = cpu_guest // ratio
+        else:
+            sockets = cpu_guest
+
+    return memory_guest, sockets, cores, threads
 
 
 def get_mismatch_vendor_label(resources_list):


### PR DESCRIPTION
##### What this PR does / why we need it:

- Fix CPU topology derivation for cluster preferences to read preferredCPUTopology.

- common-instancetypes 39926ee set windows.10/11 preferredCPUTopology to cores. The helper always put requirements.cpu.guest into sockets so windows.11 (guest 2) failed the webhook check with cores=1 < 2 (422).

- Move the helper `extract_resources_from_cluster_preference_spec`  to utils 

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
References for deriving threads: https://github.com/kubevirt/kubevirt/blob/main/pkg/instancetype/apply/cpu.go#L96-L106.  
function extract_resources_from_cluster_preference_spec is written for preferences we currently ship today so logic takes care of SocketsCoresThreads and default value SocketsCores. we knowing skip CoresThreads as no cluster preference currently use it and will be a dead code.

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Expanded automated validation for instance-type configurations.
* Added coverage for VM memory defaults and CPU topologies using sockets, cores, threads, and spread configurations.
* Centralized preference handling to improve consistency across VM startup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->