### PR TITLE
[Storage] - online_resize: guard DV wait with restart-threshold stop status

### DIFF
--- a/tests/storage/online_resize/utils.py
+++ b/tests/storage/online_resize/utils.py
@@ -11,6 +11,7 @@ from ocp_resources.virtual_machine_restore import VirtualMachineRestore
 from pyhelper_utils.shell import run_ssh_commands
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities.constants.timeouts import TIMEOUT_2MIN, TIMEOUT_4MIN, TIMEOUT_5SEC
 from utilities.storage import create_dv
 from utilities.virt import running_vm
@@ -37,7 +38,7 @@ def create_rhel_dv_from_data_source(unprivileged_client, namespace, name, storag
             "namespace": rhel_data_source.namespace,
         },
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Wires the shared `dv_stop_status_restart_threshold` stop-status guard into the `wait_for_dv_success()` call in `tests/storage/online_resize/utils.py`. It uses the default (10 min) success timeout, so without an early-exit guard it blocks until the full timeout when the clone importer restarts excessively. Reusing the existing shared helper (already used by `cdi_clone`/`golden_image`) makes it fail fast.

##### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-94470

##### Special notes for reviewer:
No new function was added — the existing shared `tests/storage/stop_status_utils.py:dv_stop_status_restart_threshold` is reused. No behavior change on the success path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

##### jira-ticket:
https://issues.redhat.com/browse/CNV-94470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved online resize test handling for RHEL data-source volumes by using the appropriate restart threshold when waiting for successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->