### PR TITLE
[Storage] - test_libguestfs: guard DV wait with restart-threshold stop status

### DIFF
--- a/tests/storage/test_libguestfs.py
+++ b/tests/storage/test_libguestfs.py
@@ -11,6 +11,7 @@ import pytest
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
+from tests.storage.stop_status_utils import dv_stop_status_restart_threshold
 from utilities.constants.pytest import UNPRIVILEGED_PASSWORD, UNPRIVILEGED_USER
 from utilities.constants.timeouts import TIMEOUT_1MIN, TIMEOUT_10MIN
 from utilities.infra import login_with_user_password
@@ -63,7 +64,7 @@ def dv_created_by_specific_user(
         },
         size=get_dv_size_from_datasource(data_source=fedora_data_source_scope_module),
     ) as dv:
-        dv.wait_for_dv_success()
+        dv.wait_for_dv_success(stop_status_func=dv_stop_status_restart_threshold, dv=dv)
         yield dv
 
 


### PR DESCRIPTION
##### What this PR does / why we need it:
Wires the shared `dv_stop_status_restart_threshold` stop-status guard into the `wait_for_dv_success()` call in `tests/storage/test_libguestfs.py`. It uses the default (10 min) success timeout, so without an early-exit guard it blocks until the full timeout when the clone importer restarts excessively. Reusing the existing shared helper (already used by `cdi_clone`/`golden_image`) makes it fail fast.

##### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-94473

##### Special notes for reviewer:
No new function was added — the existing shared `tests/storage/stop_status_utils.py:dv_stop_status_restart_threshold` is reused. No behavior change on the success path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

##### jira-ticket:
https://issues.redhat.com/browse/CNV-94473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated storage test execution to wait for successful completion using the restart-threshold stop-status condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->