### PR TITLE
[Storage] - disk_preallocation: guard DV waits with restart-threshold stop status

### DIFF
--- a/tests/storage/disk_preallocation/conftest.py
+++ b/tests/storage/disk_preallocation/conftest.py
@@ -3,6 +3,7 @@ from ocp_resources.cdi import CDI
 
 from tests.storage.constants import QUAY_FEDORA_CONTAINER_IMAGE
 from tests.storage.disk_preallocation.utils import wait_for_cdi_preallocation_enabled
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities.constants import Images
 from utilities.constants.storage import REGISTRY_STR
 from utilities.hco import (
@@ -42,7 +43,7 @@ def registry_dv_with_preallocation(namespace, storage_class_name_scope_function)
         client=namespace.client,
         preallocation=True,
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 
@@ -57,7 +58,7 @@ def registry_dv_no_preallocation_spec(namespace, storage_class_name_scope_module
         storage_class=storage_class_name_scope_module,
         client=namespace.client,
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 
@@ -73,7 +74,7 @@ def registry_dv_with_preallocation_false(namespace, storage_class_name_scope_fun
         client=namespace.client,
         preallocation=False,
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 
@@ -88,5 +89,5 @@ def blank_dv_with_preallocation(namespace, storage_class_name_scope_function):
         client=namespace.client,
         preallocation=True,
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv


### PR DESCRIPTION
##### What this PR does / why we need it:
Wires the shared `dv_stop_status_restart_threshold` stop-status guard into the four `wait_for_dv_success()` calls in `tests/storage/disk_preallocation/conftest.py`. They all use the default (10 min) success timeout, so without an early-exit guard they block until the full timeout when an importer restarts excessively. Reusing the existing shared helper (already used by `cdi_clone`/`golden_image`) makes them fail fast.

##### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-94469

##### Special notes for reviewer:
No new function was added — the existing shared `tests/storage/stop_status_utils.py:dv_stop_status_restart_threshold` is reused. No behavior change on the success path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

##### jira-ticket:
https://issues.redhat.com/browse/CNV-94469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated disk preallocation test fixtures to wait for device success using the restart-threshold stop status criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->