### PR TITLE
[Storage] - Guard golden image clone DV waits with restart-threshold stop status

### DIFF
--- a/tests/storage/golden_image/test_golden_image.py
+++ b/tests/storage/golden_image/test_golden_image.py
@@ -7,6 +7,7 @@ from ocp_resources.datavolume import DataVolume
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import config as py_config
 
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities.constants.storage import BIND_IMMEDIATE_ANNOTATION, PVC
 from utilities.constants.timeouts import TIMEOUT_20MIN
 from utilities.storage import ErrorMsg, create_dv, get_dv_size_from_datasource
@@ -38,7 +39,7 @@ def golden_image_dv_from_fedora_datasource_scope_module(
             "namespace": fedora_data_source_scope_module.namespace,
         },
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 
@@ -184,4 +185,8 @@ def test_regular_user_can_create_dv_in_ns_given_proper_rolebinding(
         "Once a proper RoleBinding created, that use the os-images.kubevirt.io:edit\
         ClusterRole, a regular user can create a DV in the golden image NS.",
     )
-    dv_created_by_unprivileged_user_with_rolebinding.wait_for_dv_success(timeout=TIMEOUT_20MIN)
+    dv_created_by_unprivileged_user_with_rolebinding.wait_for_dv_success(
+        timeout=TIMEOUT_20MIN,
+        stop_status_func=dv_stop_status_restart_threshold,
+        dv=dv_created_by_unprivileged_user_with_rolebinding,
+    )


### PR DESCRIPTION
##### What this PR does / why we need it:
Wires the shared `dv_stop_status_restart_threshold` stop-status guard into the
clone DataVolume waits in `tests/storage/golden_image/`.

Both `wait_for_dv_success()` calls in this module wait on DataVolumes cloned
from the Fedora golden-image DataSource, with no early-exit guard. When a clone
importer restarts excessively, the wait blocks until the full timeout before
failing, wasting CI time and hiding the real failure cause. The `cdi_clone`
tests already use `dv_stop_status_restart_threshold` for this reason; this PR
reuses the same shared helper so these clone waits fail fast on excessive
restarts.

##### Which issue(s) this PR fixes:
[CNV-94467](https://redhat.atlassian.net/browse/CNV-94467)

##### Special notes for reviewer:
No new function was added — the existing shared
`tests/storage/stop_status_utils.py:dv_stop_status_restart_threshold` is reused.
Changes are confined to two clone `wait_for_dv_success()` call sites in
`test_golden_image.py`. No behavior change on the success path; only adds an
early stop when a clone DV exceeds the restart threshold.

##### jira-ticket:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved golden-image DV test reliability by waiting for the expected stop-status restart threshold during DV readiness checks.
  * Updated namespace DV creation coverage to account for stop-status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->