### PR TITLE
[Storage] - general: guard DV waits (>=10min) with restart-threshold stop status

### DIFF
--- a/tests/storage/general/conftest.py
+++ b/tests/storage/general/conftest.py
@@ -11,6 +11,7 @@ from pytest_testconfig import config as py_config
 
 from tests.storage.cdi_import.utils import get_importer_pod_node, wait_dv_and_get_importer
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities.constants import Images
 from utilities.constants.architecture import AMD_64
 from utilities.constants.images import OS_FLAVOR_FEDORA
@@ -106,6 +107,10 @@ def fedora_dv_rwx_with_importer_node(
         importer_pod_node = get_importer_pod_node(importer_pod=importer_pod)
         LOGGER.info(f"Importer pod {importer_pod.name} is running on node {importer_pod_node}")
 
-        dv.wait_for_dv_success(timeout=TIMEOUT_12MIN)
+        dv.wait_for_dv_success(
+            timeout=TIMEOUT_12MIN,
+            stop_status_func=dv_stop_status_restart_threshold,
+            dv=dv,
+        )
 
         yield dv, importer_pod_node

--- a/tests/storage/general/test_storage_behavior.py
+++ b/tests/storage/general/test_storage_behavior.py
@@ -7,6 +7,7 @@ import logging
 import pytest
 
 from tests.storage.cdi_import.utils import wait_for_pvc_recreate
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities import console
 from utilities.constants import Images
 from utilities.constants.images import OS_FLAVOR_FEDORA
@@ -50,7 +51,7 @@ def test_pvc_recreates_after_deletion(fedora_data_volume, namespace, storage_cla
     wait_for_pvc_recreate(pvc=pvc, pvc_creation_timestamp=pvc_original_timestamp)
     if sc_volume_binding_mode_is_wffc(sc=storage_class_name_scope_function, client=namespace.client):
         create_dummy_first_consumer_pod(client=namespace.client, pvc=pvc)
-    fedora_data_volume.wait_for_dv_success()
+    fedora_data_volume.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=fedora_data_volume)
 
 
 @pytest.mark.polarion("CNV-3065")


### PR DESCRIPTION
##### What this PR does / why we need it:
Wires the shared `dv_stop_status_restart_threshold` stop-status guard into the `wait_for_dv_success()` calls in `tests/storage/general/` whose effective timeout is >= 10 minutes: the `TIMEOUT_12MIN` importer wait in `conftest.py` and the default-timeout (10 min) `fedora_data_volume` wait in `test_storage_behavior.py`. Without the guard these waits block until the full timeout when an importer restarts excessively; reusing the existing shared helper (already used by `cdi_clone`/`golden_image`) makes them fail fast.

##### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-94468

##### Special notes for reviewer:
No new function was added — the existing shared `tests/storage/stop_status_utils.py:dv_stop_status_restart_threshold` is reused. Only calls with an effective timeout >= 10 minutes are guarded; the `TIMEOUT_5MIN` wait is intentionally left unchanged. No behavior change on the success path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

##### jira-ticket:
https://issues.redhat.com/browse/CNV-94468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved storage test reliability by waiting for data volume operations to reach the expected restart threshold.
  * Updated test setup and validation to use the relevant data volume context when monitoring operation completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->