### PR TITLE
Remove CNV-84023 xfail references after bug fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,6 @@ from utilities.infra import (
     get_clusterversion,
     get_node_selector_dict,
 )
-from utilities.jira import is_jira_open
 from utilities.network import (
     cloud_init_network_data,
     network_device,
@@ -153,11 +152,6 @@ def openshift_current_version(admin_client):
 @pytest.fixture(scope="session")
 def ocp_current_version(openshift_current_version):
     return parse(version=openshift_current_version.split("-")[0])
-
-
-@pytest.fixture(scope="session")
-def is_postcopy_migration_bug_open(cluster_has_rhcos10_or_above):
-    return cluster_has_rhcos10_or_above and is_jira_open(jira_id="CNV-84023")
 
 
 @pytest.fixture()

--- a/tests/fixtures/cluster/nodes.py
+++ b/tests/fixtures/cluster/nodes.py
@@ -2,14 +2,12 @@
 
 import logging
 import os
-import re
 
 import bitmath
 import pytest
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.machine import Machine
 from ocp_resources.node import Node
-from packaging.version import Version
 from pytest_testconfig import config as py_config
 
 from utilities.constants.cluster import (
@@ -121,25 +119,3 @@ def hugepages_gib_values(workers):
         for worker in workers
         if (value := worker.instance.status.allocatable.get(NODE_HUGE_PAGES_1GI_KEY))
     ]
-
-
-@pytest.fixture(scope="session")
-def workers_rhcos_version(schedulable_nodes):
-    """Returns a dict mapping each schedulable node name to its RHCOS version.
-
-    Returns:
-        dict[str, str]: Node name to RHCOS version (e.g. {"node-1": "10.2.20260408", ...}).
-    """
-    rhcos_version_re = re.compile(r"CoreOS\s+([\d.]+)")
-    versions = {}
-    for node in schedulable_nodes:
-        os_image = node.instance.status.nodeInfo.osImage
-        match = rhcos_version_re.search(string=os_image)
-        assert match, f"Failed to parse RHCOS version from osImage '{os_image}' on node '{node.name}'"
-        versions[node.name] = match.group(1)
-    return versions
-
-
-@pytest.fixture(scope="session")
-def cluster_has_rhcos10_or_above(workers_rhcos_version):
-    return any(Version(ver) >= Version("10") for ver in workers_rhcos_version.values())

--- a/tests/observability/metrics/conftest.py
+++ b/tests/observability/metrics/conftest.py
@@ -495,10 +495,7 @@ def windows_vm_for_test(windows_vm_namespace, unprivileged_client):
 
 
 @pytest.fixture(scope="class")
-def vm_for_migration_metrics_test(namespace, unprivileged_client, cpu_for_migration, is_postcopy_migration_bug_open):
-    if is_postcopy_migration_bug_open:
-        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
-
+def vm_for_migration_metrics_test(namespace, unprivileged_client, cpu_for_migration):
     name = "vm-for-migration-metrics-test"
     with VirtualMachineForTests(
         name=name,

--- a/tests/observability/metrics/test_vms_metrics.py
+++ b/tests/observability/metrics/test_vms_metrics.py
@@ -140,10 +140,7 @@ def vm_metric_1(namespace, unprivileged_client, cluster_common_node_cpu):
 
 
 @pytest.fixture()
-def vm_metric_1_vmim(admin_client, vm_metric_1, is_postcopy_migration_bug_open):
-    if is_postcopy_migration_bug_open:
-        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")
-
+def vm_metric_1_vmim(admin_client, vm_metric_1):
     with VirtualMachineInstanceMigration(
         name="vm-metric-1-vmim",
         namespace=vm_metric_1.namespace,

--- a/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
+++ b/tests/virt/cluster/migration_and_maintenance/test_migration_policy.py
@@ -190,7 +190,6 @@ class TestMigrationPolicies:
         ],
         indirect=True,
     )
-    @pytest.mark.usefixtures("xfail_postcopy_migration")
     def test_migration_policy_reverts_to_default_values(
         self,
         migration_policy_a,

--- a/tests/virt/conftest.py
+++ b/tests/virt/conftest.py
@@ -390,19 +390,3 @@ def nodes_cpu_vendor(schedulable_nodes):
         return INTEL
     else:
         return None
-
-
-@pytest.fixture()
-def xfail_postcopy_migration(is_postcopy_migration_bug_open):
-    """
-    Conditionally xfail a test affected by the CNV-84023 product bug.
-
-    Calls `pytest.xfail()` while CNV-84023 is open on a cluster with
-    RHCOS 10+ nodes. No-op once CNV-84023 is resolved.
-
-    Raises:
-        _pytest.outcomes.XFailed: If CNV-84023 is open and the cluster has
-            RHCOS 10+ nodes. This terminates the requesting test's setup.
-    """
-    if is_postcopy_migration_bug_open:
-        pytest.xfail(reason="CNV-84023: post-copy migration fails on RHCOS 10+ nodes")

--- a/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
+++ b/tests/virt/node/migration_and_maintenance/test_post_copy_migration.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 pytestmark = [
     pytest.mark.rwx_default_storage,
-    pytest.mark.usefixtures("xfail_postcopy_migration", "created_post_copy_migration_policy"),
+    pytest.mark.usefixtures("created_post_copy_migration_policy"),
     pytest.mark.data_collector_scope(scope="module"),
 ]
 


### PR DESCRIPTION
CNV-84023 (post-copy migration failing on RHCOS 10+ nodes) has been fixed, so the conditional xfail gating is no longer needed.

Removed the xfail sites in the migration policy, post-copy migration, and VM metrics tests, along with the now-unused supporting fixtures (xfail_postcopy_migration, is_postcopy_migration_bug_open, cluster_has_rhcos10_or_above, workers_rhcos_version) and the imports that only served them.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
<!--  full-ticket-url needs to be provided. This would add a link to the pull request to the jira and close it when the pull request is merged
If the task is not tracked by a Jira ticket, just write "NONE".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed conditional expected-failure handling for post-copy migration scenarios.
  * Post-copy migration and migration metrics tests now run normally instead of being skipped or marked as expected failures on affected clusters.
  * Removed environment-based checks for RHCOS versions and the associated issue status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->